### PR TITLE
GDB-7785 Introduce ability to open shared query via method

### DIFF
--- a/cypress/e2e/saved-query/share-saved-query.cpec.cy.ts
+++ b/cypress/e2e/saved-query/share-saved-query.cpec.cy.ts
@@ -1,6 +1,7 @@
 import {YasqeSteps} from "../../steps/yasqe-steps";
 import {QueryStubs} from "../../stubs/query-stubs";
 import ActionsPageSteps from "../../steps/actions-page-steps";
+import {YasguiSteps} from "../../steps/yasgui-steps";
 
 describe('Share saved query action', () => {
     beforeEach(() => {
@@ -32,5 +33,25 @@ describe('Share saved query action', () => {
         // Then I expect that the share link is copied in the clipboard
         YasqeSteps.getShareSavedQueryDialog().should('not.exist');
         ActionsPageSteps.getSaveQueryPayload().should('have.value', 'http://localhost:3333/pages/actions?savedQueryName=Add%20statements');
+    });
+
+    it('Should open shared query', () => {
+        // Given I have opened yasgui which has a single tab
+        YasguiSteps.getTabs().should('have.length', 1);
+        // When I set to open a new query model
+        ActionsPageSteps.openNewQueryAction();
+        // Then I expect that new tab will be opened with the query because there is no tab with the
+        // same name and query
+        YasguiSteps.getTabs().should('have.length', 2);
+        YasguiSteps.getCurrentTab().should('contain', 'Clear graph');
+        YasqeSteps.getTabQuery(1).should('equal', 'CLEAR GRAPH <http://example>');
+        // When I select another tab
+        YasguiSteps.openTab(0);
+        YasguiSteps.getCurrentTab().should('contain', 'Query');
+        // And I set to open the same query model as above
+        ActionsPageSteps.openNewQueryAction();
+        // Then I expect that the tab with the same query and name will be opened
+        YasguiSteps.getCurrentTab().should('contain', 'Clear graph');
+        YasqeSteps.getTabQuery(1).should('equal', 'CLEAR GRAPH <http://example>');
     });
 });

--- a/cypress/steps/actions-page-steps.ts
+++ b/cypress/steps/actions-page-steps.ts
@@ -22,4 +22,8 @@ export default class ActionsPageSteps {
     static showShowSavedQueriesAction() {
         cy.get('#showLoadSavedQueriesAction').click();
     }
+
+    static openNewQueryAction() {
+        cy.get('#openNewQueryAction').click();
+    }
 }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -8,8 +8,8 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ServiceFactory } from "./services/service-factory";
 import { ConfirmationDialogConfig } from "./components/confirmation-dialog/confirmation-dialog";
 import { DialogConfig } from "./components/ontotext-dialog-web-component/ontotext-dialog-web-component";
-import { ExternalYasguiConfiguration } from "./models/external-yasgui-configuration";
-import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/model";
+import { ExternalYasguiConfiguration, TabQueryModel } from "./models/external-yasgui-configuration";
+import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/saved-query-configuration";
 import { QueryEvent, QueryResponseEvent } from "./models/event";
 import { ShareSavedQueryDialogConfig } from "./components/share-saved-query-dialog/share-saved-query-dialog";
 export namespace Components {
@@ -46,9 +46,18 @@ export namespace Components {
          */
         "language": string;
         /**
+          * Allows the client to init the editor using a query model. When the query and query name are found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and initialized using the provided query model.
+          * @param query The query model.
+         */
+        "openTab": (query: TabQueryModel) => Promise<void>;
+        /**
           * A configuration model related with all the saved queries actions.
          */
         "savedQueryConfig"?: SavedQueryConfig;
+        /**
+          * Allows the client to set a query in the current opened tab.
+          * @param query The query that should be set in the current focused tab.
+         */
         "setQuery": (query: string) => Promise<void>;
     }
     interface SaveQueryDialog {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -20,7 +20,10 @@ import Yasqe from "../../../../Yasgui/packages/yasqe/src";
 import {VisualisationUtils} from '../../services/utils/visualisation-utils';
 import {HtmlElementsUtil} from '../../services/utils/html-elements-util';
 import {OntotextYasguiService} from '../../services/yasgui/ontotext-yasgui-service';
-import {ExternalYasguiConfiguration} from "../../models/external-yasgui-configuration";
+import {
+  ExternalYasguiConfiguration,
+  TabQueryModel
+} from "../../models/external-yasgui-configuration";
 import {TranslationService} from '../../services/translation.service';
 import {ServiceFactory} from '../../services/service-factory';
 import {YasguiConfigurationBuilder} from '../../services/yasgui/configuration/yasgui-configuration-builder';
@@ -29,7 +32,7 @@ import {
   SavedQueryConfig,
   SaveQueryData,
   UpdateQueryData
-} from "../../models/model";
+} from "../../models/saved-query-configuration";
 import {ConfirmationDialogConfig} from "../confirmation-dialog/confirmation-dialog";
 import {ShareSavedQueryDialogConfig} from "../share-saved-query-dialog/share-saved-query-dialog";
 
@@ -180,9 +183,25 @@ export class OntotextYasguiWebComponent {
     this.ontotextYasgui.refresh();
   }
 
+  /**
+   * Allows the client to set a query in the current opened tab.
+   * @param query The query that should be set in the current focused tab.
+   */
   @Method()
   setQuery(query: string): Promise<void> {
     this.ontotextYasgui.setQuery(query);
+    return Promise.resolve();
+  }
+
+  /**
+   * Allows the client to init the editor using a query model. When the query and query name are
+   * found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and
+   * initialized using the provided query model.
+   * @param query The query model.
+   */
+  @Method()
+  openTab(query: TabQueryModel): Promise<void> {
+    this.ontotextYasgui.openTab(query);
     return Promise.resolve();
   }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -52,6 +52,16 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Methods
 
+### `openTab(query: SavedQueryInput) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `setQuery(query: string) => Promise<void>`
 
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -52,9 +52,11 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Methods
 
-### `openTab(query: SavedQueryInput) => Promise<void>`
+### `openTab(query: TabQueryModel) => Promise<void>`
 
-
+Allows the client to init the editor using a query model. When the query and query name are
+found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and
+initialized using the provided query model.
 
 #### Returns
 
@@ -64,7 +66,7 @@ Type: `Promise<void>`
 
 ### `setQuery(query: string) => Promise<void>`
 
-
+Allows the client to set a query in the current opened tab.
 
 #### Returns
 

--- a/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@stencil/core';
 import {TranslationService} from "../../services/translation.service";
 import {ServiceFactory} from '../../services/service-factory';
-import {SaveQueryData, UpdateQueryData} from "../../models/model";
+import {SaveQueryData, UpdateQueryData} from "../../models/saved-query-configuration";
 
 @Component({
   tag: 'save-query-dialog',

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -4,7 +4,7 @@ import {
   SavedQueriesData,
   SaveQueryData,
   UpdateQueryData
-} from "../../models/model";
+} from "../../models/saved-query-configuration";
 
 @Component({
   tag: 'saved-queries-popup',

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -142,3 +142,10 @@ export type YasqeActionButtonDefinition = {
   name: string;
   visible: boolean;
 }
+
+export interface TabQueryModel {
+  queryName: string;
+  query: string;
+  isPublic: boolean;
+  owner: string;
+}

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -69,7 +69,10 @@ export class OntotextYasgui {
 
   openTab(queryModel: TabQueryModel): void {
     const existingTab = this.getInstance().tabNameTaken(queryModel.queryName);
-    const isSameQuery = existingTab?.getQuery() === queryModel.query;
+    const config = existingTab?.getPersistedJson();
+    // We can't get the query directly from the tab because if the tab hasn't been opened before
+    // then the yasqe won't be initialized. That's why we get the query from the tab's persistence.
+    const isSameQuery = config?.yasqe?.value === queryModel.query;
     if (existingTab && isSameQuery) {
       this.getInstance().selectTabId(existingTab.getId());
     } else {

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -1,5 +1,6 @@
 import {Yasgui} from '../../../Yasgui/packages/yasgui'
 import {YasguiConfiguration} from './yasgui-configuration';
+import {TabQueryModel} from "./external-yasgui-configuration";
 
 /**
  * An adapter around the actual yasgui instance.
@@ -64,6 +65,16 @@ export class OntotextYasgui {
   // TODO: What's the difference between getQuery() and this method?
   getTabQuery(): string {
     return this.getInstance().getTab().getQuery();
+  }
+
+  openTab(queryModel: TabQueryModel): void {
+    const existingTab = this.getInstance().tabNameTaken(queryModel.queryName);
+    const isSameQuery = existingTab?.getQuery() === queryModel.query;
+    if (existingTab && isSameQuery) {
+      this.getInstance().selectTabId(existingTab.getId());
+    } else {
+      this.createNewTab(queryModel.queryName, queryModel.query);
+    }
   }
 
   createNewTab(queryName: string, query: string): void {

--- a/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
@@ -8,18 +8,18 @@ export interface SavedQueryConfig {
    * Configuration which should be set by the client when saved queries are
    * loaded. Once queries response is set, the saved queries dialog pops up.
    */
-  savedQueries: SavedQueryInput[];
+  savedQueries?: SavedQueryInput[];
   /**
    * Configurations which should be set when query saving request has
    * failed for some reason. This is taken into account when the visibility
    * of the save query dialog is resolved and what messages are rendered
    * inside it.
    */
-  saveSuccess: boolean;
+  saveSuccess?: boolean;
   /**
    * Any error message which can appear during the query saving.
    */
-  errorMessage: string[];
+  errorMessage?: string[];
   /**
    * A link for sharing particular saved query.
    */

--- a/ontotext-yasgui-web-component/src/pages/actions/index.html
+++ b/ontotext-yasgui-web-component/src/pages/actions/index.html
@@ -14,6 +14,7 @@
     <button id="showSaveQueryAction" onclick="showSaveQueryAction()">show save query</button>
     <button id="hideLoadSavedQueriesAction" onclick="hideLoadSavedQueriesAction()">hide load saved queries</button>
     <button id="showLoadSavedQueriesAction" onclick="showLoadSavedQueriesAction()">show load saved queries</button>
+    <button id="openNewQueryAction" onclick="openNewQueryAction()">set new query</button>
     <hr/>
     <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -57,6 +57,15 @@ function showLoadSavedQueriesAction() {
   };
 }
 
+function openNewQueryAction() {
+  ontoElement.openTab({
+    queryName: 'Clear graph',
+    query: 'CLEAR GRAPH <http://example>',
+    isPublic: false,
+    owner: 'admin'
+  });
+}
+
 ontoElement.addEventListener("queryExecuted", () => {
   const div = document.createElement('div');
   div.innerHTML = '<div id="queryRan">Query was Executed</div>';


### PR DESCRIPTION
## What
Allow the client to open a query model in a new or existing tab depending on if there is already existing tab with the same name and query.

## Why
The client would needs to open a shared query in editor tab, be it a new or existing one.

## How
* Exposed a component instance method for opening a query in a tab in the editor.
* Renamed the saved query config file to be closer to its purpose.
* Implemented tests.