### PR TITLE
GDB-7786 introduce expand results over owl:sameAs action

### DIFF
--- a/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
+++ b/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
@@ -12,11 +12,12 @@ describe('Configure editor actions', () => {
     });
 
     it('Should see all custom actions by default in particular order', () => {
-        YasqeSteps.getActionButtons().should('have.length', 4);
+        YasqeSteps.getActionButtons().should('have.length', 5);
         YasqeSteps.getActionButton(0).should('have.attr', 'title', 'Create saved query');
         YasqeSteps.getActionButton(1).should('have.attr', 'title', 'Show saved queries');
         YasqeSteps.getActionButton(2).should('have.attr', 'title', 'Get URL to current query');
         YasqeSteps.getActionButton(3).should('have.attr', 'title', 'Include inferred data in results: ON');
+        YasqeSteps.getActionButton(4).should('have.attr', 'title', 'Expand results over owl:sameAs: ON');
     });
 
     it('Should be able to toggle yasqe action buttons', () => {
@@ -40,13 +41,18 @@ describe('Configure editor actions', () => {
         YasqeSteps.getIncludeInferredStatementsButton().should('not.exist');
         ActionsPageSteps.showIncludeInferredStatementsAction();
         YasqeSteps.getIncludeInferredStatementsButton().should('be.visible');
+        // Toggle expand results over sameAs action
+        ActionsPageSteps.hideExpandResultsAction();
+        YasqeSteps.getExpandResultsOverSameAsButton().should('not.exist');
+        ActionsPageSteps.showExpandResultsAction();
+        YasqeSteps.getExpandResultsOverSameAsButton().should('be.visible');
     });
 
     it('Should show editor actions on each editor tab', () => {
-        YasqeSteps.getActionButtons().should('have.length', 4);
+        YasqeSteps.getActionButtons().should('have.length', 5);
         YasguiSteps.openANewTab();
-        YasqeSteps.getActionButtons().should('have.length', 4);
+        YasqeSteps.getActionButtons().should('have.length', 5);
         YasguiSteps.openTab(0);
-        YasqeSteps.getActionButtons().should('have.length', 4);
+        YasqeSteps.getActionButtons().should('have.length', 5);
     });
 });

--- a/cypress/e2e/editor-actions/expand-results-over-sameas.spec.cy.ts
+++ b/cypress/e2e/editor-actions/expand-results-over-sameas.spec.cy.ts
@@ -1,0 +1,64 @@
+import {YasqeSteps} from "../../steps/yasqe-steps";
+import {QueryStubs} from "../../stubs/query-stubs";
+import ActionsPageSteps from "../../steps/actions-page-steps";
+
+describe('Expand results over sameAs', () => {
+  beforeEach(() => {
+    QueryStubs.stubDefaultQueryResponse();
+    // Given I have opened a page with the yasgui
+    // And there is an open tab with sparql query in it
+    ActionsPageSteps.visit();
+  });
+
+  it('Should be able to toggle the include inferred button state', () => {
+    // When I open the editor
+    // Then I expect that expand results should be enabled by default
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: ON');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-on');
+    // When I click the expand results action
+    YasqeSteps.expandResultsOverSameAs();
+    // Then I expect it to be disabled
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: OFF');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-off');
+  });
+
+  it('Should be able to configure the default value of the expand results config', () => {
+    // When I open the editor
+    // Then I expect that expand results should be enabled by default
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: ON');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-on');
+    // When I change the default of the expand results config
+    ActionsPageSteps.toggleExpandResults();
+    // Then I expect that the expand results value would be changed
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.attr', 'title', 'Expand results over owl:sameAs: OFF');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('have.class', 'icon-sameas-off');
+  });
+
+  it('Should toggle sameAs parameter in requests', () => {
+    // Given I have executed the query without changing configs
+    YasqeSteps.executeQuery();
+    // Then I expect that sameAs=true will be sent with the request
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'sameAs=true');
+    // When I disable expand results statements
+    YasqeSteps.expandResultsOverSameAs();
+    YasqeSteps.executeQuery();
+    // Then I expect that sameAs=false will be sent with the request
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'sameAs=false');
+  });
+
+  it('Should toggle sameAs parameter when include inferred is changed', () => {
+    // Given I have executed the query without changing configs
+    YasqeSteps.executeQuery();
+    // Then I expect that sameAs=true and inferred=true will be sent with the request
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=true&sameAs=true');
+    // When I disable include inferred statements
+    YasqeSteps.includeInferredStatements();
+    YasqeSteps.executeQuery();
+    // Then I expect that sameAs=false and inferred=false will be sent with the request
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=false&sameAs=false');
+    // And expand results action should be disabled when inferred is disabled
+    YasqeSteps.getExpandResultsOverSameAsButton().should('be.disabled');
+    YasqeSteps.includeInferredStatements();
+    YasqeSteps.getExpandResultsOverSameAsButton().should('be.enabled');
+  });
+});

