### PR TITLE
Feature/gdb 8183 different results when clicking sort button in yasr result table

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -29,10 +29,64 @@ export class ExtendedTable extends Table {
 
   public draw(persistentConfig: PersistentConfig) {
     super.draw(persistentConfig);
+    this.setupIndexColumn();
     const explainPlanQueryElement = document.getElementById("explainPlanQuery");
     if (!explainPlanQueryElement) {
       return;
     }
     Yasqe.runMode(explainPlanQueryElement.innerText, "sparql11", explainPlanQueryElement);
+  }
+
+  protected getColumns(): DataTables.ColumnSettings[] {
+    if (!this.yasr.results) return [];
+    const prefixes = this.yasr.getPrefixes();
+
+    return [
+      {
+        searchable: false,
+        width: `${this.getSizeFirstColumn()}px`,
+        orderable: false,
+        visible: this.persistentConfig.compact !== true,
+        render: (data: number, type: any) =>
+          type === "filter" || type === "sort" || !type ? data : `<div class="rowNumber">${data}</div>`,
+      }, //prepend with row numbers column
+      ...this.yasr.results?.getVariables().map((name) => {
+        return <DataTables.ColumnSettings>{
+          name: name,
+          title: name,
+          render: (data: Parser.BindingValue | "", type: any, _row: any, _meta: DataTables.CellMetaSettings) => {
+            // Handle empty rows
+            if (data === "") {
+              return data;
+            }
+            if (!type) {
+              return data.value;
+            }
+            return this.getCellContent(data, prefixes);
+          },
+        };
+      }),
+    ];
+  }
+
+  /**
+   * Set-ups first column to be index column according official solution from DataTable.
+   * @see <a href="https://datatables.net/examples/api/counter_columns.html">Official solution from DataTable</a>
+   * @private
+   */
+  private setupIndexColumn() {
+    if (!this.dataTable) {
+      return;
+    }
+    const dataTable = this.dataTable;
+    // Set up first column to be index column according official solution from DataTable.
+    this.dataTable
+      .on("order.dt search.dt", function () {
+        let i = 1;
+        dataTable.cells(null, 0, { search: "applied", order: "applied" }).every(function (cell) {
+          this.data(i++);
+        });
+      })
+      .draw();
   }
 }

