### PR TITLE
GDB-7891: add icon to "Download as" dropdown.

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -78,6 +78,7 @@ export class ExtendedYasr extends Yasr {
       if (downloadAsConfiguration.hasOwnProperty("nameLabelKey")) {
         element.nameLabelKey = downloadAsConfiguration.nameLabelKey;
       }
+      element.tooltipLabelKey = downloadAsConfiguration.tooltipLabelKey || downloadAsConfiguration.nameLabelKey;
     } else {
       element.items = [];
     }
@@ -272,6 +273,7 @@ export class ExtendedYasr extends Yasr {
 interface DownloadAs {
   translationService: TranslationService;
   nameLabelKey: string;
+  tooltipLabelKey: string;
   query: string | undefined;
   pluginName: string;
   items: any[];

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -296,7 +296,6 @@ export class Yasr extends EventEmitter {
       );
       const button = document.createElement("button");
       addClass(button, "yasr_btn", "select_" + pluginName);
-      button.title = name;
       button.type = "button";
       button.setAttribute(
         "aria-label",
@@ -317,7 +316,11 @@ export class Yasr extends EventEmitter {
       button.appendChild(nameEl);
       button.addEventListener("click", () => this.selectPlugin(pluginName));
       const li = document.createElement("li");
-      li.appendChild(button);
+      const buttonPluginTooltip: any = document.createElement("yasgui-tooltip");
+      buttonPluginTooltip.dataTooltip = window.innerWidth < 768 ? name : "";
+      buttonPluginTooltip.placement = "top";
+      buttonPluginTooltip.appendChild(button);
+      li.appendChild(buttonPluginTooltip);
       this.pluginSelectorsEl.appendChild(li);
     }
 
@@ -478,7 +481,6 @@ export class Yasr extends EventEmitter {
           const name = this.translationService.translate(
             `yasr.plugin_control.plugin.name.${plugin.label || pluginName}`.toLowerCase()
           );
-          button.setAttribute("title", name);
           button.setAttribute(
             "aria-label",
             this.translationService.translate("yasr.plugin_control.shows_view.btn.aria_label", [
@@ -488,6 +490,10 @@ export class Yasr extends EventEmitter {
           let nameEl = button.querySelector("span");
           if (nameEl) {
             nameEl.innerText = name;
+          }
+          const buttonPluginTooltip = button.parentElement;
+          if (buttonPluginTooltip) {
+            (buttonPluginTooltip as any).dataTooltip = window.innerWidth < 768 ? name : "";
           }
         }
       }

--- a/cypress/e2e/yasr/download-as.spec.cy.ts
+++ b/cypress/e2e/yasr/download-as.spec.cy.ts
@@ -23,12 +23,16 @@ describe('Download as', () => {
 
       // Then I expect the "Download as" dropdown to not be visible.
       DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
+      DownloadAsPageSteps.getDownloadAsDropdownButton().should('not.be.visible');
+      DownloadAsPageSteps.getDropdownAsIcon().should('not.be.visible');
 
       // When I open a bew tab
       YasguiSteps.openANewTab();
 
       // Then I expect the "Download as" dropdown to not be visible.
       DownloadAsPageSteps.getDownloadAsDropdown().should('not.be.visible');
+      DownloadAsPageSteps.getDownloadAsDropdownButton().should('not.be.visible');
+      DownloadAsPageSteps.getDropdownAsIcon().should('not.be.visible');
     });
 
     it('should be visible if there are results', () => {
@@ -37,6 +41,22 @@ describe('Download as', () => {
 
       // Then "Download as" dropdown should be visible.
       DownloadAsPageSteps.getDownloadAsDropdown().should('be.visible');
+      DownloadAsPageSteps.getDownloadAsButtonName().should('be.visible');
+      DownloadAsPageSteps.getDropdownAsIcon().should('be.visible');
+    });
+
+    it('should icon be visible when screen is small', () => {
+      // When execute a query witch returns results.
+      YasqeSteps.executeQuery();
+      // And screen is less than 768px
+      cy.viewport(767, 750);
+
+      // Then "Download as" dropdown should be visible.
+      DownloadAsPageSteps.getDownloadAsDropdown().should('be.visible');
+      // And I expect the button of dropdown to not be visible.
+      DownloadAsPageSteps.getDownloadAsButtonName().should('not.be.visible');
+      // And expect icon to be visible.
+      DownloadAsPageSteps.getDropdownAsIcon().should('be.visible');
     });
   });
 

--- a/cypress/steps/download-as-page-steps.ts
+++ b/cypress/steps/download-as-page-steps.ts
@@ -10,6 +10,18 @@ export class DownloadAsPageSteps {
     return YasguiSteps.getYasgui().find('ontotext-download-as');
   }
 
+  static getDownloadAsDropdownButton() {
+    return DownloadAsPageSteps.getDownloadAsDropdown().find('.ontotext-dropdown-button');
+  }
+
+  static getDownloadAsButtonName() {
+    return this.getDownloadAsDropdownButton().find('.button-name');
+  }
+
+  static getDropdownAsIcon() {
+    return DownloadAsPageSteps.getDownloadAsDropdown().find('.icon-download');
+  }
+
   static openDownloadAsDropdown() {
     DownloadAsPageSteps.getDownloadAsDropdown().click();
   }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -47,11 +47,14 @@ export namespace Components {
         "pluginName": string;
         "query": string;
         "sameAs": boolean;
+        "tooltipLabelKey": string;
         "translationService": TranslationService;
     }
     interface OntotextDropdown {
+        "iconClass": string;
         "items": DropdownOption[];
         "nameLabelKey": string;
+        "tooltipLabelKey": string;
         "translationService": TranslationService;
     }
     /**
@@ -308,12 +311,15 @@ declare namespace LocalJSX {
         "pluginName"?: string;
         "query"?: string;
         "sameAs"?: boolean;
+        "tooltipLabelKey"?: string;
         "translationService"?: TranslationService;
     }
     interface OntotextDropdown {
+        "iconClass"?: string;
         "items"?: DropdownOption[];
         "nameLabelKey"?: string;
         "onValueChanged"?: (event: OntotextDropdownCustomEvent<InternalDropdownValueSelectedEvent>) => void;
+        "tooltipLabelKey"?: string;
         "translationService"?: TranslationService;
     }
     /**

--- a/ontotext-yasgui-web-component/src/components/download-as/download-as.scss
+++ b/ontotext-yasgui-web-component/src/components/download-as/download-as.scss
@@ -1,0 +1,7 @@
+.ontotext-download-as {
+  @media (max-width: 768px) {
+    .ontotext-dropdown .ontotext-dropdown-menu {
+      right: 0;
+    }
+  }
+}

--- a/ontotext-yasgui-web-component/src/components/download-as/download-as.tsx
+++ b/ontotext-yasgui-web-component/src/components/download-as/download-as.tsx
@@ -6,6 +6,7 @@ import {InternalDropdownValueSelectedEvent} from '../../models/internal-events/i
 
 @Component({
   tag: 'ontotext-download-as',
+  styleUrl: 'download-as.scss',
   shadow: false,
 })
 export class DownloadAs {
@@ -14,6 +15,7 @@ export class DownloadAs {
 
   @Prop() translationService: TranslationService;
   @Prop() nameLabelKey: string;
+  @Prop() tooltipLabelKey: string;
   @Prop() items: DropdownOption[];
   @Prop() pluginName: string;
   @Prop() query: string;
@@ -29,9 +31,12 @@ export class DownloadAs {
   render() {
     return (
       <ontotext-dropdown
+        class='ontotext-download-as'
         onValueChanged={ev => this.onInternalDropdownValueSelected(ev)}
         translationService={this.translationService}
+        tooltipLabelKey={this.tooltipLabelKey}
         nameLabelKey={this.nameLabelKey ? this.nameLabelKey : DownloadAs.DEFAULT_NAME_LABEL}
+        iconClass='icon-download'
         items={this.items}>
       </ontotext-dropdown>
     );

--- a/ontotext-yasgui-web-component/src/components/download-as/readme.md
+++ b/ontotext-yasgui-web-component/src/components/download-as/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property             | Attribute        | Description | Type                 | Default     |
-| -------------------- | ---------------- | ----------- | -------------------- | ----------- |
-| `infer`              | `infer`          |             | `boolean`            | `undefined` |
-| `items`              | --               |             | `DropdownOption[]`   | `undefined` |
-| `nameLabelKey`       | `name-label-key` |             | `string`             | `undefined` |
-| `pluginName`         | `plugin-name`    |             | `string`             | `undefined` |
-| `query`              | `query`          |             | `string`             | `undefined` |
-| `sameAs`             | `same-as`        |             | `boolean`            | `undefined` |
-| `translationService` | --               |             | `TranslationService` | `undefined` |
+| Property             | Attribute           | Description | Type                 | Default     |
+| -------------------- | ------------------- | ----------- | -------------------- | ----------- |
+| `infer`              | `infer`             |             | `boolean`            | `undefined` |
+| `items`              | --                  |             | `DropdownOption[]`   | `undefined` |
+| `nameLabelKey`       | `name-label-key`    |             | `string`             | `undefined` |
+| `pluginName`         | `plugin-name`       |             | `string`             | `undefined` |
+| `query`              | `query`             |             | `string`             | `undefined` |
+| `sameAs`             | `same-as`           |             | `boolean`            | `undefined` |
+| `tooltipLabelKey`    | `tooltip-label-key` |             | `string`             | `undefined` |
+| `translationService` | --                  |             | `TranslationService` | `undefined` |
 
 
 ## Events
@@ -35,6 +36,7 @@
 ```mermaid
 graph TD;
   ontotext-download-as --> ontotext-dropdown
+  ontotext-dropdown --> yasgui-tooltip
   style ontotext-download-as fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/ontotext-yasgui-web-component/src/components/dropdown/dropdown.scss
+++ b/ontotext-yasgui-web-component/src/components/dropdown/dropdown.scss
@@ -1,42 +1,16 @@
 @import 'src/css/variables';
 
 .ontotext-dropdown {
-  background-color: $color-ontotext-orange;
-  display: inline-block;
 
   .ontotext-dropdown-button {
     font-size: 1.2em;
     font-weight: 400;
-    padding: 0.1em 0.5em;
-    margin: 10px 10px 12px;
+    padding-top: 14px;
+    padding-bottom: 16px;
     border: none;
     outline: none;
     color: $color-onto-white;
     background-color: $color-ontotext-orange;
-  }
-
-  .ontotext-dropdown-button.icon-caret-down-after:after, .ontotext-dropdown-button.icon-caret-up-after:after {
-    padding-left: 10px;
-    color: $color-onto-grey;
-  }
-
-  .ontotext-dropdown-menu-item {
-    font-size: 1.2em;
-    font-weight: 400;
-    padding: 0.2em 0.5em;
-    position: relative;
-    list-style: none;
-    color: $color-onto-white;
-    background-color: $color-ontotext-orange;
-  }
-
-  .ontotext-dropdown-menu-item:hover {
-    cursor: pointer;
-    background-color: $color-ontotext-orange-dark;
-  }
-
-  .ontotext-dropdown-button:hover {
-    cursor: pointer;
   }
 
   .ontotext-dropdown-menu {
@@ -46,7 +20,45 @@
     z-index: 1000;
   }
 
+  .ontotext-dropdown-menu-item {
+    display: block;
+    text-decoration: none;
+    font-size: 1.2em;
+    font-weight: 400;
+    padding: 0.2em 0.5em;
+    color: $color-onto-white;
+    background-color: $color-ontotext-orange;
+  }
+
+  .ontotext-dropdown-menu-item:hover {
+    text-decoration: none;
+    background-color: $color-ontotext-orange-dark;
+    color: #ffffff;
+  }
+
+  .ontotext-dropdown-icon:before {
+    padding-right: 5px;
+  }
+
+  .ontotext-dropdown-button.icon-caret-down-after:after, .ontotext-dropdown-button.icon-caret-up-after:after {
+    padding-left: 10px;
+    color: $color-onto-grey;
+  }
+
   .ontotext-dropdown-menu.closed {
     display: none;
+  }
+
+  .ontotext-dropdown-button:hover {
+    cursor: pointer;
+  }
+
+  @media (max-width: 768px) {
+    .ontotext-dropdown-button:after {
+      display: none;
+    }
+    .button-name {
+      display: none;
+    }
   }
 }

--- a/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
+++ b/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
@@ -11,10 +11,13 @@ import {InternalDropdownValueSelectedEvent} from '../../models/internal-events/i
 export class Dropdown {
 
   @State() open = false;
+  @State() showTooltip = false;
 
   @Prop() translationService: TranslationService;
   @Prop() nameLabelKey: string;
+  @Prop() tooltipLabelKey: string;
   @Prop() items: DropdownOption[];
+  @Prop() iconClass = '';
 
   @Event() valueChanged: EventEmitter<InternalDropdownValueSelectedEvent>;
 
@@ -28,20 +31,25 @@ export class Dropdown {
   }
 
   render() {
+    const showToolbar = this.tooltipLabelKey && window.innerWidth < 768;
+    const dropdownButtonClass = `ontotext-dropdown-button ${this.open ? 'icon-caret-up-after' : ' icon-caret-down-after'}
+    ${this.iconClass ? `ontotext-dropdown-icon ${this.iconClass}` : ''}`;
     return (
-      <div class="ontotext-dropdown">
-        <button class={`ontotext-dropdown-button ${this.open ? 'icon-caret-up-after' : ' icon-caret-down-after'}`}
-                onClick={() => this.toggleComponent()}>
-          {this.translationService.translate(this.nameLabelKey)}
-        </button>
-
-        <ul class={`ontotext-dropdown-menu ${this.open ? 'open' : 'closed'}`}>
-          {this.items && this.items.map(item =>
-            <li class='ontotext-dropdown-menu-item' onClick={() => this.onSelect(item.value)}>
-              {this.translationService.translate(item.labelKey)}
-            </li>)}
-        </ul>
-      </div>
+      <yasgui-tooltip
+        data-tooltip={showToolbar ? this.translationService.translate(this.nameLabelKey) : ''}>
+        <div class='ontotext-dropdown'>
+          <button class={dropdownButtonClass}
+                  onClick={() => this.toggleComponent()}>
+            <span class='button-name'>{this.translationService.translate(this.nameLabelKey)}</span>
+          </button>
+          <div class={`ontotext-dropdown-menu ${this.open ? 'open' : 'closed'}`}>
+            {this.items && this.items.map(item =>
+              <a href="#" class='ontotext-dropdown-menu-item' onClick={() => this.onSelect(item.value)}>
+                {this.translationService.translate(item.labelKey)}
+              </a>)}
+          </div>
+        </div>
+      </yasgui-tooltip>
     );
   }
 }

--- a/ontotext-yasgui-web-component/src/components/dropdown/readme.md
+++ b/ontotext-yasgui-web-component/src/components/dropdown/readme.md
@@ -7,11 +7,13 @@
 
 ## Properties
 
-| Property             | Attribute        | Description | Type                 | Default     |
-| -------------------- | ---------------- | ----------- | -------------------- | ----------- |
-| `items`              | --               |             | `DropdownOption[]`   | `undefined` |
-| `nameLabelKey`       | `name-label-key` |             | `string`             | `undefined` |
-| `translationService` | --               |             | `TranslationService` | `undefined` |
+| Property             | Attribute           | Description | Type                 | Default     |
+| -------------------- | ------------------- | ----------- | -------------------- | ----------- |
+| `iconClass`          | `icon-class`        |             | `string`             | `''`        |
+| `items`              | --                  |             | `DropdownOption[]`   | `undefined` |
+| `nameLabelKey`       | `name-label-key`    |             | `string`             | `undefined` |
+| `tooltipLabelKey`    | `tooltip-label-key` |             | `string`             | `undefined` |
+| `translationService` | --                  |             | `TranslationService` | `undefined` |
 
 
 ## Events
@@ -27,9 +29,14 @@
 
  - [ontotext-download-as](../download-as)
 
+### Depends on
+
+- [yasgui-tooltip](../ontotext-tooltip-web-component)
+
 ### Graph
 ```mermaid
 graph TD;
+  ontotext-dropdown --> yasgui-tooltip
   ontotext-download-as --> ontotext-dropdown
   style ontotext-dropdown fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
@@ -68,7 +68,11 @@ export class OntotextTooltipWebComponent {
   }
 
   private createShowFunction(tooltip: Instance) {
-    return () => tooltip.show();
+    return () => {
+      if (this.dataTooltip) {
+        tooltip.show();
+      }
+    }
   }
 
   private createHideFunction(tooltip: Instance) {

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/readme.md
@@ -18,12 +18,14 @@
 
 ### Used by
 
+ - [ontotext-dropdown](../dropdown)
  - [ontotext-yasgui](../ontotext-yasgui-web-component)
  - [save-query-dialog](../save-query-dialog)
 
 ### Graph
 ```mermaid
 graph TD;
+  ontotext-dropdown --> yasgui-tooltip
   ontotext-yasgui --> yasgui-tooltip
   save-query-dialog --> yasgui-tooltip
   style yasgui-tooltip fill:#f9f,stroke:#333,stroke-width:4px

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -294,7 +294,7 @@ export class OntotextYasguiWebComponent {
   }
 
   @Listen('resize', { target: 'window' })
-  handleScroll() {
+  onResize() {
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {
         ontotextYasgui.refresh();

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -293,6 +293,14 @@ export class OntotextYasguiWebComponent {
     });
   }
 
+  @Listen('resize', { target: 'window' })
+  handleScroll() {
+    this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        ontotextYasgui.refresh();
+      });
+  }
+
   /**
    * Handler for the event fired when the save query button in the yasqe toolbar is triggered.
    */

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -224,6 +224,7 @@ export const defaultExtendedTableConfiguration = {
 
 export const defaultRawResponsePluginConfiguration = {
   nameLabelKey: 'yasr.plugin_control.download_as.raw_response.dropdown.label',
+  tooltipLabelKey: "yasr.plugin_control.download_as.raw_response.dropdown.label",
   items: [
     {
       labelKey: "yasr.plugin_control.download_as.sparql_results_json.label",

--- a/yasgui-patches/2023-02-22-added_tooltip_to_plugins_tabs_buttons_.patch
+++ b/yasgui-patches/2023-02-22-added_tooltip_to_plugins_tabs_buttons_.patch
@@ -1,0 +1,74 @@
+Subject: [PATCH] Added tooltip to plugins tabs buttons.
+---
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 542cd147517cac965b943c757b6007b2958f00b5)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision e6094506a85c1f584abbc634b7d09f7acb08b023)
+@@ -78,6 +78,7 @@
+       if (downloadAsConfiguration.hasOwnProperty("nameLabelKey")) {
+         element.nameLabelKey = downloadAsConfiguration.nameLabelKey;
+       }
++      element.tooltipLabelKey = downloadAsConfiguration.tooltipLabelKey || downloadAsConfiguration.nameLabelKey;
+     } else {
+       element.items = [];
+     }
+@@ -272,6 +273,7 @@
+ interface DownloadAs {
+   translationService: TranslationService;
+   nameLabelKey: string;
++  tooltipLabelKey: string;
+   query: string | undefined;
+   pluginName: string;
+   items: any[];
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 542cd147517cac965b943c757b6007b2958f00b5)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision e6094506a85c1f584abbc634b7d09f7acb08b023)
+@@ -296,7 +296,6 @@
+       );
+       const button = document.createElement("button");
+       addClass(button, "yasr_btn", "select_" + pluginName);
+-      button.title = name;
+       button.type = "button";
+       button.setAttribute(
+         "aria-label",
+@@ -317,7 +316,11 @@
+       button.appendChild(nameEl);
+       button.addEventListener("click", () => this.selectPlugin(pluginName));
+       const li = document.createElement("li");
+-      li.appendChild(button);
++      const buttonPluginTooltip: any = document.createElement("yasgui-tooltip");
++      buttonPluginTooltip.dataTooltip = window.innerWidth < 768 ? name : "";
++      buttonPluginTooltip.placement = "top";
++      buttonPluginTooltip.appendChild(button);
++      li.appendChild(buttonPluginTooltip);
+       this.pluginSelectorsEl.appendChild(li);
+     }
+ 
+@@ -478,7 +481,6 @@
+           const name = this.translationService.translate(
+             `yasr.plugin_control.plugin.name.${plugin.label || pluginName}`.toLowerCase()
+           );
+-          button.setAttribute("title", name);
+           button.setAttribute(
+             "aria-label",
+             this.translationService.translate("yasr.plugin_control.shows_view.btn.aria_label", [
+@@ -489,6 +491,10 @@
+           if (nameEl) {
+             nameEl.innerText = name;
+           }
++          const buttonPluginTooltip = button.parentElement;
++          if (buttonPluginTooltip) {
++            (buttonPluginTooltip as any).dataTooltip = window.innerWidth < 768 ? name : "";
++          }
+         }
+       }
+     }


### PR DESCRIPTION
## What
Adds icon "download" to "Download as" dropdown. When screen is smaller than 768px only the icon will be visible. 

## Why
This will improve UX, and is consistent with plugin tabs names.

## How
"Dropdown" component hase improved to support icon. Changed the setup of "Dropdown" component in "Download as" with download icon.