### PR TITLE
GDB-7890 expose get query mode and query type public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ After execution of command the projects will be cleared as just cloned from repo
 > For development purpose the minimization of yasgui can be skipped by setting minimize property to 
 > false of the optimization configuration in Yasgui/webpack/config.ts file.
 
-Read [Development guide](ontotext-yasgui-web-component/src/docs/development-guide.md) before 
+Read [Development guide](ontotext-yasgui-web-component/docs/developers-guide.md) before 
 starting any development in this project.
 
 ## Usage of the component

--- a/cypress/e2e/defalt-view.spec.cy.ts
+++ b/cypress/e2e/defalt-view.spec.cy.ts
@@ -1,17 +1,30 @@
-import PageSteps from '../steps/page-steps';
+import DefaultViewPageSteps from '../steps/default-view-page-steps';
 import {YasqeSteps} from '../steps/yasqe-steps';
 import {YasrSteps} from '../steps/yasr-steps';
 import {QueryStubs} from "../stubs/query-stubs";
 
 describe('Default view', () => {
 
-    beforeEach(() => {
-        QueryStubs.stubDefaultQueryResponse();
+  beforeEach(() => {
+    QueryStubs.stubDefaultQueryResponse();
+    DefaultViewPageSteps.visitDefaultViewPage();
+  });
+
+  it('Should load component with default configuration', () => {
+    YasqeSteps.executeQuery();
+    YasrSteps.getResults().should('have.length', 36);
+  });
+
+  context('Instance methods', () => {
+
+    it('Should be able to get the query mode', () => {
+      DefaultViewPageSteps.getQueryMode();
+      DefaultViewPageSteps.getOutputField().should('have.value', 'query');
     });
 
-    it('Should load component with default configuration', () => {
-        PageSteps.visitDefaultViewPage();
-        YasqeSteps.executeQuery();
-        YasrSteps.getResults().should('have.length', 36);
+    it('Should be able to get the query type', () => {
+      DefaultViewPageSteps.getQueryType();
+      DefaultViewPageSteps.getOutputField().should('have.value', 'SELECT');
     });
+  })
 })

--- a/cypress/e2e/yasgui-toolbar.spec.cy.ts
+++ b/cypress/e2e/yasgui-toolbar.spec.cy.ts
@@ -3,7 +3,7 @@ import {YasqeSteps} from '../steps/yasqe-steps';
 import {YasrSteps} from '../steps/yasr-steps';
 import {QueryStubs} from "../stubs/query-stubs";
 import {ToolbarPageSteps} from '../steps/toolbar-page-steps';
-import PageSteps from "../steps/page-steps";
+import DefaultViewPageSteps from "../steps/default-view-page-steps";
 
 describe('Yasgui Toolbar', () => {
     beforeEach(() => {
@@ -14,7 +14,7 @@ describe('Yasgui Toolbar', () => {
         it('Should be hidden', () => {
             // Given I haven configured the toolbar visibility
             // When I open a page with the yasgui
-            PageSteps.visitDefaultViewPage();
+            DefaultViewPageSteps.visitDefaultViewPage();
             // Then I expect that the toolbar should be hidden
             // TODO: Seems like the toolbar is initially visible and cypress sees that before the app to have the chance to hide it!!!
             // Find a way to remove this wait here.

--- a/cypress/e2e/yasr/plugin-table.spec.cy.ts
+++ b/cypress/e2e/yasr/plugin-table.spec.cy.ts
@@ -1,7 +1,7 @@
 import {QueryStubs} from '../../stubs/query-stubs';
 import {YasrTablePluginSteps} from '../../steps/yasr-table-plugin-steps';
 import {YasqeSteps} from '../../steps/yasqe-steps';
-import PageSteps from '../../steps/page-steps';
+import DefaultViewPageSteps from '../../steps/default-view-page-steps';
 import {YasrSteps} from '../../steps/yasr-steps';
 
 describe('Plugin: Table', () => {
@@ -35,7 +35,7 @@ describe('Plugin: Table', () => {
          YasrTablePluginSteps.getQueryResultInfo().contains(/36 results Query took \d{1}\.\d{1}s, moments ago\./);
 
          // When I go to other page
-         PageSteps.visitDefaultViewPage();
+         DefaultViewPageSteps.visitDefaultViewPage();
          // And return to the first one.
          YasrTablePluginSteps.visit();
 

--- a/cypress/steps/default-view-page-steps.ts
+++ b/cypress/steps/default-view-page-steps.ts
@@ -1,0 +1,17 @@
+export default class DefaultViewPageSteps {
+  static visitDefaultViewPage() {
+    cy.visit('/pages/default-view');
+  }
+
+  static getOutputField() {
+    return cy.get('#output');
+  }
+
+  static getQueryMode() {
+    cy.get('#getQueryMode').click();
+  }
+
+  static getQueryType() {
+    cy.get('#getQueryType').click();
+  }
+}

--- a/cypress/steps/page-steps.ts
+++ b/cypress/steps/page-steps.ts
@@ -1,5 +1,0 @@
-export default class PageSteps {
-    static visitDefaultViewPage() {
-        cy.visit('/pages/default-view');
-    }
-}

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -104,7 +104,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 
 ## Developers guide
 
-The guide can be found [here](../ontotext-yasgui-web-component/docs/developers-guide.md)
+The guide can be found [here](./docs/developers-guide.md)
 
 # License
 TODO:

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -104,7 +104,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 
 ## Developers guide
 
-The guide can be found [here](./docs/developers-guide.md)
+The guide can be found [here](../ontotext-yasgui-web-component/docs/developers-guide.md)
 
 # License
 TODO:

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -99,7 +99,12 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - <b>showResultTabs</b>: If the results tabs should be rendered or not;
 - <b>showToolbar</b>: If the toolbar with render mode buttons should be rendered or not;
 - <b>yasqePluginButtons</b>: Plugin definitions configurations for yasqe action buttons; 
-- <b>componentId</b>: Unique identifier of an instance of the component. This config is optional.
+- <b>componentId</b>: An unique identifier of an instance of the component. This config is optional.
   A unique identifier of the component instance. This configuration is optional. A unique value should be passed only if the component's internal state (open tabs, completed requests, etc.) should not be shared with its other instances.
+
+## Developers guide
+
+The guide can be found [here](./docs/developers-guide.md)
+
 # License
 TODO:

--- a/ontotext-yasgui-web-component/docs/developers-guide.md
+++ b/ontotext-yasgui-web-component/docs/developers-guide.md
@@ -88,7 +88,7 @@ const ontoElement = document.querySelector('ontotext-yasgui');
 ontoElement.openTab(...);
 ```
 
-The public API documentation can be found [here](src/components/ontotext-yasgui-web-component/readme.md)
+The public API documentation can be found [here](../src/components/ontotext-yasgui-web-component/readme.md)
 
 
 # Components

--- a/ontotext-yasgui-web-component/docs/developers-guide.md
+++ b/ontotext-yasgui-web-component/docs/developers-guide.md
@@ -78,6 +78,19 @@ before 1.7.3, then additional custom directive must be installed on the client a
   }
 ```
 
+## Public instance methods
+
+The ontotext yasgui web component exposes a public API which can be accessed through the component
+instance in the following way:
+
+```
+const ontoElement = document.querySelector('ontotext-yasgui');
+ontoElement.openTab(...);
+```
+
+The public API documentation can be found [here](src/components/ontotext-yasgui-web-component/readme.md)
+
+
 # Components
 ## OntotextTooltipWebComponent
  ### Usage

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -57,6 +57,16 @@ export namespace Components {
          */
         "config": ExternalYasguiConfiguration;
         /**
+          * Utility method allowing the client to get the mode of the query which is written in the current editor tab. The query mode can be either `query` or `update` regarding the query mode. This method just exposes the similar utility method from the yasqe component.
+          * @return A promise which resolves with a string representing the query mode.
+         */
+        "getQueryMode": () => Promise<string>;
+        /**
+          * Utility method allowing the client to get the type of the query which is written in the current editor tab. The query mode can be `INSERT`, `LOAD`, `CLEAR`, `DELETE`, etc. This method just exposes the similar utility method from the yasqe component.
+          * @return A promise which resolves with a string representing the query type.
+         */
+        "getQueryType": () => Promise<string>;
+        /**
           * An input property containing the chosen translation language.
          */
         "language": string;
@@ -284,6 +294,9 @@ declare namespace LocalJSX {
           * Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.
          */
         "onLoadSavedQueries"?: (event: OntotextYasguiCustomEvent<boolean>) => void;
+        /**
+          * Event emitted when there is a message which the client might want to show to the user or handle in some other way.
+         */
         "onNotify"?: (event: OntotextYasguiCustomEvent<NotificationMessage>) => void;
         /**
           * Event emitted when before query to be executed.

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -91,16 +91,34 @@ export class OntotextYasguiWebComponent {
    * An input object property containing the yasgui configuration.
    */
   @Prop() config: ExternalYasguiConfiguration;
+  @Watch('config')
+  configurationChanged(newConfig: ExternalYasguiConfiguration) {
+    this.init(newConfig);
+  }
 
   /**
    * An input property containing the chosen translation language.
    */
   @Prop() language: string
+  @Watch('language')
+  languageChanged(newLang: string) {
+    this.translationService.setLanguage(newLang);
+    this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        ontotextYasgui.refresh();
+      });
+  }
 
   /**
    * A configuration model related with all the saved queries actions.
    */
   @Prop() savedQueryConfig?: SavedQueryConfig;
+  @Watch('savedQueryConfig')
+  savedQueryConfigChanged() {
+    this.shouldShowSaveQueryDialog();
+    this.shouldShowSavedQueriesPopup();
+    this.saveQueryData = this.initSaveQueryData();
+  }
 
   /**
    * Event emitted when before query to be executed.
@@ -196,27 +214,6 @@ export class OntotextYasguiWebComponent {
   @State() showCopyResourceLinkDialog = false;
 
   @State() copiedResourceLink: string;
-
-  @Watch('config')
-  configurationChanged(newConfig: ExternalYasguiConfiguration) {
-    this.init(newConfig);
-  }
-
-  @Watch('savedQueryConfig')
-  savedQueryConfigChanged() {
-    this.shouldShowSaveQueryDialog();
-    this.shouldShowSavedQueriesPopup();
-    this.saveQueryData = this.initSaveQueryData();
-  }
-
-  @Watch('language')
-  languageChanged(newLang: string) {
-    this.translationService.setLanguage(newLang);
-    this.getOntotextYasgui()
-      .then((ontotextYasgui) => {
-        ontotextYasgui.refresh();
-      });
-  }
 
   /**
    * Allows the client to set a query in the current opened tab.

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -43,7 +43,7 @@ yasgui can be tweaked using the values from the configuration.
 | `createSavedQuery`     | Event emitted when saved query payload is collected and the query should be saved by the component client.                                              | `CustomEvent<SaveQueryData>`         |
 | `deleteSavedQuery`     | Event emitted when a saved query should be deleted. In result the client must perform a query delete.                                                   | `CustomEvent<SaveQueryData>`         |
 | `loadSavedQueries`     | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`               |
-| `notify`               |                                                                                                                                                         | `CustomEvent<NotificationMessage>`   |
+| `notify`               | Event emitted when there is a message which the client might want to show to the user or handle in some other way.                                      | `CustomEvent<NotificationMessage>`   |
 | `queryExecuted`        | Event emitted when before query to be executed.                                                                                                         | `CustomEvent<{ query: string; }>`    |
 | `queryResponse`        | Event emitted when after query response is returned.                                                                                                    | `CustomEvent<{ duration: number; }>` |
 | `queryShareLinkCopied` | Event emitted when query share link gets copied in the clipboard.                                                                                       | `CustomEvent<any>`                   |
@@ -53,6 +53,32 @@ yasgui can be tweaked using the values from the configuration.
 
 
 ## Methods
+
+### `getQueryMode() => Promise<string>`
+
+Utility method allowing the client to get the mode of the query which is written in the current
+editor tab.
+The query mode can be either `query` or `update` regarding the query mode. This method just
+exposes the similar utility method from the yasqe component.
+
+#### Returns
+
+Type: `Promise<string>`
+
+A promise which resolves with a string representing the query mode.
+
+### `getQueryType() => Promise<string>`
+
+Utility method allowing the client to get the type of the query which is written in the current
+editor tab.
+The query mode can be `INSERT`, `LOAD`, `CLEAR`, `DELETE`, etc. This method just exposes the
+similar utility method from the yasqe component.
+
+#### Returns
+
+Type: `Promise<string>`
+
+A promise which resolves with a string representing the query type.
 
 ### `openTab(queryModel: TabQueryModel) => Promise<void>`
 

--- a/ontotext-yasgui-web-component/src/js/main.js
+++ b/ontotext-yasgui-web-component/src/js/main.js
@@ -1,9 +1,4 @@
-let ontoElement = document.querySelector(".instanceOne");
+let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
-  endpoint: "/repositories/test-repo"
-};
-
-let ontoElementTwo = document.querySelector(".instanceTwo");
-ontoElementTwo.config = {
   endpoint: "/repositories/test-repo"
 };

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -50,6 +50,14 @@ export class OntotextYasgui {
     return this.yasgui.getTab().getYasqe().getValue();
   }
 
+  getQueryMode(): string {
+    return this.yasgui.getTab().getYasqe().getQueryMode();
+  }
+
+  getQueryType(): string {
+    return this.yasgui.getTab().getYasqe().getQueryType();
+  }
+
   getConfig() {
     return this.config;
   }

--- a/ontotext-yasgui-web-component/src/pages/default-view/index.html
+++ b/ontotext-yasgui-web-component/src/pages/default-view/index.html
@@ -10,6 +10,9 @@
     <script src="./default-view/main.js" defer></script>
   </head>
   <body>
+  <button id="getQueryMode" onclick="getQueryMode()">get query mode</button>
+  <button id="getQueryType" onclick="getQueryType()">get query type</button>
+  <hr/>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>
 </html>

--- a/ontotext-yasgui-web-component/src/pages/default-view/main.js
+++ b/ontotext-yasgui-web-component/src/pages/default-view/main.js
@@ -2,3 +2,19 @@ let ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
   endpoint: "/repositories/test-repo"
 };
+
+let textAreaElement = document.createElement('textarea');
+textAreaElement.id = 'output';
+document.body.appendChild(textAreaElement);
+
+function getQueryMode() {
+  ontoElement.getQueryMode().then((queryMode) => {
+    textAreaElement.value = queryMode;
+  });
+}
+
+function getQueryType() {
+  ontoElement.getQueryType().then((queryType) => {
+    textAreaElement.value = queryType;
+  });
+}

--- a/ontotext-yasgui-web-component/src/pages/multiple-instances/index.html
+++ b/ontotext-yasgui-web-component/src/pages/multiple-instances/index.html
@@ -7,9 +7,11 @@
 
     <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
     <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
-    <script src="js/main.js" defer></script>
+    <script src="./multiple-instances/main.js" defer></script>
   </head>
   <body>
-  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  <ontotext-yasgui class="instanceOne" data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+
+  <ontotext-yasgui class="instanceTwo" data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>
 </html>

--- a/ontotext-yasgui-web-component/src/pages/multiple-instances/main.js
+++ b/ontotext-yasgui-web-component/src/pages/multiple-instances/main.js
@@ -1,0 +1,9 @@
+let ontoElement = document.querySelector(".instanceOne");
+ontoElement.config = {
+  endpoint: "/repositories/test-repo"
+};
+
+let ontoElementTwo = document.querySelector(".instanceTwo");
+ontoElementTwo.config = {
+  endpoint: "/repositories/test-repo"
+};


### PR DESCRIPTION
## What
Expose public methods which allows the component client to get the query mode and type.

## Why
Some implementations on the client side require the client to know the query mode and type.

## How
* Exposed the new methods which delegate the task for resolving this information to the yasqe component.
* Implemented tests.
* Additionally some organization in the main component was done.

Additionally:
* Added a fake server which allows more test cases to be easily executed in the example pages.
* Added an editorconfig file to allow more consistent formatting.