### PR TITLE
GDB-8112: Skip the count query if results are less than one page

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -397,7 +397,7 @@ export class Tab extends EventEmitter {
     this.yasqe.on("autocompletionClose", this.handleAutocompletionClose);
 
     this.yasqe.on("queryResponse", this.handleQueryResponse);
-    this.yasqe.on("totalElementChanged", this.handleTotalElementChanged);
+    this.yasqe.on("totalElementsChanged", this.handleTotalElementsChanged);
     this.yasqe.on("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
     this.yasqe.on("openNewTab", this.handleOpenNewTab);
     this.yasqe.on("openNextTab", this.handleOpenNextTab);
@@ -413,7 +413,7 @@ export class Tab extends EventEmitter {
     this.yasqe?.off("autocompletionShown", this.handleAutocompletionShown);
     this.yasqe?.off("autocompletionClose", this.handleAutocompletionClose);
     this.yasqe?.off("queryResponse", this.handleQueryResponse);
-    this.yasqe?.off("totalElementChanged", this.handleTotalElementChanged);
+    this.yasqe?.off("totalElementsChanged", this.handleTotalElementsChanged);
     this.yasqe?.off("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
     this.yasqe?.off("openNewTab", this.handleOpenNewTab);
     this.yasqe?.off("openNextTab", this.handleOpenNextTab);
@@ -500,11 +500,12 @@ export class Tab extends EventEmitter {
     response: any,
     duration: number,
     queryStartedTime: number,
-    hasMorePages?: boolean
+    hasMorePages?: boolean,
+    possibleElementsCount?: number
   ) => {
     this.emit("queryResponse", this);
     if (!this.yasr) throw new Error("Resultset visualizer not initialized. Cannot draw results");
-    this.yasr.setResponse(response, duration, queryStartedTime, hasMorePages);
+    this.yasr.setResponse(response, duration, queryStartedTime, hasMorePages, possibleElementsCount);
     if (!this.yasr.results) return;
     const responseAsStoreObject = this.yasr.results.getAsStoreObject(this.yasgui.config.yasr.maxPersistentResponseSize);
     if (!this.yasr.results.hasError()) {
@@ -518,7 +519,7 @@ export class Tab extends EventEmitter {
     this.emit("change", this, this.persistentJson);
   };
 
-  handleTotalElementChanged = (_yasqe: Yasqe, totalElements = -1) => {
+  handleTotalElementsChanged = (_yasqe: Yasqe, totalElements = -1) => {
     if (this.yasr?.results) {
       const response = this.persistentJson.yasr.response;
       if (response) {

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -32,8 +32,8 @@ export interface Yasqe {
     eventName: "queryResponse",
     handler: (instance: Yasqe, req: superagent.SuperAgentRequest, duration: number, queryStartedTime: number) => void
   ): void;
-  on(event: "totalElementChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
-  off(event: "totalElementChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
+  on(event: "totalElementsChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
+  off(event: "totalElementsChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
   on(
     event: "countAffectedRepositoryStatementsChanged",
     handler: (instance: Yasqe, totalElements: number) => void

--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -24,7 +24,7 @@ export class ExtendedYasr extends Yasr {
     this.externalPluginsConfigurations = conf.externalPluginsConfigurations;
     if (yasqe.config.paginationOn) {
       this.yasqe.on("queryResponse", this.updateQueryResultPaginationElementHandler.bind(this));
-      this.yasqe.on("countQueryReady", this.updateQueryResultPaginationElementHandler.bind(this));
+      this.yasqe.on("totalElementsPersisted", this.updateQueryResultPaginationElementHandler.bind(this));
       this.updateQueryResultPaginationElement(this.resultQueryPaginationElement);
     }
     this.yasqe.on("countAffectedRepositoryStatementsPersisted", this.updateResponseInfo.bind(this));
@@ -299,8 +299,8 @@ export class ExtendedYasr extends Yasr {
     let totalResult = "";
     if (totalElements) {
       totalResult = this.getTotalResultsMessage(totalElements) + ".";
-    } else if (this.persistentJson?.yasr.response?.hasMorePages) {
-      totalResult = this.getHasMoreResultsMessage(to + 1) + ".";
+    } else if (this.persistentJson?.yasr.response?.possibleElementsCount) {
+      totalResult = this.getHasMoreResultsMessage(this.persistentJson.yasr.response.possibleElementsCount) + ".";
     }
     return `${fromToMessage} ${totalResult}`;
   }

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -599,9 +599,15 @@ export class Yasr extends EventEmitter {
       }
     }
   }
-  public setResponse(data: any, duration?: number, queryStartedTime?: number, hasMorePages?: boolean) {
+  public setResponse(
+    data: any,
+    duration?: number,
+    queryStartedTime?: number,
+    hasMorePages?: boolean,
+    possibleElementsCount?: number
+  ) {
     if (!data) return;
-    this.results = new Parser(data, duration, queryStartedTime, hasMorePages);
+    this.results = new Parser(data, duration, queryStartedTime, hasMorePages, possibleElementsCount);
 
     this.draw();
 

--- a/Yasgui/packages/yasr/src/parsers/index.ts
+++ b/Yasgui/packages/yasr/src/parsers/index.ts
@@ -43,6 +43,7 @@ namespace Parser {
     totalElements?: number;
     countAffectedRepositoryStatements?: number;
     hasMorePages?: boolean;
+    possibleElementsCount?: number;
   }
   export type PostProcessBinding = (binding: Binding) => Binding;
 }
@@ -76,13 +77,14 @@ class Parser {
   private executionTime: number | undefined;
   private queryStartedTime: number | undefined;
   private countAffectedRepositoryStatements?: number | undefined;
-
+  private possibleElementsCount?: number;
   private readonly hasMorePages?: boolean;
   constructor(
     responseOrObject: Parser.ResponseSummary | SuperAgent.Response | Error | any,
     executionTime?: number,
     queryStartedTime?: number,
-    hasMorePages?: boolean
+    hasMorePages?: boolean,
+    possibleElementsCount?: number
   ) {
     if (responseOrObject.executionTime) this.executionTime = responseOrObject.executionTime;
     if (executionTime) this.executionTime = executionTime; // Parameter has priority
@@ -93,6 +95,7 @@ class Parser {
       this.queryStartedTime = responseOrObject.queryStartedTime;
     }
     this.hasMorePages = hasMorePages;
+    this.possibleElementsCount = possibleElementsCount;
 
     this.countAffectedRepositoryStatements = responseOrObject.countAffectedRepositoryStatements;
 
@@ -191,6 +194,10 @@ class Parser {
 
   public getHasMorePages() {
     return this.hasMorePages;
+  }
+
+  public getPossibleElementsCount(): number | undefined {
+    return this.possibleElementsCount;
   }
 
   public setCountAffectedRepositoryStatements(countAffectedRepositoryStatements: number) {
@@ -326,6 +333,7 @@ class Parser {
         executionTime: this.getResponseTime(),
         queryStartedTime: this.getQueryStartedTime(),
         hasMorePages: this.getHasMorePages(),
+        possibleElementsCount: this.getPossibleElementsCount(),
         countAffectedRepositoryStatements: this.getCountAffectedRepositoryStatements(),
       };
     }
@@ -342,6 +350,7 @@ class Parser {
         executionTime: this.getResponseTime(),
         queryStartedTime: this.getQueryStartedTime(),
         hasMorePages: this.getHasMorePages(),
+        possibleElementsCount: this.getPossibleElementsCount(),
         countAffectedRepositoryStatements: this.getCountAffectedRepositoryStatements(),
       };
     }

--- a/yasgui-patches/2023-04-03-GDB-8112_Skip_the_count_query_if_results_are_less_than_one_page.patch
+++ b/yasgui-patches/2023-04-03-GDB-8112_Skip_the_count_query_if_results_are_less_than_one_page.patch
@@ -1,0 +1,261 @@
+Subject: [PATCH] GDB-8112: Skip the count query if results are less than one page
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -397,7 +397,7 @@
+     this.yasqe.on("autocompletionClose", this.handleAutocompletionClose);
+ 
+     this.yasqe.on("queryResponse", this.handleQueryResponse);
+-    this.yasqe.on("totalElementChanged", this.handleTotalElementChanged);
++    this.yasqe.on("totalElementsChanged", this.handleTotalElementsChanged);
+     this.yasqe.on("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
+     this.yasqe.on("openNewTab", this.handleOpenNewTab);
+     this.yasqe.on("openNextTab", this.handleOpenNextTab);
+@@ -413,7 +413,7 @@
+     this.yasqe?.off("autocompletionShown", this.handleAutocompletionShown);
+     this.yasqe?.off("autocompletionClose", this.handleAutocompletionClose);
+     this.yasqe?.off("queryResponse", this.handleQueryResponse);
+-    this.yasqe?.off("totalElementChanged", this.handleTotalElementChanged);
++    this.yasqe?.off("totalElementsChanged", this.handleTotalElementsChanged);
+     this.yasqe?.off("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
+     this.yasqe?.off("openNewTab", this.handleOpenNewTab);
+     this.yasqe?.off("openNextTab", this.handleOpenNextTab);
+@@ -500,11 +500,12 @@
+     response: any,
+     duration: number,
+     queryStartedTime: number,
+-    hasMorePages?: boolean
++    hasMorePages?: boolean,
++    possibleElementsCount?: number
+   ) => {
+     this.emit("queryResponse", this);
+     if (!this.yasr) throw new Error("Resultset visualizer not initialized. Cannot draw results");
+-    this.yasr.setResponse(response, duration, queryStartedTime, hasMorePages);
++    this.yasr.setResponse(response, duration, queryStartedTime, hasMorePages, possibleElementsCount);
+     if (!this.yasr.results) return;
+     const responseAsStoreObject = this.yasr.results.getAsStoreObject(this.yasgui.config.yasr.maxPersistentResponseSize);
+     if (!this.yasr.results.hasError()) {
+@@ -518,7 +519,7 @@
+     this.emit("change", this, this.persistentJson);
+   };
+ 
+-  handleTotalElementChanged = (_yasqe: Yasqe, totalElements = -1) => {
++  handleTotalElementsChanged = (_yasqe: Yasqe, totalElements = -1) => {
+     if (this.yasr?.results) {
+       const response = this.persistentJson.yasr.response;
+       if (response) {
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -32,8 +32,8 @@
+     eventName: "queryResponse",
+     handler: (instance: Yasqe, req: superagent.SuperAgentRequest, duration: number, queryStartedTime: number) => void
+   ): void;
+-  on(event: "totalElementChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
+-  off(event: "totalElementChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
++  on(event: "totalElementsChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
++  off(event: "totalElementsChanged", handler: (instance: Yasqe, totalElements: number) => void): void;
+   on(
+     event: "countAffectedRepositoryStatementsChanged",
+     handler: (instance: Yasqe, totalElements: number) => void
+Index: Yasgui/packages/yasqe/src/sparql.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/sparql.ts b/Yasgui/packages/yasqe/src/sparql.ts
+--- a/Yasgui/packages/yasqe/src/sparql.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasqe/src/sparql.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -118,24 +118,36 @@
+     yasqe.emit("query", req, populatedConfig);
+     return await req.then(
+       (result) => {
+-        let hasMorePage = false;
+-        if (!yasqe.isUpdateQuery() && !yasqe.isAskQuery() && yasqe.config.paginationOn) {
+-          // If client hadn't set total Element we will execute count query.
+-          if (!result.body.totalElements) {
+-            executeCountQuery(yasqe, config);
+-          } else {
+-            yasqe.emit("totalElementChanged", parseInt(result.body.totalElements));
+-          }
++        let hasMorePages = false;
++        let totalElements;
++        if (!isNaN(result.body.totalElements)) {
++          totalElements = parseInt(result.body.totalElements);
++        }
++        let possibleElementsCount;
++
++        // if response contains total elements then don't need to execute count Query.
++        // Also count query is skipped for update and ask query.
++        if (!totalElements && !yasqe.isUpdateQuery() && !yasqe.isAskQuery() && yasqe.config.paginationOn) {
+           const pageSize = yasqe.getPageSize();
+-          if (pageSize) {
+-            hasMorePage = result.body.results.bindings.length > pageSize;
+-            if (hasMorePage) {
++          const pageNumber = yasqe.getPageNumber();
++          if (pageSize && pageNumber) {
++            hasMorePages = result.body.results.bindings.length > pageSize;
++            possibleElementsCount = pageSize * (pageNumber - 1) + result.body.results.bindings.length;
++            if (hasMorePages) {
+               result.body.results.bindings.pop();
++              executeCountQuery(yasqe, config);
++            } else {
++              totalElements = possibleElementsCount;
+             }
+           }
+         }
+-        yasqe.emit("queryResponse", result, Date.now() - queryStart, queryStart, hasMorePage);
++
++        yasqe.emit("queryResponse", result, Date.now() - queryStart, queryStart, hasMorePages, possibleElementsCount);
+         yasqe.emit("queryResults", result.body, Date.now() - queryStart);
++        if (totalElements) {
++          yasqe.emit("totalElementsChanged", totalElements);
++          yasqe.emit("totalElementsPersisted", totalElements);
++        }
+         return result.body;
+       },
+       (e) => {
+@@ -175,8 +187,8 @@
+   req.then(
+     (countResponse) => {
+       yasqe.emit("countQueryResponse", countResponse);
+-      yasqe.emit("totalElementChanged", parseInt(countResponse.body.totalElements));
+-      yasqe.emit("countQueryReady", parseInt(countResponse.body.totalElements));
++      yasqe.emit("totalElementsChanged", parseInt(countResponse.body.totalElements));
++      yasqe.emit("totalElementsPersisted", parseInt(countResponse.body.totalElements));
+     },
+     (error) => {
+       // Nothing to do. In tab persistence "totalElements" will stay undefined.
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -24,7 +24,7 @@
+     this.externalPluginsConfigurations = conf.externalPluginsConfigurations;
+     if (yasqe.config.paginationOn) {
+       this.yasqe.on("queryResponse", this.updateQueryResultPaginationElementHandler.bind(this));
+-      this.yasqe.on("countQueryReady", this.updateQueryResultPaginationElementHandler.bind(this));
++      this.yasqe.on("totalElementsPersisted", this.updateQueryResultPaginationElementHandler.bind(this));
+       this.updateQueryResultPaginationElement(this.resultQueryPaginationElement);
+     }
+     this.yasqe.on("countAffectedRepositoryStatementsPersisted", this.updateResponseInfo.bind(this));
+@@ -299,8 +299,8 @@
+     let totalResult = "";
+     if (totalElements) {
+       totalResult = this.getTotalResultsMessage(totalElements) + ".";
+-    } else if (this.persistentJson?.yasr.response?.hasMorePages) {
+-      totalResult = this.getHasMoreResultsMessage(to + 1) + ".";
++    } else if (this.persistentJson?.yasr.response?.possibleElementsCount) {
++      totalResult = this.getHasMoreResultsMessage(this.persistentJson.yasr.response.possibleElementsCount) + ".";
+     }
+     return `${fromToMessage} ${totalResult}`;
+   }
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -599,9 +599,15 @@
+       }
+     }
+   }
+-  public setResponse(data: any, duration?: number, queryStartedTime?: number, hasMorePages?: boolean) {
++  public setResponse(
++    data: any,
++    duration?: number,
++    queryStartedTime?: number,
++    hasMorePages?: boolean,
++    possibleElementsCount?: number
++  ) {
+     if (!data) return;
+-    this.results = new Parser(data, duration, queryStartedTime, hasMorePages);
++    this.results = new Parser(data, duration, queryStartedTime, hasMorePages, possibleElementsCount);
+ 
+     this.draw();
+ 
+Index: Yasgui/packages/yasr/src/parsers/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/parsers/index.ts b/Yasgui/packages/yasr/src/parsers/index.ts
+--- a/Yasgui/packages/yasr/src/parsers/index.ts	(revision b3fcdd8b5e157e48825e243b55e9b88357fa9bce)
++++ b/Yasgui/packages/yasr/src/parsers/index.ts	(revision eb121081d6ff2dab3a316edb1b45eefd3e5d53ae)
+@@ -43,6 +43,7 @@
+     totalElements?: number;
+     countAffectedRepositoryStatements?: number;
+     hasMorePages?: boolean;
++    possibleElementsCount?: number;
+   }
+   export type PostProcessBinding = (binding: Binding) => Binding;
+ }
+@@ -76,13 +77,14 @@
+   private executionTime: number | undefined;
+   private queryStartedTime: number | undefined;
+   private countAffectedRepositoryStatements?: number | undefined;
+-
++  private possibleElementsCount?: number;
+   private readonly hasMorePages?: boolean;
+   constructor(
+     responseOrObject: Parser.ResponseSummary | SuperAgent.Response | Error | any,
+     executionTime?: number,
+     queryStartedTime?: number,
+-    hasMorePages?: boolean
++    hasMorePages?: boolean,
++    possibleElementsCount?: number
+   ) {
+     if (responseOrObject.executionTime) this.executionTime = responseOrObject.executionTime;
+     if (executionTime) this.executionTime = executionTime; // Parameter has priority
+@@ -93,6 +95,7 @@
+       this.queryStartedTime = responseOrObject.queryStartedTime;
+     }
+     this.hasMorePages = hasMorePages;
++    this.possibleElementsCount = possibleElementsCount;
+ 
+     this.countAffectedRepositoryStatements = responseOrObject.countAffectedRepositoryStatements;
+ 
+@@ -193,6 +196,10 @@
+     return this.hasMorePages;
+   }
+ 
++  public getPossibleElementsCount(): number | undefined {
++    return this.possibleElementsCount;
++  }
++
+   public setCountAffectedRepositoryStatements(countAffectedRepositoryStatements: number) {
+     this.countAffectedRepositoryStatements = countAffectedRepositoryStatements;
+   }
+@@ -326,6 +333,7 @@
+         executionTime: this.getResponseTime(),
+         queryStartedTime: this.getQueryStartedTime(),
+         hasMorePages: this.getHasMorePages(),
++        possibleElementsCount: this.getPossibleElementsCount(),
+         countAffectedRepositoryStatements: this.getCountAffectedRepositoryStatements(),
+       };
+     }
+@@ -342,6 +350,7 @@
+         executionTime: this.getResponseTime(),
+         queryStartedTime: this.getQueryStartedTime(),
+         hasMorePages: this.getHasMorePages(),
++        possibleElementsCount: this.getPossibleElementsCount(),
+         countAffectedRepositoryStatements: this.getCountAffectedRepositoryStatements(),
+       };
+     }


### PR DESCRIPTION
## What
Skips the count query when the results of fulfilled query are less or equal of the page size.

## Why
- Better performance;
- WB has such functionality.

## How
Added checks after every one query and if returned results are less or equal of page size, then total elements are calculates depends on the current page, the page size and the count of results.

Additional work:
- "totalElementChanged" event name is renamed to "totalElementsChanged";
- "countQueryReady" event name is renamed to "totalElementsPersisted",