### PR TITLE
GDB-8036 GDB-8037 ask for confirmation on yasgui tab close

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -11,6 +11,7 @@ import * as superagent from "superagent";
 require("./tab.scss");
 import { getRandomId, default as Yasgui, YasguiRequestConfig } from "./";
 import { ExtendedYasr } from "@triply/yasr/src/extended-yasr";
+import { CloseTabConfirmation } from "./closeTabConfirmation";
 export interface PersistedJsonYasr extends YasrPersistentConfig {
   responseSummary: Parser.ResponseSummary;
 }
@@ -139,44 +140,35 @@ export class Tab extends EventEmitter {
   public select() {
     this.yasgui.selectTabId(this.persistentJson.id);
   }
-  public close() {
-    let confirmationDialog: any = document.createElement("confirmation-dialog");
-    confirmationDialog.translationService = this.yasgui.config.translationService;
-    confirmationDialog.config = {
-        title: this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
-        message: this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.message')
-    };
-    const rejectedhandler = () => {
-        closeConfirmation();
-    };
-    const confirmationHandler = () => {
-        closeConfirmation();
-        if (this.yasqe) this.yasqe.abortQuery();
-        if (this.yasgui.getTab() === this) {
-            //it's the active tab
-            //first select other tab
-            const tabs = this.yasgui.persistentConfig.getTabs();
-            const i = tabs.indexOf(this.persistentJson.id);
-            if (i > -1) {
-                this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
-            }
-        }
-        this.yasgui._removePanel(this.rootEl);
-        this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
-        this.yasgui.emit("tabClose", this.yasgui, this);
-        this.emit("close", this);
-        this.yasgui.tabElements.get(this.persistentJson.id).delete();
-        delete this.yasgui._tabs[this.persistentJson.id];
-    };
-    const closeConfirmation = () => {
-        document.body.removeChild(confirmationDialog);
-        confirmationDialog.removeEventListener('internalConfirmationRejectedEvent', rejectedhandler);
-        confirmationDialog.removeEventListener('internalConfirmationApprovedEvent', confirmationHandler);
-        confirmationDialog = null;
-    }
-    confirmationDialog.addEventListener("internalConfirmationRejectedEvent", rejectedhandler);
-    confirmationDialog.addEventListener("internalConfirmationApprovedEvent", confirmationHandler);
-    document.body.appendChild(confirmationDialog);
+  public close(confirm = true) {
+      const closeTab = () => {
+          if (this.yasqe) this.yasqe.abortQuery();
+          if (this.yasgui.getTab() === this) {
+              //it's the active tab
+              //first select other tab
+              const tabs = this.yasgui.persistentConfig.getTabs();
+              const i = tabs.indexOf(this.persistentJson.id);
+              if (i > -1) {
+                  this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
+              }
+          }
+          this.yasgui._removePanel(this.rootEl);
+          this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
+          this.yasgui.emit("tabClose", this.yasgui, this);
+          this.emit("close", this);
+          this.yasgui.tabElements.get(this.persistentJson.id).delete();
+          delete this.yasgui._tabs[this.persistentJson.id];
+      };
+      if (confirm) {
+          new CloseTabConfirmation(
+              this.yasgui.config.translationService,
+              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
+              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.message'),
+              closeTab
+          ).open();
+      } else {
+          closeTab();
+      }
   }
   public getQuery() {
     if (!this.yasqe) {

--- a/Yasgui/packages/yasgui/src/closeTabConfirmation.ts
+++ b/Yasgui/packages/yasgui/src/closeTabConfirmation.ts
@@ -1,0 +1,47 @@
+import { TranslationService } from "@triply/yasgui-utils";
+
+export class CloseTabConfirmation {
+    private confirmationDialog: any;
+    private boundRejectHandler: Function;
+    private boundConfirmationHandler: Function;
+
+    constructor(public translationService: TranslationService,
+                public confirmationTitle: string,
+                public confirmationMessage: string,
+                public onConfirm: Function) {
+        this.init();
+        this.boundRejectHandler = this.rejectedhandler.bind(this);
+        this.boundConfirmationHandler = this.confirmationHandler.bind(this);
+    }
+
+    open() {
+        this.confirmationDialog.addEventListener("internalConfirmationRejectedEvent", this.boundRejectHandler);
+        this.confirmationDialog.addEventListener("internalConfirmationApprovedEvent", this.boundConfirmationHandler);
+        document.body.appendChild(this.confirmationDialog);
+    }
+
+    private init() {
+        this.confirmationDialog = document.createElement("confirmation-dialog");
+        this.confirmationDialog.translationService = this.translationService;
+        this.confirmationDialog.config = {
+            title: this.confirmationTitle,
+            message: this.confirmationMessage
+        };
+    }
+
+    private rejectedhandler() {
+        this.closeConfirmation();
+    };
+
+    private confirmationHandler() {
+        this.closeConfirmation();
+        this.onConfirm();
+    };
+
+    private closeConfirmation() {
+        document.body.removeChild(this.confirmationDialog);
+        this.confirmationDialog.removeEventListener('internalConfirmationRejectedEvent', this.boundRejectHandler);
+        this.confirmationDialog.removeEventListener('internalConfirmationApprovedEvent', this.boundConfirmationHandler);
+        this.confirmationDialog = null;
+    }
+}

--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -11,6 +11,7 @@ import { default as Yasqe, PartialConfig as YasqeConfig, RequestConfig } from "@
 import { default as Yasr, Config as YasrConfig } from "@triply/yasr";
 import { addClass, NotificationMessageService, removeClass } from "@triply/yasgui-utils";
 import { TranslationService } from "@triply/yasgui-utils";
+import { CloseTabConfirmation } from "./closeTabConfirmation";
 require("./index.scss");
 require("@triply/yasr/src/scss/global.scss");
 if (window) {
@@ -238,11 +239,19 @@ export class Yasgui extends EventEmitter {
     return tab;
   }
   public closeOtherTabs(currentTabId: string): void {
-    for (const tabId of Object.keys(this._tabs)) {
-      if (tabId !== currentTabId) {
-        this.getTab(tabId)?.close();
+      const closeOtherTabs = () => {
+        for (const tabId of Object.keys(this._tabs)) {
+          if (tabId !== currentTabId) {
+            this.getTab(tabId)?.close(false);
+          }
+        }
       }
-    }
+      new CloseTabConfirmation(
+          this.translationService,
+          this.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
+          this.translationService.translate('yasgui.tab_list.close_other_tabs.confirmation.message'),
+          closeOtherTabs
+      ).open();
   }
   /**
    * Checks if two persistent tab configuration are the same based.

--- a/cypress/e2e/defalt-view.spec.cy.ts
+++ b/cypress/e2e/defalt-view.spec.cy.ts
@@ -26,5 +26,5 @@ describe('Default view', () => {
       DefaultViewPageSteps.getQueryType();
       DefaultViewPageSteps.getOutputField().should('have.value', 'SELECT');
     });
-  })
+  });
 })

--- a/cypress/e2e/saved-query/delete-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/delete-saved-query.spec.cy.ts
@@ -1,6 +1,7 @@
 import {YasqeSteps} from "../../steps/yasqe-steps";
 import {QueryStubs} from "../../stubs/query-stubs";
 import ActionsPageSteps from "../../steps/actions-page-steps";
+import {ConfirmationDialogSteps} from "../../steps/confirmation-dialog.steps";
 
 describe('Delete saved query action', () => {
     beforeEach(() => {
@@ -18,12 +19,12 @@ describe('Delete saved query action', () => {
         // When I click the delete button for some query
         YasqeSteps.deleteQuery(4);
         // Then I expect to see a confirmation popup
-        YasqeSteps.getDeleteQueryConfirmation().should('be.visible')
+        ConfirmationDialogSteps.getConfirmation().should('be.visible')
             .and('contain.text', 'Are you sure you want to delete the saved query \'q2\'?');
         // When I confirm operation
-        YasqeSteps.confirmQueryDelete();
+        ConfirmationDialogSteps.confirm();
         // Then I expect query to be deleted
-        YasqeSteps.getDeleteQueryConfirmation().should('not.exist');
+        ConfirmationDialogSteps.getConfirmation().should('not.exist');
         YasqeSteps.showSavedQueries();
         YasqeSteps.getSavedQueries().should('have.length', 11)
             .and('not.contain.text', 'q2');
@@ -37,12 +38,12 @@ describe('Delete saved query action', () => {
         // When I click the delete button for some query
         YasqeSteps.deleteQuery(4);
         // Then I expect to see a confirmation popup
-        YasqeSteps.getDeleteQueryConfirmation().should('be.visible')
+        ConfirmationDialogSteps.getConfirmation().should('be.visible')
             .and('contain.text', 'Are you sure you want to delete the saved query \'q2\'?');
         // When I reject operation
-        YasqeSteps.rejectQueryDelete();
+        ConfirmationDialogSteps.reject();
         // Then I expect query to not be deleted
-        YasqeSteps.getDeleteQueryConfirmation().should('not.exist');
+        ConfirmationDialogSteps.getConfirmation().should('not.exist');
         YasqeSteps.showSavedQueries();
         YasqeSteps.getSavedQueries().should('have.length', 12)
             .and('contain.text', 'q2');

--- a/cypress/e2e/yasgui-tabs.spec.cy.ts
+++ b/cypress/e2e/yasgui-tabs.spec.cy.ts
@@ -15,15 +15,12 @@ describe('Yasgui tabs', () => {
   it('Should ask for confirmation on tab close', () => {
     // Given I have opened yasgui with a single opened tab
     // And I have created a second tab
-    YasguiSteps.openANewTab();
-    YasguiSteps.getTabs().should('have.length', 2);
-    // Do this check just for a bit of delay before closing the tab
-    YasqeSteps.executeQuery(1);
-    YasrSteps.getResults().should('have.length', 6);
+    openNewTab(1, 2);
     // When I close the second tab
     YasguiSteps.closeTab(1);
     // Then I expect a confirmation dialog to be opened
     ConfirmationDialogSteps.getConfirmation().should('be.visible');
+    ConfirmationDialogSteps.getConfirmation().should('contain.text', 'Are you sure you want to close this query tab?');
     // When I cancel the operation
     ConfirmationDialogSteps.reject();
     ConfirmationDialogSteps.getConfirmation().should('not.exist');
@@ -36,16 +33,13 @@ describe('Yasgui tabs', () => {
     ConfirmationDialogSteps.confirm();
     // Then I expect that the tab will be closed
     YasguiSteps.getTabs().should('have.length', 1);
+    YasguiSteps.getCurrentTabTitle().should('have.text', 'Unnamed');
   });
 
   it('Should ask for confirmation on tab close through tab context menu', () => {
     // Given I have opened yasgui with a single opened tab
     // And I have created a second tab
-    YasguiSteps.openANewTab();
-    YasguiSteps.getTabs().should('have.length', 2);
-    // Do this check just for a bit of delay before closing the tab
-    YasqeSteps.executeQuery(1);
-    YasrSteps.getResults().should('have.length', 6);
+    openNewTab(1, 2);
     // When I close the second tab
     YasguiSteps.openTabContextMenu(1).should('be.visible');
     TabContextMenu.closeTab();
@@ -55,5 +49,40 @@ describe('Yasgui tabs', () => {
     ConfirmationDialogSteps.confirm();
     // Then I expect that the tab will be closed
     YasguiSteps.getTabs().should('have.length', 1);
+    YasguiSteps.getCurrentTabTitle().should('have.text', 'Unnamed');
+  });
+
+  it('Should ask for confirmation on close other tabs action', () => {
+    // Given I have opened yasgui with a single opened tab
+    // And I have created more tabs
+    openNewTab(1, 2);
+    openNewTab(2, 3);
+    // When I try closing all other tabs but the last one
+    YasguiSteps.openTabContextMenu(2).should('be.visible');
+    TabContextMenu.closeOtherTabs();
+    // Then I expect a confirmation dialog to be opened
+    ConfirmationDialogSteps.getConfirmation().should('be.visible');
+    ConfirmationDialogSteps.getConfirmation().should('contain.text', 'Are you sure you want to close all other query tabs?');
+    // When I cancel the operation
+    ConfirmationDialogSteps.reject();
+    ConfirmationDialogSteps.getConfirmation().should('not.exist');
+    // Then I expect that to remain opened
+    YasguiSteps.getTabs().should('have.length', 3);
+    YasguiSteps.openTabContextMenu(2).should('be.visible');
+    TabContextMenu.closeOtherTabs();
+    ConfirmationDialogSteps.getConfirmation().should('be.visible');
+    // And I confirm
+    ConfirmationDialogSteps.confirm();
+    // Then I expect that the tab will be closed
+    YasguiSteps.getTabs().should('have.length', 1);
+    YasguiSteps.getCurrentTabTitle().should('have.text', 'Unnamed 2');
   });
 });
+
+function openNewTab(tabIndex: number, expectedTabsCount: number) {
+  YasguiSteps.openANewTab();
+  YasguiSteps.getTabs().should('have.length', expectedTabsCount);
+  // Do this check just for a bit of delay before closing the tab
+  YasqeSteps.executeQuery(tabIndex);
+  YasrSteps.getResults(tabIndex).should('have.length', 6);
+}

--- a/cypress/e2e/yasgui-tabs.spec.cy.ts
+++ b/cypress/e2e/yasgui-tabs.spec.cy.ts
@@ -2,7 +2,8 @@ import DefaultViewPageSteps from '../steps/default-view-page-steps';
 import {QueryStubDescription, QueryStubs} from "../stubs/query-stubs";
 import {YasqeSteps} from "../steps/yasqe-steps";
 import {YasrSteps} from "../steps/yasr-steps";
-import {YasguiSteps} from "../steps/yasgui-steps";
+import {TabContextMenu, YasguiSteps} from "../steps/yasgui-steps";
+import {ConfirmationDialogSteps} from "../steps/confirmation-dialog.steps";
 
 describe('Yasgui tabs', () => {
 
@@ -22,15 +23,36 @@ describe('Yasgui tabs', () => {
     // When I close the second tab
     YasguiSteps.closeTab(1);
     // Then I expect a confirmation dialog to be opened
-
+    ConfirmationDialogSteps.getConfirmation().should('be.visible');
     // When I cancel the operation
-
+    ConfirmationDialogSteps.reject();
+    ConfirmationDialogSteps.getConfirmation().should('not.exist');
     // Then I expect that to remain opened
-
+    YasguiSteps.getTabs().should('have.length', 2);
     // When I try closing it again
-
+    YasguiSteps.closeTab(1);
+    ConfirmationDialogSteps.getConfirmation().should('be.visible');
     // And I confirm
+    ConfirmationDialogSteps.confirm();
+    // Then I expect that the tab will be closed
+    YasguiSteps.getTabs().should('have.length', 1);
+  });
 
+  it('Should ask for confirmation on tab close through tab context menu', () => {
+    // Given I have opened yasgui with a single opened tab
+    // And I have created a second tab
+    YasguiSteps.openANewTab();
+    YasguiSteps.getTabs().should('have.length', 2);
+    // Do this check just for a bit of delay before closing the tab
+    YasqeSteps.executeQuery(1);
+    YasrSteps.getResults().should('have.length', 6);
+    // When I close the second tab
+    YasguiSteps.openTabContextMenu(1).should('be.visible');
+    TabContextMenu.closeTab();
+    // Then I expect a confirmation dialog to be opened
+    ConfirmationDialogSteps.getConfirmation().should('be.visible');
+    // And I confirm
+    ConfirmationDialogSteps.confirm();
     // Then I expect that the tab will be closed
     YasguiSteps.getTabs().should('have.length', 1);
   });

--- a/cypress/e2e/yasgui-tabs.spec.cy.ts
+++ b/cypress/e2e/yasgui-tabs.spec.cy.ts
@@ -1,0 +1,37 @@
+import DefaultViewPageSteps from '../steps/default-view-page-steps';
+import {QueryStubDescription, QueryStubs} from "../stubs/query-stubs";
+import {YasqeSteps} from "../steps/yasqe-steps";
+import {YasrSteps} from "../steps/yasr-steps";
+import {YasguiSteps} from "../steps/yasgui-steps";
+
+describe('Yasgui tabs', () => {
+
+  beforeEach(() => {
+    DefaultViewPageSteps.visitDefaultViewPage();
+    QueryStubs.stubQueryResults(new QueryStubDescription().setPageSize(10).setTotalElements(6));
+  });
+
+  it('Should ask for confirmation on tab close', () => {
+    // Given I have opened yasgui with a single opened tab
+    // And I have created a second tab
+    YasguiSteps.openANewTab();
+    YasguiSteps.getTabs().should('have.length', 2);
+    // Do this check just for a bit of delay before closing the tab
+    YasqeSteps.executeQuery(1);
+    YasrSteps.getResults().should('have.length', 6);
+    // When I close the second tab
+    YasguiSteps.closeTab(1);
+    // Then I expect a confirmation dialog to be opened
+
+    // When I cancel the operation
+
+    // Then I expect that to remain opened
+
+    // When I try closing it again
+
+    // And I confirm
+
+    // Then I expect that the tab will be closed
+    YasguiSteps.getTabs().should('have.length', 1);
+  });
+});

--- a/cypress/steps/confirmation-dialog.steps.ts
+++ b/cypress/steps/confirmation-dialog.steps.ts
@@ -1,0 +1,13 @@
+export class ConfirmationDialogSteps {
+  static getConfirmation() {
+    return cy.get('.confirmation-dialog');
+  }
+
+  static confirm() {
+    this.getConfirmation().find('.confirm-button').click();
+  }
+
+  static reject() {
+    this.getConfirmation().find('.cancel-button').click();
+  }
+}

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -15,6 +15,10 @@ export class YasguiSteps {
         return cy.get('.tab.active');
     }
 
+    static getCurrentTabTitle() {
+        return this.getCurrentTab().find('[role=tab] > span');
+    }
+
     static openANewTab() {
         cy.get('button.addTab').click();
     }
@@ -48,5 +52,9 @@ export class TabContextMenu {
 
   static closeTab() {
     this.getContextMenu().contains('Close Tab').click();
+  }
+
+  static closeOtherTabs() {
+    this.getContextMenu().contains('Close other tabs').click();
   }
 }

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -23,6 +23,10 @@ export class YasguiSteps {
         this.getTabs().eq(index).click();
     }
 
+    static closeTab(index: number) {
+        this.getTabs().eq(index).find('.closeTab').click();
+    }
+
     static isVerticalOrientation() {
         this.getYasguiTag().should('have.class', 'orientation-vertical');
     }

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -27,6 +27,11 @@ export class YasguiSteps {
         this.getTabs().eq(index).find('.closeTab').click();
     }
 
+    static openTabContextMenu(index: number) {
+      this.getTabs().eq(index).rightclick();
+      return TabContextMenu.getContextMenu();
+    }
+
     static isVerticalOrientation() {
         this.getYasguiTag().should('have.class', 'orientation-vertical');
     }
@@ -34,4 +39,14 @@ export class YasguiSteps {
     static isHorizontalOrientation() {
         this.getYasguiTag().should('have.class', 'orientation-horizontal');
     }
+}
+
+export class TabContextMenu {
+  static getContextMenu() {
+    return cy.get('.yasgui .context-menu');
+  }
+
+  static closeTab() {
+    this.getContextMenu().contains('Close Tab').click();
+  }
 }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -181,18 +181,6 @@ export class YasqeSteps {
     this.getSavedQueries().eq(index).realHover().find('.share-saved-query').click();
   }
 
-  static getDeleteQueryConfirmation() {
-    return cy.get('.confirmation-dialog');
-  }
-
-  static confirmQueryDelete() {
-    this.getDeleteQueryConfirmation().find('.confirm-button').click();
-  }
-
-  static rejectQueryDelete() {
-    this.getDeleteQueryConfirmation().find('.cancel-button').click();
-  }
-
   static getShareSavedQueryDialog() {
     return cy.get('.share-saved-query-dialog');
   }

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -1,6 +1,6 @@
 export class YasrSteps {
-  static getYasr() {
-    return cy.get('.yasr');
+  static getYasr(index = 0) {
+    return cy.get('.yasr').eq(index);
   }
 
   static getResultHeader() {
@@ -11,57 +11,57 @@ export class YasrSteps {
     return cy.get('.errorHeader');
   }
 
-  static getResultsTable() {
-    return YasrSteps.getYasr().find('.yasr_results tbody');
+  static getResultsTable(yasrIndex = 0) {
+    return YasrSteps.getYasr(yasrIndex).find('.yasr_results tbody');
   }
 
-  static getResults() {
-    return cy.get('.yasr_results tbody').find('tr');
+  static getResults(yasrIndex = 0) {
+    return this.getYasr(yasrIndex).find('.yasr_results tbody').find('tr');
   }
 
-  static getResultRow(rowNumber: number) {
-    return this.getResults().eq(rowNumber);
+  static getResultRow(rowNumber: number, yasrIndex = 0) {
+    return this.getResults(yasrIndex).eq(rowNumber);
   }
 
-  static getResultCell(rowNumber: number, cellNumber: number) {
-    return this.getResultRow(rowNumber).find('td').eq(cellNumber);
+  static getResultCell(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    return this.getResultRow(rowNumber, yasrIndex).find('td').eq(cellNumber);
   }
 
-  static getResultLink(rowNumber: number, cellNumber: number) {
-    return YasrSteps.getResultCell(rowNumber, cellNumber).find('a');
+  static getResultLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    return YasrSteps.getResultCell(rowNumber, cellNumber, yasrIndex).find('a');
   }
 
-  static getTriple(rowNumber: number, tripleNumber: 0 | 1 | 2) {
-    return this.getResultCell(rowNumber, 1).find('.triple-list').find('li').eq(tripleNumber);
+  static getTriple(rowNumber: number, tripleNumber: 0 | 1 | 2, yasrIndex = 0) {
+    return this.getResultCell(rowNumber, 1, yasrIndex).find('.triple-list').find('li').eq(tripleNumber);
   }
 
-  static hoverTripleResource(rowNumber: number, tripleNumber: 0 | 1 | 2) {
-    this.getTriple(rowNumber, tripleNumber).realHover();
+  static hoverTripleResource(rowNumber: number, tripleNumber: 0 | 1 | 2, yasrIndex = 0) {
+    this.getTriple(rowNumber, tripleNumber, yasrIndex).realHover();
   }
 
-  static getTripleCopyResourceLink(rowNumber: number, tripleNumber: 0 | 1 | 2) {
-    return this.getTriple(rowNumber, tripleNumber)
+  static getTripleCopyResourceLink(rowNumber: number, tripleNumber: 0 | 1 | 2, yasrIndex = 0) {
+    return this.getTriple(rowNumber, tripleNumber, yasrIndex)
       .realHover()
       .find('.resource-copy-link a');
   }
 
-  static hoverCell(rowNumber: number, cellNumber: number) {
-    this.getResultCell(rowNumber, cellNumber).realHover();
+  static hoverCell(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    this.getResultCell(rowNumber, cellNumber, yasrIndex).realHover();
   }
 
-  static showSharedResourceLink(rowNumber: number, cellNumber: number) {
-    return this.getResultCell(rowNumber, cellNumber)
+  static showSharedResourceLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    return this.getResultCell(rowNumber, cellNumber, yasrIndex)
       .realHover()
       .find('.resource-copy-link a');
   }
 
-  static getCopyResourceLink(rowNumber: number, cellNumber: number) {
-    return this.getResultCell(rowNumber, cellNumber)
+  static getCopyResourceLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    return this.getResultCell(rowNumber, cellNumber, yasrIndex)
       .find('.resource-copy-link a');
   }
 
-  static clickOnCopyResourceLink(rowNumber: number, cellNumber: number) {
-    this.showSharedResourceLink(rowNumber, cellNumber).realClick();
+  static clickOnCopyResourceLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    this.showSharedResourceLink(rowNumber, cellNumber, yasrIndex).realClick();
   }
 
   static clickCopyLinkDialogCloseButton() {
@@ -100,20 +100,20 @@ export class YasrSteps {
     return cy.get('.tableFilter');
   }
 
-  static switchToPlugin(pluginName: string) {
-    YasrSteps.getYasr().find(`.select_${pluginName}`).realClick();
+  static switchToPlugin(pluginName: string, yasrIndex = 0) {
+    YasrSteps.getYasr(yasrIndex).find(`.select_${pluginName}`).realClick();
 
   }
 
-  static switchToExtendedTablePlugin() {
-    YasrSteps.switchToPlugin('extended_table');
+  static switchToExtendedTablePlugin(yasrIndex = 0) {
+    YasrSteps.switchToPlugin('extended_table', yasrIndex);
   }
 
-  static switchToRawResponsePlugin() {
-    YasrSteps.switchToPlugin('response');
+  static switchToRawResponsePlugin(yasrIndex = 0) {
+    YasrSteps.switchToPlugin('response', yasrIndex);
   }
 
-  static getPagination() {
-    return YasrSteps.getYasr().find('.ontotext-pagination');
+  static getPagination(yasrIndex = 0) {
+    return YasrSteps.getYasr(yasrIndex).find('.ontotext-pagination');
   }
 }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -5,10 +5,10 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ServiceFactory } from "./services/service-factory";
+import { TranslationService } from "./services/translation.service";
 import { ConfirmationDialogConfig } from "./components/confirmation-dialog/confirmation-dialog";
 import { CopyLinkDialogConfig, CopyLinkObserver } from "./components/copy-link-dialog/copy-link-dialog";
-import { TranslationService } from "./services/translation.service";
+import { ServiceFactory } from "./services/service-factory";
 import { DialogConfig } from "./components/ontotext-dialog-web-component/ontotext-dialog-web-component";
 import { DropdownOption } from "./models/dropdown-option";
 import { InternalDownloadAsEvent } from "./models/internal-events/internal-download-as-event";
@@ -22,7 +22,7 @@ import { ShareQueryDialogConfig } from "./components/share-query-dialog/share-qu
 export namespace Components {
     interface ConfirmationDialog {
         "config": ConfirmationDialogConfig;
-        "serviceFactory": ServiceFactory;
+        "translationService": TranslationService;
     }
     interface CopyLinkDialog {
         "classes": string;
@@ -306,7 +306,7 @@ declare namespace LocalJSX {
           * Event fired when confirmation is rejected and the dialog should be closed.
          */
         "onInternalConfirmationRejectedEvent"?: (event: ConfirmationDialogCustomEvent<any>) => void;
-        "serviceFactory"?: ServiceFactory;
+        "translationService"?: TranslationService;
     }
     interface CopyLinkDialog {
         "classes"?: string;

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
@@ -1,6 +1,5 @@
 import {Component, Event, EventEmitter, h, Host, Prop} from '@stencil/core';
 import {TranslationService} from "../../services/translation.service";
-import {ServiceFactory} from "../../services/service-factory";
 
 export type ConfirmationDialogConfig = {
   title: string;
@@ -14,9 +13,7 @@ export type ConfirmationDialogConfig = {
 })
 export class ConfirmationDialog {
 
-  private translationService: TranslationService;
-
-  @Prop() serviceFactory: ServiceFactory
+  @Prop() translationService: TranslationService;
 
   @Prop() config: ConfirmationDialogConfig = {
     title: 'Confirmation',
@@ -32,10 +29,6 @@ export class ConfirmationDialog {
    * Event fired when confirmation is rejected and the dialog should be closed.
    */
   @Event() internalConfirmationApprovedEvent: EventEmitter;
-
-  componentWillLoad(): void {
-    this.translationService = this.serviceFactory.get(TranslationService);
-  }
 
   onClose(evt: MouseEvent): void {
     const target = evt.target as HTMLElement;

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/readme.md
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property         | Attribute | Description | Type                                  | Default                                                       |
-| ---------------- | --------- | ----------- | ------------------------------------- | ------------------------------------------------------------- |
-| `config`         | --        |             | `{ title: string; message: string; }` | `{     title: 'Confirmation',     message: 'Confirming?'   }` |
-| `serviceFactory` | --        |             | `ServiceFactory`                      | `undefined`                                                   |
+| Property             | Attribute | Description | Type                                  | Default                                                       |
+| -------------------- | --------- | ----------- | ------------------------------------- | ------------------------------------------------------------- |
+| `config`             | --        |             | `{ title: string; message: string; }` | `{     title: 'Confirmation',     message: 'Confirming?'   }` |
+| `translationService` | --        |             | `TranslationService`                  | `undefined`                                                   |
 
 
 ## Events

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -731,7 +731,7 @@ export class OntotextYasguiWebComponent {
           <saved-queries-popup config={this.getSaveQueriesData()}></saved-queries-popup>}
 
         {this.showConfirmationDialog &&
-          <confirmation-dialog serviceFactory={this.serviceFactory}
+          <confirmation-dialog translationService={this.translationService}
                                config={this.getDeleteQueryConfirmationConfig()}></confirmation-dialog>}
 
         {this.showShareQueryDialog &&

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -16,6 +16,8 @@
   "yasgui.control_bar.settings.btn.open_settings.aria_label": "Open settings",
   "yasgui.tab_list.add_tab.btn.label": "Add a new tab",
   "yasgui.tab_list.close_tab.btn.label": "Close tab",
+  "yasgui.tab_list.close_tab.confirmation.title": "Confirm",
+  "yasgui.tab_list.close_tab.confirmation.message": "Are you sure you want to close this query tab?",
   "yasgui.tab_list.tab.default.name": "Unnamed",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Close other tabs",
   "yasgui.tab_list.menu.close_tab.btn.label": "Close Tab",

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -18,6 +18,7 @@
   "yasgui.tab_list.close_tab.btn.label": "Close tab",
   "yasgui.tab_list.close_tab.confirmation.title": "Confirm",
   "yasgui.tab_list.close_tab.confirmation.message": "Are you sure you want to close this query tab?",
+  "yasgui.tab_list.close_other_tabs.confirmation.message": "Are you sure you want to close all other query tabs?",
   "yasgui.tab_list.tab.default.name": "Unnamed",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Close other tabs",
   "yasgui.tab_list.menu.close_tab.btn.label": "Close Tab",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -18,6 +18,7 @@
   "yasgui.tab_list.close_tab.btn.label": "Close tab",
   "yasgui.tab_list.close_tab.confirmation.title": "Confirmer",
   "yasgui.tab_list.close_tab.confirmation.message": "Êtes-vous sûr de vouloir fermer cet onglet de requête?",
+  "yasgui.tab_list.close_other_tabs.confirmation.message": "Are you sure you want to close all other query tabs?",
   "yasgui.tab_list.tab.default.name": "Anonyme",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Close other tabs",
   "yasgui.tab_list.menu.close_tab.btn.label": "Close Tab",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -16,6 +16,8 @@
   "yasgui.control_bar.settings.btn.open_settings.aria_label": "Open settings",
   "yasgui.tab_list.add_tab.btn.label": "Add a new tab",
   "yasgui.tab_list.close_tab.btn.label": "Close tab",
+  "yasgui.tab_list.close_tab.confirmation.title": "Confirmer",
+  "yasgui.tab_list.close_tab.confirmation.message": "Êtes-vous sûr de vouloir fermer cet onglet de requête?",
   "yasgui.tab_list.tab.default.name": "Anonyme",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Close other tabs",
   "yasgui.tab_list.menu.close_tab.btn.label": "Close Tab",

--- a/yasgui-patches/2023-03-27_GDB-8036_GDB-8037_confirmation_on_tab_close_using_our_custom_confirmation_dialog.patch
+++ b/yasgui-patches/2023-03-27_GDB-8036_GDB-8037_confirmation_on_tab_close_using_our_custom_confirmation_dialog.patch
@@ -1,0 +1,188 @@
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision e8919237bee636e0d4f6c389c2d2999621e92e11)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 67dbf93f33a237e4fdf5161e98483bc96fab7710)
+@@ -11,6 +11,7 @@
+ require("./tab.scss");
+ import { getRandomId, default as Yasgui, YasguiRequestConfig } from "./";
+ import { ExtendedYasr } from "@triply/yasr/src/extended-yasr";
++import { CloseTabConfirmation } from "./closeTabConfirmation";
+ export interface PersistedJsonYasr extends YasrPersistentConfig {
+   responseSummary: Parser.ResponseSummary;
+ }
+@@ -139,44 +140,35 @@
+   public select() {
+     this.yasgui.selectTabId(this.persistentJson.id);
+   }
+-  public close() {
+-    let confirmationDialog: any = document.createElement("confirmation-dialog");
+-    confirmationDialog.translationService = this.yasgui.config.translationService;
+-    confirmationDialog.config = {
+-        title: this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
+-        message: this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.message')
+-    };
+-    const rejectedhandler = () => {
+-        closeConfirmation();
+-    };
+-    const confirmationHandler = () => {
+-        closeConfirmation();
+-        if (this.yasqe) this.yasqe.abortQuery();
+-        if (this.yasgui.getTab() === this) {
+-            //it's the active tab
+-            //first select other tab
+-            const tabs = this.yasgui.persistentConfig.getTabs();
+-            const i = tabs.indexOf(this.persistentJson.id);
+-            if (i > -1) {
+-                this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
+-            }
+-        }
+-        this.yasgui._removePanel(this.rootEl);
+-        this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
+-        this.yasgui.emit("tabClose", this.yasgui, this);
+-        this.emit("close", this);
+-        this.yasgui.tabElements.get(this.persistentJson.id).delete();
+-        delete this.yasgui._tabs[this.persistentJson.id];
+-    };
+-    const closeConfirmation = () => {
+-        document.body.removeChild(confirmationDialog);
+-        confirmationDialog.removeEventListener('internalConfirmationRejectedEvent', rejectedhandler);
+-        confirmationDialog.removeEventListener('internalConfirmationApprovedEvent', confirmationHandler);
+-        confirmationDialog = null;
+-    }
+-    confirmationDialog.addEventListener("internalConfirmationRejectedEvent", rejectedhandler);
+-    confirmationDialog.addEventListener("internalConfirmationApprovedEvent", confirmationHandler);
+-    document.body.appendChild(confirmationDialog);
++  public close(confirm = true) {
++      const closeTab = () => {
++          if (this.yasqe) this.yasqe.abortQuery();
++          if (this.yasgui.getTab() === this) {
++              //it's the active tab
++              //first select other tab
++              const tabs = this.yasgui.persistentConfig.getTabs();
++              const i = tabs.indexOf(this.persistentJson.id);
++              if (i > -1) {
++                  this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
++              }
++          }
++          this.yasgui._removePanel(this.rootEl);
++          this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
++          this.yasgui.emit("tabClose", this.yasgui, this);
++          this.emit("close", this);
++          this.yasgui.tabElements.get(this.persistentJson.id).delete();
++          delete this.yasgui._tabs[this.persistentJson.id];
++      };
++      if (confirm) {
++          new CloseTabConfirmation(
++              this.yasgui.config.translationService,
++              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
++              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.message'),
++              closeTab
++          ).open();
++      } else {
++          closeTab();
++      }
+   }
+   public getQuery() {
+     if (!this.yasqe) {
+Index: Yasgui/packages/yasgui/src/closeTabConfirmation.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/closeTabConfirmation.ts b/Yasgui/packages/yasgui/src/closeTabConfirmation.ts
+new file mode 100644
+--- /dev/null	(revision 67dbf93f33a237e4fdf5161e98483bc96fab7710)
++++ b/Yasgui/packages/yasgui/src/closeTabConfirmation.ts	(revision 67dbf93f33a237e4fdf5161e98483bc96fab7710)
+@@ -0,0 +1,47 @@
++import { TranslationService } from "@triply/yasgui-utils";
++
++export class CloseTabConfirmation {
++    private confirmationDialog: any;
++    private boundRejectHandler: Function;
++    private boundConfirmationHandler: Function;
++
++    constructor(public translationService: TranslationService,
++                public confirmationTitle: string,
++                public confirmationMessage: string,
++                public onConfirm: Function) {
++        this.init();
++        this.boundRejectHandler = this.rejectedhandler.bind(this);
++        this.boundConfirmationHandler = this.confirmationHandler.bind(this);
++    }
++
++    open() {
++        this.confirmationDialog.addEventListener("internalConfirmationRejectedEvent", this.boundRejectHandler);
++        this.confirmationDialog.addEventListener("internalConfirmationApprovedEvent", this.boundConfirmationHandler);
++        document.body.appendChild(this.confirmationDialog);
++    }
++
++    private init() {
++        this.confirmationDialog = document.createElement("confirmation-dialog");
++        this.confirmationDialog.translationService = this.translationService;
++        this.confirmationDialog.config = {
++            title: this.confirmationTitle,
++            message: this.confirmationMessage
++        };
++    }
++
++    private rejectedhandler() {
++        this.closeConfirmation();
++    };
++
++    private confirmationHandler() {
++        this.closeConfirmation();
++        this.onConfirm();
++    };
++
++    private closeConfirmation() {
++        document.body.removeChild(this.confirmationDialog);
++        this.confirmationDialog.removeEventListener('internalConfirmationRejectedEvent', this.boundRejectHandler);
++        this.confirmationDialog.removeEventListener('internalConfirmationApprovedEvent', this.boundConfirmationHandler);
++        this.confirmationDialog = null;
++    }
++}
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision e8919237bee636e0d4f6c389c2d2999621e92e11)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision 67dbf93f33a237e4fdf5161e98483bc96fab7710)
+@@ -11,6 +11,7 @@
+ import { default as Yasr, Config as YasrConfig } from "@triply/yasr";
+ import { addClass, NotificationMessageService, removeClass } from "@triply/yasgui-utils";
+ import { TranslationService } from "@triply/yasgui-utils";
++import { CloseTabConfirmation } from "./closeTabConfirmation";
+ require("./index.scss");
+ require("@triply/yasr/src/scss/global.scss");
+ if (window) {
+@@ -238,11 +239,19 @@
+     return tab;
+   }
+   public closeOtherTabs(currentTabId: string): void {
+-    for (const tabId of Object.keys(this._tabs)) {
+-      if (tabId !== currentTabId) {
+-        this.getTab(tabId)?.close();
+-      }
+-    }
++      const closeOtherTabs = () => {
++        for (const tabId of Object.keys(this._tabs)) {
++          if (tabId !== currentTabId) {
++            this.getTab(tabId)?.close(false);
++          }
++        }
++      }
++      new CloseTabConfirmation(
++          this.translationService,
++          this.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
++          this.translationService.translate('yasgui.tab_list.close_other_tabs.confirmation.message'),
++          closeOtherTabs
++      ).open();
+   }
+   /**
+    * Checks if two persistent tab configuration are the same based.


### PR DESCRIPTION
## What
Yasgui should ask the user for confirmation on yasgui tab close.

## Why
This prevents accidental loss of already written queries. Also if a query was ran, closing the tab would abort the query which might be unexpected.

## How
* Plugged in our confirmation dialog component in yasgui tab when close operation get triggered.