### PR TITLE
Remove release notes script from jenkins file.

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -93,18 +93,6 @@ pipeline {
                sh "git commit -a -m 'Release ${ReleaseVersion}'"
                sh "git tag -a v${ReleaseVersion} -m 'Release v${ReleaseVersion}'"
                sh "git push --set-upstream origin ${branch} && git push --tags"
-
-              script {
-                def latest = getLatestReleaseTagName()
-                echo "Last revision ${latest}"
-
-                def gitMessages = getReleaseMessagesFromGit(latest)
-                echo "Recent merge commit messages collected"
-
-                def commitMessage = composeReleaseMessage(gitMessages)
-                def result = postRelease(commitMessage)
-                echo result
-              }
             }
         }
     }
@@ -125,57 +113,4 @@ pipeline {
       sh "rm -f .npmrc"
     }
   }
-}
-
-// Latest revision tag name getter
-def getLatestReleaseTagName() {
-  def latest = readJSON text: sh(script: 'curl -H \"Accept: application/vnd.github.v3+json\" ${API_URL}/releases/latest', returnStdout: true)
-  return latest.tag_name
-}
-
-// Merge commit messages getter
-// Returns commit messages between given commit tag and master
-def getReleaseMessagesFromGit(String latest) {
-  def response = sh(script: "curl -H \"Accept: application/vnd.github.v3+json\" ${API_URL}/compare/${latest}...master", returnStdout: true)
-  def resp = readJSON text: response
-
-  def commits = resp.commits
-  def message = ""
-  def matcher = "Merge pull request #"
-  for(commit in commits) {
-    if(commit.commit.message != null && commit.commit.message.startsWith(matcher)) {
-      // Remove unnecessary repetitive merge descriptions
-      def commitMessage = commit.commit.message.substring(matcher.length() - 1)
-      message += newlineToHtml("* ${commitMessage}")
-    }
-  }
-  return message
-}
-
-// Composes final release message from jenkins build configuration, github commit messages and environment variables
-def composeReleaseMessage(String gitMessages) {
-   def message = ""
-   def releaseDescription = newlineToHtml(params.ReleaseDescription)
-   wrap([$class: 'BuildUser']) {
-      message = "${releaseDescription} <br/> ${gitMessages} <br/> Released on ${new Date().format("yyyy/MM/dd HH:mm", TimeZone.getTimeZone('UTC'))} UTC by ${env.BUILD_USER}"
-    }
-  return message
-}
-
-// Post release to github
-// returns response from the operation
-def postRelease(String desc) {
-  return sh(script: "curl -X POST -H \"Accept: application/vnd.github.v3+json\" -H \"Authorization: token ${AUTH}\" --data '{\"tag_name\": \"v${ReleaseVersion}\", \"target_commitish\": \"${branch}\", \"name\": \"v${ReleaseVersion}\", \"body\": \"${desc}\", \"draft\": false, \"prerelease\": ${PreRelease}}' ${API_URL}/releases" , returnStdout: true)
-}
-
-// New line symbol to html br tag converter.
-def newlineToHtml(String desc) {
-  def description = ""
-
-  def lines = desc.tokenize("\n")
-  for (line in lines) {
-    description += line
-    description += "<br/>"
-  }
-  return description
 }


### PR DESCRIPTION
## What
Removed the release notes building script from the jenkins file

## Why
It seems like there is a change in the github API and the script currently doesn't work as expected and throws error.

## How
Removed the script from the jenkins file. It can be introduced again someday but it'd require some extra work to be updated.