### PR TITLE
GDB-8105: YASR: Error handling

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -63,14 +63,16 @@ export class ExtendedYasr extends Yasr {
     }
   }
 
-  updatePluginSelectorNames() {
-    if (this.yasqe.isAskQuery()) {
-      // hides plugins buttons if "query" mode query had been executed.
+  draw() {
+    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery() || this.results?.hasError()) {
       this.hidePluginElementVisibility();
-      return;
+    } else {
+      this.showPluginElementVisibility();
     }
-    // shows plugins buttons if "update" mode query had been executed.
-    this.showPluginElementVisibility();
+    super.draw();
+  }
+
+  updatePluginSelectorNames() {
     super.updatePluginSelectorNames();
     if (this.downloadAsElement) {
       this.updateDownloadAsElement(this.toDownloadAs(this.downloadAsElement));
@@ -305,6 +307,13 @@ export class ExtendedYasr extends Yasr {
 
   updateResponseInfo() {
     const responseInfoElement = this.getResponseInfoElement();
+
+    removeClass(responseInfoElement, "hidden");
+    if (this.results?.hasError()) {
+      addClass(responseInfoElement, "hidden");
+      return;
+    }
+
     const responseTime = this.results?.getResponseTime();
     const queryStartedTime = this.results?.getQueryStartedTime();
 
@@ -356,7 +365,7 @@ export class ExtendedYasr extends Yasr {
     );
   }
 
-  private getResultTimeMessage(responseTime: number, queryFinishedTime: number): string {
+  public getResultTimeMessage(responseTime: number, queryFinishedTime: number): string {
     const params = [
       {
         key: "seconds",

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -48,7 +48,7 @@ export class Yasr extends EventEmitter {
   private selectedPlugin: string | undefined;
 
   protected readonly translationService: TranslationService;
-  protected readonly yasqe: Yasqe;
+  readonly yasqe: Yasqe;
 
   // Utils
   public utils = { addScript: addScript, addCSS: addCss, sanitize: sanitize };
@@ -186,7 +186,7 @@ export class Yasr extends EventEmitter {
   public draw() {
     this.updateHelpButton();
     this.updateResponseInfo();
-    if (!this.results || this.yasqe.isUpdateQuery()) return;
+    if (!this.results) return;
     this.updatePluginSelectorNames();
     const compatiblePlugins = this.getCompatiblePlugins();
     if (this.drawnPlugin && this.getSelectedPluginName() !== this.drawnPlugin) {
@@ -231,7 +231,7 @@ export class Yasr extends EventEmitter {
         (_e) => console.error
       );
     } else {
-      this.resultsEl.textContent = "cannot render result";
+      this.resultsEl.textContent = this.translationService.translate("yasr.plugin.no_compatible.message");
       this.updateExportHeaders();
       this.updatePluginSelectors(compatiblePlugins);
     }
@@ -471,6 +471,9 @@ export class Yasr extends EventEmitter {
   }
 
   updatePluginSelectorNames() {
+    if (!this.pluginSelectorsEl) {
+      return;
+    }
     const pluginOrder = this.config.pluginOrder;
     for (const pluginName of pluginOrder) {
       if (!this.config.plugins[pluginName] || !this.config.plugins[pluginName].enabled) {
@@ -684,9 +687,11 @@ import { TranslationService } from "@triply/yasgui-utils";
 import Yasqe from "@triply/yasqe";
 import ExtendedBoolean from "./plugins/boolean/extended-boolean";
 import ExtendedResponse from "./plugins/response/extended-response";
+import ExtendedError from "./plugins/error/extended-error";
 
 Yasr.registerPlugin("extended_boolean", ExtendedBoolean as any);
-Yasr.registerPlugin("response", ExtendedResponse as any);
+Yasr.registerPlugin("extended_response", ExtendedResponse as any);
+Yasr.registerPlugin("extended_error", ExtendedError as any);
 Yasr.registerPlugin("error", YasrPluginError.default as any);
 Yasr.registerPlugin("extended_table", ExtendedTable as any);
 

--- a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+++ b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
@@ -1,0 +1,42 @@
+import Error from "./index";
+import Parser from "../../parsers";
+
+export default class ExtendedError extends Error {
+  async draw() {
+    const error = this.yasr.results?.getError();
+    if (error) {
+      this.yasr.resultsEl.appendChild(this.createErrorElement(error));
+    }
+  }
+
+  private createErrorElement(error: Parser.ErrorSummary): HTMLDivElement {
+    const errorResponseElement = document.createElement("div");
+    errorResponseElement.className = "error-response-plugin";
+    errorResponseElement.innerHTML = this.getErrorMessage(error);
+    return errorResponseElement;
+  }
+
+  private getErrorMessage(error: Parser.ErrorSummary): string {
+    return `<div class="error-response-plugin-header">
+                    <div class="error-response-plugin-error-status">
+                        ${error.status ? error.status + ":" : ""} ${error.statusText}
+                    </div>
+                    <div class="error-response-plugin-error-time-message">
+                        ${this.getResultTimeMessage()}
+                    </div>
+                 </div>
+                 <div class="error-response-plugin-body">
+                    ${error.text || ""}
+                 </div>`;
+  }
+
+  private getResultTimeMessage(): string {
+    const responseTime = this.yasr.results?.getResponseTime();
+    const queryStartedTime = this.yasr.results?.getQueryStartedTime();
+    if (responseTime && queryStartedTime) {
+      const queryFinishedTime = queryStartedTime + responseTime;
+      return this.yasr.getResultTimeMessage(responseTime, queryFinishedTime);
+    }
+    return "";
+  }
+}

--- a/Yasgui/packages/yasr/src/plugins/error/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/error/index.ts
@@ -2,15 +2,15 @@
  * Make sure not to include any deps from our main index file. That way, we can easily publish the publin as standalone build
  */
 import { Plugin } from "../";
-import Yasr from "../../";
 import { addClass } from "@triply/yasgui-utils";
 import { TranslationService } from "@triply/yasgui-utils";
+import { ExtendedYasr } from "../../extended-yasr";
 require("./index.scss");
 
 export default class Error implements Plugin<never> {
-  private yasr: Yasr;
+  protected yasr: ExtendedYasr;
   private readonly translationService: TranslationService;
-  constructor(yasr: Yasr) {
+  constructor(yasr: ExtendedYasr) {
     this.yasr = yasr;
     this.translationService = this.yasr.config.translationService;
   }

--- a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+++ b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
@@ -2,6 +2,16 @@ import Response from "./index";
 import { addClass } from "@triply/yasgui-utils";
 
 export default class ExtendedResponse extends Response {
+  priority = 1;
+
+  canHandleResults() {
+    if (!this.yasr.results || !this.yasr.results.getOriginalResponseAsString || this.yasr.yasqe.isUpdateQuery()) {
+      return false;
+    }
+
+    return !this.yasr.results.hasError();
+  }
+
     // Function is overriden and download button is removed from the view because we already has one.
     showLess(setValue = true) {
         if (!this.cm) return;

--- a/cypress/e2e/languages.spec.cy.ts
+++ b/cypress/e2e/languages.spec.cy.ts
@@ -48,27 +48,6 @@ describe('Languages', () => {
 
   describe('Yasr internationalization support', () => {
 
-    it('Should translate errors', () => {
-      // When execute a query and receive an error.
-      cy.intercept('/repositories/test-repo', {
-        statusCode: 401,
-      });
-      YasqeSteps.executeQuery();
-
-      // Then I expect to see error message be translated to English language.
-      YasrSteps.getErrorHeader().contains('Try query in new browser window');
-
-      // When change the language to be French
-      LanguagesSteps.switchToFr();
-      // Yasgui re-renders all DOM elements to shows the new labels. This includes the plugins of yasr which is time-consuming.
-      // We have to wait a bit because cypress is too fast and grabs the old element (with the old label) and the test fails.
-      cy.wait(500);
-
-      // Then I expect to see error message be translated to French language.
-      YasrSteps.getErrorHeader().contains('Essayez la requête dans une nouvelle fenêtre du navigateur');
-
-    });
-
     it('Should translate labels in table plugin', {
       retries: {
         runMode: 1,

--- a/cypress/e2e/yasr/download-as.spec.cy.ts
+++ b/cypress/e2e/yasr/download-as.spec.cy.ts
@@ -36,7 +36,7 @@ describe('Download as', () => {
     });
 
     it('should be visible if there are results', () => {
-      // When execute a query witch returns results.
+      // When execute a query which returns results.
       YasqeSteps.executeQuery();
 
       // Then "Download as" dropdown should be visible.
@@ -46,7 +46,7 @@ describe('Download as', () => {
     });
 
     it('should icon be visible when screen is small', () => {
-      // When execute a query witch returns results.
+      // When execute a query which returns results.
       YasqeSteps.executeQuery();
       // And screen is less than 768px
       cy.viewport(767, 750);
@@ -62,7 +62,7 @@ describe('Download as', () => {
     it('should not exist when is turned off in configuration', () => {
       // When visit a page with ontotext-yasgui component in it which is configured to turnoff download as dropdown.
       DownloadAsPageSteps.turnOffDownloadAsDropdown();
-      // and execute a query witch returns results.
+      // and execute a query which returns results.
       YasqeSteps.executeQuery();
 
       // Then "Download as" dropdown should not exist.
@@ -71,7 +71,7 @@ describe('Download as', () => {
   });
 
   it('Should emit "downloadAs" event with value the selected of selected option, current plugin name, and last executed query.', () => {
-    // When execute a query witch returns results.
+    // When execute a query which returns results.
     YasqeSteps.executeQuery();
     // And select an option of "Download as" button.
     DownloadAsPageSteps.openDownloadAsDropdown();
@@ -88,11 +88,11 @@ describe('Download as', () => {
     DownloadAsPageSteps.openDownloadAsDropdown();
     DownloadAsPageSteps.downloadAsJSON();
     // Then I expect a download event to be fired with "Raw Response" plugin name
-    DownloadAsPageSteps.getDownloadAsEventElement().contains('{"TYPE":"downloadAs","payload":{"value":"application/sparql-results+json","pluginName":"response","query":"select * where { \\n ?s ?p ?o . \\n } limit 100","infer":true,"sameAs":true}}');
+    DownloadAsPageSteps.getDownloadAsEventElement().contains('{"TYPE":"downloadAs","payload":{"value":"application/sparql-results+json","pluginName":"extended_response","query":"select * where { \\n ?s ?p ?o . \\n } limit 100","infer":true,"sameAs":true}}');
   });
 
   it('Should emit "downloadAs" event with last executed query', () => {
-    // When execute a query witch returns results.
+    // When execute a query which returns results.
     YasqeSteps.executeQuery();
     // And select an option of "Download as" button.
     DownloadAsPageSteps.openDownloadAsDropdown();
@@ -127,7 +127,7 @@ describe('Download as', () => {
   });
 
   it('Should "Download as" dropdown has more than options when "Table" plugin is selected', () => {
-    // When execute a query witch returns results.
+    // When execute a query which returns results.
     YasqeSteps.executeQuery();
     // And extended table plugin is selected.
     YasrSteps.switchToExtendedTablePlugin();
@@ -141,7 +141,7 @@ describe('Download as', () => {
   it('Should "Download as" dropdown be configured by external configuration', () => {
     // When extended table_plugin is configured to shows only 3 results.
     DownloadAsPageSteps.configWithExternalConfiguration();
-    // And execute a query witch returns results.
+    // And execute a query which returns results.
     YasqeSteps.executeQuery();
     // And extended_table plugin is selected.
     YasrSteps.switchToExtendedTablePlugin();

--- a/cypress/e2e/yasr/error-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/error-plugin.spec.cy.ts
@@ -1,0 +1,33 @@
+import DefaultViewPageSteps from '../../steps/default-view-page-steps';
+import {QueryStubs} from '../../stubs/query-stubs';
+import {YasqeSteps} from '../../steps/yasqe-steps';
+import {ErrorPluginSteps} from '../../steps/error-plugin-steps';
+import {YasrSteps} from '../../steps/yasr-steps';
+
+describe('Error handling', () => {
+
+  beforeEach(() => {
+    DefaultViewPageSteps.visit();
+  });
+
+  it('should show error when execute wrong query', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    // and execute wrong query.
+    QueryStubs.stubLoadQueryErrorResponse()
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor('LOAD <file:///datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq>\n INTO GRAPH <file:///datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq>');
+    YasqeSteps.executeQuery();
+
+    // Then I expect to see a message that
+    // describes error status and error text,
+    ErrorPluginSteps.getErrorPluginErrorStatus().should('have.text', '500: Internal Server Error');
+    // and time when the query is executed,
+    ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
+    // and error message sent by server,
+    ErrorPluginSteps.getErrorPluginBody().should('have.text', '/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)');
+    // and toolbar with plugins to not be visible,
+    YasrSteps.getResultHeader().should('not.be.visible');
+    // and message info to not be visible
+    YasrSteps.getResponseInfo().should('not.be.visible');
+  });
+});

--- a/cypress/e2e/yasr/error-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/error-plugin.spec.cy.ts
@@ -20,11 +20,11 @@ describe('Error handling', () => {
 
     // Then I expect to see a message that
     // describes error status and error text,
-    ErrorPluginSteps.getErrorPluginErrorStatus().should('have.text', '500: Internal Server Error');
+    ErrorPluginSteps.getErrorPluginErrorStatus().contains('500: Internal Server Error');
     // and time when the query is executed,
     ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
     // and error message sent by server,
-    ErrorPluginSteps.getErrorPluginBody().should('have.text', '/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)');
+    ErrorPluginSteps.getErrorPluginBody().contains('/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)');
     // and toolbar with plugins to not be visible,
     YasrSteps.getResultHeader().should('not.be.visible');
     // and message info to not be visible

--- a/cypress/e2e/yasr/plugin-raw-response.spec.cy.ts
+++ b/cypress/e2e/yasr/plugin-raw-response.spec.cy.ts
@@ -34,7 +34,7 @@ describe('Plugin: Raw response', () => {
   it('should be able to download response in two formats', () => {
     // When I open the raw response tab
     YasrSteps.openRawResponseTab();
-    // When execute a query witch returns results.
+    // When execute a query which returns results.
     YasqeSteps.executeQuery();
     // And dropdown is opened.
     DownloadAsPageSteps.openDownloadAsDropdown();

--- a/cypress/steps/error-plugin-steps.ts
+++ b/cypress/steps/error-plugin-steps.ts
@@ -1,0 +1,22 @@
+export class ErrorPluginSteps {
+
+  static getErrorPlugin() {
+    return cy.get('.error-response-plugin');
+  }
+
+  static getErrorPluginHeader() {
+    return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-header');
+  }
+
+  static getErrorPluginErrorStatus() {
+    return ErrorPluginSteps.getErrorPluginHeader().find('.error-response-plugin-error-status');
+  }
+
+  static getErrorPluginErrorTimeMessage() {
+    return ErrorPluginSteps.getErrorPluginHeader().find('.error-response-plugin-error-time-message');
+  }
+
+  static getErrorPluginBody() {
+    return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-body');
+  }
+}

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -114,7 +114,7 @@ export class YasrSteps {
   }
 
   static switchToRawResponsePlugin(yasrIndex = 0) {
-    YasrSteps.switchToPlugin('response', yasrIndex);
+    YasrSteps.switchToPlugin('extended_response', yasrIndex);
   }
 
   static getPagination(yasrIndex = 0) {
@@ -126,7 +126,7 @@ export class YasrSteps {
   }
 
   static openRawResponseTab() {
-    this.getYasr().find('.select_response').click();
+    this.getYasr().find('.select_extended_response').click();
   }
 
 

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -30,6 +30,13 @@ export class QueryStubs {
     cy.intercept('/repositories/test-repo', {fixture, delay: withDelay}).as(alias);
   }
 
+  static stubLoadQueryErrorResponse() {
+    cy.intercept('/repositories/test-repo', {
+      statusCode: 500,
+      body: '/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)'
+    }).as('loadQueryErrorResponse');
+  }
+
   static stubQueryResults(queryDescription: QueryStubDescription) {
     const resultType = queryDescription.resultType;
     const pageSize = queryDescription.pageSize;

--- a/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.scss
@@ -49,7 +49,7 @@
   }
 
   kbd {
-    background-color: $background-onto-default;
+    background-color: $background-color-onto-default;
   }
 }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-dialog-web-component/ontotext-dialog-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-dialog-web-component/ontotext-dialog-web-component.scss
@@ -25,7 +25,7 @@
   z-index: 1001;
   max-width: 90vw;
   max-height: 90vh;
-  background-color: $background-onto-default;
+  background-color: $background-color-onto-default;
   box-shadow: 0 5px 15px rgb(0 0 0 / 50%);
   font-family: inherit;
   font-weight: inherit;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -234,6 +234,21 @@
         padding-left: 10px;
         padding-right: 10px;
       }
+
+      .error-response-plugin {
+        padding: 10px;
+        background-color: $background-color-onto-error;
+
+        .error-response-plugin-header {
+          display: flex;
+          justify-content: space-between;
+
+          .error-response-plugin-error-status {
+            font-weight: 400;
+            margin-bottom: 0.5em;
+          }
+        }
+      }
     }
 
     .pageSizeWrapper, .dataTables_info, .dataTables_paginate {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -248,6 +248,10 @@
             margin-bottom: 0.5em;
           }
         }
+
+        .error-response-plugin-body {
+          white-space: pre-wrap;
+        }
       }
     }
 

--- a/ontotext-yasgui-web-component/src/components/pagination/pagination.scss
+++ b/ontotext-yasgui-web-component/src/components/pagination/pagination.scss
@@ -13,7 +13,7 @@
   .page-selector {
     color: $onto-blue-light;
     padding: 2px 5px;
-    background-color: $background-onto-default;
+    background-color: $background-color-onto-default;
     border: none;
     cursor: pointer;
   }

--- a/ontotext-yasgui-web-component/src/css/_variables.scss
+++ b/ontotext-yasgui-web-component/src/css/_variables.scss
@@ -6,4 +6,5 @@ $color-onto-green: #02a99a1a;
 $color-onto-white: #FFFFFF;
 $color-onto-grey: #00000059;
 $onto-blue-light: #0060b0;
-$background-onto-default: #FFF;
+$background-color-onto-default: #FFF;
+$background-color-onto-error: #fbdbd5;

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -148,6 +148,7 @@
   "yasr.plugin.table.table_filter.input.placeholder": "Filter query results",
   "yasr.plugin.extended_boolean.true": "YES",
   "yasr.plugin.extended_boolean.false": "NO",
+  "yasr.plugin.no_compatible.message": " ",
   "yasqe.actions.save_query.button.tooltip": "Create saved query",
   "yasqe.actions.save_query.dialog.title": "Create New Saved Query",
   "yasqe.actions.save_query.dialog.query.label": "Create your sample query",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -148,6 +148,7 @@
   "yasr.plugin.table.table_filter.input.placeholder": "Filtrer les résultats des requêtes",
   "yasr.plugin.extended_boolean.true": "OUI",
   "yasr.plugin.extended_boolean.false": "NON",
+  "yasr.plugin.no_compatible.message": " ",
   "yasqe.actions.save_query.button.tooltip": "Create saved query",
   "yasqe.actions.save_query.dialog.title": "Create New Saved Query",
   "yasqe.actions.save_query.dialog.query.label": "Create your sample query",

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -37,14 +37,14 @@ export class YasrService {
   }
 
   private static addRawResponseConfiguration(pluginsConfigurations: Map<string, any>, externalPluginsConfigurations: Map<string, any>) {
-    const externalExtendedTableConfig = externalPluginsConfigurations ? externalPluginsConfigurations['response'] : null;
+    const externalExtendedResponseConfig = externalPluginsConfigurations ? externalPluginsConfigurations['extended_response'] : null;
     const configuration = {
       downloadAsConfig: {
-        nameLabelKey: externalExtendedTableConfig?.downloadAsConfig?.nameLabelKey || defaultRawResponsePluginConfiguration.nameLabelKey,
-        items: externalExtendedTableConfig?.downloadAsConfig?.items || defaultRawResponsePluginConfiguration.items
+        nameLabelKey: externalExtendedResponseConfig?.downloadAsConfig?.nameLabelKey || defaultRawResponsePluginConfiguration.nameLabelKey,
+        items: externalExtendedResponseConfig?.downloadAsConfig?.items || defaultRawResponsePluginConfiguration.items
       }
     };
-    pluginsConfigurations.set('response', configuration);
+    pluginsConfigurations.set('extended_response', configuration);
   }
 
   // @ts-ignore

--- a/yasgui-patches/2023-03-31-GDB-8105__YASR__Error_handling.patch
+++ b/yasgui-patches/2023-03-31-GDB-8105__YASR__Error_handling.patch
@@ -1,0 +1,310 @@
+Subject: [PATCH] GDB-8105: YASR: Error handling
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision 4be91fa274df2de1a972048707bbc88064b14b19)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -141,34 +141,34 @@
+     this.yasgui.selectTabId(this.persistentJson.id);
+   }
+   public close(confirm = true) {
+-      const closeTab = () => {
+-          if (this.yasqe) this.yasqe.abortQuery();
+-          if (this.yasgui.getTab() === this) {
+-              //it's the active tab
+-              //first select other tab
+-              const tabs = this.yasgui.persistentConfig.getTabs();
+-              const i = tabs.indexOf(this.persistentJson.id);
+-              if (i > -1) {
+-                  this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
+-              }
+-          }
+-          this.yasgui._removePanel(this.rootEl);
+-          this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
+-          this.yasgui.emit("tabClose", this.yasgui, this);
+-          this.emit("close", this);
+-          this.yasgui.tabElements.get(this.persistentJson.id).delete();
+-          delete this.yasgui._tabs[this.persistentJson.id];
+-      };
+-      if (confirm) {
+-          new CloseTabConfirmation(
+-              this.yasgui.config.translationService,
+-              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.title'),
+-              this.yasgui.config.translationService.translate('yasgui.tab_list.close_tab.confirmation.message'),
+-              closeTab
+-          ).open();
+-      } else {
+-          closeTab();
+-      }
++    const closeTab = () => {
++      if (this.yasqe) this.yasqe.abortQuery();
++      if (this.yasgui.getTab() === this) {
++        //it's the active tab
++        //first select other tab
++        const tabs = this.yasgui.persistentConfig.getTabs();
++        const i = tabs.indexOf(this.persistentJson.id);
++        if (i > -1) {
++          this.yasgui.selectTabId(tabs[i === tabs.length - 1 ? i - 1 : i + 1]);
++        }
++      }
++      this.yasgui._removePanel(this.rootEl);
++      this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
++      this.yasgui.emit("tabClose", this.yasgui, this);
++      this.emit("close", this);
++      this.yasgui.tabElements.get(this.persistentJson.id).delete();
++      delete this.yasgui._tabs[this.persistentJson.id];
++    };
++    if (confirm) {
++      new CloseTabConfirmation(
++        this.yasgui.config.translationService,
++        this.yasgui.config.translationService.translate("yasgui.tab_list.close_tab.confirmation.title"),
++        this.yasgui.config.translationService.translate("yasgui.tab_list.close_tab.confirmation.message"),
++        closeTab
++      ).open();
++    } else {
++      closeTab();
++    }
+   }
+   public getQuery() {
+     if (!this.yasqe) {
+@@ -506,13 +506,14 @@
+     if (!this.yasr) throw new Error("Resultset visualizer not initialized. Cannot draw results");
+     this.yasr.setResponse(response, duration, queryStartedTime, hasMorePages);
+     if (!this.yasr.results) return;
++    const responseAsStoreObject = this.yasr.results.getAsStoreObject(this.yasgui.config.yasr.maxPersistentResponseSize);
+     if (!this.yasr.results.hasError()) {
+-      this.persistentJson.yasr.response = this.yasr.results.getAsStoreObject(
+-        this.yasgui.config.yasr.maxPersistentResponseSize
+-      );
++      this.persistentJson.yasr.response = responseAsStoreObject;
+     } else {
+-      // Don't persist if there is an error and remove the previous result
+-      this.persistentJson.yasr.response = undefined;
++      if (responseAsStoreObject && responseAsStoreObject.error) {
++        responseAsStoreObject.error.text = responseAsStoreObject.error.text.replace(/^([^: ]+: )+/, "");
++      }
++      this.persistentJson.yasr.response = responseAsStoreObject;
+     }
+     this.emit("change", this, this.persistentJson);
+   };
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 4be91fa274df2de1a972048707bbc88064b14b19)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -63,14 +63,16 @@
+     }
+   }
+ 
+-  updatePluginSelectorNames() {
+-    if (this.yasqe.isAskQuery()) {
+-      // hides plugins buttons if "query" mode query had been executed.
++  draw() {
++    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery() || this.results?.hasError()) {
+       this.hidePluginElementVisibility();
+-      return;
+-    }
+-    // shows plugins buttons if "update" mode query had been executed.
+-    this.showPluginElementVisibility();
++    } else {
++      this.showPluginElementVisibility();
++    }
++    super.draw();
++  }
++
++  updatePluginSelectorNames() {
+     super.updatePluginSelectorNames();
+     if (this.downloadAsElement) {
+       this.updateDownloadAsElement(this.toDownloadAs(this.downloadAsElement));
+@@ -305,6 +307,13 @@
+ 
+   updateResponseInfo() {
+     const responseInfoElement = this.getResponseInfoElement();
++
++    removeClass(responseInfoElement, "hidden");
++    if (this.results?.hasError()) {
++      addClass(responseInfoElement, "hidden");
++      return;
++    }
++
+     const responseTime = this.results?.getResponseTime();
+     const queryStartedTime = this.results?.getQueryStartedTime();
+ 
+@@ -356,7 +365,7 @@
+     );
+   }
+ 
+-  private getResultTimeMessage(responseTime: number, queryFinishedTime: number): string {
++  public getResultTimeMessage(responseTime: number, queryFinishedTime: number): string {
+     const params = [
+       {
+         key: "seconds",
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 4be91fa274df2de1a972048707bbc88064b14b19)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -48,7 +48,7 @@
+   private selectedPlugin: string | undefined;
+ 
+   protected readonly translationService: TranslationService;
+-  protected readonly yasqe: Yasqe;
++  readonly yasqe: Yasqe;
+ 
+   // Utils
+   public utils = { addScript: addScript, addCSS: addCss, sanitize: sanitize };
+@@ -186,7 +186,7 @@
+   public draw() {
+     this.updateHelpButton();
+     this.updateResponseInfo();
+-    if (!this.results || this.yasqe.isUpdateQuery()) return;
++    if (!this.results) return;
+     this.updatePluginSelectorNames();
+     const compatiblePlugins = this.getCompatiblePlugins();
+     if (this.drawnPlugin && this.getSelectedPluginName() !== this.drawnPlugin) {
+@@ -231,7 +231,7 @@
+         (_e) => console.error
+       );
+     } else {
+-      this.resultsEl.textContent = "cannot render result";
++      this.resultsEl.textContent = this.translationService.translate("yasr.plugin.no_compatible.message");
+       this.updateExportHeaders();
+       this.updatePluginSelectors(compatiblePlugins);
+     }
+@@ -471,6 +471,9 @@
+   }
+ 
+   updatePluginSelectorNames() {
++    if (!this.pluginSelectorsEl) {
++      return;
++    }
+     const pluginOrder = this.config.pluginOrder;
+     for (const pluginName of pluginOrder) {
+       if (!this.config.plugins[pluginName] || !this.config.plugins[pluginName].enabled) {
+@@ -684,9 +687,11 @@
+ import Yasqe from "@triply/yasqe";
+ import ExtendedBoolean from "./plugins/boolean/extended-boolean";
+ import ExtendedResponse from "./plugins/response/extended-response";
++import ExtendedError from "./plugins/error/extended-error";
+ 
+ Yasr.registerPlugin("extended_boolean", ExtendedBoolean as any);
+-Yasr.registerPlugin("response", ExtendedResponse as any);
++Yasr.registerPlugin("extended_response", ExtendedResponse as any);
++Yasr.registerPlugin("extended_error", ExtendedError as any);
+ Yasr.registerPlugin("error", YasrPluginError.default as any);
+ Yasr.registerPlugin("extended_table", ExtendedTable as any);
+ 
+Index: Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+new file mode 100644
+--- /dev/null	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
++++ b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -0,0 +1,42 @@
++import Error from "./index";
++import Parser from "../../parsers";
++
++export default class ExtendedError extends Error {
++  async draw() {
++    const error = this.yasr.results?.getError();
++    if (error) {
++      this.yasr.resultsEl.appendChild(this.createErrorElement(error));
++    }
++  }
++
++  private createErrorElement(error: Parser.ErrorSummary): HTMLDivElement {
++    const errorResponseElement = document.createElement("div");
++    errorResponseElement.className = "error-response-plugin";
++    errorResponseElement.innerHTML = this.getErrorMessage(error);
++    return errorResponseElement;
++  }
++
++  private getErrorMessage(error: Parser.ErrorSummary): string {
++    return `<div class="error-response-plugin-header">
++                    <div class="error-response-plugin-error-status">
++                        ${error.status ? error.status + ":" : ""} ${error.statusText}
++                    </div>
++                    <div class="error-response-plugin-error-time-message">
++                        ${this.getResultTimeMessage()}
++                    </div>
++                 </div>
++                 <div class="error-response-plugin-body">
++                    ${error.text || ""}
++                 </div>`;
++  }
++
++  private getResultTimeMessage(): string {
++    const responseTime = this.yasr.results?.getResponseTime();
++    const queryStartedTime = this.yasr.results?.getQueryStartedTime();
++    if (responseTime && queryStartedTime) {
++      const queryFinishedTime = queryStartedTime + responseTime;
++      return this.yasr.getResultTimeMessage(responseTime, queryFinishedTime);
++    }
++    return "";
++  }
++}
+Index: Yasgui/packages/yasr/src/plugins/error/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/error/index.ts b/Yasgui/packages/yasr/src/plugins/error/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/error/index.ts	(revision 4be91fa274df2de1a972048707bbc88064b14b19)
++++ b/Yasgui/packages/yasr/src/plugins/error/index.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -2,15 +2,15 @@
+  * Make sure not to include any deps from our main index file. That way, we can easily publish the publin as standalone build
+  */
+ import { Plugin } from "../";
+-import Yasr from "../../";
+ import { addClass } from "@triply/yasgui-utils";
+ import { TranslationService } from "@triply/yasgui-utils";
++import { ExtendedYasr } from "../../extended-yasr";
+ require("./index.scss");
+ 
+ export default class Error implements Plugin<never> {
+-  private yasr: Yasr;
++  protected yasr: ExtendedYasr;
+   private readonly translationService: TranslationService;
+-  constructor(yasr: Yasr) {
++  constructor(yasr: ExtendedYasr) {
+     this.yasr = yasr;
+     this.translationService = this.yasr.config.translationService;
+   }
+Index: Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+--- a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts	(revision 4be91fa274df2de1a972048707bbc88064b14b19)
++++ b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts	(revision 85432746b77e20f963b380d12f7bf3a7de3777d8)
+@@ -2,6 +2,16 @@
+ import { addClass } from "@triply/yasgui-utils";
+ 
+ export default class ExtendedResponse extends Response {
++  priority = 1;
++
++  canHandleResults() {
++    if (!this.yasr.results || !this.yasr.results.getOriginalResponseAsString || this.yasr.yasqe.isUpdateQuery()) {
++      return false;
++    }
++
++    return !this.yasr.results.hasError();
++  }
++
+     // Function is overriden and download button is removed from the view because we already has one.
+     showLess(setValue = true) {
+         if (!this.cm) return;


### PR DESCRIPTION
## What
Added an error plugin that displays error messages when something goes wrong during query execution.

## Why
WB has such functionality that displays a message that describes to the user what the reason for which the exception occurred.

## How
A new "extended_error" plugin is added. It has responsibility to displays the error messages that can be occurred during query execution.
Added error info to yasr persistence.

Additional work:
-Rename the registration name of the ExtendedResponse plugin to be similar like other extended plugins.
-Rename "$background-onto-default" to "$background-color-onto-default".
- Remove a test form language suite because, after error plugin implementation, it doesn't sense.