### PR TITLE
GDB-8247: Update results cells to not cut the long IRIs

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -219,11 +219,14 @@
       }
 
       .uri-cell {
-        word-wrap: break-word;
+        // overrides yasr value of word-break property
+        // import is needed because yasr selector has bigger weight ".dataTable:not(.ellipseTable) div:not(.expanded)"
+        word-break: break-word !important;
+        overflow-wrap: break-word;
       }
 
       .literal-cell {
-        word-wrap: break-word;
+        overflow-wrap: break-word;
         -webkit-hyphens: auto;
         -moz-hyphens: auto;
         hyphens: auto;


### PR DESCRIPTION
## What
When data of a result cell is IRI that contains a long word. For example "http://example.com/foobarbaz/meeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeow/123", then the data is cut at the end.

## Why
YASR set property `word-break` to be `break-all` when Ellipse result header is not checked.

## How
Sets `word-break` to be 'break-word'.