### PR TITLE
Fixed configuration passed to ontotext-yasgui-web-component

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -5,6 +5,27 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+This is the custom web component which is adapter for the yasgui library. It allows as to
+configure and extend the library without potentially breaking the component clients.
+
+The component have some sane defaults for most of its configurations. So, in practice, it can be
+used as is by providing just the sparql endpoint config.
+For other customizations, the default configurations can be overridden by providing a
+configuration object to the component.
+
+There is a configuration watcher which triggers the initialization again after a change is
+detected.
+
+During the component initialization, the provided configuration is passed down to a bunch of
+configuration helpers which use it to override and extend the defaults.
+
+After the configuration is ready, then a yasgui instance is created with it.
+
+After the yasgui instance is ready, then a post initialization phase begins. During the phase the
+yasgui can be tweaked using the values from the configuration.
+
 ## Properties
 
 | Property | Attribute | Description                                                   | Type                  | Default     |

--- a/ontotext-yasgui-web-component/src/js/main.js
+++ b/ontotext-yasgui-web-component/src/js/main.js
@@ -1,6 +1,6 @@
 let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: "/repositories/test-repo"
     }

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -1,6 +1,6 @@
 let ontoElement = document.querySelector('ontotext-yasgui');
 ontoElement.config = {
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: '/repositories/test-repo'
     }

--- a/ontotext-yasgui-web-component/src/pages/default-view/main.js
+++ b/ontotext-yasgui-web-component/src/pages/default-view/main.js
@@ -1,6 +1,6 @@
 let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: "/repositories/test-repo"
     }

--- a/ontotext-yasgui-web-component/src/pages/toolbar/main.js
+++ b/ontotext-yasgui-web-component/src/pages/toolbar/main.js
@@ -1,6 +1,6 @@
 let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: "/repositories/test-repo"
     }

--- a/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
@@ -1,7 +1,7 @@
 const ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
   query: '',
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: "/repositories/test-repo"
     }

--- a/ontotext-yasgui-web-component/src/pages/view-modes/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/main.js
@@ -1,6 +1,6 @@
 let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
-  yasguiConfig: {
+  defaultYasguiConfiguration: {
     requestConfig: {
       endpoint: "/repositories/test-repo"
     }

--- a/ontotext-yasgui-web-component/src/services/yasgui/yasgui-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/yasgui-builder.ts
@@ -28,7 +28,7 @@ class YasguiBuilderDefinition {
     const yasguiConfiguration = this.yasguiConfigurationBuilder.build(externalConfiguration);
 
     // @ts-ignore
-    const yasgui = new Yasgui(HtmlElementsUtil.getOntotextYasgui(hostElement), yasguiConfiguration.yasguiConfig);
+    const yasgui = new Yasgui(HtmlElementsUtil.getOntotextYasgui(hostElement), yasguiConfiguration.defaultYasguiConfiguration);
 
     // monkey patches have to be applied before return yasgui.
     return new OntotextYasgui(yasgui, yasguiConfiguration);


### PR DESCRIPTION
## What
Original yasgui configuration not built correct.

## Why
We renamed configuration field "yasguiConfig" to "defaultYasguiConfiguration", but didn't change it in all main.js classes. Test are passed because yasgui is created with old configuration.

## How
Changed configuration name.