### PR TITLE
Fixes NPE when type of cell is not uri.

### DIFF
--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -72,13 +72,13 @@ export class YasrService {
   // @ts-ignore
   private static getTripleCellContent(_binding: Parser.BindingValue, _prefixes?: { [label: string]: string }): string {
     // TODO implement it.
-    return '';
+    return `<div></div>`;
   }
 
   // @ts-ignore
   private static getLiteralCellContent(_binding: Parser.BindingValue, _prefixes?: { [label: string]: string }): string {
     // TODO implement it.
-    return '';
+    return `<div></div>`;
   }
 
   /**


### PR DESCRIPTION
Fixes NPE when type of cell is not uri.

What?
There is an error when sorting results in table plugin.

Why?
Implementation is not completed. At the moment it is ready for type uri only. When the content of cell is not uri an empty string is returned and sort functionality throws an exception because can't found first element into the cell.

How?
Changed return type to be empty div element instead empty string.