### PR TITLE
GDB-7821 introduce saved query delete operation

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -5,11 +5,16 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { ServiceFactory } from "./services/service-factory";
+import { ConfirmationDialogConfig } from "./components/confirmation-dialog/confirmation-dialog";
 import { ExternalYasguiConfiguration } from "./models/external-yasgui-configuration";
 import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/model";
 import { QueryEvent, QueryResponseEvent } from "./models/event";
-import { ServiceFactory } from "./services/service-factory";
 export namespace Components {
+    interface ConfirmationDialog {
+        "config": ConfirmationDialogConfig;
+        "serviceFactory": ServiceFactory;
+    }
     /**
      * This is the custom web component which is adapter for the yasgui library. It allows as to
      * configure and extend the library without potentially breaking the component clients.
@@ -57,6 +62,10 @@ export namespace Components {
         "showOnClick": false;
     }
 }
+export interface ConfirmationDialogCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLConfirmationDialogElement;
+}
 export interface OntotextYasguiCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOntotextYasguiElement;
@@ -70,6 +79,12 @@ export interface SavedQueriesPopupCustomEvent<T> extends CustomEvent<T> {
     target: HTMLSavedQueriesPopupElement;
 }
 declare global {
+    interface HTMLConfirmationDialogElement extends Components.ConfirmationDialog, HTMLStencilElement {
+    }
+    var HTMLConfirmationDialogElement: {
+        prototype: HTMLConfirmationDialogElement;
+        new (): HTMLConfirmationDialogElement;
+    };
     /**
      * This is the custom web component which is adapter for the yasgui library. It allows as to
      * configure and extend the library without potentially breaking the component clients.
@@ -111,6 +126,7 @@ declare global {
         new (): HTMLYasguiTooltipElement;
     };
     interface HTMLElementTagNameMap {
+        "confirmation-dialog": HTMLConfirmationDialogElement;
         "ontotext-yasgui": HTMLOntotextYasguiElement;
         "save-query-dialog": HTMLSaveQueryDialogElement;
         "saved-queries-popup": HTMLSavedQueriesPopupElement;
@@ -118,6 +134,18 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface ConfirmationDialog {
+        "config"?: ConfirmationDialogConfig;
+        /**
+          * Event fired when confirmation is rejected and the dialog should be closed.
+         */
+        "onInternalConfirmationApprovedEvent"?: (event: ConfirmationDialogCustomEvent<any>) => void;
+        /**
+          * Event fired when confirmation is rejected and the dialog should be closed.
+         */
+        "onInternalConfirmationRejectedEvent"?: (event: ConfirmationDialogCustomEvent<any>) => void;
+        "serviceFactory"?: ServiceFactory;
+    }
     /**
      * This is the custom web component which is adapter for the yasgui library. It allows as to
      * configure and extend the library without potentially breaking the component clients.
@@ -147,6 +175,10 @@ declare namespace LocalJSX {
           * Event emitted when saved query payload is collected and the query should be saved by the component client.
          */
         "onCreateSavedQuery"?: (event: OntotextYasguiCustomEvent<SaveQueryData>) => void;
+        /**
+          * Event emitted when a saved query should be deleted. In result the client must perform a query delete.
+         */
+        "onDeleteSavedQuery"?: (event: OntotextYasguiCustomEvent<SaveQueryData>) => void;
         /**
           * Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.
          */
