### PR TITLE
GDB-7768 migrate autocomplete utils

### DIFF
--- a/ontotext-yasgui-web-component/src/pages/fake-server.js
+++ b/ontotext-yasgui-web-component/src/pages/fake-server.js
@@ -8,129 +8,155 @@ module.exports = function (req, res, next) {
   } else if (req.url.endsWith('/repositories/test-repo/namespaces')) {
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(namespacesResponse));
+  } else if (req.url === 'https://lov.linkeddata.es/dataset/lov/api/v2/autocomplete/terms?q=rdf&page_size=50&type=property') {
+    res.writeHead(200, {"Content-Type": "application/json"});
+    res.end(JSON.stringify(localNamesResponse));
   } else {
     // pass request on to the default dev server
     next();
   }
 };
 
+const localNamesResponse = {
+  "suggestions": [{
+    "type": "prefix",
+    "value": "rdf",
+    "description": "PREFIX <b>rdf</b>: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;"
+  }, {
+    "type": "prefix",
+    "value": "rdfs",
+    "description": "PREFIX <b>rdf</b>s: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;"
+  }, {
+    "type": "prefix",
+    "value": "rdf4j",
+    "description": "PREFIX <b>rdf</b>4j: &lt;http://rdf4j.org/schema/rdf4j#&gt;"
+  }, {
+    "type": "uri",
+    "value": "http://www.w3.org/ns/ldp#RDFSource",
+    "description": "http://www.w3.org/ns/ldp#<b>RDF</b>Source"
+  }, {
+    "type": "uri",
+    "value": "http://www.w3.org/ns/ldp#NonRDFSource",
+    "description": "http://www.w3.org/ns/ldp#Non<b>RDF</b>Source"
+  }]
+}
 const namespacesResponse = {
-  "head" : {
-    "vars" : [
+  "head": {
+    "vars": [
       "prefix",
       "namespace"
     ]
   },
-  "results" : {
-    "bindings" : [
+  "results": {
+    "bindings": [
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "path"
+        "prefix": {
+          "type": "literal",
+          "value": "path"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.ontotext.com/path#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.ontotext.com/path#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "wgs"
+        "prefix": {
+          "type": "literal",
+          "value": "wgs"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/2003/01/geo/wgs84_pos#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/2003/01/geo/wgs84_pos#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "rdf"
+        "prefix": {
+          "type": "literal",
+          "value": "rdf"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "owl"
+        "prefix": {
+          "type": "literal",
+          "value": "owl"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/2002/07/owl#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/2002/07/owl#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "gn"
+        "prefix": {
+          "type": "literal",
+          "value": "gn"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.geonames.org/ontology#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.geonames.org/ontology#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "xsd"
+        "prefix": {
+          "type": "literal",
+          "value": "xsd"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/2001/XMLSchema#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/2001/XMLSchema#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "fn"
+        "prefix": {
+          "type": "literal",
+          "value": "fn"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/2005/xpath-functions#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/2005/xpath-functions#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "rdfs"
+        "prefix": {
+          "type": "literal",
+          "value": "rdfs"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.w3.org/2000/01/rdf-schema#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "sesame"
+        "prefix": {
+          "type": "literal",
+          "value": "sesame"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://www.openrdf.org/schema/sesame#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://www.openrdf.org/schema/sesame#"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "dc"
+        "prefix": {
+          "type": "literal",
+          "value": "dc"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://purl.org/dc/elements/1.1/"
+        "namespace": {
+          "type": "literal",
+          "value": "http://purl.org/dc/elements/1.1/"
         }
       },
       {
-        "prefix" : {
-          "type" : "literal",
-          "value" : "rdf4j"
+        "prefix": {
+          "type": "literal",
+          "value": "rdf4j"
         },
-        "namespace" : {
-          "type" : "literal",
-          "value" : "http://rdf4j.org/schema/rdf4j#"
+        "namespace": {
+          "type": "literal",
+          "value": "http://rdf4j.org/schema/rdf4j#"
         }
       }
     ]
@@ -138,1077 +164,1077 @@ const namespacesResponse = {
 };
 
 const queryResponse = {
-  "head" : {
-    "vars" : [
+  "head": {
+    "vars": [
       "s",
       "p",
       "o"
     ]
   },
-  "results" : {
-    "bindings" : [
+  "results": {
+    "bindings": [
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#TransitiveProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#TransitiveProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#SymmetricProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#TransitiveProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#SymmetricProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#TransitiveProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#TransitiveProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "s": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#SymmetricProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#object"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#object"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#differentFrom"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#differentFrom"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#SymmetricProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#SymmetricProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#string"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#string"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/title"
+        "s": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/title"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/creator"
+        "s": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/creator"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "s": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "o": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#seeAlso"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#seeAlso"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/title"
+        "s": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/title"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/title"
+        "o": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/title"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/creator"
+        "s": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/creator"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/creator"
+        "o": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/creator"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Container"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Container"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Container"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Container"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Container"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Container"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#ContainerMembershipProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Literal"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Literal"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Datatype"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Datatype"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#string"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2001/XMLSchema#string"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2001/XMLSchema#string"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#object"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#object"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#domain"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#domain"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Class"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Class"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#List"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#comment"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#comment"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Literal"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Literal"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#label"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#label"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#range"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#range"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#Literal"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#Literal"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "p": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "p": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "p": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "p": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://proton.semanticweb.org/protonsys#transitiveOver"
+        "p": {
+          "type": "uri",
+          "value": "http://proton.semanticweb.org/protonsys#transitiveOver"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentProperty"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentProperty"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#equivalentClass"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#equivalentClass"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#differentFrom"
+        "s": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#differentFrom"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#inverseOf"
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#inverseOf"
         },
-        "o" : {
-          "type" : "uri",
-          "value" : "http://www.w3.org/2002/07/owl#differentFrom"
+        "o": {
+          "type": "uri",
+          "value": "http://www.w3.org/2002/07/owl#differentFrom"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://example/book1"
+        "s": {
+          "type": "uri",
+          "value": "http://example/book1"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/title"
+        "p": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/title"
         },
-        "o" : {
-          "type" : "literal",
-          "value" : "A new book"
+        "o": {
+          "type": "literal",
+          "value": "A new book"
         }
       },
       {
-        "s" : {
-          "type" : "uri",
-          "value" : "http://example/book1"
+        "s": {
+          "type": "uri",
+          "value": "http://example/book1"
         },
-        "p" : {
-          "type" : "uri",
-          "value" : "http://purl.org/dc/elements/1.1/creator"
+        "p": {
+          "type": "uri",
+          "value": "http://purl.org/dc/elements/1.1/creator"
         },
-        "o" : {
-          "type" : "literal",
-          "value" : "A.N.Other"
+        "o": {
+          "type": "literal",
+          "value": "A.N.Other"
         }
       }
     ]

--- a/yasgui-patches/2023-02-27_migrated_the_autocomplete_utils_functions.patch
+++ b/yasgui-patches/2023-02-27_migrated_the_autocomplete_utils_functions.patch
@@ -1,0 +1,40 @@
+Index: Yasgui/packages/yasqe/src/autocompleters/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/autocompleters/index.ts b/Yasgui/packages/yasqe/src/autocompleters/index.ts
+--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision f50c900b9aebfc29fe7ea8ce8074f664f0305195)
++++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision d467ffe95b00687fb46c2c204088ef1a4cf4652e)
+@@ -289,13 +289,28 @@
+   return token;
+ }
+ 
+-export function postprocessIriCompletion(_yasqe: Yasqe, token: AutocompletionToken, suggestedString: string) {
++export function postprocessIriCompletion(yasqe: Yasqe, token: AutocompletionToken, suggestedString: string) {
+   if (token.tokenPrefix && token.autocompletionString && token.tokenPrefixUri) {
+     // we need to get the suggested string back to prefixed form
+     suggestedString = token.tokenPrefix + suggestedString.substring(token.tokenPrefixUri.length);
+   } else {
+-    // it is a regular uri. add '<' and '>' to string
+-    suggestedString = "<" + suggestedString + ">";
++      // it is a regular uri. add '<' and '>' to string
++      const queryPrefixes = yasqe.getPrefixesFromQuery();
++      const existingPrefix = Object.values(queryPrefixes).filter((prefix) => suggestedString.startsWith(prefix));
++      if (existingPrefix.length > 0) {
++          const prefixFound = Object.keys(queryPrefixes).find((key) => existingPrefix[0] === key)!;
++          suggestedString = prefixFound + ":" + suggestedString.substring(queryPrefixes[prefixFound].length);
++      } else {
++          // Do not put brackets to prefixes
++          if (suggestedString.indexOf("<b>" + token.string) === 0) {
++              return suggestedString;
++          }
++          // Do not put brackets on nested triples
++          if (suggestedString.startsWith("<<") && suggestedString.endsWith(">>")) {
++              return suggestedString;
++          }
++          suggestedString = "<" + suggestedString + ">";
++      }
+   }
+   return suggestedString;
+ }


### PR DESCRIPTION
## What
Migrated the autocomplete utils functions.

## Why
Changes in these utility functions affect all autocompleters in the yasqe.

## How
In the latest yasgui these autocomplete utils are moved in the yasqe index.ts. Most of the changes there are related with wrapping the tripples in the query with brackets. Also the code was refactored to not depend on jquery or lodash as it was in the old version.

Add additional endpoint handling in the fake server