--- a/cypress/e2e/editor-actions/include-inferred-statements.spec.cy.ts
+++ b/cypress/e2e/editor-actions/include-inferred-statements.spec.cy.ts
@@ -38,11 +38,11 @@ describe('Include inferred action', () => {
     // Given I have executing the query without changing configs
     YasqeSteps.executeQuery();
     // Then I expect that infer=true will be sent with the request
-    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=true&sameAs=true');
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=true');
     // When I disable include inferred statements
     YasqeSteps.includeInferredStatements();
     YasqeSteps.executeQuery();
     // Then I expect that infer=false will be sent with the request
-    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=false&sameAs=true');
+    cy.wait('@getDefaultQueryResponse').its('request.body').should('contain', 'infer=false');
   });
 });

--- a/cypress/steps/actions-page-steps.ts
+++ b/cypress/steps/actions-page-steps.ts
@@ -46,4 +46,16 @@ export default class ActionsPageSteps {
     static toggleIncludeInferred() {
         cy.get('#toggleIncludeInferred').click();
     }
+
+    static hideExpandResultsAction() {
+        cy.get('#hideExpandResultsAction').click();
+    }
+
+    static showExpandResultsAction() {
+        cy.get('#showExpandResultsAction').click();
+    }
+
+    static toggleExpandResults() {
+        cy.get('#toggleExpandResults').click();
+    }
 }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -195,4 +195,12 @@ export class YasqeSteps {
     static includeInferredStatements() {
       this.getIncludeInferredStatementsButton().click();
     }
+
+    static getExpandResultsOverSameAsButton() {
+      return cy.get('.yasqe_expandResultsButton');
+    }
+
+    static expandResultsOverSameAs() {
+      this.getExpandResultsOverSameAsButton().click();
+    }
 }

--- a/ontotext-yasgui-web-component/docs/developers-guide.md
+++ b/ontotext-yasgui-web-component/docs/developers-guide.md
@@ -160,7 +160,7 @@ createSavedQueryButton.addEventListener("click",
   () => this.eventService.emit(InternalCreateSavedQueryEvent.TYPE, new InternalCreateSavedQueryEvent()));
 ```
 
-Currently, the action buttons which are plugged in are:
+Currently, the action buttons which are plugged in:
 ```
 "createSavedQuery" - opens the save query dialog  
 ```
@@ -172,6 +172,9 @@ Currently, the action buttons which are plugged in are:
 ```
 ```
 "includeInferredStatements" - include infered data in sparql results
+```
+```
+"expandResultsOverSameAs" - expand results over owl:sameAs
 ```
 
 ## Recommendations for implementing custom action buttons

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -407,6 +407,18 @@ export class OntotextYasguiWebComponent {
     const yasguiConfiguration: YasguiConfiguration = this.ontotextYasgui.getConfig();
     const infer = yasguiConfiguration.yasguiConfig.infer === undefined ? defaultYasguiConfig.infer : yasguiConfiguration.yasguiConfig.infer;
     yasguiConfiguration.yasguiConfig.infer = !infer;
+    yasguiConfiguration.yasguiConfig.sameAs = !infer;
+    this.rebuild(yasguiConfiguration);
+  }
+
+  /**
+   * Handles event for changing the include inferred statements config.
+   */
+  @Listen('internalExpandResultsOverSameAsEvent')
+  expandResultsOverSameAsEventHandler() {
+    const yasguiConfiguration: YasguiConfiguration = this.ontotextYasgui.getConfig();
+    const sameAs = yasguiConfiguration.yasguiConfig.sameAs === undefined ? defaultYasguiConfig.sameAs : yasguiConfiguration.yasguiConfig.sameAs;
+    yasguiConfiguration.yasguiConfig.sameAs = !sameAs;
     this.rebuild(yasguiConfiguration);
   }
 

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -102,6 +102,8 @@
   "yasqe.actions.share_query.button.tooltip": "Get URL to current query",
   "yasqe.actions.include_inferred.true.button.tooltip": "Include inferred data in results: ON",
   "yasqe.actions.include_inferred.false.button.tooltip": "Include inferred data in results: OFF",
