### PR TITLE
GDB-7784 implement show saved queries action

### DIFF
--- a/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
+++ b/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
@@ -10,14 +10,22 @@ describe('Configure editor actions', () => {
         ActionsPageSteps.visit();
     });
 
-    it('Should see all custom actions by default', () => {
-        YasqeSteps.getCreateSavedQueryButton().should('be.visible');
+    it('Should see all custom actions by default in particular order', () => {
+        YasqeSteps.getActionButtons().should('have.length', 2);
+        YasqeSteps.getActionButton(0).should('have.attr', 'title', 'Create saved query');
+        YasqeSteps.getActionButton(1).should('have.attr', 'title', 'Show saved queries');
     });
 
     it('Should be able to toggle yasqe action buttons', () => {
+        // Toggle save query action
         ActionsPageSteps.hideSaveQueryAction();
         YasqeSteps.getCreateSavedQueryButton().should('not.exist');
         ActionsPageSteps.showSaveQueryAction();
         YasqeSteps.getCreateSavedQueryButton().should('be.visible');
+        // Toggle show saved queries action
+        ActionsPageSteps.hideShowSavedQueriesAction();
+        YasqeSteps.getShowSavedQueriesButton().should('not.exist');
+        ActionsPageSteps.showShowSavedQueriesAction();
+        YasqeSteps.getShowSavedQueriesButton().should('be.visible');
     });
 });

--- a/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
+++ b/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
@@ -1,0 +1,51 @@
+import {YasqeSteps} from "../../steps/yasqe-steps";
+import {QueryStubs} from "../../stubs/query-stubs";
+import ActionsPageSteps from "../../steps/actions-page-steps";
+import {YasguiSteps} from "../../steps/yasgui-steps";
+
+describe('Show saved queries action', () => {
+    beforeEach(() => {
+        QueryStubs.stubDefaultQueryResponse();
+        // Given I have opened a page with the yasgui
+        // And there is an open tab with sparql query in it
+        ActionsPageSteps.visit();
+    });
+
+    it('Should open a popup with the saved queries list', () => {
+        // When I click on show saved queries button
+        YasqeSteps.showSavedQueries();
+        // Then I expect that a popup with a saved queries list to be opened
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        YasqeSteps.getSavedQueries().should('have.length', 4);
+        YasqeSteps.verifySavedQueries([
+            {queryName: 'Add statements'},
+            {queryName: 'Clear graph'},
+            {queryName: 'new query'},
+            {queryName: 'q1'}
+        ]);
+    });
+
+    it('Should be able to select a query from the list', () => {
+        // Given I have opened the saved queries popup
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        // When I select a query from the list
+        YasqeSteps.selectSavedQuery(1);
+        // Then I expect that the popup should be closed
+        YasqeSteps.getSavedQueriesPopup().should('not.exist');
+        // And the query will be populated in a new tab in the yasgui
+        YasguiSteps.getTabs().should('have.length', 2);
+        YasguiSteps.getCurrentTab().should('contain', 'Clear graph');
+        YasqeSteps.getTabQuery(1).should('equal', 'CLEAR GRAPH <http://example>');
+    });
+
+    it('Should be able to close the popup by clicking outside', () => {
+        // Given I have opened the saved queries popup
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        // When I click outside of the popup
+        cy.get('body').click();
+        // Then the popup should be closed
+        YasqeSteps.getSavedQueriesPopup().should('not.exist');
+    });
+});

--- a/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
+++ b/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
@@ -16,12 +16,20 @@ describe('Show saved queries action', () => {
         YasqeSteps.showSavedQueries();
         // Then I expect that a popup with a saved queries list to be opened
         YasqeSteps.getSavedQueriesPopup().should('be.visible');
-        YasqeSteps.getSavedQueries().should('have.length', 4);
+        YasqeSteps.getSavedQueries().should('have.length', 12);
         YasqeSteps.verifySavedQueries([
             {queryName: 'Add statements'},
             {queryName: 'Clear graph'},
             {queryName: 'new query'},
-            {queryName: 'q1'}
+            {queryName: 'q1'},
+            {queryName: 'q2'},
+            {queryName: 'q3'},
+            {queryName: 'q4'},
+            {queryName: 'q5'},
+            {queryName: 'q6'},
+            {queryName: 'q7'},
+            {queryName: 'q8'},
+            {queryName: 'q9'}
         ]);
     });
 

--- a/cypress/steps/actions-page-steps.ts
+++ b/cypress/steps/actions-page-steps.ts
@@ -14,4 +14,12 @@ export default class ActionsPageSteps {
     static showSaveQueryAction() {
         cy.get('#showSaveQueryAction').click();
     }
+
+    static hideShowSavedQueriesAction() {
+        cy.get('#hideLoadSavedQueriesAction').click();
+    }
+
+    static showShowSavedQueriesAction() {
+        cy.get('#showLoadSavedQueriesAction').click();
+    }
 }

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -11,6 +11,10 @@ export class YasguiSteps {
         return cy.get('.tab');
     }
 
