### PR TITLE
GDB-7815: Extends ontotext-yasgui-web-component to support persistence context

### DIFF
--- a/cypress/e2e/persistence.spec.cy.ts
+++ b/cypress/e2e/persistence.spec.cy.ts
@@ -1,0 +1,23 @@
+import {PersistenceSteps} from '../steps/persistence-steps';
+import {YasguiSteps} from '../steps/yasgui-steps';
+
+describe('Persistence context', () => {
+
+   it('Should be able to create instances independent each other', () => {
+      // When I create an instance of "ontotext-yasgui-web-component".
+      PersistenceSteps.visitFirstInstancePage();
+      // And I open a new tab
+      YasguiSteps.openANewTab();
+      // And I create another instance.
+      PersistenceSteps.visitSecondInstancePage();
+
+      // Then I expect the new instance to have only one tab.
+      YasguiSteps.getTabs().should('have.length', 1);
+
+      // And when I go to page with first instance
+      PersistenceSteps.visitFirstInstancePage();
+
+      // Then I expect to see two tabs
+      YasguiSteps.getTabs().should('have.length', 2);
+   });
+});

--- a/cypress/steps/persistence-steps.ts
+++ b/cypress/steps/persistence-steps.ts
@@ -1,0 +1,9 @@
+export class PersistenceSteps {
+   static visitFirstInstancePage() {
+      cy.visit('/pages/persistence/instance');
+   }
+
+   static visitSecondInstancePage() {
+      cy.visit('/pages/persistence/second-instance');
+   }
+}

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -97,7 +97,9 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - <b>defaultTabName?</b>: The default tab name when a new tab is created;
 - <b>showEditorTabs</b>: If the query editor tabs should be rendered or not;
 - <b>showResultTabs</b>: If the results tabs should be rendered or not;
-- <b>showToolbar</b>: If the toolbar with render mode buttons should be rendered or not.
-- <b>yasqePluginButtons</b>: Plugin definitions configurations for yasqe action buttons. 
+- <b>showToolbar</b>: If the toolbar with render mode buttons should be rendered or not;
+- <b>yasqePluginButtons</b>: Plugin definitions configurations for yasqe action buttons; 
+- <b>componentId</b>: Unique identifier of an instance of the component. This config is optional.
+  A unique identifier of the component instance. This configuration is optional. A unique value should be passed only if the component's internal state (open tabs, completed requests, etc.) should not be shared with its other instances.
 # License
 TODO:

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -91,6 +91,20 @@ export interface ExternalYasguiConfiguration {
    */
   copyEndpointOnNewTab: boolean;
 
+  /**
+   * Yasgui use browser local storage to persist its state. In its state, yasgui holds information about:
+   * 1. default query when a tab is opened;
+   * 2. YASR plugins configuration;
+   * 3. selected plugin;
+   * 4. request configuration: endpoint, headers, method and so on;
+   * 5. opened tabs;
+   * 5. which tab is active.
+   * The <code>componentId</code> configuration options defines uniqueness of this persistent state. Passed value will be used to generate
+   * the key which will be used into browser local store. For example if value is "123" then the key will be "yasgui__123".
+   * Default value is "ontotext-yasgui-config".
+   */
+  componentId: string;
+
   // ***********************************************************
   //
   // All configurations related with the yasqe instance

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -75,6 +75,7 @@ export interface YasguiConfiguration {
       headers?: () => Record<string, string>;
     },
     copyEndpointOnNewTab?: boolean;
+    persistenceLabelConfig?: string;
     yasqe?: {
       /**
        * Default query when a tab is opened.
@@ -122,6 +123,7 @@ export const defaultYasguiConfig: Record<string, any> = {
   translate: (key, parameters) => TranslationService.Instance.translate(key, parameters),
   defaultTabName: TranslationService.Instance.translate('yasgui.tab_list.tab.default.name'),
   copyEndpointOnNewTab: true,
+  persistenceLabelConfig: "ontotext-yasgui-config",
   endpoint: '',
   method: 'POST',
   headers: () => {

--- a/ontotext-yasgui-web-component/src/pages/persistence/instance/index.html
+++ b/ontotext-yasgui-web-component/src/pages/persistence/instance/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
+
+    <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="./instance/main.js" defer></script>
+  </head>
+  <body>
+  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  </body>
+</html>

--- a/ontotext-yasgui-web-component/src/pages/persistence/instance/main.js
+++ b/ontotext-yasgui-web-component/src/pages/persistence/instance/main.js
@@ -1,0 +1,6 @@
+let ontoElement = document.querySelector("ontotext-yasgui");
+ontoElement.config = {
+  endpoint: "/repositories/test-repo",
+  showToolbar: false,
+  componentId: 'first_instance'
+};

--- a/ontotext-yasgui-web-component/src/pages/persistence/second-instance/index.html
+++ b/ontotext-yasgui-web-component/src/pages/persistence/second-instance/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
+
+    <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="./second-instance/main.js" defer></script>
+  </head>
+  <body>
+  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  </body>
+</html>

--- a/ontotext-yasgui-web-component/src/pages/persistence/second-instance/main.js
+++ b/ontotext-yasgui-web-component/src/pages/persistence/second-instance/main.js
@@ -1,0 +1,6 @@
+let ontoElement = document.querySelector("ontotext-yasgui");
+ontoElement.config = {
+  endpoint: "/repositories/test-repo",
+  showToolbar: false,
+  componentId: 'second_instance'
+};

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -57,6 +57,7 @@ export class YasguiConfigurationBuilderDefinition {
     config.yasguiConfig.tabName = externalConfiguration.defaultTabName || defaultYasguiConfig.defaultTabName;
     config.yasguiConfig.requestConfig.headers = externalConfiguration.headers || defaultYasguiConfig.headers;
     config.yasguiConfig.copyEndpointOnNewTab = externalConfiguration.copyEndpointOnNewTab !== undefined ? externalConfiguration.copyEndpointOnNewTab : defaultYasguiConfig.copyEndpointOnNewTab;
+    config.yasguiConfig.persistenceLabelConfig = externalConfiguration.componentId || defaultYasguiConfig.persistenceLabelConfig;
     config.yasguiConfig.yasqe.value = externalConfiguration.query || defaultYasqeConfig.query;
 
     // prepare the yasqe config


### PR DESCRIPTION
Extends ontotext-yasgui-web-component to support persistence context

What?
Added persistence context to "ontotext-yasgui-web-component".

Why?
Client needs to have independent instances of "ontotext-yasgui-web-component". This means that you when make changes to an instance, all other will not be affected.

How?
Yasgui has such functionality. Extends "ontotext-yasgui-web-component" with configuration "componentId". The value of configuration will be used to create independent persisted state of component.