### PR TITLE
GDB-8007 introduce sparql functions autocompleter

### DIFF
--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts
@@ -364,6 +364,7 @@ import variableCompleter from "./variables";
 // Replaced by our sesame-prefixes completer
 // import prefixCompleter from "./prefixes";
 import sesamePrefixes from "./sesame-prefixes";
+import sparqlFunctions from "./sparql-functions";
 import propertyCompleter from "./properties";
 import classCompleter from "./classes";
-export var completers: CompleterConfig[] = [variableCompleter, sesamePrefixes, propertyCompleter, classCompleter];
+export var completers: CompleterConfig[] = [variableCompleter, sesamePrefixes, sparqlFunctions, propertyCompleter, classCompleter];

--- a/Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts
@@ -1,0 +1,33 @@
+import * as Autocompleter from "./";
+
+//Taken from http://www.w3.org/TR/sparql11-query/#grammar BuiltInCall
+const functions = ['COUNT', 'SUM', 'MIN', 'MAX', 'AVG', 'SAMPLE', 'STR', 'LANG', 'LANGMATCHES', 'DATATYPE', 'BOUND', 'IRI', 'URI',
+  'BNODE', 'RAND', 'ABS', 'CEIL', 'FLOOR', 'ROUND', 'CONCAT', 'SUBSTR', 'STRLEN', 'REPLACE', 'UCASE', 'LCASE', 'ENCODE_FOR_URI',
+  'CONTAINS', 'STRSTARTS', 'STRENDS', 'STRBEFORE', 'STRAFTER', 'YEAR', 'MONTH', 'DAY', 'HOURS', 'MINUTES', 'SECONDS', 'TIMEZONE',
+  'TZ', 'NOW', 'UUID', 'STRUUID', 'MD5', 'SHA1', 'SHA256', 'SHA384', 'SHA512', 'COALESCE', 'IF', 'STRLANG', 'STRDT', 'sameTerm',
+  'isIRI', 'isURI', 'isBLANK', 'isLITERAL', 'isNUMERIC', 'REGEX', 'EXISTS', 'FILTER'
+];
+
+const conf: Autocompleter.CompleterConfig = {
+    isValidCompletionPosition: function (yasqe) {
+        let token = yasqe.getTokenAt(yasqe.getCursor());
+        if (token.type !== "ws") {
+            token = yasqe.getCompleteToken();
+            if (token.string.length > 1) {
+                return true;
+            }
+        }
+        return false;
+    },
+    get: function (_yasqe, token) {
+        const lowercaseToken = token?.string.toLowerCase() || '';
+        const res = functions.filter((func) => func.toLowerCase().indexOf(lowercaseToken) === 0)
+            .map((func) => `${func}(`)
+            .sort();
+        return Promise.resolve(res);
+    },
+    bulk: false,
+    autoShow: true,
+    name: "sparql-functions"
+};
+export default conf;

--- a/yasgui-patches/2023-03-08_1-introduce_sparql_functions_autocompleter.patch
+++ b/yasgui-patches/2023-03-08_1-introduce_sparql_functions_autocompleter.patch
@@ -1,0 +1,60 @@
+Index: Yasgui/packages/yasqe/src/autocompleters/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/autocompleters/index.ts b/Yasgui/packages/yasqe/src/autocompleters/index.ts
+--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision e50b2ecd21afdce2a90579401fa31706f2d6c87e)
++++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision 1abfa6703d86c05ca05dab61f2ade39ad4046b8d)
+@@ -364,6 +364,7 @@
+ // Replaced by our sesame-prefixes completer
+ // import prefixCompleter from "./prefixes";
+ import sesamePrefixes from "./sesame-prefixes";
++import sparqlFunctions from "./sparql-functions";
+ import propertyCompleter from "./properties";
+ import classCompleter from "./classes";
+-export var completers: CompleterConfig[] = [variableCompleter, sesamePrefixes, propertyCompleter, classCompleter];
++export var completers: CompleterConfig[] = [variableCompleter, sesamePrefixes, sparqlFunctions, propertyCompleter, classCompleter];
+Index: Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts b/Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts
+new file mode 100644
+--- /dev/null	(revision 1abfa6703d86c05ca05dab61f2ade39ad4046b8d)
++++ b/Yasgui/packages/yasqe/src/autocompleters/sparql-functions.ts	(revision 1abfa6703d86c05ca05dab61f2ade39ad4046b8d)
+@@ -0,0 +1,33 @@
++import * as Autocompleter from "./";
++
++//Taken from http://www.w3.org/TR/sparql11-query/#grammar BuiltInCall
++const functions = ['COUNT', 'SUM', 'MIN', 'MAX', 'AVG', 'SAMPLE', 'STR', 'LANG', 'LANGMATCHES', 'DATATYPE', 'BOUND', 'IRI', 'URI',
++  'BNODE', 'RAND', 'ABS', 'CEIL', 'FLOOR', 'ROUND', 'CONCAT', 'SUBSTR', 'STRLEN', 'REPLACE', 'UCASE', 'LCASE', 'ENCODE_FOR_URI',
++  'CONTAINS', 'STRSTARTS', 'STRENDS', 'STRBEFORE', 'STRAFTER', 'YEAR', 'MONTH', 'DAY', 'HOURS', 'MINUTES', 'SECONDS', 'TIMEZONE',
++  'TZ', 'NOW', 'UUID', 'STRUUID', 'MD5', 'SHA1', 'SHA256', 'SHA384', 'SHA512', 'COALESCE', 'IF', 'STRLANG', 'STRDT', 'sameTerm',
++  'isIRI', 'isURI', 'isBLANK', 'isLITERAL', 'isNUMERIC', 'REGEX', 'EXISTS', 'FILTER'
++];
++
++const conf: Autocompleter.CompleterConfig = {
++    isValidCompletionPosition: function (yasqe) {
++        let token = yasqe.getTokenAt(yasqe.getCursor());
++        if (token.type !== "ws") {
++            token = yasqe.getCompleteToken();
++            if (token.string.length > 1) {
++                return true;
++            }
++        }
++        return false;
++    },
++    get: function (_yasqe, token) {
++        const lowercaseToken = token?.string.toLowerCase() || '';
++        const res = functions.filter((func) => func.toLowerCase().indexOf(lowercaseToken) === 0)
++            .map((func) => `${func}(`)
++            .sort();
++        return Promise.resolve(res);
++    },
++    bulk: false,
++    autoShow: true,
++    name: "sparql-functions"
++};
++export default conf;


### PR DESCRIPTION
## What
Introduced sparql functions autocomplete addon

## Why
This is a handy feature existing in current version of the WB where there is an autocomplete for standard sparql functions.

## How
Migrated the standard.js autocomplete and registered as sparql-functions in yasqe.