+    static getCurrentTab() {
+        return cy.get('.tab.active');
+    }
+
     static openANewTab() {
         cy.get('button.addTab').click();
     }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -11,6 +11,18 @@ export class YasqeSteps {
         return cy.get(".yasqe:visible");
     }
 
+    static getActionsToolbar() {
+        return this.getEditor().find('.yasqe_buttons');
+    }
+
+    static getActionButtons() {
+        return this.getActionsToolbar().find('.custom-button');
+    }
+
+    static getActionButton(index: number) {
+        return this.getActionButtons().eq(index);
+    }
+
     static getExecuteQueryButton() {
         return cy.get('.yasqe_queryButton');
     }
@@ -85,5 +97,37 @@ export class YasqeSteps {
 
     static getControlBar() {
         return cy.get('.controlbar');
+    }
+
+    static getShowSavedQueriesButton() {
+        return cy.get('.yasqe_showSavedQueriesButton');
+    }
+
+    static showSavedQueries() {
+        this.getShowSavedQueriesButton().click();
+    }
+
+    static getSavedQueriesPopup() {
+        return cy.get('.saved-queries-popup');
+    }
+
+    static getSavedQueries() {
+        return this.getSavedQueriesPopup().find('.saved-query');
+    }
+
+    static verifySavedQueries(data: {queryName: string}[]) {
+        this.getSavedQueries().each((el, index) => {
+            cy.wrap(el).should('contain', data[index].queryName);
+        })
+    }
+
+    static selectSavedQuery(index: number) {
+        this.getSavedQueries().eq(index).find('a').click();
+    }
+
+    static getTabQuery(tabIndex: number) {
+        return cy.get('.yasqe .CodeMirror').then((el) => {
+            return el[tabIndex].CodeMirror.getValue();
+        });
     }
 }

