### PR TITLE
GDB-7769 migrate yasqe defaults.js module

### DIFF
--- a/Yasgui/packages/yasqe/src/defaults.ts
+++ b/Yasgui/packages/yasqe/src/defaults.ts
@@ -45,6 +45,10 @@ SELECT * WHERE {
         const yasqe: Yasqe = _yasqe;
         yasqe.autocomplete();
       },
+      "Alt-Enter": function (_yasqe: any) {
+        const yasqe: Yasqe = _yasqe;
+        yasqe.autocomplete();
+      },
       "Shift-Ctrl-K": function (_yasqe: any) {
         const yasqe: Yasqe = _yasqe;
         const lineNumber = yasqe.getDoc().getCursor().line;

--- a/yasgui-patches/2023-02-24_3_migrate_yasqe_defaults_js_module.patch
+++ b/yasgui-patches/2023-02-24_3_migrate_yasqe_defaults_js_module.patch
@@ -1,0 +1,19 @@
+Index: Yasgui/packages/yasqe/src/defaults.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/defaults.ts b/Yasgui/packages/yasqe/src/defaults.ts
+--- a/Yasgui/packages/yasqe/src/defaults.ts	(revision b133c011540f19fea83e04b468a012409c57a436)
++++ b/Yasgui/packages/yasqe/src/defaults.ts	(revision 65a29b30b1121490a64d363cea7f73204027aa4b)
+@@ -45,6 +45,10 @@
+         const yasqe: Yasqe = _yasqe;
+         yasqe.autocomplete();
+       },
++      "Alt-Enter": function (_yasqe: any) {
++        const yasqe: Yasqe = _yasqe;
++        yasqe.autocomplete();
++      },
+       "Shift-Ctrl-K": function (_yasqe: any) {
+         const yasqe: Yasqe = _yasqe;
+         const lineNumber = yasqe.getDoc().getCursor().line;


### PR DESCRIPTION
## What
Migrated the yasqe defaults.js module from old yasqe

## Why
There is new hot-key combination added in the module which allows autocompleter to be triggered.

## How
* Registered the new hot-key combination.