### PR TITLE
GDB-7709 move sesame-prefixes autocompleter in yasqe

### DIFF
--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts
@@ -363,6 +363,7 @@ export const fetchFromLov = (
 import variableCompleter from "./variables";
 // Replaced by our sesame-prefixes completer
 // import prefixCompleter from "./prefixes";
+import sesamePrefixes from "./sesame-prefixes";
 import propertyCompleter from "./properties";
 import classCompleter from "./classes";
-export var completers: CompleterConfig[] = [variableCompleter, propertyCompleter, classCompleter];
+export var completers: CompleterConfig[] = [variableCompleter, sesamePrefixes, propertyCompleter, classCompleter];

--- a/Yasgui/packages/yasqe/src/autocompleters/sesame-prefixes.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/sesame-prefixes.ts
@@ -1,0 +1,104 @@
+import * as Autocompleter from "./";
+
+const tokenTypes: { [id: string]: "prefixed" | "var" } = {
+    "string-2": "prefixed",
+    "atom": "var"
+};
+
+const conf: Autocompleter.CompleterConfig = {
+    onInitialize: function (yasqe) {
+        /**
+         * This event listener makes sure we auto-add prefixes whenever we use them
+         */
+        yasqe.on("change", () => {
+            //this autocompleter is disabled
+            if (!yasqe.config.autocompleters || yasqe.config.autocompleters.indexOf(this.name) == -1) return;
+
+            const cur = yasqe.getDoc().getCursor();
+            const token = yasqe.getTokenAt(cur);
+            if (token.type && tokenTypes[token.type] === "prefixed") {
+                const colonIndex = token.string.indexOf(":");
+                if (colonIndex !== -1) {
+                    // check previous token isn't PREFIX, or a '<'(which would mean we are in a uri)
+                    // let firstTokenString = yasqe.getNextNonWsToken(cur.line).string.toUpperCase();
+                    const lastNonWsTokenString = yasqe.getPreviousNonWsToken(cur.line, token).string.toUpperCase();
+                    const previousToken = yasqe.getTokenAt({
+                        line: cur.line,
+                        ch: token.start
+                    }); // needs to be null (beginning of line), or whitespace
+
+                    if (lastNonWsTokenString !== "PREFIX" && (previousToken.type === "ws" || previousToken.type === null)) {
+                        // check whether it isn't defined already (saves us from looping through the array)
+                        const currentPrefix = token.string.substring(0, colonIndex + 1);
+                        const queryPrefixes = yasqe.getPrefixesFromQuery();
+                        if (queryPrefixes[currentPrefix.slice(0, -1)] === undefined) {
+                            // ok, so it isn't added yet!
+                            yasqe.autocompleters[this.name]?.getCompletions(token).then((suggestions) => {
+                                if (suggestions.length) {
+                                    yasqe.addPrefixes(suggestions[0]);
+                                    // Re-activate auto-completer after adding prefixes, so another auto-completer can kick in
+                                    yasqe.autocomplete();
+                                }
+                            }, console.warn);
+                        }
+                    }
+                }
+            }
+        });
+    },
+    isValidCompletionPosition: function (yasqe) {
+        const cur = yasqe.getDoc().getCursor();
+        let token = yasqe.getTokenAt(cur);
+
+        // not at end of line
+        const line = yasqe.getDoc().getLine(cur.line);
+        if (line.length > cur.ch) {
+            return false;
+        }
+
+        if (token.type !== "ws") {
+            // we want to complete token, e.g. when the prefix starts with an a
+            // (treated as a token in itself..)
+            // but we to avoid including the PREFIX tag. So when we have just
+            // typed a space after the prefix tag, don't get the complete token
+            token = yasqe.getCompleteToken();
+        }
+
+        // we shouldn't be at the uri part the prefix declaration
+        // also check whether current token isn't 'a' (that makes codemirror
+        // thing a namespace is a possible current
+        if (token.string.indexOf("a") === 0 && token.state.possibleCurrent.indexOf("PNAME_NS") < 0) {
+            return false;
+        }
+
+        // First token of line needs to be PREFIX,
+        // there should be no trailing text (otherwise, text is wrongly inserted in between)
+        const previousToken = yasqe.getPreviousNonWsToken(cur.line, token);
+        const isPrefixToken = previousToken.string.toUpperCase() !== "PREFIX";
+        return !(!previousToken || isPrefixToken);
+    },
+    get: function (yasqe) {
+        const prefixes: string[] = yasqe.config.prefixes;
+        return Promise.resolve(prefixes);
+    },
+    preProcessToken: function (yasqe, token) {
+        const previousToken = yasqe.getPreviousNonWsToken(yasqe.getDoc().getCursor().line, token);
+        if (previousToken && previousToken.string && previousToken.string.slice(-1) === ":") {
+            //combine both tokens! In this case we have the cursor at the end of line "PREFIX bla: <".
+            //we want the token to be "bla: <", en not "<"
+            token = {
+                start: previousToken.start,
+                end: token.end,
+                string: previousToken.string + " " + token.string,
+                state: token.state,
+                type: token.type
+            };
+        }
+        return token;
+    },
+    bulk: true,
+    autoShow: true,
+    name: "sesame-prefixes",
+}
+
+export default conf;

--- a/Yasgui/packages/yasqe/src/defaults.ts
+++ b/Yasgui/packages/yasqe/src/defaults.ts
@@ -138,6 +138,7 @@ SELECT * WHERE {
     editorHeight: "300px",
     queryingDisabled: undefined,
     prefixCcApi: prefixCcApi,
+    prefixes: []
   };
   const requestConfig: PlainRequestConfig = {
     queryArgument: undefined, //undefined means: get query argument based on query mode

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -1118,6 +1118,7 @@ export interface Config extends Partial<CodeMirror.EditorConfiguration> {
   editorHeight: string;
   queryingDisabled: string | undefined; // The string will be the message displayed when hovered
   prefixCcApi: string; // the suggested default prefixes URL API getter
+  prefixes: string[];
   translationService: TranslationService;
   infer?: boolean;
   sameAs?: boolean;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -99,6 +99,8 @@ export interface YasguiConfiguration {
       createShareableLink?: (yasqe: any) => string | null;
 
       showQueryButton?: boolean;
+
+      prefixes: string[];
     }
     yasr: {
       /**

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -12,7 +12,6 @@ import {YasqeService} from "../../yasqe/yasqe-service";
 import {ServiceFactory} from '../../service-factory';
 import {TranslationService} from '../../translation.service';
 import {YasrService} from '../../yasr/yasr-service';
-import SesamePrefixesAutocompleter from "../../yasqe/autocompleter/sesame-prefixes";
 import {NamespaceService} from "../../namespace-service";
 
 /**
@@ -52,7 +51,9 @@ export class YasguiConfigurationBuilder {
       requestConfig: {},
       paginationOn: externalConfiguration.paginationOn !== undefined ? externalConfiguration.paginationOn : defaultYasguiConfig.paginationOn,
       pageSize: externalConfiguration.pageSize !== undefined ? externalConfiguration.pageSize : defaultYasguiConfig.pageSize,
-      yasqe: {},
+      yasqe: {
+        prefixes: []
+      },
       yasr: {
         prefixes: {},
         defaultPlugin: '',
@@ -79,6 +80,7 @@ export class YasguiConfigurationBuilder {
 
     // prepare the yasqe config
     config.yasguiConfig.yasqe.value = externalConfiguration.query || defaultYasqeConfig.query;
+    config.yasguiConfig.yasqe.prefixes = NamespaceService.namespacesMapToArray(config.yasguiConfig.yasr.prefixes);
     config.yasqeConfig = {};
     config.yasqeConfig.initialQuery = externalConfiguration.initialQuery || defaultYasqeConfig.initialQuery;
     config.yasguiConfig.yasqe.createShareableLink = externalConfiguration.createShareableLink || defaultYasqeConfig.createShareableLink;
@@ -95,21 +97,10 @@ export class YasguiConfigurationBuilder {
 
     YasrService.disablePlugin('table');
 
-    // Register autocompleters
-    this.registerCustomAutocompleters(config);
-
     // prepare the yasr config
 
     return config;
   }
-
-  // @ts-ignore
-  private registerCustomAutocompleters(config: YasguiConfiguration): void {
-    const namespaces = NamespaceService.namespacesMapToArray(config.yasguiConfig.yasr.prefixes);
-    // @ts-ignore
-    Yasqe.registerAutocompleter(SesamePrefixesAutocompleter(namespaces), true);
-  }
-
 
   // @ts-ignore
   getYasqeActionButtons(yasguiConfiguration: YasguiConfiguration, defaultYasqeConfig: Record<string, any>, yasqe: Yasqe): HTMLElement[] {


### PR DESCRIPTION
## What
Moved the sesame-autocompleter in yasqe.

## Why
This was needed because we had troubles compiling and running the ontotext-yasgui component when we imported whatever from the yasgui. This enforced us to move our addons in their codebase in order to be able to reuse their api functions properly without duplicating them on our side.

## How
Just moved the autocompleter implementation and registered it.