### PR TITLE
GDB-7704 Introduce yasgui layout orientation switching

### DIFF
--- a/cypress/e2e/view-modes.spec.cy.ts
+++ b/cypress/e2e/view-modes.spec.cy.ts
@@ -28,16 +28,35 @@ describe('View modes', () => {
         YasqeSteps.getYasqe().should('be.visible');
         YasguiSteps.getTabs().should('have.length', 1);
         YasqeSteps.executeQuery();
+        // And yasr should be hidden
         YasrSteps.getYasr().should('not.be.visible');
     });
 
     it('Should render mode-yasr', () => {
         PageSteps.visitViewModesPage();
-        // When I switch to mode-yasqe
+        // When I switch to mode-yasr
         PageSteps.switchToModeYasr();
-        // Then Only yasqe should be visible
+        // Then Only yasqe should not be visible
         YasqeSteps.getYasqe().should('not.be.visible');
+        // And the yasqe tabs should not be visible
         YasguiSteps.getTabs().should('not.be.visible');
+        // And yasr should be visible
         YasrSteps.getYasr().should('be.visible');
+    });
+
+    it('Should change orientation to horizontal and vertical', () => {
+        PageSteps.visitViewModesPage();
+        // Orientation should be vertical by default
+        YasguiSteps.getYasguiTag().should('have.class', 'orientation-vertical');
+        // When The view mode is yasgui
+        PageSteps.switchToModeYasgui();
+        // And I switch orientation to horizontal
+        PageSteps.switchToHorizontalOrientation();
+        // Then I expect yasqe and yasr to be placed side by side
+        YasguiSteps.getYasguiTag().should('have.class', 'orientation-horizontal');
+        // When I switch to vertical orientation
+        PageSteps.switchToVerticalOrientation();
+        // Then I expect yasqe and yasr to be placed on top of each other
+        YasguiSteps.getYasguiTag().should('have.class', 'orientation-vertical');
     });
 })

--- a/cypress/steps/page-steps.ts
+++ b/cypress/steps/page-steps.ts
@@ -1,12 +1,12 @@
 export default class PageSteps {
 
-   static visitDefaultViewPage() {
-      cy.visit('/pages/default-view');
-   }
+    static visitDefaultViewPage() {
+        cy.visit('/pages/default-view');
+    }
 
-   static visitViewModesPage() {
-       cy.visit('/pages/view-modes');
-   }
+    static visitViewModesPage() {
+        cy.visit('/pages/view-modes');
+    }
 
    static visitConfigurationPage() {
       cy.visit('/pages/view-configurations');
@@ -36,11 +36,23 @@ export default class PageSteps {
       cy.get('#setDefaultQuery').click();
    }
 
+    static switchToModeYasgui() {
+        cy.get('#renderModeYasgui').click();
+    }
+
    static switchToModeYasqe() {
        cy.get('#renderModeYasqe').click();
    }
 
-   static switchToModeYasr() {
-       cy.get('#renderModeYasr').click();
-   }
+    static switchToModeYasr() {
+        cy.get('#renderModeYasr').click();
+    }
+
+    static switchToHorizontalOrientation() {
+        cy.get('#renderHorizontal').click();
+    }
+
+    static switchToVerticalOrientation() {
+        cy.get('#renderVertical').click();
+    }
 }

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -1,4 +1,8 @@
 export class YasguiSteps {
+    static getYasguiTag() {
+        return cy.get('ontotext-yasgui');
+    }
+
     static getYasgui() {
         return cy.get('.yasgui');
     }
@@ -7,7 +11,7 @@ export class YasguiSteps {
         return cy.get('.tab');
     }
 
-   static openANewTab() {
-      cy.get('button.addTab').click();
-   }
+    static openANewTab() {
+        cy.get('button.addTab').click();
+    }
 }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -28,6 +28,18 @@
   }
 }
 