+  "yasqe.actions.expand_results_sameas.true.button.tooltip": "Expand results over owl:sameAs: ON",
+  "yasqe.actions.expand_results_sameas.false.button.tooltip": "Expand results over owl:sameAs: OFF",
   "yasqe.share.query.dialog.title": "Copy URL to clipboard",
   "yasqe.share.query.dialog.copy.btn.label": "Copy to clipboard"
 }

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -102,6 +102,8 @@
   "yasqe.actions.share_query.button.tooltip": "Obtenir l'URL de la requête en cours",
   "yasqe.actions.include_inferred.true.button.tooltip": "Inclure les données déduites dans les résultats: AU",
   "yasqe.actions.include_inferred.false.button.tooltip": "Inclure les données déduites dans les résultats: DÉSACTIVÉ",
+  "yasqe.actions.expand_results_sameas.true.button.tooltip": "Développer les résultats sur owl:sameAs: ON",
+  "yasqe.actions.expand_results_sameas.false.button.tooltip": "Développer les résultats sur owl:sameAs: OFF",
   "yasqe.share.query.dialog.title": "Copier l'URL dans le presse-papiers",
   "yasqe.share.query.dialog.copy.btn.label": "Copier dans le presse-papiers"
 }

--- a/ontotext-yasgui-web-component/src/models/event.ts
+++ b/ontotext-yasgui-web-component/src/models/event.ts
@@ -18,6 +18,10 @@ export class InternalIncludeInferredEvent {
   static readonly TYPE = 'internalIncludeInferredEvent';
 }
 
+export class InternalExpandResultsOverSameAsEvent {
+  static readonly TYPE = 'internalExpandResultsOverSameAsEvent';
+}
+
 export class InternalShowSavedQueriesEvent {
   static readonly TYPE = 'internalShowSavedQueriesEvent';
   constructor(public buttonInstance: HTMLElement) {

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -158,5 +158,6 @@ export const defaultYasqeConfig: Record<string, any> = {
     {name: 'showSavedQueries', visible: true},
     {name: 'shareQuery', visible: true},
     {name: 'includeInferredStatements', visible: true},
+    {name: 'expandResultsOverSameAs', visible: true}
   ]
 }

--- a/ontotext-yasgui-web-component/src/pages/actions/index.html
+++ b/ontotext-yasgui-web-component/src/pages/actions/index.html
@@ -19,6 +19,9 @@
     <button id="showIncludeInferredAction" onclick="showIncludeInferredAction()">show inferred</button>
     <button id="hideIncludeInferredAction" onclick="hideIncludeInferredAction()">hide inferred</button>
     <button id="toggleIncludeInferred" onclick="toggleIncludeInferred()">toggle inferred</button>
+    <button id="showExpandResultsAction" onclick="showExpandResultsAction()">show expand results</button>
+    <button id="hideExpandResultsAction" onclick="hideExpandResultsAction()">hide expand results</button>
+    <button id="toggleExpandResults" onclick="toggleExpandResults()">toggle inferred</button>
     <button id="openNewQueryAction" onclick="openNewQueryAction()">set new query</button>
     <hr/>
     <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -131,6 +131,38 @@ function toggleIncludeInferred() {
   };
 }
 
