### PR TITLE
GDB-7711 fixes extend table plugin issues

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -91,7 +91,7 @@ export class ExtendedYasr extends Yasr {
 
   private updateDownloadAsElementVisibility() {
     removeClass(this.downloadAsElement, "hidden");
-    if (!this.results || (this.downloadAsElement as any).items.length < 1) {
+    if (!this.results?.getBindings()?.length) {
       addClass(this.downloadAsElement, "hidden");
     }
   }

--- a/cypress/e2e/yasr/download-as.spec.cy.ts
+++ b/cypress/e2e/yasr/download-as.spec.cy.ts
@@ -1,6 +1,8 @@
 import {DownloadAsPageSteps} from '../../steps/download-as-page-steps';
 import {YasqeSteps} from '../../steps/yasqe-steps';
 import {YasrSteps} from '../../steps/yasr-steps';
+import {QueryStubs} from '../../stubs/query-stubs';
+import {YasguiSteps} from '../../steps/yasgui-steps';
 
 describe('Download as', () => {
 
@@ -9,18 +11,33 @@ describe('Download as', () => {
     DownloadAsPageSteps.visit();
   });
 
-  it('Should dropdown not be visible if there isn\'t results', () => {
-    // When yasr has not result
-    // Then download dropdown should not be visible.
-    DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
-  });
+  describe('"Download as" dropdown visibility', () => {
+    it('should not be visible if there aren\'t results', () => {
+      // When yasr is not initialized
+      // Then download dropdown should not be visible.
+      DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
 
-  it('Should "Download as" dropdown be visible if there is results', () => {
-    // When execute a query witch returns results.
-    YasqeSteps.executeQuery();
+      // When I execute a query without result
+      QueryStubs.stubEmptyQueryResponse();
+      YasqeSteps.executeQuery();
 
-    // Then "Download as" dropdown should be visible.
-    DownloadAsPageSteps.getDownloadAsDropdown().should('be.visible');
+      // Then I expect the "Download as" dropdown to not be visible.
+      DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
+
+      // When I open a bew tab
+      YasguiSteps.openANewTab();
+
+      // Then I expect the "Download as" dropdown to not be visible.
+      DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
+    });
+
+    it('should be visible if there are results', () => {
+      // When execute a query witch returns results.
+      YasqeSteps.executeQuery();
+
+      // Then "Download as" dropdown should be visible.
+      DownloadAsPageSteps.getDownloadAsDropdown().should('be.visible');
+    });
   });
 
   it('Should emit "downloadAs" event with value the selected of selected option, current plugin name, and last executed query.', () => {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -88,6 +88,7 @@
     .dataTable tr.even {
       background-color: white;
     }
+
     .yasr_header > * {
       margin-left: 0;
     }
@@ -104,6 +105,7 @@
         .spacer {
           width: 100%;
         }
+
         li {
           white-space: nowrap;
         }
@@ -250,5 +252,9 @@
         grid-template-columns: 0 1fr 1fr;
       }
     }
+  }
+
+  button, button:focus {
+    outline: none;
   }
 }

--- a/yasgui-patches/2023-02-20-fixes-are-results-check.patch
+++ b/yasgui-patches/2023-02-20-fixes-are-results-check.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] GDB-7711 plugins issues
+---
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 262fc056a759c4039f50b97349008cbbf4cbda97)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 7f8922ffb96f3685a89e5921e1cc6246da26f0b6)
+@@ -91,7 +91,7 @@
+ 
+   private updateDownloadAsElementVisibility() {
+     removeClass(this.downloadAsElement, "hidden");
+-    if (!this.results || (this.downloadAsElement as any).items.length < 1) {
++    if (!this.results?.getBindings()?.length) {
+       addClass(this.downloadAsElement, "hidden");
+     }
+   }


### PR DESCRIPTION
GDB-7711 plugins issues

## What
- There is outline styling on a plugin tab when it is focused.
- "Download as" dropdown is visible when there aren't results.

## Why
- Outline styling was set from client theme.
- Wrong check are there results.

## How
- Removes outline from all "ontotext-yasgui" buttons.
- Fixes check if there are results.