### PR TITLE
GDB-8020: stop execution of query

### DIFF
--- a/Yasgui/packages/yasqe/src/defaults.ts
+++ b/Yasgui/packages/yasqe/src/defaults.ts
@@ -15,6 +15,7 @@ export default function get() {
   const config: Omit<Config, "requestConfig"> = {
     translationService: TranslationService.INSTANCE,
     notificationMessageService: NotificationMessageService.INSTANCE,
+    isVirtualRepository: false,
     mode: "sparql11",
     value: `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -217,7 +217,12 @@ export class ExtendedYasr extends Yasr {
       if (yasqe) {
         yasqe.setPageNumber(page.pageNumber || 1);
         yasqe.setPageSize(page.pageSize || 10);
-        yasqe.query();
+        yasqe
+          .query()
+          .then()
+          .catch(() => {
+            // catch this to avoid unhandled rejection
+          });
       }
     };
   }

--- a/cypress/e2e/editor-actions/execute-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/execute-query.spec.cy.ts
@@ -36,7 +36,12 @@ describe('Execute query action', () => {
     ActionsPageSteps.getEventLog().should('have.value', '\n"select * where {  \\n ?s ?p ?o . \\n } limit 100"');
   });
 
-  it('should not run explain plan query for update query ', () => {
+  it('should not run explain plan query for update query ', {
+    retries: {
+      runMode: 1,
+      openMode: 0
+    }
+  }, () => {
     // When I visit a page with "ontotext-yasgui-web-component" in it,
     KeyboardShortcutPageSteps.visit();
     // and write an update query,

--- a/cypress/e2e/editor-actions/execute-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/execute-query.spec.cy.ts
@@ -3,13 +3,15 @@ import {YasrSteps} from "../../steps/yasr-steps";
 import {QueryStubDescription, QueryStubs} from "../../stubs/query-stubs";
 import ActionsPageSteps from "../../steps/actions-page-steps";
 import {YasguiSteps} from "../../steps/yasgui-steps";
+import {KeyboardShortcutSteps} from '../../steps/keyboard-shortcut-steps';
+import {KeyboardShortcutPageSteps} from '../../steps/pages/keyboard-shortcut-page-steps';
 
 describe('Execute query action', () => {
   beforeEach(() => {
     QueryStubs.stubQueryResults(new QueryStubDescription().setPageSize(10).setTotalElements(6));
   });
 
-  it.only('Should be able to execute a query', () => {
+  it('Should be able to execute a query', () => {
     ActionsPageSteps.visit();
     YasqeSteps.getExecuteQueryButtonTooltip().should('have.attr', 'data-tooltip', 'Run query');
     YasqeSteps.getExecuteQueryButton().should('be.visible');
@@ -21,7 +23,7 @@ describe('Execute query action', () => {
     QueryStubs.stubDefaultQueryResponse(2000);
     ActionsPageSteps.visit();
     YasqeSteps.executeQuery();
-    YasrSteps.getResults().should('have.length', 6);
+    YasqeSteps.getTabWithProgressBar().should('exist');
   });
 
   it('Should emit queryExecuted event on each editor tab', () => {
@@ -32,5 +34,48 @@ describe('Execute query action', () => {
     ActionsPageSteps.clearEventLog();
     YasqeSteps.executeQuery(1);
     ActionsPageSteps.getEventLog().should('have.value', '\n"select * where {  \\n ?s ?p ?o . \\n } limit 100"');
+  });
+
+  it('should not run explain plan query for update query ', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    KeyboardShortcutPageSteps.visit();
+    // and write an update query,
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("INSERT DATA { ontogen:name rdf:label \"Test name\"");
+    // and execute explain plan query.
+    KeyboardShortcutSteps.clickOnExplainPlanQueryShortcut();
+
+    // Then I expect the query don't run,
+    YasrSteps.getResultsTable().should('not.exist');
+    // and a notification message to be emitted.
+    KeyboardShortcutPageSteps.getActionOutputField().should('have.value', '{"code":"explain_not_allowed","messageType":"warning","message":"Explain only works with SELECT or CONSTRUCT queries."}');
+  });
+
+  it('should not run explain plan query when repository is virtual.', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    KeyboardShortcutPageSteps.visit();
+    // and repository is virtual
+    KeyboardShortcutPageSteps.setVirtualRepository();
+    // and execute explain plan query.
+    KeyboardShortcutSteps.clickOnExplainPlanQueryShortcut();
+
+    // Then I expect the query don't run,
+    YasrSteps.getResultsTable().should('not.exist');
+    // and a notification message to be emitted.
+    KeyboardShortcutPageSteps.getActionOutputField().should('have.value', '{"code":"explain_not_allowed","messageType":"warning","message":"Explain not supported for Virtual repositories."}');
+  });
+
+  it('should not run update query when repository is virtual.', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    KeyboardShortcutPageSteps.visit();
+    KeyboardShortcutPageSteps.setVirtualRepository();
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("INSERT DATA { ontogen:name rdf:label \"Test name\"");
+    YasqeSteps.executeQuery();
+
+    // Then I expect the query don't run,
+    YasrSteps.getResultsTable().should('not.exist');
+    // and a notification message to be emitted.
+    KeyboardShortcutPageSteps.getActionOutputField().should('have.value', '{"code":"explain_not_allowed","messageType":"warning","message":"Updates are not supported for Virtual repositories."}');
   });
 });

--- a/cypress/e2e/yasr/plugin-table.spec.cy.ts
+++ b/cypress/e2e/yasr/plugin-table.spec.cy.ts
@@ -81,7 +81,12 @@ describe('Plugin: Table', () => {
         YasrTablePluginSteps.getQueryResultInfo().contains(/No results\. Query took \d{1}\.\d{1}s, moments ago\./);
       });
 
-      it('should show correct message when results are less than one page', () => {
+      it('should show correct message when results are less than one page', {
+        retries: {
+          runMode: 1,
+          openMode: 0
+        }
+      }, () => {
         // When I visit a page with "ontotext-yasgui" in it,
         // and execute a query which returns results less than one Page.
         const queryDescription = new QueryStubDescription()

--- a/cypress/steps/keyboard-shortcut-steps.ts
+++ b/cypress/steps/keyboard-shortcut-steps.ts
@@ -93,10 +93,6 @@ export class KeyboardShortcutSteps {
     KeyboardShortcutSteps.clickOn('t');
   }
 
-  static getActionOutputField() {
-    return cy.get('actionOutputField');
-  }
-
   static clickOnDeleteCurrentLineShortcut() {
     cy.get('body').type('{ctrl+k}');
   }

--- a/cypress/steps/pages/keyboard-shortcut-page-steps.ts
+++ b/cypress/steps/pages/keyboard-shortcut-page-steps.ts
@@ -2,4 +2,12 @@ export class KeyboardShortcutPageSteps {
   static visit() {
     cy.visit('/pages/keyboard-shortcuts');
   }
+
+  static getActionOutputField() {
+    return cy.get('#actionOutputField');
+  }
+
+  static setVirtualRepository() {
+    cy.get('#setVirtualRepo').realClick();
+  }
 }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -11,6 +11,10 @@ export class YasqeSteps {
     return YasqeSteps.getQueryTabs().find('.tab');
   }
 
+  static getTabWithProgressBar() {
+    return cy.get('.tab.active.querying');
+  }
+
   static getEditor() {
     return cy.get(".yasqe:visible");
   }

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -11,6 +11,10 @@ export class YasrSteps {
     return cy.get('.errorHeader');
   }
 
+  static getResultsTable() {
+    return YasrSteps.getYasr().find('.yasr_results tbody');
+  }
+
   static getResults() {
     return cy.get('.yasr_results tbody').find('tr');
   }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -165,5 +165,7 @@
   "yasqe.share.copy_link.dialog.copy.btn.label": "Copy to clipboard",
   "yasqe.share.copy_link.dialog.copy.btn.title": "Copy to clipboard",
   "yasqe.share.copy_link.dialog.copy.message.success": "URL copied successfully to clipboard.",
-  "yasqe.share.saved_query.dialog.copy.btn.label": "Copy to clipboard"
+  "yasqe.share.saved_query.dialog.copy.btn.label": "Copy to clipboard",
+  "yasqe.update_query.virtual_repository.error.message": "Updates are not supported for Virtual repositories.",
+  "yasqe.explain_query.virtual_repository.error.message": "Explain not supported for Virtual repositories."
 }

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -165,5 +165,7 @@
   "yasqe.share.copy_link.dialog.copy.btn.label": "Copier dans le presse-papiers",
   "yasqe.share.copy_link.dialog.copy.btn.title": "Copier l'URL dans le presse-papiers",
   "yasqe.share.copy_link.dialog.copy.message.success": "URL copied successfully to clipboard.",
-  "yasqe.share.saved_query.dialog.copy.btn.label": "Copy to clipboard"
+  "yasqe.share.saved_query.dialog.copy.btn.label": "Copy to clipboard",
+  "yasqe.update_query.virtual_repository.error.message": "Les mises à jour ne sont pas prises en charge pour les dépôts virtuels.",
+  "yasqe.explain_query.virtual_repository.error.message": "Explain n'est pas pris en charge pour les dépôts virtuels."
 }

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -212,6 +212,12 @@ export interface ExternalYasguiConfiguration {
    * Registered yasqe autocomplete handlers. Every handler is mapped by its name.
    */
   yasqeAutocomplete?: Record<string, AutocompleteLoader>;
+
+  /**
+   * Flag that controls update operations. If this flag is set to true, then all update operations will be disabled.
+   * For virtual repositories only select queries are allowed.
+   */
+  isVirtualRepository?: boolean;
 }
 
 export type AutocompleteLoader = () => any;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -131,7 +131,13 @@ export interface YasguiConfiguration {
       /**
        * Array with keyboard shortcut names {@link KeyboardShortcutName}.
        */
-      keyboardShortcutDescriptions: string[]
+      keyboardShortcutDescriptions: string[],
+
+      /**
+       * Flag that controls update operations. If this flag is set to true, then all update operations will be disabled.
+       * For virtual repositories only select queries are allowed.
+       */
+      isVirtualRepository: boolean;
     }
     yasr: {
       /**
@@ -246,7 +252,8 @@ export const defaultYasqeConfig: Record<string, any> = {
   ],
   prefixes: {
 
-  }
+  },
+  isVirtualRepository: false
 }
 
 export const defaultYasrConfig: Record<string, any> = {

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -150,9 +150,11 @@ function openNewQueryAction() {
   });
 }
 
-ontoElement.addEventListener("queryExecuted", (data) => {
-  console.log('%cqueryexecuted', 'background-color:red', data);
-  eventLog.value = eventLog.value + '\n' + JSON.stringify(data.detail.query);
+ontoElement.addEventListener("output", (evt) => {
+  console.log('%cqueryexecuted', 'background-color:red', evt);
+  if ("query" === evt.detail.TYPE) {
+    eventLog.value = eventLog.value + '\n' + JSON.stringify(evt.detail.payload.query);
+  }
 });
 
 ontoElement.addEventListener('queryResponse', (data) => {

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -151,7 +151,6 @@ function openNewQueryAction() {
 }
 
 ontoElement.addEventListener("output", (evt) => {
-  console.log('%cqueryexecuted', 'background-color:red', evt);
   if ("query" === evt.detail.TYPE) {
     eventLog.value = eventLog.value + '\n' + JSON.stringify(evt.detail.payload.query);
   }

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
@@ -11,6 +11,8 @@
     <script src="./keyboard-shortcuts/main.js" defer></script>
   </head>
   <body>
+  <button id="setVirtualRepo" onclick="setVirtualRepository()">Set Virtual Repository</button>
+  <hr>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
 
   <input id="actionOutputField">

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
@@ -1,1 +1,12 @@
 let ontoElement = getOntotextYasgui();
+
+ontoElement.addEventListener('output', (evt) => {
+  console.log(evt);
+  if ('notificationMessage' === evt.detail.TYPE) {
+    document.getElementById('actionOutputField').value = JSON.stringify(evt.detail.payload);
+  }
+});
+
+function setVirtualRepository() {
+  ontoElement.config = {... ontoElement.config, isVirtualRepository: true}
+}

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
@@ -1,7 +1,6 @@
 let ontoElement = getOntotextYasgui();
 
 ontoElement.addEventListener('output', (evt) => {
-  console.log(evt);
   if ('notificationMessage' === evt.detail.TYPE) {
     document.getElementById('actionOutputField').value = JSON.stringify(evt.detail.payload);
   }

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -107,7 +107,7 @@ export class KeyboardShortcutService {
         return;
       }
 
-      yasqe.getDoc().replaceRange(line + "\n" + currentLine, { ch: 0, line: cursor.line }, { ch: line.length, line: cursor.line });
+      yasqe.getDoc().replaceRange(line + "\n" + currentLine, {ch: 0, line: cursor.line}, {ch: line.length, line: cursor.line});
       // Sets cursor in same position.
       cursor = yasqe.getCursor();
       cursor.ch = cursorLinePosition;
@@ -159,7 +159,9 @@ export class KeyboardShortcutService {
     keyboardShortcut.keyboardShortcuts.push('Cmd-Enter');
     //@ts-ignore
     keyboardShortcut.executeFunction = (yasqe: Yasqe) => {
-      yasqe.query().then().catch();
+      yasqe.query().then().catch(() => {
+        // catch this to avoid unhandled rejection
+      });
     };
     return keyboardShortcut;
   }
@@ -171,7 +173,9 @@ export class KeyboardShortcutService {
     keyboardShortcut.keyboardShortcuts.push('Shift-Cmd-Enter');
     //@ts-ignore
     keyboardShortcut.executeFunction = (yasqe: Yasqe) => {
-      yasqe.query(undefined, true).catch();
+      yasqe.query(undefined, true).catch(() => {
+        // catch this to avoid unhandled rejection
+      });
     };
     return keyboardShortcut;
   }
@@ -183,7 +187,7 @@ export class KeyboardShortcutService {
     keyboardShortcut.keyboardShortcuts.push('Cmd-Alt-T');
     //@ts-ignore
     keyboardShortcut.executeFunction = (yasqe: Yasqe) => {
-     yasqe.emit('openNewTab');
+      yasqe.emit('openNewTab');
     };
     return keyboardShortcut;
   }

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -65,7 +65,8 @@ export class YasguiConfigurationBuilder {
       yasqe: {
         prefixes: [],
         extraKeys: {},
-        keyboardShortcutDescriptions: []
+        keyboardShortcutDescriptions: [],
+        isVirtualRepository: externalConfiguration.isVirtualRepository !== undefined ? externalConfiguration.isVirtualRepository : defaultYasqeConfig.isVirtualRepository
       },
       yasr: {
         prefixes: {},
@@ -120,8 +121,11 @@ export class YasguiConfigurationBuilder {
   }
 
   private registerCustomAutocompleters(config: YasguiConfiguration): void {
-    // @ts-ignore
-    Yasqe.registerAutocompleter(LocalNamesAutocompleter(config.yasqeAutocomplete['LocalNamesAutocompleter']), true);
+    const localNamesLoader = config.yasqeAutocomplete['LocalNamesAutocompleter'];
+    if ('function' === typeof localNamesLoader) {
+      // @ts-ignore
+      Yasqe.registerAutocompleter(LocalNamesAutocompleter(localNamesLoader), true);
+    }
   }
 
   private initShortcuts(config: YasguiConfiguration): void {

--- a/yasgui-patches/2023-03-22-stop_execution_of_query.patch
+++ b/yasgui-patches/2023-03-22-stop_execution_of_query.patch
@@ -1,0 +1,108 @@
+Subject: [PATCH] GDB-8020: stop execution of query
+---
+Index: Yasgui/packages/yasqe/src/defaults.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/defaults.ts b/Yasgui/packages/yasqe/src/defaults.ts
+--- a/Yasgui/packages/yasqe/src/defaults.ts	(revision f537e9daa8fcc0b5498553a04827fafb96cd08fe)
++++ b/Yasgui/packages/yasqe/src/defaults.ts	(revision e273fb8062f4dbbe588acf6a97001ce4aaf1e332)
+@@ -15,6 +15,7 @@
+   const config: Omit<Config, "requestConfig"> = {
+     translationService: TranslationService.INSTANCE,
+     notificationMessageService: NotificationMessageService.INSTANCE,
++    isVirtualRepository: false,
+     mode: "sparql11",
+     value: `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision f537e9daa8fcc0b5498553a04827fafb96cd08fe)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision e273fb8062f4dbbe588acf6a97001ce4aaf1e332)
+@@ -82,6 +82,7 @@
+   private isExplainPlanQuery?: boolean;
+   public readonly translationService: TranslationService;
+   public readonly notificationMessageService: NotificationMessageService;
++  private readonly isVirtualRepository: boolean;
+   constructor(parent: HTMLElement, conf: PartialConfig = {}) {
+     super();
+     if (!parent) throw new Error("No parent passed as argument. Dont know where to draw YASQE");
+@@ -90,6 +91,7 @@
+     parent.appendChild(this.rootEl);
+     this.config = merge({}, Yasqe.defaults, conf);
+     this.translationService = this.config.translationService;
++    this.isVirtualRepository = this.config.isVirtualRepository;
+     this.notificationMessageService = this.config.notificationMessageService;
+     this.infer = this.config.infer;
+     this.sameAs = this.config.sameAs;
+@@ -987,10 +989,14 @@
+       return Promise.reject();
+     }
+ 
+-    if (isExplainPlanQuery && this.isUpdateQuery()) {
+-      const message = this.translationService.translate(
+-        "yasqe.keyboard_shortcuts.action.explain_plan_query.error.message"
+-      );
++    if (isExplainPlanQuery && this.isVirtualRepository) {
++      const message = this.translationService.translate("yasqe.explain_query.virtual_repository.error.message");
++      this.notificationMessageService.warning("explain_not_allowed", message);
++      return Promise.reject();
++    }
++
++    if (this.isUpdateQuery() && this.isVirtualRepository) {
++      const message = this.translationService.translate("yasqe.update_query.virtual_repository.error.message");
+       this.notificationMessageService.warning("explain_not_allowed", message);
+       return Promise.reject();
+     }
+@@ -1000,6 +1006,7 @@
+     this.setIsExplainPlanQuery(isExplainPlanQuery);
+     return Sparql.executeQuery(this, config);
+   }
++
+   private isSelectQuery(): boolean {
+     return "select" === this.getQueryType()?.toLowerCase();
+   }
+@@ -1007,7 +1014,7 @@
+     return "construct" === this.getQueryType()?.toLowerCase();
+   }
+   private isUpdateQuery(): boolean {
+-    return "update" === this.getQueryType()?.toLowerCase();
++    return "update" === this.getQueryMode()?.toLowerCase();
+   }
+ 
+   public getUrlParams() {
+@@ -1220,6 +1227,7 @@
+   isExplainPlanQuery?: boolean;
+   paginationOn?: boolean;
+   keyboardShortcutDescriptions?: [];
++  isVirtualRepository: boolean;
+ }
+ export interface PersistentConfig {
+   query: string;
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision f537e9daa8fcc0b5498553a04827fafb96cd08fe)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision e273fb8062f4dbbe588acf6a97001ce4aaf1e332)
+@@ -217,7 +217,12 @@
+       if (yasqe) {
+         yasqe.setPageNumber(page.pageNumber || 1);
+         yasqe.setPageSize(page.pageSize || 10);
+-        yasqe.query();
++        yasqe
++          .query()
++          .then()
++          .catch(() => {
++            // catch this to avoid unhandled rejection
++          });
+       }
+     };
+   }


### PR DESCRIPTION
## What
Stops execution of a query when:
- try to execute explain plan query for update query;
- try to execute update query on virtual repository

## Why
- Explain plan query can be executed only for construct or select queries;
- Virtual repository can't be updated.

## How
Added checks and if they not pass emits message to notify user about reason why query not executed.

Additional work:
- Fixes NPE localNamesLoader is not passed as configuration;
- Fixes "Uncaught TypeError" exception when query is rejected;
- Fixes broken test "Should emit queryExecuted event on each editor tab";
- Fixes broken "Execute query action" tests.