+function showExpandResultsAction() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    yasqeActionButtons: [
+      {
+        name: 'expandResultsOverSameAs',
+        visible: true
+      }
+    ]
+  };
+}
+
+function hideExpandResultsAction() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    yasqeActionButtons: [
+      {
+        name: 'expandResultsOverSameAs',
+        visible: false
+      }
+    ]
+  };
+}
+
+function toggleExpandResults() {
+  const sameAs = ontoElement.config.sameAs === undefined ? false : !ontoElement.config.sameAs
+  ontoElement.config = {
+    ...ontoElement.config,
+    sameAs: sameAs
+  };
+}
+
 function openNewQueryAction() {
   ontoElement.openTab({
     queryName: 'Clear graph',

--- a/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
@@ -1,6 +1,6 @@
 import {EventService} from "../event-service";
 import {
-  InternalCreateSavedQueryEvent, InternalIncludeInferredEvent,
+  InternalCreateSavedQueryEvent, InternalExpandResultsOverSameAsEvent, InternalIncludeInferredEvent,
   InternalShareQueryEvent,
   InternalShowSavedQueriesEvent
 } from "../../models/event";
@@ -22,6 +22,7 @@ export class YasqeService {
     this.buttonBuilders.set('showSavedQueries', () => this.buildShowSavedQueriesButton());
     this.buttonBuilders.set('shareQuery', () => this.buildShareQueryButton());
     this.buttonBuilders.set('includeInferredStatements', (externalConfiguration) => this.buildInferStatementsButton(externalConfiguration));
+    this.buttonBuilders.set('expandResultsOverSameAs', (externalConfiguration) => this.buildExpandResultsOverSameAsButton(externalConfiguration));
   }
 
   getButtonInstance(buttonDefinition: { name }, yasguiConfiguration: YasguiConfiguration): HTMLElement {
@@ -65,14 +66,29 @@ export class YasqeService {
 
   private buildInferStatementsButton(yasguiConfiguration: YasguiConfiguration): HTMLElement {
     const buttonElement = document.createElement("button");
-    const inludeInferred = yasguiConfiguration.yasguiConfig.infer === undefined || yasguiConfiguration.yasguiConfig.infer;
-    const iconClass = inludeInferred ? 'icon-inferred-on' : 'icon-inferred-off'
+    const includeInferred = yasguiConfiguration.yasguiConfig.infer === undefined || yasguiConfiguration.yasguiConfig.infer;
+    const iconClass = includeInferred ? 'icon-inferred-on' : 'icon-inferred-off'
     buttonElement.className = `yasqe_inferStatementsButton custom-button ${iconClass}`;
-    const title = this.translationService.translate(`yasqe.actions.include_inferred.${inludeInferred}.button.tooltip`);
+    const title = this.translationService.translate(`yasqe.actions.include_inferred.${includeInferred}.button.tooltip`);
     buttonElement.title = title;
     buttonElement.setAttribute("aria-label", title);
     buttonElement.addEventListener("click",
       () => this.eventService.emit(InternalIncludeInferredEvent.TYPE, new InternalIncludeInferredEvent()));
+    return buttonElement;
+  }
+
+  private buildExpandResultsOverSameAsButton(yasguiConfiguration: YasguiConfiguration): HTMLElement {
+    const buttonElement = document.createElement("button");
+    const expandResults = yasguiConfiguration.yasguiConfig.sameAs === undefined || yasguiConfiguration.yasguiConfig.sameAs;
+    const includeInferred = yasguiConfiguration.yasguiConfig.infer === undefined || yasguiConfiguration.yasguiConfig.infer;
+    const iconClass = expandResults ? 'icon-sameas-on' : 'icon-sameas-off'
+    buttonElement.className = `yasqe_expandResultsButton custom-button ${iconClass}`;
+    const title = this.translationService.translate(`yasqe.actions.expand_results_sameas.${expandResults}.button.tooltip`);
+    buttonElement.title = title;
+    buttonElement.setAttribute("aria-label", title);
+    buttonElement.disabled = !includeInferred;
+    buttonElement.addEventListener("click",
+      () => this.eventService.emit(InternalExpandResultsOverSameAsEvent.TYPE, new InternalExpandResultsOverSameAsEvent()));
     return buttonElement;
   }
 }


### PR DESCRIPTION
## What
This MR introduces support for action that toggles the expand results over owl:sameAs.

## Why
GDB workbench supports changing the results expansion over owl:sameAs.

## How
* Introduced the new action button in the yasqe which allows the sameAs configuration and request parameter and to be toggled.
* Implemented tests.