--- a/ontotext-yasgui-web-component/docs/developers-guide.md
+++ b/ontotext-yasgui-web-component/docs/developers-guide.md
@@ -192,6 +192,44 @@ export class ServiceName {
 }
 ```
 
+# Integration events - Actions
+
+In result of certain operations in the yasgui component are raised events that are responsibility
+of the client to handle properly and to respond in the expected way.
+
+* **queryExecuted: EventEmitter\<QueryEvent>**: 
+  * Description: Event emitted when before query to be executed.
+  * Response: None
+* **queryResponse: EventEmitter\<QueryResponseEvent>**
+  * Description: Event emitted when after query response is returned.
+  * Response: None
+* **createSavedQuery: EventEmitter\<SaveQueryData>**:
+  * Description: Event emitted when saved query payload is collected and the query should be saved by the component client. 
+  * Response: The client must set in the config following data.
+  ```
+    {
+      savedQuery: {
+        saveSuccess: boolean; // if save was successful or not
+        errorMessage: string[]; // if any error happen then messages must be passed back
+      }
+    };
+  ```
+* **loadSavedQueries: EventEmitter\<boolean>**:
+  * Description: Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.
+  * Response: The client must set in the config following data:
+  ```
+  {
+    savedQueries: {
+      data: {
+        queryName: string;
+        query: string;
+        owner: string;
+        isPublic: boolean;
+      }[]
+    }
+  }
+  ```
+
 # Useful References
 1. [State Management with State Tunnel in StencilJS](https://www.joshmorony.com/state-management-with-state-tunnel-in-stencil-js/)
 2. [Using Services/Providers to Share Data in a StencilJS Application](https://www.joshmorony.com/using-services-providers-to-share-data-in-a-stencil-js-application/)

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -7,7 +7,7 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ExternalYasguiConfiguration } from "./models/external-yasgui-configuration";
 import { QueryEvent, QueryResponseEvent } from "./models/event";
-import { SaveQueryData } from "./models/model";
+import { SavedQueriesData, SaveQueryData } from "./models/model";
 export namespace Components {
     /**
      * This is the custom web component which is adapter for the yasgui library. It allows as to
@@ -42,6 +42,9 @@ export namespace Components {
          */
         "data": SaveQueryData;
     }
+    interface SavedQueriesPopup {
+        "data": SavedQueriesData;
+    }
     interface YasguiTooltip {
         "dataTooltip": string;
         "placement": string;
@@ -55,6 +58,10 @@ export interface OntotextYasguiCustomEvent<T> extends CustomEvent<T> {
 export interface SaveQueryDialogCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSaveQueryDialogElement;
+}
+export interface SavedQueriesPopupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSavedQueriesPopupElement;
 }
 declare global {
     /**
@@ -85,6 +92,12 @@ declare global {
         prototype: HTMLSaveQueryDialogElement;
         new (): HTMLSaveQueryDialogElement;
     };
+    interface HTMLSavedQueriesPopupElement extends Components.SavedQueriesPopup, HTMLStencilElement {
+    }
+    var HTMLSavedQueriesPopupElement: {
+        prototype: HTMLSavedQueriesPopupElement;
+        new (): HTMLSavedQueriesPopupElement;
+    };
     interface HTMLYasguiTooltipElement extends Components.YasguiTooltip, HTMLStencilElement {
     }
     var HTMLYasguiTooltipElement: {
@@ -94,6 +107,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "ontotext-yasgui": HTMLOntotextYasguiElement;
         "save-query-dialog": HTMLSaveQueryDialogElement;
+        "saved-queries-popup": HTMLSavedQueriesPopupElement;
         "yasgui-tooltip": HTMLYasguiTooltipElement;
     }
 }
@@ -128,6 +142,10 @@ declare namespace LocalJSX {
          */
         "onCreateSavedQuery"?: (event: OntotextYasguiCustomEvent<SaveQueryData>) => void;
         /**
+          * Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.
+         */
+        "onLoadSavedQueries"?: (event: OntotextYasguiCustomEvent<boolean>) => void;
+        /**
           * Event emitted when before query to be executed.
          */
         "onQueryExecuted"?: (event: OntotextYasguiCustomEvent<QueryEvent>) => void;
@@ -150,6 +168,17 @@ declare namespace LocalJSX {
          */
         "onInternalSaveQueryEvent"?: (event: SaveQueryDialogCustomEvent<SaveQueryData>) => void;
     }
+    interface SavedQueriesPopup {
+        "data"?: SavedQueriesData;
+        /**
+          * Event fired when the saved queries popup should be closed.
+         */
+        "onInternalCloseSavedQueriesPopupEvent"?: (event: SavedQueriesPopupCustomEvent<any>) => void;
+        /**
+          * Event fired when a saved query is selected from the list.
+         */
+        "onInternalSaveQuerySelectedEvent"?: (event: SavedQueriesPopupCustomEvent<SaveQueryData>) => void;
+    }
     interface YasguiTooltip {
         "dataTooltip"?: string;
         "placement"?: string;
@@ -158,6 +187,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "ontotext-yasgui": OntotextYasgui;
         "save-query-dialog": SaveQueryDialog;
+        "saved-queries-popup": SavedQueriesPopup;
         "yasgui-tooltip": YasguiTooltip;
     }
 }
@@ -183,6 +213,7 @@ declare module "@stencil/core" {
              */
             "ontotext-yasgui": LocalJSX.OntotextYasgui & JSXBase.HTMLAttributes<HTMLOntotextYasguiElement>;
             "save-query-dialog": LocalJSX.SaveQueryDialog & JSXBase.HTMLAttributes<HTMLSaveQueryDialogElement>;
+            "saved-queries-popup": LocalJSX.SavedQueriesPopup & JSXBase.HTMLAttributes<HTMLSavedQueriesPopupElement>;
             "yasgui-tooltip": LocalJSX.YasguiTooltip & JSXBase.HTMLAttributes<HTMLYasguiTooltipElement>;
         }
     }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -24,7 +24,7 @@ import {YasguiConfigurationBuilderDefinition} from "../../services/yasgui/config
 import {ExternalYasguiConfiguration} from "../../models/external-yasgui-configuration";
 import {TranslationService} from '../../services/translation.service';
 import {EventService} from "../../services/event-service";
-import {SaveQueryData} from "../../models/model";
+import {SavedQueriesData, SaveQueryData} from "../../models/model";
 import {YasqeService} from "../../services/yasqe/yasqe-service";
 
 type EventArguments = [Yasqe, Request, number];
@@ -109,6 +109,12 @@ export class OntotextYasguiWebComponent {
   @Event() createSavedQuery: EventEmitter<SaveQueryData>;
 
   /**
+   * Event emitted when saved queries is expected to be loaded by the component client and provided
+   * back in order to be displayed.
+   */
+  @Event() loadSavedQueries: EventEmitter<boolean>;
+
+  /**
    * The instance of our adapter around the actual yasgui instance.
    */
   ontotextYasgui: OntotextYasgui;
@@ -148,7 +154,7 @@ export class OntotextYasguiWebComponent {
   @State() showSaveQueryDialog = false;
 
   /**
-   * Handler for the event fired when the button in the yasqe is triggered.
+   * Handler for the event fired when the save query button in the yasqe toolbar is triggered.
    */
   @Listen('internalCreateSavedQueryEvent')
   saveQueryHandler() {
@@ -169,6 +175,38 @@ export class OntotextYasguiWebComponent {
   @Listen('internalSaveQueryDialogClosedEvent')
   closeSaveDialogHandler() {
     this.showSaveQueryDialog = false;
+  }
+
+  /**
+   * Flag controlling the visibility of the saved queries list popup.
+   */
+  @State() showSavedQueriesPopup = false;
+
+  /**
+   * Handler for the event fired when the show saved queries button in the yasqe toolbar is triggered.
+   */
+  @Listen('internalShowSavedQueriesEvent')
+  showSavedQueriesHandler() {
+    this.loadSavedQueries.emit(true);
+  }
+
+  /**
+   * Handler for the event fired when the saved query is selected from the saved queries list.
+   */
+  @Listen('internalSaveQuerySelectedEvent')
+  savedQuerySelectedHandler(event: CustomEvent<SaveQueryData>) {
+    const queryData: SaveQueryData = event.detail;
+    this.config.savedQueries.data = [];
+    this.showSavedQueriesPopup = false;
+    this.ontotextYasgui.createNewTab(queryData.queryName, queryData.query);
+  }
+
+  /**
+   * Handler for the event for closing the saved queries popup.
+   */
+  @Listen('internalCloseSavedQueriesPopupEvent')
+  closeSavedQueriesPopupHandler() {
+    this.showSavedQueriesPopup = false;
   }
 
   componentWillLoad() {
@@ -211,6 +249,7 @@ export class OntotextYasguiWebComponent {
       this.ontotextYasguiService.postConstruct(this.hostElement, this.ontotextYasgui.getConfig());
 
       this.shouldShowSaveQueryDialog();
+      this.shouldShowSavedQueriesPopup();
 
       // * Register any needed event handler
       this.ontotextYasgui.registerYasqeEventListener('query', this.onQuery.bind(this));
@@ -257,6 +296,24 @@ export class OntotextYasguiWebComponent {
     return data;
   }
 
+  private getSaveQueriesData(): SavedQueriesData {
+    const data: SavedQueriesData = {
+      savedQueriesList: []
+    };
+    if (this.config.savedQueries) {
+      data.savedQueriesList = this.config.savedQueries.data.map((savedQuery) => {
+        return {
+          queryName: savedQuery.name,
+          query: savedQuery.body,
+          isPublic: savedQuery.shared,
+          owner: savedQuery.owner
+        }
+      });
+
+    }
+    return data;
+  }
+
   private getRenderMode() {
     return this.config.render || defaultOntotextYasguiConfig.render;
   }
@@ -271,6 +328,10 @@ export class OntotextYasguiWebComponent {
 
   private isSavedQuerySaved() {
     return this.config.savedQuery && this.config.savedQuery.saveSuccess;
+  }
+
+  private shouldShowSavedQueriesPopup(): void {
+    this.showSavedQueriesPopup = this.showSavedQueriesPopup || !!(this.config.savedQueries?.data && this.config.savedQueries?.data.length > 0);
   }
 
   private destroy() {
@@ -311,10 +372,13 @@ export class OntotextYasguiWebComponent {
                     onClick={() => this.changeOrientation()}>&nbsp;</button>
           </yasgui-tooltip>
         </div>
-        <div class="ontotext-yasgui">&nbsp;</div>
+        <div class="ontotext-yasgui"></div>
 
         {this.showSaveQueryDialog &&
         <save-query-dialog data={this.getSaveQueryData()}>&nbsp;</save-query-dialog>}
+
+        {this.showSavedQueriesPopup &&
+        <saved-queries-popup data={this.getSaveQueriesData()}></saved-queries-popup>}
       </Host>
     );
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -196,7 +196,6 @@ export class OntotextYasguiWebComponent {
   @Listen('internalSaveQuerySelectedEvent')
   savedQuerySelectedHandler(event: CustomEvent<SaveQueryData>) {
     const queryData: SaveQueryData = event.detail;
-    this.config.savedQueries.data = [];
     this.showSavedQueriesPopup = false;
     this.ontotextYasgui.createNewTab(queryData.queryName, queryData.query);
   }
@@ -303,9 +302,9 @@ export class OntotextYasguiWebComponent {
     if (this.config.savedQueries) {
       data.savedQueriesList = this.config.savedQueries.data.map((savedQuery) => {
         return {
-          queryName: savedQuery.name,
-          query: savedQuery.body,
-          isPublic: savedQuery.shared,
+          queryName: savedQuery.queryName,
+          query: savedQuery.query,
+          isPublic: savedQuery.isPublic,
           owner: savedQuery.owner
         }
       });

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -37,11 +37,12 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Events
 
-| Event              | Description                                                                                                | Type                                 |
-| ------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `createSavedQuery` | Event emitted when saved query payload is collected and the query should be saved by the component client. | `CustomEvent<SaveQueryData>`         |
-| `queryExecuted`    | Event emitted when before query to be executed.                                                            | `CustomEvent<{ query: string; }>`    |
-| `queryResponse`    | Event emitted when after query response is returned.                                                       | `CustomEvent<{ duration: number; }>` |
+| Event              | Description                                                                                                                   | Type                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `createSavedQuery` | Event emitted when saved query payload is collected and the query should be saved by the component client.                    | `CustomEvent<SaveQueryData>`         |
+| `loadSavedQueries` | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed. | `CustomEvent<boolean>`               |
+| `queryExecuted`    | Event emitted when before query to be executed.                                                                               | `CustomEvent<{ query: string; }>`    |
+| `queryResponse`    | Event emitted when after query response is returned.                                                                          | `CustomEvent<{ duration: number; }>` |
 
 
 ## Methods
@@ -63,12 +64,14 @@ Type: `Promise<void>`
 
 - [yasgui-tooltip](../ontotext-tooltip-web-component)
 - [save-query-dialog](../save-query-dialog)
+- [saved-queries-popup](../saved-queries-popup)
 
 ### Graph
 ```mermaid
 graph TD;
   ontotext-yasgui --> yasgui-tooltip
   ontotext-yasgui --> save-query-dialog
