### PR TITLE
GDB-8207: Add explain plan command for DESCRIBE queries

### DIFF
--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -1078,7 +1078,7 @@ export class Yasqe extends CodeMirror {
   public query(config?: Sparql.YasqeAjaxConfig, isExplainPlanQuery = false) {
     if (this.config.queryingDisabled) return Promise.reject("Querying is disabled.");
 
-    if (isExplainPlanQuery && !(this.isSelectQuery() || this.isConstructQuery())) {
+    if (isExplainPlanQuery && !(this.isSelectQuery() || this.isConstructQuery() || this.isDescribeQuery())) {
       const message = this.translationService.translate(
         "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message"
       );
@@ -1116,6 +1116,10 @@ export class Yasqe extends CodeMirror {
   }
   public isUpdateQuery(): boolean {
     return "update" === this.getQueryMode()?.toLowerCase();
+  }
+
+  public isDescribeQuery(): boolean {
+    return "describe" === this.getQueryType()?.toLowerCase();
   }
 
   public isAskQuery(): boolean {

--- a/cypress/e2e/editor-actions/execute-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/execute-query.spec.cy.ts
@@ -58,7 +58,7 @@ describe('Execute query action', () => {
     // Then I expect the query don't run,
     YasrSteps.getResultsTable().should('not.exist');
     // and a notification message to be emitted.
-    KeyboardShortcutPageSteps.getActionOutputField().should('have.value', '{"code":"explain_not_allowed","messageType":"warning","message":"Explain only works with SELECT or CONSTRUCT queries."}');
+    KeyboardShortcutPageSteps.getActionOutputField().should('have.value', '{"code":"explain_not_allowed","messageType":"warning","message":"Explain only works with SELECT, CONSTRUCT or DESCRIBE queries."}');
   });
 
   it('should not run explain plan query when repository is virtual.', () => {

--- a/cypress/e2e/keyboard-shortcuts.spec.cy.ts
+++ b/cypress/e2e/keyboard-shortcuts.spec.cy.ts
@@ -240,10 +240,23 @@ describe('Keyboard Shortcuts', () => {
     it('should trigger "EXECUTE_EXPLAIN_PLAN_FOR_QUERY" action', () => {
       // Given: I visit a page with "ontotext-yasgui-web-component" in it,
       QueryStubs.stubExplainPlanQueryResponse();
-      // When press the "Create saved query" keyboard shortcut.
+      // When press the "Explain plan" keyboard shortcut.
       KeyboardShortcutSteps.clickOnExplainPlanQueryShortcut();
 
-      // Then I expect "Create New Saved Query" to be visible.
+      // Then I expect to see explain plan message.
+      YasrSteps.getTableResults().contains('NOTE: Optimization groups are evaluated one after another exactly in the given order.');
+    });
+
+    it('should trigger "EXECUTE_EXPLAIN_PLAN_FOR_QUERY" action on DESCRIBE query', () => {
+
+      YasqeSteps.clearEditor();
+      YasqeSteps.writeInEditor('DESCRIBE * WHERE {\n ?s ?p ?o \n}');
+      // Given: I visit a page with "ontotext-yasgui-web-component" in it,
+      QueryStubs.stubExplainPlanQueryResponse();
+      // When press the "Explain plan" keyboard shortcut.
+      KeyboardShortcutSteps.clickOnExplainPlanQueryShortcut();
+
+      // Then I expect to see explain plan message.
       YasrSteps.getTableResults().contains('NOTE: Optimization groups are evaluated one after another exactly in the given order.');
     });
   });

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -82,7 +82,7 @@
   "yasqe.keyboard_shortcuts.dialog.item.explain_exit_fullscreen.message": "Press F11 or Esc to exit full screen",
   "yasqe.keyboard_shortcuts.dialog.item.esc.label": "Esc",
   "yasqe.keyboard_shortcuts.dialog.item.esc.description": "Press Esc to exit full screen",
-  "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message": "Explain only works with SELECT or CONSTRUCT queries.",
+  "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message": "Explain only works with SELECT, CONSTRUCT or DESCRIBE queries.",
   "yasqe.keyboard_shortcuts.action.explain_plan_query.error.message": "Cannot execute updates from this editor.",
   "yasr.message_info.removed_statements.message": "Removed {{countAffectedRepositoryStatements}} statements.",
   "yasr.message_info.added_statements.message": "Added {{countAffectedRepositoryStatements}} statements.",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -82,7 +82,7 @@
   "yasqe.keyboard_shortcuts.dialog.item.explain_exit_fullscreen.message": "Press F11 or Esc to exit full screen",
   "yasqe.keyboard_shortcuts.dialog.item.esc.label": "Esc",
   "yasqe.keyboard_shortcuts.dialog.item.esc.description": "Press Esc to exit full screen",
-  "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message": "Explain ne fonctionne qu'avec les requêtes SELECT ou CONSTRUCT.",
+  "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message": "Explain ne fonctionne qu'avec les requêtes SELECT, CONSTRUCT ou DESCRIBE.",
   "yasqe.keyboard_shortcuts.action.explain_plan_query.error.message": "Impossible d'exécuter les mises à jour depuis cet éditeur.",
   "yasr.message_info.removed_statements.message": "Suppression de {{countAffectedRepositoryStatements}} déclarations.",
   "yasr.message_info.added_statements.message": "Ajout de {{countAffectedRepositoryStatements}} déclarations.",

--- a/yasgui-patches/2023-04-27-GDB-8207_add_explain_plan_command_for_DESCRIBE_queries.patch
+++ b/yasgui-patches/2023-04-27-GDB-8207_add_explain_plan_command_for_DESCRIBE_queries.patch
@@ -1,0 +1,30 @@
+Subject: [PATCH] GDB-8207: Add explain plan command for DESCRIBE queries
+---
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 95d1314a6d09d85f313a0d7cbafa324740c7cacf)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision ae467960e750350fd6ef316ce3788af8118a2b52)
+@@ -1078,7 +1078,7 @@
+   public query(config?: Sparql.YasqeAjaxConfig, isExplainPlanQuery = false) {
+     if (this.config.queryingDisabled) return Promise.reject("Querying is disabled.");
+ 
+-    if (isExplainPlanQuery && !(this.isSelectQuery() || this.isConstructQuery())) {
++    if (isExplainPlanQuery && !(this.isSelectQuery() || this.isConstructQuery() || this.isDescribeQuery())) {
+       const message = this.translationService.translate(
+         "yasqe.keyboard_shortcuts.action.explain_plan_query.warning.message"
+       );
+@@ -1118,6 +1118,10 @@
+     return "update" === this.getQueryMode()?.toLowerCase();
+   }
+ 
++  public isDescribeQuery(): boolean {
++    return "describe" === this.getQueryType()?.toLowerCase();
++  }
++
+   public isAskQuery(): boolean {
+     return "ASK" === this.getQueryType();
+   }


### PR DESCRIPTION
## What
Extends the supported explain plan queries with a DESCRIBE query.

## Why
WB was extended to support explain plan for DESCRIBE query.

## How
Extends restriction of supported queries of explain plan command.