--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -40,11 +40,11 @@ function expand(this: HTMLDivElement, event: MouseEvent) {
 
 export default class Table implements Plugin<PluginConfig> {
   private config: DeepReadonly<PluginConfig>;
-  private persistentConfig: PersistentConfig = {};
-  private yasr: Yasr;
+  protected persistentConfig: PersistentConfig = {};
+  protected yasr: Yasr;
   private tableControls: Element | undefined;
   private tableEl: HTMLTableElement | undefined;
-  private dataTable: DataTables.Api | undefined;
+  protected dataTable: DataTables.Api | undefined;
   private tableFilterField: HTMLInputElement | undefined;
   private tableSizeField: HTMLSelectElement | undefined;
   private tableCompactSwitch: HTMLInputElement | undefined;
@@ -149,7 +149,7 @@ export default class Table implements Plugin<PluginConfig> {
     return stringRepresentation;
   }
 
-  private getColumns(): DataTables.ColumnSettings[] {
+  protected getColumns(): DataTables.ColumnSettings[] {
     if (!this.yasr.results) return [];
     const prefixes = this.yasr.getPrefixes();
 
@@ -178,7 +178,7 @@ export default class Table implements Plugin<PluginConfig> {
       }),
     ];
   }
-  private getSizeFirstColumn() {
+  protected getSizeFirstColumn() {
     const numResults = this.yasr.results?.getBindings()?.length || 0;
     return numResults.toString().length * 8;
   }

--- a/cypress/e2e/yasr/plugins/error/error-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/error/error-plugin.spec.cy.ts
@@ -1,8 +1,8 @@
-import DefaultViewPageSteps from '../../steps/default-view-page-steps';
-import {QueryStubs} from '../../stubs/query-stubs';
-import {YasqeSteps} from '../../steps/yasqe-steps';
-import {ErrorPluginSteps} from '../../steps/error-plugin-steps';
-import {YasrSteps} from '../../steps/yasr-steps';
+import DefaultViewPageSteps from '../../../../steps/default-view-page-steps';
+import {QueryStubs} from '../../../../stubs/query-stubs';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import {ErrorPluginSteps} from '../../../../steps/error-plugin-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
 
 describe('Error handling', () => {
 

--- a/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
@@ -1,8 +1,8 @@
-import {QueryStubs} from '../../stubs/query-stubs';
-import {YasrTablePluginSteps} from '../../steps/yasr-table-plugin-steps';
-import {YasqeSteps} from '../../steps/yasqe-steps';
-import {YasrSteps} from '../../steps/yasr-steps';
-import {DownloadAsPageSteps} from "../../steps/download-as-page-steps";
+import {QueryStubs} from '../../../../stubs/query-stubs';
+import {YasrTablePluginSteps} from '../../../../steps/yasr-table-plugin-steps';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
+import {DownloadAsPageSteps} from "../../../../steps/download-as-page-steps";
 
 describe('Plugin: Raw response', () => {
   beforeEach(() => {

--- a/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
@@ -1,10 +1,10 @@
-import {QueryStubDescription, QueryStubs, ResultType} from '../../stubs/query-stubs';
-import {YasrTablePluginSteps} from '../../steps/yasr-table-plugin-steps';
-import {YasqeSteps} from '../../steps/yasqe-steps';
-import DefaultViewPageSteps from '../../steps/default-view-page-steps';
-import {YasrSteps} from '../../steps/yasr-steps';
-import {PaginationPageSteps} from '../../steps/pages/pagination-page-steps';
-import {PaginationSteps} from '../../steps/pagination-steps';
+import {QueryStubDescription, QueryStubs, ResultType} from '../../../../stubs/query-stubs';
+import {YasrTablePluginSteps} from '../../../../steps/yasr-table-plugin-steps';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import DefaultViewPageSteps from '../../../../steps/default-view-page-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
+import {PaginationPageSteps} from '../../../../steps/pages/pagination-page-steps';
+import {PaginationSteps} from '../../../../steps/pagination-steps';
 
 describe('Plugin: Table', () => {
 

--- a/cypress/e2e/yasr/plugins/table/sort-results.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/sort-results.spec.cy.ts
@@ -1,0 +1,41 @@
+import DefaultViewPageSteps from '../../../../steps/default-view-page-steps';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
+
+describe('Sort table plugin functionality', () => {
+
+  beforeEach(() => {
+    DefaultViewPageSteps.visit();
+  });
+
+  it('should sort results', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    // and execute a query that returns results.
+    YasqeSteps.executeQuery();
+
+    // Then I expect the first column shows the result row number,
+    YasrSteps.getResultCell(0, 0).should('have.text', '1');
+    YasrSteps.getResultCell(1, 0).should('have.text', '2');
+    // and results are displayed without sorting,
+    YasrSteps.getResultCell(73, 1).should('have.text', 'owl:differentFrom');
+    YasrSteps.getResultCell(74, 1).should('have.text', 'http://example/book1');
+
+    // When I click on a table column.
+    YasrSteps.clickOnColumnHeader(1);
+    // Then I expect the first column shows the result row number,
+    YasrSteps.getResultCell(0, 0).should('have.text', '1');
+    YasrSteps.getResultCell(1, 0).should('have.text', '2');
+    // and results are sorted ascending,
+    YasrSteps.getResultCell(0, 1).should('have.text', 'http://example/book1');
+    YasrSteps.getResultCell(1, 1).should('have.text', 'http://purl.org/dc/elements/1.1/creator');
+
+    // When I click on a table column.
+    YasrSteps.clickOnColumnHeader(1);
+    // Then I expect the first column shows the result row number,
+    YasrSteps.getResultCell(0, 0).should('have.text', '1');
+    YasrSteps.getResultCell(1, 0).should('have.text', '2');
+    // and results are sorted descending,
+    YasrSteps.getResultCell(2, 1).should('have.text', 'xsd:string');
+    YasrSteps.getResultCell(3, 1).should('have.text', 'xsd:nonNegativeInteger');
+  });
+});

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -18,6 +18,17 @@ export class YasrSteps {
   static getResultsTable(yasrIndex = 0) {
     return YasrSteps.getYasr(yasrIndex).find('.yasr_results tbody');
   }
+  static getResultsTableHeaders(yasrIndex = 0) {
+    return YasrSteps.getYasr(yasrIndex).find('.yasr_results thead');
+  }
+
+  static getHeaderCell(columnNumber = 0, yasrIndex = 0) {
+    return YasrSteps.getResultsTableHeaders(yasrIndex).find('th').eq(columnNumber);
+  }
+
+  static clickOnColumnHeader(columnNumber = 0) {
+    YasrSteps.getHeaderCell(columnNumber).click();
+  }
 
   static getTableResults(yasrIndex = 0) {
     return this.getYasr(yasrIndex).find('.yasr_results tbody').find('tr');

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -141,6 +141,7 @@
   .yasr {
     table.dataTable thead th {
       background-color: $color-onto-green;
+      text-align: center;
     }
 
     .dataTable td, .dataTable thead tr th {
@@ -310,6 +311,27 @@
 
       .response-error {
         background-color: #fbdbd5;
+      }
+    }
+
+    .dataTables_wrapper .dataTable thead {
+
+      th {
+        background-position: calc(100% - 5px) center;
+      }
+      .sorting {
+        background-size: 0.9em;
+        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z'/%3E%3C/svg%3E" );
+      }
+
+      .sorting_asc {
+        background-size: 1em;
+        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm240-64H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 446.37V464a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 321.63V304a16 16 0 0 0-16-16zm31.06-85.38l-59.27-160A16 16 0 0 0 372.72 32h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 224h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 224H432a16 16 0 0 0 15.06-21.38zM335.61 144L352 96l16.39 48z'/%3E%3C/svg%3E" );
+      }
+
+      .sorting_desc {
+        background-size: 1em;
+        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm112-128h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 65.63V48a16 16 0 0 0-16-16H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 190.37V208a16 16 0 0 0 16 16zm159.06 234.62l-59.27-160A16 16 0 0 0 372.72 288h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 480h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 480H432a16 16 0 0 0 15.06-21.38zM335.61 400L352 352l16.39 48z'/%3E%3C/svg%3E" );
       }
     }
   }

--- a/yasgui-patches/2023-05-11-GDB-8183__different_results_when_clicking_sort_button_in_yasr_result_table.patch
+++ b/yasgui-patches/2023-05-11-GDB-8183__different_results_when_clicking_sort_button_in_yasr_result_table.patch
@@ -1,0 +1,116 @@
+Subject: [PATCH] GDB-8183: different results when clicking sort button in yasr result table
+---
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 8b89607a51c3e9c8151521684b634d4e287029f3)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision b977827001a7f2fc1f6dd52504452597621efc4f)
+@@ -29,10 +29,64 @@
+ 
+   public draw(persistentConfig: PersistentConfig) {
+     super.draw(persistentConfig);
++    this.setupIndexColumn();
+     const explainPlanQueryElement = document.getElementById("explainPlanQuery");
+     if (!explainPlanQueryElement) {
+       return;
+     }
+     Yasqe.runMode(explainPlanQueryElement.innerText, "sparql11", explainPlanQueryElement);
+   }
++
++  protected getColumns(): DataTables.ColumnSettings[] {
++    if (!this.yasr.results) return [];
++    const prefixes = this.yasr.getPrefixes();
++
++    return [
++      {
++        searchable: false,
++        width: `${this.getSizeFirstColumn()}px`,
++        orderable: false,
++        visible: this.persistentConfig.compact !== true,
++        render: (data: number, type: any) =>
++          type === "filter" || type === "sort" || !type ? data : `<div class="rowNumber">${data}</div>`,
++      }, //prepend with row numbers column
++      ...this.yasr.results?.getVariables().map((name) => {
++        return <DataTables.ColumnSettings>{
++          name: name,
++          title: name,
++          render: (data: Parser.BindingValue | "", type: any, _row: any, _meta: DataTables.CellMetaSettings) => {
++            // Handle empty rows
++            if (data === "") {
++              return data;
++            }
++            if (!type) {
++              return data.value;
++            }
++            return this.getCellContent(data, prefixes);
++          },
++        };
++      }),
++    ];
++  }
++
++  /**
++   * Set-ups first column to be index column according official solution from DataTable.
++   * @see <a href="https://datatables.net/examples/api/counter_columns.html">Official solution from DataTable</a>
++   * @private
++   */
++  private setupIndexColumn() {
++    if (!this.dataTable) {
++      return;
++    }
++    const dataTable = this.dataTable;
++    // Set up first column to be index column according official solution from DataTable.
++    this.dataTable
++      .on("order.dt search.dt", function () {
++        let i = 1;
++        dataTable.cells(null, 0, { search: "applied", order: "applied" }).every(function (cell) {
++          this.data(i++);
++        });
++      })
++      .draw();
++  }
+ }
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 8b89607a51c3e9c8151521684b634d4e287029f3)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision b977827001a7f2fc1f6dd52504452597621efc4f)
+@@ -40,11 +40,11 @@
+ 
+ export default class Table implements Plugin<PluginConfig> {
+   private config: DeepReadonly<PluginConfig>;
+-  private persistentConfig: PersistentConfig = {};
+-  private yasr: Yasr;
++  protected persistentConfig: PersistentConfig = {};
++  protected yasr: Yasr;
+   private tableControls: Element | undefined;
+   private tableEl: HTMLTableElement | undefined;
+-  private dataTable: DataTables.Api | undefined;
++  protected dataTable: DataTables.Api | undefined;
+   private tableFilterField: HTMLInputElement | undefined;
+   private tableSizeField: HTMLSelectElement | undefined;
+   private tableCompactSwitch: HTMLInputElement | undefined;
+@@ -149,7 +149,7 @@
+     return stringRepresentation;
+   }
+ 
+-  private getColumns(): DataTables.ColumnSettings[] {
++  protected getColumns(): DataTables.ColumnSettings[] {
+     if (!this.yasr.results) return [];
+     const prefixes = this.yasr.getPrefixes();
+ 
+@@ -178,7 +178,7 @@
+       }),
+     ];
+   }
+-  private getSizeFirstColumn() {
++  protected getSizeFirstColumn() {
+     const numResults = this.yasr.results?.getBindings()?.length || 0;
+     return numResults.toString().length * 8;
+   }


### PR DESCRIPTION
## What
- When run query that returns results and click on a results table column to sort them, the results are sorted differently than those in WB;
- When run query that returns results and click on a results table column to sort them, the numbers of the first column are not consecutive.

## Why
 - The [DataTables](https://datatables.net/) column configuration has a rendering function defined, called to format data table cells. The result of the function is a string that is used as cell data, sorting, and filtering. When the render function is called for visualisation purpose, data from server is formatted. For example if the data is uri it is transformed from full uri to short uri with prefix. When the function is called for sorting and filtering it returns original data from the server. This is the reason for the difference with the WB. In WB, the same formatting is used for visualisation, sorting, and filtering;
 - The first column is implemented as a simple data column, and when the table is sorted, the first column is rendered according to the sorting algorithm.

## How
- The render function is refactored, to returns same result for visualisation, sorting and filtering;
- The first column configuration is changed according [Official solution from DataTable](https://datatables.net/examples/api/counter_columns.html).

Additional work:
- The text of header cells is centered to look like in WB;
- The sort buttons are changed to look like in WB.