+  ontotext-yasgui --> saved-queries-popup
   save-query-dialog --> yasgui-tooltip
   style ontotext-yasgui fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
@@ -1,0 +1,38 @@
+# saved-queries-popup
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description | Type               | Default     |
+| -------- | --------- | ----------- | ------------------ | ----------- |
+| `data`   | --        |             | `SavedQueriesData` | `undefined` |
+
+
+## Events
+
+| Event                                 | Description                                                | Type                         |
+| ------------------------------------- | ---------------------------------------------------------- | ---------------------------- |
+| `internalCloseSavedQueriesPopupEvent` | Event fired when the saved queries popup should be closed. | `CustomEvent<any>`           |
+| `internalSaveQuerySelectedEvent`      | Event fired when a saved query is selected from the list.  | `CustomEvent<SaveQueryData>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [ontotext-yasgui](../ontotext-yasgui-web-component)
+
+### Graph
+```mermaid
+graph TD;
+  ontotext-yasgui --> saved-queries-popup
+  style saved-queries-popup fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
@@ -1,0 +1,62 @@
+:host {
+  display: block;
+}
+
+.saved-queries-container {
+  position: absolute;
+  // prevent CodeMirror stuff to overlap the popup
+  z-index: 10;
+  border: 1px solid #ccc;
+  font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 300;
+
+  .saved-queries-popup {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+
+    ul {
+      padding: 15px;
+      margin: 0;
+
+      .saved-query {
+        list-style-type: none;
+
+        a {
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+
+  .arrow {
+    position: absolute;
+    display: block;
+    right: calc(-0.5rem - 1px);
+    width: 8px;
+    height: 16px;
+    margin: 0.3rem 0;
+
+    &::before, &::after {
+      position: absolute;
+      display: block;
+      content: "";
+      border-color: transparent;
+      border-style: solid;
+    }
+
+    &::before {
+      right: 0;
+      border-width: 0.5rem 0 0.5rem 0.5rem;
+      border-left-color: rgba(0,0,0,.25);
+    }
+
+    &::after {
+      right: 1px;
+      border-width: 0.5rem 0 0.5rem 0.5rem;
+      border-left-color: #fff;
+    }
+  }
+}

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
@@ -1,3 +1,5 @@
+@import "src/css/variables";
+
 :host {
   display: block;
 }
@@ -9,8 +11,11 @@
   border: 1px solid #ccc;
   font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 300;
+  background-color: #fff;
 
   .saved-queries-popup {
+    height: 250px;
+    overflow-y: scroll;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 
     ul {
@@ -19,9 +24,13 @@
 
       .saved-query {
         list-style-type: none;
+        padding: 5px 0;
 
         a {
+          display: block;
           text-decoration: none;
+          cursor: pointer;
+          color: $color-onto-blue;
 
           &:hover {
             text-decoration: underline;

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -1,0 +1,70 @@
+import {Component, Element, Event, EventEmitter, h, Host, Listen, Prop} from '@stencil/core';
+import {SavedQueriesData, SaveQueryData} from "../../models/model";
+
+@Component({
+  tag: 'saved-queries-popup',
+  styleUrl: 'saved-queries-popup.scss',
+  shadow: false,
+})
+export class SavedQueriesPopup {
+
+  @Element() hostElement: HTMLElement;
+
+  @Prop() data: SavedQueriesData;
+
+  /**
+   * Event fired when a saved query is selected from the list.
+   */
+  @Event() internalSaveQuerySelectedEvent: EventEmitter<SaveQueryData>;
+
+  /**
+   * Event fired when the saved queries popup should be closed.
+   */
+  @Event() internalCloseSavedQueriesPopupEvent: EventEmitter;
+
+  @Listen('click', { target: 'window' })
+  onWindowResize(event: PointerEvent) {
+    const target: HTMLElement = event.target as HTMLElement;
+    if (!target.closest('.saved-queries-container')) {
+      this.internalCloseSavedQueriesPopupEvent.emit();
+    }
+  }
+
+
+  onSelect(evt, selectedQuery: SaveQueryData): void {
+    evt.stopPropagation();
+    this.internalSaveQuerySelectedEvent.emit(selectedQuery);
+  }
+
+  componentDidRender() {
+    this.setPopupPosition();
+  }
+
+  private setPopupPosition(): void {
+    const panelRect = this.hostElement.getBoundingClientRect();
+    const buttonEl: HTMLElement = document.querySelector('.yasqe_showSavedQueriesButton');
+    const buttonRect = buttonEl.getBoundingClientRect();
+    this.hostElement.style.top = ((buttonRect.top + buttonRect.height / 2) - panelRect.height / 2) + 'px';
+    this.hostElement.style.left = (buttonRect.left - panelRect.width - 10) + 'px';
+    const arrowEl: HTMLElement = this.hostElement.querySelector('.arrow');
+    arrowEl.style.top = panelRect.height / 2 - 16 + 'px';
+  }
+
+  render() {
+    return (
+      <Host class="saved-queries-container">
+        <div class="arrow"></div>
+        <div class="saved-queries-popup">
+          <ul>
+          {this.data.savedQueriesList.map((savedQuery) => (
+            <li class="saved-query">
+              <a href="#" onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
+            </li>
+          ))}
+          </ul>
+        </div>
+      </Host>
+    );
+  }
+
+}

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -58,7 +58,7 @@ export class SavedQueriesPopup {
           <ul>
           {this.data.savedQueriesList.map((savedQuery) => (
             <li class="saved-query">
-              <a href="#" onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
+              <a onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
             </li>
           ))}
           </ul>

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -78,5 +78,6 @@
   "yasqe.actions.save_query.dialog.public_query.label": "Share query with other users",
   "yasqe.actions.save_query.dialog.public_query.tooltip": "If checked other users will be able to see the query but not delete or edit it",
   "yasqe.actions.save_query.dialog.create.button": "Create",
-  "yasqe.actions.save_query.dialog.cancel.button": "Cancel"
+  "yasqe.actions.save_query.dialog.cancel.button": "Cancel",
+  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries"
 }

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -79,5 +79,6 @@
   "yasqe.actions.save_query.dialog.public_query.label": "Share query with other users",
   "yasqe.actions.save_query.dialog.public_query.tooltip": "If checked other users will be able to see the query but not delete or edit it",
   "yasqe.actions.save_query.dialog.create.button": "Create",
-  "yasqe.actions.save_query.dialog.cancel.button": "Cancel"
+  "yasqe.actions.save_query.dialog.cancel.button": "Cancel",
+  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries"
 }

--- a/ontotext-yasgui-web-component/src/models/event.ts
+++ b/ontotext-yasgui-web-component/src/models/event.ts
@@ -9,3 +9,7 @@ export type QueryResponseEvent = {
 export class InternalCreateSavedQueryEvent {
   static readonly TYPE = 'internalCreateSavedQueryEvent';
 }
+
+export class InternalShowSavedQueriesEvent {
+  static readonly TYPE = 'internalShowSavedQueriesEvent';
+}

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -41,6 +41,12 @@ export interface ExternalYasguiConfiguration {
   savedQuery?: SavedQueryControlConfig;
 
   /**
+   * Configuration which should be set by the client when saved queries are
+   * loaded. Once queries response is set, the saved queries dialog pops up.
+   */
+  savedQueries?: LoadedSavedQueriesConfig;
+
+  /**
    * If the control bar should be rendered or not.
    */
   showControlBar?: boolean;
@@ -154,4 +160,15 @@ export type YasqeActionButtonDefinition = {
 export type SavedQueryControlConfig = {
   saveSuccess: boolean;
   errorMessage: string[];
+}
+
+type SavedQuery = {
+  name: string;
+  body: string;
+  shared: boolean;
+  owner: string;
+}
+
+export type LoadedSavedQueriesConfig = {
+  data: SavedQuery[];
 }

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -163,9 +163,9 @@ export type SavedQueryControlConfig = {
 }
 
 type SavedQuery = {
-  name: string;
-  body: string;
-  shared: boolean;
+  queryName: string;
+  query: string;
+  isPublic: boolean;
   owner: string;
 }
 

--- a/ontotext-yasgui-web-component/src/models/model.ts
+++ b/ontotext-yasgui-web-component/src/models/model.ts
@@ -6,3 +6,8 @@ export class SaveQueryData {
               public messages?: string[]) {
   }
 }
+
+export class SavedQueriesData {
+  constructor(public savedQueriesList: SaveQueryData[]) {
+  }
+}

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -66,6 +66,13 @@ export class OntotextYasgui {
     return this.getInstance().getTab().getQuery();
   }
 
+  createNewTab(queryName: string, query: string): void {
+    const tabInstance = this.getInstance().addTab(true, {
+      name: queryName
+    });
+    tabInstance.setQuery(query);
+  }
+
   destroy() {
     if (this.yasgui) {
       Object.keys(this.yasgui._tabs).forEach((tabId) => {

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -139,6 +139,7 @@ export const defaultYasqeConfig: Record<string, any> = {
   query: 'select * where {  ?s ?p ?o . } limit 100',
   initialQuery: '',
   yasqeActionButtons: [
-    {name: 'createSavedQuery', visible: true}
+    {name: 'createSavedQuery', visible: true},
+    {name: 'showSavedQueries', visible: true}
   ]
 }

--- a/ontotext-yasgui-web-component/src/pages/actions/index.html
+++ b/ontotext-yasgui-web-component/src/pages/actions/index.html
@@ -12,6 +12,8 @@
   <body>
     <button id="hideSaveQueryAction" onclick="hideSaveQueryAction()">hide save query</button>
     <button id="showSaveQueryAction" onclick="showSaveQueryAction()">show save query</button>
+    <button id="hideLoadSavedQueriesAction" onclick="hideLoadSavedQueriesAction()">hide load saved queries</button>
+    <button id="showLoadSavedQueriesAction" onclick="showLoadSavedQueriesAction()">show load saved queries</button>
     <hr/>
     <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -33,6 +33,30 @@ function showSaveQueryAction() {
   };
 }
 
+function hideLoadSavedQueriesAction() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    yasqeActionButtons: [
+      {
+        name: 'showSavedQueries',
+        visible: false
+      }
+    ]
+  };
+}
+
+function showLoadSavedQueriesAction() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    yasqeActionButtons: [
+      {
+        name: 'showSavedQueries',
+        visible: true
+      }
+    ]
+  };
+}
+
 ontoElement.addEventListener("queryExecuted", () => {
   const div = document.createElement('div');
   div.innerHTML = '<div id="queryRan">Query was Executed</div>';
@@ -71,3 +95,38 @@ ontoElement.addEventListener('createSavedQuery', (event) => {
   }
 });
 
+const savedQueries = [
+  {
+    "name": "Add statements",
+    "body": "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title \"A new book\" ;\n                                 dc:creator \"A.N.Other\" .\n          }\n      }",
+    "shared": false,
+    "owner": "admin"
+  },
+  {
+    "name": "Clear graph",
+    "body": "CLEAR GRAPH <http://example>",
+    "shared": false,
+    "owner": "admin"
+  },
+  {
+    "name": "new query",
+    "body": "select *",
+    "shared": true,
+    "owner": "admin"
+  },
+  {
+    "name": "q1",
+    "body": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "shared": false,
+    "owner": "admin"
+  }
+];
+ontoElement.addEventListener('loadSavedQueries', (event) => {
+  console.log('loadSavedQueries event', event);
+  ontoElement.config = {
+    ...ontoElement.config,
+    savedQueries: {
+      data: savedQueries
+    }
+  };
+});

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -95,32 +95,6 @@ ontoElement.addEventListener('createSavedQuery', (event) => {
   }
 });
 
-const savedQueries = [
-  {
-    "name": "Add statements",
-    "body": "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title \"A new book\" ;\n                                 dc:creator \"A.N.Other\" .\n          }\n      }",
-    "shared": false,
-    "owner": "admin"
-  },
-  {
-    "name": "Clear graph",
-    "body": "CLEAR GRAPH <http://example>",
-    "shared": false,
-    "owner": "admin"
-  },
-  {
-    "name": "new query",
-    "body": "select *",
-    "shared": true,
-    "owner": "admin"
-  },
-  {
-    "name": "q1",
-    "body": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
-    "shared": false,
-    "owner": "admin"
-  }
-];
 ontoElement.addEventListener('loadSavedQueries', (event) => {
   console.log('loadSavedQueries event', event);
   ontoElement.config = {
@@ -130,3 +104,78 @@ ontoElement.addEventListener('loadSavedQueries', (event) => {
     }
   };
 });
+
+const savedQueries = [
+  {
+    "queryName": "Add statements",
+    "query": "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title \"A new book\" ;\n                                 dc:creator \"A.N.Other\" .\n          }\n      }",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "Clear graph",
+    "query": "CLEAR GRAPH <http://example>",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "new query",
+    "query": "select *",
+    "isPublic": true,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q1",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q2",
+    "query": "slect * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q3",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q4",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q5",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q6",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q7",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q8",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+  {
+    "queryName": "q9",
+    "query": "select * where { \n\t?s ?p ?o .\n} limit 100 \n",
+    "isPublic": false,
+    "owner": "admin"
+  },
+];

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -73,22 +73,29 @@ export class YasguiConfigurationBuilderDefinition {
   }
 
   getYasqeActionButtons(externalConfiguration: ExternalYasguiConfiguration, defaultYasqeConfig: Record<string, any>): HTMLElement[] {
-    const buttonsMap: Map<string, HTMLElement> = new Map<string, HTMLElement>();
-    defaultYasqeConfig.yasqeActionButtons
-      .filter((buttonDefinition: YasqeActionButtonDefinition) => buttonDefinition.visible)
-      .forEach((buttonDefinition: YasqeActionButtonDefinition) => {
-        buttonsMap.set(buttonDefinition.name, this.yasqeService.getButtonInstance(buttonDefinition));
-      });
+    const visibleDefaultButtonDefinitions: YasqeActionButtonDefinition[] = defaultYasqeConfig.yasqeActionButtons
+      .filter((buttonDefinition: YasqeActionButtonDefinition) => buttonDefinition.visible);
 
     if (externalConfiguration.yasqeActionButtons && externalConfiguration.yasqeActionButtons.length) {
       externalConfiguration.yasqeActionButtons.forEach((buttonDefinition) => {
+        const buttonIndex = visibleDefaultButtonDefinitions.findIndex(
+          (defaultButtonDefinition) => defaultButtonDefinition.name === buttonDefinition.name
+        );
         if (buttonDefinition.visible) {
-          buttonsMap.set(buttonDefinition.name, this.yasqeService.getButtonInstance(buttonDefinition));
+          // add new or replace existing definition
+          if (buttonIndex == -1) {
+            visibleDefaultButtonDefinitions.push(buttonDefinition);
+          } else {
+            visibleDefaultButtonDefinitions.splice(buttonIndex, 1, buttonDefinition);
+          }
         } else {
-          buttonsMap.delete(buttonDefinition.name);
+          visibleDefaultButtonDefinitions.splice(buttonIndex, 1);
         }
       });
     }
-    return Array.from(buttonsMap.values());
+
+    return visibleDefaultButtonDefinitions.map(
+      (buttonDefinition) => (this.yasqeService.getButtonInstance(buttonDefinition))
+    );
   }
 }

--- a/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
@@ -1,5 +1,5 @@
 import {EventService} from "../event-service";
-import {InternalCreateSavedQueryEvent} from "../../models/event";
+import {InternalCreateSavedQueryEvent, InternalShowSavedQueriesEvent} from "../../models/event";
 import {TranslationService} from "../translation.service";
 
 export class YasqeService {
@@ -24,6 +24,7 @@ export class YasqeService {
 
   init(): void {
     this.buttonInstances.set('createSavedQuery', this.buildCreateSaveQueryButton());
+    this.buttonInstances.set('showSavedQueries', this.buildShowSavedQueriesButton());
   }
 
   getButtonInstance(buttonDefinition: {name}): HTMLElement {
@@ -33,13 +34,25 @@ export class YasqeService {
     return this.buttonInstances.get(buttonDefinition.name);
   }
 
+  private buildShowSavedQueriesButton(): HTMLElement {
+    const buttonElement = document.createElement("button");
+    buttonElement.className = "yasqe_showSavedQueriesButton custom-button icon-folder";
+    buttonElement.title = this.translationService.translate('yasqe.actions.show_saved_queries.button.tooltip');
+    buttonElement.setAttribute("aria-label", this.translationService.translate('yasqe.actions.show_saved_queries.button.tooltip'));
+    buttonElement.addEventListener("click",
+      () => {
+        this.eventService.emit(InternalShowSavedQueriesEvent.TYPE, new InternalShowSavedQueriesEvent())
+      });
+    return buttonElement;
+  }
+
   private buildCreateSaveQueryButton(): HTMLElement {
-    const createSavedQueryButton = document.createElement("button");
-    createSavedQueryButton.className = "yasqe_createSavedQueryButton custom-button icon-save";
-    createSavedQueryButton.title = this.translationService.translate('yasqe.actions.save_query.button.tooltip');
-    createSavedQueryButton.setAttribute("aria-label", this.translationService.translate('yasqe.actions.save_query.button.tooltip'));
-    createSavedQueryButton.addEventListener("click",
+    const buttonElement = document.createElement("button");
+    buttonElement.className = "yasqe_createSavedQueryButton custom-button icon-save";
+    buttonElement.title = this.translationService.translate('yasqe.actions.save_query.button.tooltip');
+    buttonElement.setAttribute("aria-label", this.translationService.translate('yasqe.actions.save_query.button.tooltip'));
+    buttonElement.addEventListener("click",
       () => this.eventService.emit(InternalCreateSavedQueryEvent.TYPE, new InternalCreateSavedQueryEvent()));
-    return createSavedQueryButton;
+    return buttonElement;
   }
 }


### PR DESCRIPTION
## What
Introduce a show saved queries action.

## Why
Save query action exists in current implementation in the GDB WB. It allows the user to load and see the available saved queries then for each query additional actions can be performed, e.g. select, edit, delete.

## How
* Add custom button in the yasqe buttons extension point. The button rises an event for loading of the saved queries. Handling of this event is responsibility of the client who then must set the queries list in the config. Setting the queries in the config triggers the popup to appear.
* Add a saved queries popup which implements the visualization of the saved queries list. Each saved query is represented as a link and can be selected via click which then opens the query in a new yasgui tab. The dialog can be closed via click outside.
* Implemented tests.