### PR TITLE
GDB-8132: Add appropriate headers depending on query mode and type

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -491,7 +491,7 @@ export class OntotextYasguiWebComponent {
   }
 
   private onCountQuery(yasqe: Yasqe, request: Request) {
-    this.output.emit(new CountQueryEvent(request, yasqe.getValue(), this.ontotextYasgui.getQueryMode()));
+    this.output.emit(new CountQueryEvent(request, yasqe.getValue(), yasqe.getQueryMode(), yasqe.getQueryType(), yasqe.getPageSize()));
   }
 
   private onCountQueryResponse(_yasqe: Yasqe, countQueryResponse: any) {
@@ -505,7 +505,7 @@ export class OntotextYasguiWebComponent {
 
   // @ts-ignore
   private onQuery(yasqe: Yasqe, request: Request): void {
-    this.output.emit(new QueryEvent(request, yasqe.getValue(), yasqe.getQueryMode()));
+    this.output.emit(new QueryEvent(request, yasqe.getValue(), yasqe.getQueryMode(), yasqe.getQueryType(), yasqe.getPageSize()));
     this.showQueryProgress = true;
   }
 

--- a/ontotext-yasgui-web-component/src/models/output-events/count-query-event.ts
+++ b/ontotext-yasgui-web-component/src/models/output-events/count-query-event.ts
@@ -2,7 +2,7 @@ import {OutputEvent} from './output-event';
 
 export class CountQueryEvent extends OutputEvent {
   static OUTPUT_TYPE = 'countQuery';
-  constructor(request: any, query: string, queryMode: string) {
-    super(CountQueryEvent.OUTPUT_TYPE, {request, query, queryMode});
+  constructor(request: any, query: string, queryMode: string, queryType: string, pageSize: number) {
+    super(CountQueryEvent.OUTPUT_TYPE, {request, query, queryMode, queryType, pageSize});
   }
 }

--- a/ontotext-yasgui-web-component/src/models/output-events/query-event.ts
+++ b/ontotext-yasgui-web-component/src/models/output-events/query-event.ts
@@ -2,7 +2,7 @@ import {OutputEvent} from './output-event';
 
 export class QueryEvent extends OutputEvent {
   static OUTPUT_TYPE = 'query';
-  constructor(request: any, query: string, queryMode: string) {
-    super(QueryEvent.OUTPUT_TYPE, {request, query, queryMode});
+  constructor(request: any, query: string, queryMode: string, queryType: string, pageSize: number) {
+    super(QueryEvent.OUTPUT_TYPE, {request, query, queryMode, queryType, pageSize});
   }
 }


### PR DESCRIPTION
## What
Extends "QueryEvent" and "CountQueryEvent" event models to support the query type and the page size.

## Why
The client (WB) needs this information to set up correct request headers.

## How
Extends the event payload to deliver required information.