@@ -201,6 +233,10 @@ declare namespace LocalJSX {
           * Event fired when a saved query is selected from the list.
          */
         "onInternalSaveQuerySelectedEvent"?: (event: SavedQueriesPopupCustomEvent<SaveQueryData>) => void;
+        /**
+          * Event fired when the delete saved query button is triggered.
+         */
+        "onInternalSavedQuerySelectedForDeleteEvent"?: (event: SavedQueriesPopupCustomEvent<SaveQueryData>) => void;
     }
     interface YasguiTooltip {
         "dataTooltip"?: string;
@@ -208,6 +244,7 @@ declare namespace LocalJSX {
         "showOnClick"?: false;
     }
     interface IntrinsicElements {
+        "confirmation-dialog": ConfirmationDialog;
         "ontotext-yasgui": OntotextYasgui;
         "save-query-dialog": SaveQueryDialog;
         "saved-queries-popup": SavedQueriesPopup;
@@ -218,6 +255,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "confirmation-dialog": LocalJSX.ConfirmationDialog & JSXBase.HTMLAttributes<HTMLConfirmationDialogElement>;
             /**
              * This is the custom web component which is adapter for the yasgui library. It allows as to
              * configure and extend the library without potentially breaking the component clients.

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
@@ -1,0 +1,111 @@
+@import "src/css/variables";
+@import 'src/css/common';
+@import "src/css/icons";
+
+:host {
+  display: block;
+}
+
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  // Because the tooltip we use position itself on z-index: 9999
+  z-index: 9998;
+  margin-left: -10px;
+  background-color: rgba(0, 0, 0, .5);
+  font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 300;
+  color: #373a3c;
+}
+
+.dialog {
+  z-index: 1001;
+  width: 600px;
+  max-width: 600px;
+  background-color: #fff;
+  box-shadow: 0 5px 15px rgb(0 0 0 / 50%);
+  font-family: inherit;
+  font-weight: inherit;
+
+  .dialog-header {
+    display: flex;
+    justify-content: space-between;
+    padding: 15px;
+    border-bottom: 1px solid #e5e5e5;
+    font-size: 20px;
+
+    .dialog-title {
+      margin: .5rem 0;
+      font-weight: 400;
+    }
+
+    .close-button {
+      background-color: #fff;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      transition: all .15s ease-out;
+
+      &:hover, &:focus {
+        font-weight: bold;
+      }
+    }
+  }
+
+  .dialog-body {
+    padding: 15px;
+  }
+
+  .dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 15px;
+    border-top: 1px solid #e5e5e5;
+
+    button {
+      display: inline-block;
+      font-weight: 400;
+      line-height: 1.25;
+      text-align: center;
+      white-space: nowrap;
+      vertical-align: middle;
+      cursor: pointer;
+      user-select: none;
+      border: 1px solid transparent;
+      outline: none;
+      padding: .5rem 1rem;
+      font-size: 1rem;
+      border-radius: 0;
+      transition: all .15s ease-out;
+    }
+
+    .confirm-button {
+      background-color: $color-ontotext-orange;
+      border-color: $color-ontotext-orange;
+      color: #fff;
+      margin-right: 10px;
+
+      &:hover, &:focus {
+        background-color: $color-ontotext-orange-dark;
+        border-color: $color-ontotext-orange-dark;
+      }
+    }
+
+    .cancel-button {
+      color: $color-onto-blue;
+
+      &:hover, &:focus {
+        background-color: #d4d4d4;
+        border-color: #d4d4d4;
+      }
+    }
+  }
+}

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
@@ -1,0 +1,78 @@
+import {Component, Event, EventEmitter, h, Host, Prop} from '@stencil/core';
+import {TranslationService} from "../../services/translation.service";
+import {ServiceFactory} from "../../services/service-factory";
+
+export type ConfirmationDialogConfig = {
+  title: string;
+  message: string;
+}
+
+@Component({
+  tag: 'confirmation-dialog',
+  styleUrl: 'confirmation-dialog.scss',
+  shadow: false,
+})
+export class ConfirmationDialog {
+
+  private translationService: TranslationService;
+
+  @Prop() serviceFactory: ServiceFactory
+
+  @Prop() config: ConfirmationDialogConfig = {
+    title: 'Confirmation',
+    message: 'Confirming?'
+  }
+
+  /**
+   * Event fired when confirmation is rejected and the dialog should be closed.
+   */
+  @Event() internalConfirmationRejectedEvent: EventEmitter;
+
+  /**
+   * Event fired when confirmation is rejected and the dialog should be closed.
+   */
+  @Event() internalConfirmationApprovedEvent: EventEmitter;
+
+  componentWillLoad(): void {
+    this.translationService = this.serviceFactory.get(TranslationService);
+  }
+
+  onClose(evt: MouseEvent): void {
+    const target = evt.target as HTMLElement;
+    evt.stopPropagation();
+    const isOverlay = target.classList.contains('dialog-overlay');
+    const isCloseButton = target.classList.contains('close-button');
+    const isCancelButton = target.classList.contains('cancel-button');
+    if (isOverlay || isCloseButton || isCancelButton) {
+      this.internalConfirmationRejectedEvent.emit();
+    }
+  }
+
+  onConfirm(evt: MouseEvent): void {
+    evt.stopPropagation();
+    this.internalConfirmationApprovedEvent.emit();
+  }
+
+  render() {
+    return (
+      <Host>
+        <div class="dialog-overlay" onClick={(evt) => this.onClose(evt)}>
+          <div class="dialog confirmation-dialog">
+            <div class="dialog-header">
+              <h3 class="dialog-title">{this.config.title}</h3>
+              <button class="close-button icon-close" onClick={(evt) => this.onClose(evt)}></button>
+            </div>
+            <div class="dialog-body">{this.config.message}</div>
+            <div class="dialog-footer">
+              <button class="confirm-button"
+                      onClick={(evt) => this.onConfirm(evt)}>{this.translationService.translate('confirmation.btn.confirm.label')}</button>
+              <button class="cancel-button"
+                      onClick={(evt) => this.onClose(evt)}>{this.translationService.translate('confirmation.btn.cancel.label')}</button>
+            </div>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+
+}

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
@@ -14,11 +14,12 @@
 
 ## Events
 
-| Event                                 | Description                                                | Type                         |
-| ------------------------------------- | ---------------------------------------------------------- | ---------------------------- |
-| `internalCloseSavedQueriesPopupEvent` | Event fired when the saved queries popup should be closed. | `CustomEvent<any>`           |
-| `internalEditSavedQueryEvent`         | Event fired when the edit saved query button is triggered. | `CustomEvent<SaveQueryData>` |
-| `internalSaveQuerySelectedEvent`      | Event fired when a saved query is selected from the list.  | `CustomEvent<SaveQueryData>` |
+| Event                                 | Description                                                  | Type                         |
+| ------------------------------------- | ------------------------------------------------------------ | ---------------------------- |
+| `internalCloseSavedQueriesPopupEvent` | Event fired when the saved queries popup should be closed.   | `CustomEvent<any>`           |
+| `internalDeleteSavedQueryEvent`       | Event fired when the delete saved query button is triggered. | `CustomEvent<SaveQueryData>` |
+| `internalEditSavedQueryEvent`         | Event fired when the edit saved query button is triggered.   | `CustomEvent<SaveQueryData>` |
+| `internalSaveQuerySelectedEvent`      | Event fired when a saved query is selected from the list.    | `CustomEvent<SaveQueryData>` |
 
 
 ## Dependencies

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
@@ -15,7 +15,7 @@
 
   .saved-queries-popup {
     height: 250px;
-    width: 200px;
+    width: 300px;
     overflow-y: scroll;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 
@@ -24,10 +24,18 @@
       margin: 0;
 
       .saved-query {
+        position: relative;
         display: flex;
         justify-content: space-between;
         padding: 5px 0;
         list-style-type: none;
+
+        &:hover {
+
+          .saved-query-actions {
+            display: block;
+          }
+        }
 
         a {
           flex-grow: 2;
@@ -40,8 +48,13 @@
           }
         }
 
-        .saved-query-action {
+        .saved-query-actions {
           display: none;
+          position: absolute;
+          right: 0;
+        }
+
+        .saved-query-action {
           border: none;
           background-color: #fff;
           color: $color-ontotext-orange;
@@ -53,13 +66,6 @@
           &:hover {
             color: $color-ontotext-orange-dark;
             transform: scale(1.2);
-          }
-        }
-
-        &:hover {
-
-          .saved-query-action {
-            display: block;
           }
         }
       }

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -1,5 +1,10 @@
 import {Component, Element, Event, EventEmitter, h, Host, Listen, Prop} from '@stencil/core';
-import {SavedQueriesData, SaveQueryData, UpdateQueryData} from "../../models/model";
+import {
+  DeleteQueryData,
+  SavedQueriesData,
+  SaveQueryData,
+  UpdateQueryData
+} from "../../models/model";
 
 @Component({
   tag: 'saved-queries-popup',
@@ -21,6 +26,11 @@ export class SavedQueriesPopup {
    * Event fired when the edit saved query button is triggered.
    */
   @Event() internalEditSavedQueryEvent: EventEmitter<SaveQueryData>;
+
+  /**
+   * Event fired when the delete saved query button is triggered.
+   */
+  @Event() internalSavedQuerySelectedForDeleteEvent: EventEmitter<SaveQueryData>;
 
   /**
    * Event fired when the saved queries popup should be closed.
@@ -49,6 +59,11 @@ export class SavedQueriesPopup {
     this.internalEditSavedQueryEvent.emit(new UpdateQueryData(selectedQuery.queryName, selectedQuery.query, selectedQuery.isPublic, false));
   }
 
+  onDelete(evt: MouseEvent, selectedQuery): void {
+    evt.stopPropagation();
+    this.internalSavedQuerySelectedForDeleteEvent.emit(new DeleteQueryData(selectedQuery.queryName, selectedQuery.query, selectedQuery.isPublic));
+  }
+
   private setPopupPosition(): void {
     const panelRect = this.hostElement.getBoundingClientRect();
     const buttonEl: HTMLElement = document.querySelector('.yasqe_showSavedQueriesButton');
@@ -68,9 +83,14 @@ export class SavedQueriesPopup {
             {this.data.savedQueriesList.map((savedQuery) => (
               <li class="saved-query">
                 <a onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
-                <button class="saved-query-action edit-saved-query icon-edit"
-                        title="Edit"
-                        onClick={(evt) => this.onEdit(evt, savedQuery)}></button>
+                <span class="saved-query-actions">
+                  <button class="saved-query-action edit-saved-query icon-edit"
+                          title="Edit"
+                          onClick={(evt) => this.onEdit(evt, savedQuery)}></button>
+                <button class="saved-query-action delete-saved-query icon-trash"
+                        title="Delete"
+                        onClick={(evt) => this.onDelete(evt, savedQuery)}></button>
+                </span>
               </li>
             ))}
           </ul>

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -1,4 +1,6 @@
 {
+  "confirmation.btn.confirm.label": "Yes",
+  "confirmation.btn.cancel.label": "Cancel",
   "yasgui.control_bar.accept_headers.label": "Accept Headers",
   "yasgui.control_bar.arguments.label": "Arguments",
   "yasgui.control_bar.ask_select.label": "Ask / Select",
@@ -79,5 +81,9 @@
   "yasqe.actions.save_query.dialog.public_query.tooltip": "If checked other users will be able to see the query but not delete or edit it",
   "yasqe.actions.save_query.dialog.create.button": "Create",
   "yasqe.actions.save_query.dialog.cancel.button": "Cancel",
-  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries"
+  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries",
+  "yasqe.actions.edit_saved_query.button.tooltip": "Edit",
+  "yasqe.actions.delete_saved_query.button.tooltip": "Delete",
+  "yasqe.actions.delete_saved_query.confirm.dialog.label": "Confirm",
+  "yasqe.actions.delete_saved_query.confirm.dialog.message": "Are you sure you want to delete the saved query '{{query}}'?"
 }

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -1,4 +1,6 @@
 {
+  "confirmation.btn.confirm.label": "Yes",
+  "confirmation.btn.cancel.label": "Cancel",
   "yasgui.control_bar.accept_headers.label": "Accept Headers",
   "yasgui.control_bar.arguments.label": "Arguments",
   "yasgui.control_bar.ask_select.label": "Ask / Select",
@@ -80,5 +82,9 @@
   "yasqe.actions.save_query.dialog.public_query.tooltip": "If checked other users will be able to see the query but not delete or edit it",
   "yasqe.actions.save_query.dialog.create.button": "Create",
   "yasqe.actions.save_query.dialog.cancel.button": "Cancel",
-  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries"
+  "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries",
+  "yasqe.actions.edit_saved_query.button.tooltip": "Edit",
+  "yasqe.actions.delete_saved_query.button.tooltip": "Delete",
+  "yasqe.actions.delete_saved_query.confirm.dialog.label": "Confirm",
+  "yasqe.actions.delete_saved_query.confirm.dialog.message": "Are you sure you want to delete the saved query '{{query}}'?"
 }

--- a/ontotext-yasgui-web-component/src/models/model.ts
+++ b/ontotext-yasgui-web-component/src/models/model.ts
@@ -40,6 +40,9 @@ export class SaveQueryData {
 export class UpdateQueryData extends SaveQueryData {
 }
 
+export class DeleteQueryData extends SaveQueryData {
+}
+
 export class SavedQueriesData {
   constructor(public savedQueriesList: SaveQueryData[]) {
   }

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -109,7 +109,15 @@ ontoElement.addEventListener('loadSavedQueries', (event) => {
   };
 });
 
-const savedQueries = [
+ontoElement.addEventListener('deleteSavedQuery', (event) => {
+  let selectedQuery = event.detail;
+  savedQueries = savedQueries.filter((savedQuery) => savedQuery.queryName !== selectedQuery.queryName);
+  ontoElement.savedQueryConfig = {
+    savedQueries: savedQueries
+  };
+});
+
+let savedQueries = [
   {
     "queryName": "Add statements",
     "query": "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title \"A new book\" ;\n                                 dc:creator \"A.N.Other\" .\n          }\n      }",


### PR DESCRIPTION
## What
This MR introduces support for deleting of saved queries.

## Why
GDB workbench supports functionality for saving sparql queries as well as managing the saved queries like deleting them.

## How
* Introduced the delete query action in the saved queries popup as well as respective handlers in the ontotext yasgui component.
* Implemented tests.