### PR TITLE
GDB-8247: Update results cells to not cut the long IRIs

### DIFF
--- a/cypress/e2e/yasr/sparql-result-formatting.spec.cy.ts
+++ b/cypress/e2e/yasr/sparql-result-formatting.spec.cy.ts
@@ -1,0 +1,66 @@
+import DefaultViewPageSteps from '../../steps/default-view-page-steps';
+import {QueryStubs} from '../../stubs/query-stubs';
+import {YasqeSteps} from '../../steps/yasqe-steps';
+import {YasrSteps} from '../../steps/yasr-steps';
+
+describe('Formatting of SPARQL result bindings.', () => {
+
+  beforeEach(() => {
+    DefaultViewPageSteps.visit();
+  });
+
+  it('should format result cell properly if result binding is IRI', () => {
+    // When I execute a query that returns IRI result.
+    QueryStubs.stubSingleIRIResult();
+    YasqeSteps.executeQuery();
+
+    // Then I expect "/" character and "://" sequence to be followed by <wbr> tag.
+    YasrSteps.getResultCellLink(0, 1).then(function($el) {
+      expect($el.html()).to.eq('http://<wbr>example.com/<wbr>foobarbaz/<wbr>meow/<wbr>123');
+    });
+    // and break-word is applied,
+    YasrSteps.getResultCellLink(0, 1).should('have.css', 'word-wrap', 'break-word');
+    YasrSteps.getResultUriCell(0, 1).should('have.attr', 'lang', 'xx');
+  });
+
+  it('should format properly result cell if result binding is literal and has language tag', () => {
+    // When I execute a query that returns literal result.
+    QueryStubs.stubSingleLiteralWithLangTagResult();
+    YasqeSteps.executeQuery();
+
+    // Then I expect break-word is applied,
+    YasrSteps.getResultNoUriCell(0, 1).should('have.css', 'word-wrap', 'break-word');
+    // language attribute is applied.
+    YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'en-GB');
+    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
+  });
+
+  it('should format properly result cell if result binding is literal and has not language tag', () => {
+    // When I execute a query that returns literal result.
+    QueryStubs.stubSingleLiteralWithoutLangTagResult();
+    YasqeSteps.executeQuery();
+
+    // Then I expect break-word is applied,
+    YasrSteps.getResultNoUriCell(0, 1).should('have.css', 'word-wrap', 'break-word');
+    // language attribute is applied.
+    YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'xx');
+    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
+  });
+
+  it('should format result cell properly if result binding is literal and contains data type value', () => {
+    // When I execute a query that returns literal result.
+    QueryStubs.stubSingleLiteralWithDataTypeResult();
+    YasqeSteps.executeQuery();
+
+    // Then I expect "^^" to be prefixed with <wbr> tag,
+    YasrSteps.getResultNoUriCell(0, 1).then(function($el) {
+      expect($el.html()).to.eq("\"some text with data type 2.0<wbr>^^xsd:<wbr>floatsup\"");
+    });
+
+    // and I expect break-word is applied,
+    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'word-wrap', 'break-word');
+    // and language attribute is applied.
+    YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'xx');
+    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
+  });
+});

--- a/cypress/fixtures/queries/single-iri-result.json
+++ b/cypress/fixtures/queries/single-iri-result.json
@@ -1,0 +1,17 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "type": "uri",
+          "value": "http://example.com/foobarbaz/meow/123"
+        }
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/queries/single-literal-with-data-type-response.json
+++ b/cypress/fixtures/queries/single-literal-with-data-type-response.json
@@ -1,0 +1,17 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "type": "literal",
+          "value": "some text with data type 2.0^^xsd:floatsup"
+        }
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/queries/single-literal-with-lang-tag-response.json
+++ b/cypress/fixtures/queries/single-literal-with-lang-tag-response.json
@@ -1,0 +1,18 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "xml:lang": "en-GB",
+          "type": "literal",
+          "value": "some text "
+        }
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/queries/single-literal-without-lang-tag-response.json
+++ b/cypress/fixtures/queries/single-literal-without-lang-tag-response.json
@@ -1,0 +1,17 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "type": "literal",
+          "value": "some text "
+        }
+      }
+    ]
+  }
+}

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -154,4 +154,20 @@ export class YasrSteps {
   static getYasrToolbar() {
     return cy.get('.yasr-toolbar');
   }
+
+  static getResultCellLink(rowIndex: number, columnIndex: number) {
+    return YasrSteps.getResultCell(rowIndex, columnIndex).find('a').eq(0);
+  }
+
+  static getResultUriCell(rowIndex: number, columnIndex: number) {
+    return YasrSteps.getResultCell(rowIndex, columnIndex).find('.uri-cell');
+  }
+
+  static getResultNoUriCell(rowIndex: number, columnIndex: number) {
+    return YasrSteps.getResultCell(rowIndex, columnIndex).find('.nonUri');
+  }
+
+  static getResultLiteralCell(rowIndex, columnIndex) {
+    return YasrSteps.getResultCell(rowIndex, columnIndex).find('.literal-cell');
+  }
 }

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -26,6 +26,22 @@ export class QueryStubs {
     QueryStubs.stubQueryResponse('/queries/ask-false-query-response.json', 'askFalseQueryResponse', withDelay);
   }
 
+  static stubSingleIRIResult(withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-iri-result.json', 'single-iri-result', withDelay);
+  }
+
+  static stubSingleLiteralWithLangTagResult(withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-with-lang-tag-response.json', 'single-iri-result', withDelay);
+  }
+
+  static stubSingleLiteralWithoutLangTagResult(withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-without-lang-tag-response.json', 'single-iri-result', withDelay);
+  }
+
+  static stubSingleLiteralWithDataTypeResult(withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-with-data-type-response.json', 'single-iri-result', withDelay);
+  }
+
   static stubQueryResponse(fixture: string, alias: string, withDelay: number = 0) {
     cy.intercept('/repositories/test-repo', {fixture, delay: withDelay}).as(alias);
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -217,6 +217,17 @@
         display: none;
       }
 
+      .uri-cell {
+        word-wrap: break-word;
+      }
+
+      .literal-cell {
+        word-wrap: break-word;
+        -webkit-hyphens: auto;
+        -moz-hyphens: auto;
+        hyphens: auto;
+      }
+
       /** Shows copy resource link when mouse is over a table row with resources of type uri */
       .dataTable tbody td:hover:not(:has(.triple-cell)) div.uri-cell .resource-copy-link {
         display: inline;


### PR DESCRIPTION
## What
When IRIs in SPARQL results are shown and don’t fit in the available column size they aren’t wrapped to the next line. This varies between browsers and versions.

## Why
Browsers have different defaults about word-wrapping.

## How
Added word break rules depends on result binding type.

- For IRIs and blank nodes:
 - adds word-wrap: break-word to all cell with IRI content;
 - inserts at strategic places: after :, /, -, _ but treat sequences of those as one thing, e.g. http://example…;
 - set attribute lang="xx" on the element.
- For literals:
  - adds word-wrap: break-word to all cell with literal content;
  - added hyphens: auto (+ -moz- and -webkit- prefixed version) to all cell with literal content;
  - if the literal has a language tag;
    - set attribute lang="" on the element;
  - if literal without language tag; - set attribute lang="" on the element; if literal with a datatype; - set attribute lang="" on the element; - inserts before the ^^ of the datatype; - inserts within the IRI of the datatype following the same rules as for a standalone IRI; The embedded triples recursively use rules from IRI and literals.