### PR TITLE
GDB-7821 fixes disappearing yasqe actions when switching tabs

### DIFF
--- a/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
+++ b/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
@@ -1,6 +1,7 @@
 import {YasqeSteps} from "../../steps/yasqe-steps";
 import {QueryStubs} from "../../stubs/query-stubs";
 import ActionsPageSteps from "../../steps/actions-page-steps";
+import {YasguiSteps} from "../../steps/yasgui-steps";
 
 describe('Configure editor actions', () => {
     beforeEach(() => {
@@ -27,5 +28,13 @@ describe('Configure editor actions', () => {
         YasqeSteps.getShowSavedQueriesButton().should('not.exist');
         ActionsPageSteps.showShowSavedQueriesAction();
         YasqeSteps.getShowSavedQueriesButton().should('be.visible');
+    });
+
+    it('Should show editor actions on each editor tab', () => {
+        YasqeSteps.getActionButtons().should('have.length', 2);
+        YasguiSteps.openANewTab();
+        YasqeSteps.getActionButtons().should('have.length', 2);
+        YasguiSteps.openTab(0);
+        YasqeSteps.getActionButtons().should('have.length', 2);
     });
 });

--- a/cypress/e2e/editor-actions/save-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/save-query.spec.cy.ts
@@ -1,6 +1,7 @@
 import {YasqeSteps} from "../../steps/yasqe-steps";
 import {QueryStubs} from "../../stubs/query-stubs";
 import ActionsPageSteps from "../../steps/actions-page-steps";
+import {YasguiSteps} from "../../steps/yasgui-steps";
 
 describe('Save query action', () => {
     beforeEach(() => {
@@ -20,6 +21,26 @@ describe('Save query action', () => {
         YasqeSteps.closeSaveQueryDialog();
         // Then save query dialog should hide
         YasqeSteps.getSaveQueryDialog().should('not.exist');
+    });
+
+    it('Should work on each new yasgui tab', () => {
+        // When I click on save query button
+        YasqeSteps.createSavedQuery();
+        // Then I should see the save query dialog
+        YasqeSteps.getSaveQueryDialog().should('be.visible');
+        YasqeSteps.closeSaveQueryDialog();
+        // When I open a new yasgui tab
+        YasguiSteps.openANewTab();
+        // Then I expect that the button will still work as expected
+        YasqeSteps.createSavedQuery(1);
+        YasqeSteps.getSaveQueryDialog().should('be.visible');
+        YasqeSteps.closeSaveQueryDialog();
+        // When I open the previous tab
+        YasguiSteps.openTab(0);
+        // Then I expect that the button will still work as expected
+        YasqeSteps.createSavedQuery();
+        YasqeSteps.getSaveQueryDialog().should('be.visible');
+        YasqeSteps.closeSaveQueryDialog();
     });
 
     it('Should be able to cancel the save query operation', () => {

--- a/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
+++ b/cypress/e2e/editor-actions/show-saved-queries.spec.cy.ts
@@ -33,6 +33,23 @@ describe('Show saved queries action', () => {
         ]);
     });
 
+    it('Should work on each new yasgui tab', () => {
+        // When I click on show saved queries button
+        YasqeSteps.showSavedQueries();
+        // Then I expect that a popup with a saved queries list to be opened
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        // When I open a new yasgui tab
+        YasguiSteps.openANewTab();
+        // Then I expect that the button will still work as expected
+        YasqeSteps.showSavedQueries(1);
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        // When I open the previous tab
+        YasguiSteps.openTab(0);
+        // Then I expect that the button will still work as expected
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+    });
+
     it('Should be able to select a query from the list', () => {
         // Given I have opened the saved queries popup
         YasqeSteps.showSavedQueries();

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -19,6 +19,10 @@ export class YasguiSteps {
         cy.get('button.addTab').click();
     }
 
+    static openTab(index: number) {
+        this.getTabs().eq(index).click();
+    }
+
     static isVerticalOrientation() {
         this.getYasguiTag().should('have.class', 'orientation-vertical');
     }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -35,8 +35,8 @@ export class YasqeSteps {
         return cy.get('.yasqe_createSavedQueryButton');
     }
 
-    static createSavedQuery() {
-        this.getCreateSavedQueryButton().click();
+    static createSavedQuery(index = 0) {
+        this.getCreateSavedQueryButton().eq(index).click();
     }
 
     static getSaveQueryDialog() {
@@ -107,8 +107,9 @@ export class YasqeSteps {
         return cy.get('.yasqe_showSavedQueriesButton');
     }
 
-    static showSavedQueries() {
-        this.getShowSavedQueriesButton().click();
+    static showSavedQueries(index = 0) {
+        // When more than one yasgui tabs are opened, then these buttons are the same number as the tabs
+        this.getShowSavedQueriesButton().eq(index).click();
     }
 
     static getSavedQueriesPopup() {

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -54,7 +54,7 @@ export namespace Components {
         "serviceFactory": ServiceFactory;
     }
     interface SavedQueriesPopup {
-        "data": SavedQueriesData;
+        "config": SavedQueriesData;
     }
     interface YasguiTooltip {
         "dataTooltip": string;
@@ -220,7 +220,7 @@ declare namespace LocalJSX {
         "serviceFactory"?: ServiceFactory;
     }
     interface SavedQueriesPopup {
-        "data"?: SavedQueriesData;
+        "config"?: SavedQueriesData;
         /**
           * Event fired when the saved queries popup should be closed.
          */

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/readme.md
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/readme.md
@@ -1,0 +1,39 @@
+# confirmation-dialog
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute | Description | Type                                  | Default                                                       |
+| ---------------- | --------- | ----------- | ------------------------------------- | ------------------------------------------------------------- |
+| `config`         | --        |             | `{ title: string; message: string; }` | `{     title: 'Confirmation',     message: 'Confirming?'   }` |
+| `serviceFactory` | --        |             | `ServiceFactory`                      | `undefined`                                                   |
+
+
+## Events
+
+| Event                               | Description                                                                | Type               |
+| ----------------------------------- | -------------------------------------------------------------------------- | ------------------ |
+| `internalConfirmationApprovedEvent` | Event fired when confirmation is rejected and the dialog should be closed. | `CustomEvent<any>` |
+| `internalConfirmationRejectedEvent` | Event fired when confirmation is rejected and the dialog should be closed. | `CustomEvent<any>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [ontotext-yasgui](../ontotext-yasgui-web-component)
+
+### Graph
+```mermaid
+graph TD;
+  ontotext-yasgui --> confirmation-dialog
+  style confirmation-dialog fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -15,7 +15,7 @@ import {defaultOntotextYasguiConfig, RenderingMode} from '../../models/yasgui-co
 import {YASGUI_MIN_SCRIPT} from '../yasgui/yasgui-script';
 import {YasguiBuilder} from '../../services/yasgui/yasgui-builder';
 import {OntotextYasgui} from '../../models/ontotext-yasgui';
-import {QueryEvent, QueryResponseEvent} from "../../models/event";
+import {InternalShowSavedQueriesEvent, QueryEvent, QueryResponseEvent} from "../../models/event";
 import Yasqe from "../../../../Yasgui/packages/yasqe/src";
 import {VisualisationUtils} from '../../services/utils/visualisation-utils';
 import {HtmlElementsUtil} from '../../services/utils/html-elements-util';
@@ -227,14 +227,16 @@ export class OntotextYasguiWebComponent {
    * Flag controlling the visibility of the saved queries list popup.
    */
   @State() showSavedQueriesPopup = false;
+  @State() showSavedQueriesPopupTarget: HTMLElement;
 
   /**
    * Handler for the event fired when the show saved queries button in the yasqe toolbar is triggered.
    */
   @Listen('internalShowSavedQueriesEvent')
-  showSavedQueriesHandler() {
+  showSavedQueriesHandler(event: CustomEvent<InternalShowSavedQueriesEvent>) {
     this.loadSavedQueries.emit(true);
     this.showSavedQueriesPopup = true;
+    this.showSavedQueriesPopupTarget = event.detail.buttonInstance;
   }
 
   /**
@@ -403,7 +405,8 @@ export class OntotextYasguiWebComponent {
 
   private getSaveQueriesData(): SavedQueriesData {
     const data: SavedQueriesData = {
-      savedQueriesList: []
+      savedQueriesList: [],
+      popupTarget: this.showSavedQueriesPopupTarget
     };
     if (this.savedQueryConfig && this.savedQueryConfig.savedQueries) {
       data.savedQueriesList = this.savedQueryConfig.savedQueries.map((savedQuery) => {
@@ -495,7 +498,7 @@ export class OntotextYasguiWebComponent {
                            serviceFactory={this.serviceFactory}>&nbsp;</save-query-dialog>}
 
         {this.showSavedQueriesPopup &&
-        <saved-queries-popup data={this.getSaveQueriesData()}></saved-queries-popup>}
+        <saved-queries-popup config={this.getSaveQueriesData()}></saved-queries-popup>}
 
         {this.showConfirmationDialog &&
         <confirmation-dialog serviceFactory={this.serviceFactory}

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -41,6 +41,7 @@ yasgui can be tweaked using the values from the configuration.
 | Event              | Description                                                                                                                                             | Type                                 |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `createSavedQuery` | Event emitted when saved query payload is collected and the query should be saved by the component client.                                              | `CustomEvent<SaveQueryData>`         |
+| `deleteSavedQuery` | Event emitted when a saved query should be deleted. In result the client must perform a query delete.                                                   | `CustomEvent<SaveQueryData>`         |
 | `loadSavedQueries` | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`               |
 | `queryExecuted`    | Event emitted when before query to be executed.                                                                                                         | `CustomEvent<{ query: string; }>`    |
 | `queryResponse`    | Event emitted when after query response is returned.                                                                                                    | `CustomEvent<{ duration: number; }>` |
@@ -67,6 +68,7 @@ Type: `Promise<void>`
 - [yasgui-tooltip](../ontotext-tooltip-web-component)
 - [save-query-dialog](../save-query-dialog)
 - [saved-queries-popup](../saved-queries-popup)
+- [confirmation-dialog](../confirmation-dialog)
 
 ### Graph
 ```mermaid
@@ -74,6 +76,7 @@ graph TD;
   ontotext-yasgui --> yasgui-tooltip
   ontotext-yasgui --> save-query-dialog
   ontotext-yasgui --> saved-queries-popup
+  ontotext-yasgui --> confirmation-dialog
   save-query-dialog --> yasgui-tooltip
   style ontotext-yasgui fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/readme.md
@@ -9,17 +9,17 @@
 
 | Property | Attribute | Description | Type               | Default     |
 | -------- | --------- | ----------- | ------------------ | ----------- |
-| `data`   | --        |             | `SavedQueriesData` | `undefined` |
+| `config` | --        |             | `SavedQueriesData` | `undefined` |
 
 
 ## Events
 
-| Event                                 | Description                                                  | Type                         |
-| ------------------------------------- | ------------------------------------------------------------ | ---------------------------- |
-| `internalCloseSavedQueriesPopupEvent` | Event fired when the saved queries popup should be closed.   | `CustomEvent<any>`           |
-| `internalDeleteSavedQueryEvent`       | Event fired when the delete saved query button is triggered. | `CustomEvent<SaveQueryData>` |
-| `internalEditSavedQueryEvent`         | Event fired when the edit saved query button is triggered.   | `CustomEvent<SaveQueryData>` |
-| `internalSaveQuerySelectedEvent`      | Event fired when a saved query is selected from the list.    | `CustomEvent<SaveQueryData>` |
+| Event                                      | Description                                                  | Type                         |
+| ------------------------------------------ | ------------------------------------------------------------ | ---------------------------- |
+| `internalCloseSavedQueriesPopupEvent`      | Event fired when the saved queries popup should be closed.   | `CustomEvent<any>`           |
+| `internalEditSavedQueryEvent`              | Event fired when the edit saved query button is triggered.   | `CustomEvent<SaveQueryData>` |
+| `internalSavedQuerySelectedForDeleteEvent` | Event fired when the delete saved query button is triggered. | `CustomEvent<SaveQueryData>` |
+| `internalSaveQuerySelectedEvent`           | Event fired when a saved query is selected from the list.    | `CustomEvent<SaveQueryData>` |
 
 
 ## Dependencies

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -15,7 +15,7 @@ export class SavedQueriesPopup {
 
   @Element() hostElement: HTMLElement;
 
-  @Prop() data: SavedQueriesData;
+  @Prop() config: SavedQueriesData;
 
   /**
    * Event fired when a saved query is selected from the list.
@@ -66,8 +66,7 @@ export class SavedQueriesPopup {
 
   private setPopupPosition(): void {
     const panelRect = this.hostElement.getBoundingClientRect();
-    const buttonEl: HTMLElement = document.querySelector('.yasqe_showSavedQueriesButton');
-    const buttonRect = buttonEl.getBoundingClientRect();
+    const buttonRect = this.config.popupTarget.getBoundingClientRect();
     this.hostElement.style.top = ((buttonRect.top + buttonRect.height / 2) - panelRect.height / 2) + 'px';
     this.hostElement.style.left = (buttonRect.left - panelRect.width - 10) + 'px';
     const arrowEl: HTMLElement = this.hostElement.querySelector('.arrow');
@@ -80,7 +79,7 @@ export class SavedQueriesPopup {
         <div class="arrow"></div>
         <div class="saved-queries-popup">
           <ul>
-            {this.data.savedQueriesList.map((savedQuery) => (
+            {this.config.savedQueriesList.map((savedQuery) => (
               <li class="saved-query">
                 <a onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
                 <span class="saved-query-actions">

--- a/ontotext-yasgui-web-component/src/models/event.ts
+++ b/ontotext-yasgui-web-component/src/models/event.ts
@@ -12,4 +12,6 @@ export class InternalCreateSavedQueryEvent {
 
 export class InternalShowSavedQueriesEvent {
   static readonly TYPE = 'internalShowSavedQueriesEvent';
+  constructor(public buttonInstance: HTMLElement) {
+  }
 }

--- a/ontotext-yasgui-web-component/src/models/model.ts
+++ b/ontotext-yasgui-web-component/src/models/model.ts
@@ -44,6 +44,7 @@ export class DeleteQueryData extends SaveQueryData {
 }
 
 export class SavedQueriesData {
-  constructor(public savedQueriesList: SaveQueryData[]) {
+  constructor(public savedQueriesList: SaveQueryData[],
+              public popupTarget: HTMLElement) {
   }
 }

--- a/ontotext-yasgui-web-component/src/services/event-service.ts
+++ b/ontotext-yasgui-web-component/src/services/event-service.ts
@@ -23,7 +23,7 @@ export class EventService implements EventEmitter {
    * @param evt The event payload.
    */
   emit(type: string, evt?: any): CustomEvent {
-    const event = new CustomEvent(type, evt);
+    const event = new CustomEvent(type, {detail: evt});
     this.hostElement.dispatchEvent(event);
     return event;
   }

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -13,7 +13,6 @@ export class OntotextYasguiService {
   }
 
   postConstruct(hostElement: HTMLElement, config: YasguiConfiguration): void {
-
     OntotextYasguiService.initEditorTabs(hostElement, config);
     OntotextYasguiService.initControlBar(hostElement, config);
     OntotextYasguiService.initResultTabs(hostElement, config);

--- a/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
@@ -8,20 +8,20 @@ export class YasqeService {
   private eventService: EventService;
   private translationService: TranslationService;
 
-  buttonInstances: Map<string, HTMLElement> = new Map<string, HTMLElement>();
+  buttonBuilders: Map<string, (() => HTMLElement)> = new Map<string, (() => HTMLElement)>();
 
   constructor(serviceFactory: ServiceFactory) {
     this.eventService = serviceFactory.getEventService();
     this.translationService = serviceFactory.get(TranslationService);
-    this.buttonInstances.set('createSavedQuery', this.buildCreateSaveQueryButton());
-    this.buttonInstances.set('showSavedQueries', this.buildShowSavedQueriesButton());
+    this.buttonBuilders.set('createSavedQuery', () => this.buildCreateSaveQueryButton());
+    this.buttonBuilders.set('showSavedQueries', () => this.buildShowSavedQueriesButton());
   }
 
   getButtonInstance(buttonDefinition: {name}): HTMLElement {
-    if (!this.buttonInstances.has(buttonDefinition.name)) {
-      throw Error(`No yasqe button instance was found for ${buttonDefinition.name}`);
+    if (!this.buttonBuilders.has(buttonDefinition.name)) {
+      throw Error(`No yasqe button builder was found for ${buttonDefinition.name}`);
     }
-    return this.buttonInstances.get(buttonDefinition.name);
+    return this.buttonBuilders.get(buttonDefinition.name)();
   }
 
   private buildShowSavedQueriesButton(): HTMLElement {
@@ -31,7 +31,7 @@ export class YasqeService {
     buttonElement.setAttribute("aria-label", this.translationService.translate('yasqe.actions.show_saved_queries.button.tooltip'));
     buttonElement.addEventListener("click",
       () => {
-        this.eventService.emit(InternalShowSavedQueriesEvent.TYPE, new InternalShowSavedQueriesEvent())
+        this.eventService.emit(InternalShowSavedQueriesEvent.TYPE, new InternalShowSavedQueriesEvent(buttonElement))
       });
     return buttonElement;
   }


### PR DESCRIPTION
## What
When creating new yasgui tab the actions in the previous tab disappears.

## Why
The reason is that we build the button instances once and reuse them for each new tab. The yasqe reattaches the buttons to each new instance making them to disappear from the other once.

## How
* Make button builders to produce new button instance on each invocation.
* Also calculate the saved queries popup position based on the actual button which triggered it.
* Implemented tests.