### PR TITLE
Fixes NPE when ontotext yasgui

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -464,12 +464,10 @@ export class OntotextYasguiWebComponent {
   }
 
   private init(externalConfiguration: ExternalYasguiConfiguration): void {
-    this.destroy();
-
-    if (!externalConfiguration) {
+    if (!HtmlElementsUtil.getOntotextYasgui(this.hostElement) || !externalConfiguration) {
       return;
     }
-
+    this.destroy();
     // @ts-ignore
     if (window.Yasgui) {
       // * Build the internal yasgui configuration using the provided external configuration
@@ -580,11 +578,11 @@ export class OntotextYasguiWebComponent {
   }
 
   private getRenderMode() {
-    return this.config.render || defaultOntotextYasguiConfig.render;
+    return this.config && this.config.render || defaultOntotextYasguiConfig.render;
   }
 
   private getOrientationMode() {
-    return this.config.orientation || defaultOntotextYasguiConfig.orientation;
+    return this.config && this.config.orientation || defaultOntotextYasguiConfig.orientation;
   }
 
   private shouldShowSaveQueryDialog(): void {
@@ -627,10 +625,6 @@ export class OntotextYasguiWebComponent {
   }
 
   render() {
-    if (!this.config) {
-      return (<Host></Host>);
-    }
-
     const classList = `yasgui-host-element ${this.getOrientationMode()} ${this.getRenderMode()}`;
     return (
       <Host class={classList}>

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -97,12 +97,7 @@ export class OntotextYasgui {
 
   destroy() {
     if (this.yasgui) {
-      Object.keys(this.yasgui._tabs).forEach((tabId) => {
-        const tab = this.yasgui._tabs[tabId];
-        tab.getYasr() && tab.getYasr().destroy();
-      });
       this.yasgui.destroy();
-      // this.yasguiElement = null;
       this.yasgui = null;
       localStorage.removeItem('yasqe__query');
     }


### PR DESCRIPTION
What?
From time to time there is an NPE when instantiating ontotext-yasgui-web-component.

Why?
The initializer function is called before the ontotext yasgui DOM is created.

How?
Execution of function is prevented if DOM is not created.