+.orientation-horizontal {
+
+  .yasgui {
+    display: grid;
+
+    .tabPanel > div {
+      display: grid;
+      grid-template-columns: 0 1fr 1fr;
+    }
+  }
+}
+
 .yasgui {
 
   .autocompleteWrapper {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -63,7 +63,7 @@ export class OntotextYasguiWebComponent {
 
   render() {
     return (
-      <Host class={this.config.render}>
+      <Host>
       </Host>
     );
   }

--- a/ontotext-yasgui-web-component/src/docs/development-guide.md
+++ b/ontotext-yasgui-web-component/src/docs/development-guide.md
@@ -1,28 +1,38 @@
 
 # Ontotext Yasgui Web Component
 
-## Approach for the component implementation
-- For every change, patch or configuration in the library there must be a unit or UI test which covers the case except for changes in the styling.
+## Approach for the component implementation and YASGUI customization
+
+- For every change, patch or configuration in the library there must be a unit or UI test which 
+  covers the case except for changes in the styling.
 - Applying a fix means: for every needed change, find a way to apply it in an unobtrusive way first.
   1. Try to configure the YASGUI/YASQE/YASR using their configuration;
   2. Try to change the needed behaviour by YASGUI/YASQE/YASR using their public api;
   3. Тry to do some runtime monkey-patching:
-  4. In the end, if the change is impossible to be introduced in an unobtrusive way, then apply the change in the respective file in the library, then create a patch file following proper naming convention which includes the date/timestamp and include it in the source code with the WB so that it can be easier to be applied to newer versions of the library.
+  4. In the end, if the change is impossible to be introduced in an unobtrusive way, then apply the
+     change in the respective file in the library, then create a patch file following proper naming
+     convention which includes the date/timestamp and include it in the source code with the WB so
+     that it can be easier to be applied to newer versions of the library.
 
+## Implementation and testing of new features/customizations
 
-"ontotex-yasgui-web-component" component is build with Stencil compiler.
+For each new feature or extension in the component and/or YASGUI, a new page should be implemented 
+in `ontotext-yasgui-web-component/src/pages` where the component should be included with the 
+respective configurations and event handlers. The pages are used for manual testing of the features
+and by the automated component tests.
+
+In cypress component tests, for any particular feature the respective page is visited first, then
+actions and verifications are applied.
 
 ## Stencil
 
-Stencil is a compiler for building fast web apps using Web Components.
+"ontotex-yasgui-web-component" component is build with Stencil compiler.
 
-Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than run-time tool.  Stencil takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that run in any browser supporting the Custom Elements v1 spec.
+Check out stenciljs docs [here](https://stenciljs.com/docs/my-first-component).
 
-Stencil components are just Web Components, so they work in any major framework or with no framework at all.
-
-Need help with stensiljs? Check out stenciljs docs [here](https://stenciljs.com/docs/my-first-component).
-
-When component is built it can be used everywhere but there are difference if it used in angulajs version before 1.7.3.
+When component is built it can be used in any supported by stenciljs environment or in native 
+javascript web application, but there might be differences, e.g. if it's used in angulajs version 
+before 1.7.3, then additional custom directive must be installed on the client application.
 
 # Development tips
 
@@ -55,5 +65,5 @@ When component is built it can be used everywhere but there are difference if it
 ```
 
 # Usefull References
-1.  [State Management with State Tunnel in StencilJS](https://www.joshmorony.com/state-management-with-state-tunnel-in-stencil-js/)
+1. [State Management with State Tunnel in StencilJS](https://www.joshmorony.com/state-management-with-state-tunnel-in-stencil-js/)
 2. [Using Services/Providers to Share Data in a StencilJS Application](https://www.joshmorony.com/using-services-providers-to-share-data-in-a-stencil-js-application/)

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -1,9 +1,21 @@
 import {Config} from '../../../Yasgui/packages/yasgui'
 
 export interface YasguiConfiguration {
+  /**
+   * The default yasgui config.
+   */
   yasguiConfig: Config,
+
+  /**
+   * Configure what part of the yasgui should be rendered.
+   */
   render: RenderingMode;
+
+  /**
+   * Configure the yasgui layout orientation.
+   */
   orientation: Orientation;
+
   /**
    * Default query when a tab is opened.
    */
@@ -13,12 +25,14 @@ export interface YasguiConfiguration {
    * Initial query when yasgui is rendered if not set the default query will be set.
    */
   initialQuery?: string;
+
   /**
-   * if the yasgui tabs should be rendered or no
+   * If the yasgui tabs should be rendered or not.
    */
   showEditorTabs: boolean;
+
   /**
-   * if the yasr tabs should be rendered or not
+   * If the yasr tabs should be rendered or not.
    */
   showResultTabs: boolean;
 }

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -23,5 +23,13 @@ export interface YasguiConfiguration {
   showResultTabs: boolean;
 }
 
-export type RenderingMode = 'mode-yasgui' | 'mode-yasqe' | 'mode-yasr';
-export type Orientation = 'mode-vertical' | 'mode-horizontal';
+export enum RenderingMode {
+  YASGUI = 'mode-yasgui',
+  YASQE = 'mode-yasqe',
+  YASR = 'mode-yasr'
+}
+
+export enum Orientation {
+  VERTICAL = 'orientation-vertical',
+  HORIZONTAL = 'orientation-horizontal'
+}

--- a/ontotext-yasgui-web-component/src/pages/view-modes/index.html
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/index.html
@@ -13,6 +13,8 @@
   <button id="renderModeYasgui" onclick="renderMode('mode-yasgui')">yasgui</button>
   <button id="renderModeYasqe" onclick="renderMode('mode-yasqe')">yasqe</button>
   <button id="renderModeYasr" onclick="renderMode('mode-yasr')">yasr</button>
+  <button id="renderVertical" onclick="renderOrientation('orientation-vertical')">vertical</button>
+  <button id="renderHorizontal" onclick="renderOrientation('orientation-horizontal')">horizontal</button>
   <hr/>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/view-modes/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/main.js
@@ -6,9 +6,13 @@ ontoElement.config = {
     }
   },
   render: 'mode-yasgui',
-  orientation: 'mode-vertical'
+  orientation: 'orientation-vertical'
 };
 
 function renderMode(mode) {
-  ontoElement.config = {...ontoElement.config, render: mode}
+  ontoElement.config = {...ontoElement.config, render: mode};
+}
+
+function renderOrientation(mode) {
+  ontoElement.config = {...ontoElement.config, orientation: mode};
 }

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configurator.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configurator.ts
@@ -1,11 +1,14 @@
 import {Configurator} from './configurator';
-import {YasguiConfiguration} from '../../../models/yasgui-configuration';
+import {
+  Orientation,
+  RenderingMode,
+  YasguiConfiguration
+} from '../../../models/yasgui-configuration';
 import {Config} from '../../../../../Yasgui/packages/yasgui'
 import deepmerge from 'deepmerge';
 
 /**
  * Manages all top configuration of yasgui.
- *
  */
 class YasguiConfiguratorDefinition implements Configurator {
 
@@ -25,7 +28,30 @@ class YasguiConfiguratorDefinition implements Configurator {
   }
 
   config(_el: HTMLElement, config: Config, yasguiConfig: YasguiConfiguration): Config {
+    YasguiConfiguratorDefinition.setOrientation(yasguiConfig, _el);
+    YasguiConfiguratorDefinition.setRenderMode(yasguiConfig, _el);
+
     return deepmerge.all([config, this.defaultYasguiConfig, yasguiConfig.yasguiConfig ]) as Config;
+  }
+
+  private static setRenderMode(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
+    if (!!yasguiConfig.render) {
+      const newMode: RenderingMode = yasguiConfig.render;
+      // @ts-ignore
+      const modes: string[] = Object.values(RenderingMode);
+      _el.classList.remove(...modes);
+      _el.classList.add(newMode);
+    }
+  }
+
+  private static setOrientation(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
+    if (!!yasguiConfig.orientation) {
+      const newOrientation: Orientation = yasguiConfig.orientation;
+      // @ts-ignore
+      const orientations: string[] = Object.values(Orientation);
+      _el.classList.remove(...orientations);
+      _el.classList.add(newOrientation);
+    }
   }
 }
 

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configurator.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configurator.ts
@@ -13,6 +13,8 @@ import deepmerge from 'deepmerge';
 class YasguiConfiguratorDefinition implements Configurator {
 
   private defaultYasguiConfig = {
+    render: RenderingMode.YASGUI,
+    orientation: Orientation.VERTICAL,
     copyEndpointOnNewTab: true,
     requestConfig: {
       endpoint: '',
@@ -28,30 +30,26 @@ class YasguiConfiguratorDefinition implements Configurator {
   }
 
   config(_el: HTMLElement, config: Config, yasguiConfig: YasguiConfiguration): Config {
-    YasguiConfiguratorDefinition.setOrientation(yasguiConfig, _el);
-    YasguiConfiguratorDefinition.setRenderMode(yasguiConfig, _el);
+    this.setOrientation(yasguiConfig, _el);
+    this.setRenderMode(yasguiConfig, _el);
 
-    return deepmerge.all([config, this.defaultYasguiConfig, yasguiConfig.yasguiConfig ]) as Config;
+    return deepmerge.all([config, this.defaultYasguiConfig, yasguiConfig.yasguiConfig]) as Config;
   }
 
-  private static setRenderMode(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
-    if (!!yasguiConfig.render) {
-      const newMode: RenderingMode = yasguiConfig.render;
-      // @ts-ignore
-      const modes: string[] = Object.values(RenderingMode);
-      _el.classList.remove(...modes);
-      _el.classList.add(newMode);
-    }
+  private setRenderMode(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
+    // @ts-ignore
+    const modes: string[] = Object.values(RenderingMode);
+    _el.classList.remove(...modes);
+    const newMode: RenderingMode = !!yasguiConfig.render ? yasguiConfig.render : this.defaultYasguiConfig.render;
+    _el.classList.add(newMode);
   }
 
-  private static setOrientation(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
-    if (!!yasguiConfig.orientation) {
-      const newOrientation: Orientation = yasguiConfig.orientation;
-      // @ts-ignore
-      const orientations: string[] = Object.values(Orientation);
-      _el.classList.remove(...orientations);
-      _el.classList.add(newOrientation);
-    }
+  private setOrientation(yasguiConfig: YasguiConfiguration, _el: HTMLElement): void {
+    // @ts-ignore
+    const orientations: string[] = Object.values(Orientation);
+    _el.classList.remove(...orientations);
+    const newOrientation: Orientation = !!yasguiConfig.orientation ? yasguiConfig.orientation : this.defaultYasguiConfig.orientation;
+    _el.classList.add(newOrientation);
   }
 }
 


### PR DESCRIPTION
## What
Support for the yasgui layout orientation switching is added. The orientation of the yasgui can be switched by setting config.orienation='orientation-horizontal' or 'orientation-vertical' where the vertical orientation is the default.

## Why
The client expectation is to be able to switch the orientation if different views.

## How
* Extend the yasgui configuration with additional options for the orientation modes.
* Expose the configuration mode as a css class on the host element and style the yasgui appropriately.
* Add tests.