### PR TITLE
GDB-8006: Integration in create sparql template view

### DIFF
--- a/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
+++ b/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
@@ -50,4 +50,22 @@ describe('Configure editor actions', () => {
         YasguiSteps.openTab(0);
         YasqeSteps.getActionButtons().should('have.length', 5);
     });
+
+    it('should toggle query button', () => {
+      // When I visit a page with "ontotext-yasgui-web-component" in it.
+      // Then I expect "Run" query button to be visible.
+      YasqeSteps.getRunQueryButton().should('be.visible');
+
+      // When "ontotext-yasgui-we-component" is configured to hide "Run" query button.
+      ActionsPageSteps.hideQueryButton();
+
+      // Then I expect "Run" query button to not be visible.
+      YasqeSteps.getRunQueryButton().should('not.exist');
+
+      // When "ontotext-yasgui-we-component" is configured to show "Run" query button.
+      ActionsPageSteps.showQueryButton();
+
+      // Then I expect "Run" query button to not be visible.
+      YasqeSteps.getRunQueryButton().should('be.visible');
+    });
 });

--- a/cypress/e2e/keyboard-shortcuts.spec.cy.ts
+++ b/cypress/e2e/keyboard-shortcuts.spec.cy.ts
@@ -13,7 +13,7 @@ describe('Keyboard Shortcuts', () => {
   });
 
   describe('Dialog info', () => {
-    it('should open dialog', () => {
+    it('should open dialog with information for all keyboard shortcuts actions', () => {
       // When I visit a page with "ontotext-yasgui-web-component" in it.
       // Then I expect to see the "keyboard shortcuts" button in it.
       KeyboardShortcutSteps.getInfoDialogButton().should('be.visible');
@@ -25,8 +25,23 @@ describe('Keyboard Shortcuts', () => {
       KeyboardShortcutSteps.getInfoDialog().should('exist');
       // and have title
       KeyboardShortcutSteps.getInfoDialogTitle().should('have.text', 'Keyboard shortcuts');
-      // and expect 16 keyboard shortcuts to be displayed.
+      // and expect see information for all available actions.
       KeyboardShortcutSteps.getKeyboardShortcutDescriptions().should('have.length', 17);
+    });
+
+    it('should open dialog with information only for readonly keyboard shortcuts actions', () => {
+      // When I visit a page with "ontotext-yasgui-web-component" in it,
+      // and component is configured to be read only
+      KeyboardShortcutPageSteps.hideRunButton();
+
+      // Then I expect to see the "keyboard shortcuts" button in it.
+      KeyboardShortcutSteps.getInfoDialogButton().should('be.visible');
+
+      // When I click on the button.
+      KeyboardShortcutSteps.openInfoDialog();
+
+      // Then I expect to see information for read only operations.
+      KeyboardShortcutSteps.getKeyboardShortcutDescriptions().should('have.length', 10);
     });
   });
 

--- a/cypress/steps/pages/actions-page-steps.ts
+++ b/cypress/steps/pages/actions-page-steps.ts
@@ -43,6 +43,14 @@ export default class ActionsPageSteps {
     cy.get('#showIncludeInferredAction').click();
   }
 
+  static hideQueryButton() {
+    cy.get('#hideQueryButton').click();
+  }
+
+  static showQueryButton() {
+    cy.get('#showQueryButton').click();
+  }
+
   static getEventLog() {
     return cy.get('#eventLog');
   }

--- a/cypress/steps/pages/keyboard-shortcut-page-steps.ts
+++ b/cypress/steps/pages/keyboard-shortcut-page-steps.ts
@@ -10,4 +10,8 @@ export class KeyboardShortcutPageSteps {
   static setVirtualRepository() {
     cy.get('#setVirtualRepo').realClick();
   }
+
+  static hideRunButton() {
+    cy.get('#hideRunButton').click();
+  }
 }

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -49,8 +49,11 @@ export class YasqeSteps {
     return this.getActionButtonsTooltips().eq(index);
   }
 
+  static getRunQueryButton() {
+    return cy.get('.yasqe_queryButton');
+  }
   static getExecuteQueryButton(index = 0) {
-    return cy.get('.yasqe_queryButton').eq(index);
+    return YasqeSteps.getRunQueryButton().eq(index);
   }
 
   static executeQuery(index = 0) {

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -105,6 +105,11 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - **pageSize**: the size of a page. Default value is 10.
 - **downloadAsOn**: if false "Download as" dropdown will not be shown.
 - **yasrToolbarPlugins**: "ontotext-yasgui-web-component" has a toolbar on the right next to the plugin buttons. **yasrToolbarPlugins** have to contain elements that implements [YasrToolbarPlugin](src/models/yasr-toolbar-plugin.ts) interface.
+- **readonly**: There are three options:
+   - true - the query can be edited;
+   - false - the editor is read-only, but the query can be copied;
+   - 'nocursor' - the editor is read-only and hte query can't be copied.
+- **showQueryButton**: if false the "Run" query button will be hidden. Default value is true.
 
 ## Developers guide
 

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -92,6 +92,10 @@ export namespace Components {
         "getEmbeddedResultAsCSV": () => Promise<unknown>;
         "getEmbeddedResultAsJson": () => Promise<unknown>;
         /**
+          * Fetches the query from YASQE editor.
+         */
+        "getQuery": () => Promise<string>;
+        /**
           * Utility method allowing the client to get the mode of the query which is written in the current editor tab. The query mode can be either `query` or `update` regarding the query mode. This method just exposes the similar utility method from the yasqe component.
           * @return A promise which resolves with a string representing the query mode.
          */
@@ -101,6 +105,10 @@ export namespace Components {
           * @return A promise which resolves with a string representing the query type.
          */
         "getQueryType": () => Promise<string>;
+        /**
+          * Checks if query is valid.
+         */
+        "isQueryValid": () => Promise<boolean>;
         /**
           * An input property containing the chosen translation language.
          */

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -217,6 +217,28 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
+   * Fetches the query from YASQE editor.
+   */
+  @Method()
+  getQuery(): Promise<string> {
+    return this.getOntotextYasgui()
+      .then(() => {
+        return this.ontotextYasgui.getQuery();
+      });
+  }
+
+  /**
+   * Checks if query is valid.
+   */
+  @Method()
+  isQueryValid(): Promise<boolean> {
+    return this.getOntotextYasgui()
+      .then(() => {
+        return this.ontotextYasgui.isQueryValid();
+      });
+  }
+
+  /**
    * Allows the client to init the editor using a query model. When the query and query name are
    * found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and
    * initialized using the provided query model.

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -72,6 +72,16 @@ Type: `Promise<unknown>`
 
 
 
+### `getQuery() => Promise<string>`
+
+Fetches the query from YASQE editor.
+
+#### Returns
+
+Type: `Promise<string>`
+
+
+
 ### `getQueryMode() => Promise<string>`
 
 Utility method allowing the client to get the mode of the query which is written in the current
@@ -97,6 +107,16 @@ similar utility method from the yasqe component.
 Type: `Promise<string>`
 
 A promise which resolves with a string representing the query type.
+
+### `isQueryValid() => Promise<boolean>`
+
+Checks if query is valid.
+
+#### Returns
+
+Type: `Promise<boolean>`
+
+
 
 ### `openTab(queryModel: TabQueryModel) => Promise<void>`
 

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -3,6 +3,8 @@ import {Prefixes} from '../../../Yasgui/packages/yasr';
 import {BeforeUpdateQueryResult} from './before-update-query-result';
 import {YasrToolbarPlugin} from './yasr-toolbar-plugin';
 
+export type ReadonlyType = boolean | 'nocursor';
+
 export interface ExternalYasguiConfiguration {
   // ***********************************************************
   //
@@ -39,6 +41,11 @@ export interface ExternalYasguiConfiguration {
    * If the control bar should be rendered or not.
    */
   showControlBar?: boolean;
+
+  /**
+   * If "Run" button should be rendered or not. Default is true.
+   */
+  showQueryButton?: boolean;
 
   // ***********************************************************
   //
@@ -110,6 +117,14 @@ export interface ExternalYasguiConfiguration {
    * Default value is "ontotext-yasgui-config".
    */
   componentId: string;
+
+  /**
+   * Setup yasqe editor. There are three options:
+   * 1. true - the query can be edited;
+   * 2. false - the editor is read-only, but the query can be copied;
+   * 3.'nocursor' - the editor is read-only and hte query can't be copied.
+   */
+  readonly?: ReadonlyType;
 
   // ***********************************************************
   //

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -50,6 +50,10 @@ export class OntotextYasgui {
     return this.yasgui.getTab().getYasqe().getValue();
   }
 
+  isQueryValid(): boolean {
+    return this.yasgui.getTab().getYasqe().queryValid;
+  }
+
   getQueryMode(): string {
     return this.yasgui.getTab().getYasqe().getQueryMode();
   }

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -1,6 +1,6 @@
 import {TranslationService} from '../services/translation.service';
 import {NotificationMessageService} from '../services/notification-message-service';
-import {AutocompleteLoader, YasqeActionButtonDefinition} from "./external-yasgui-configuration";
+import {AutocompleteLoader, ReadonlyType, YasqeActionButtonDefinition} from "./external-yasgui-configuration";
 import {BeforeUpdateQueryResult} from './before-update-query-result';
 import {YasrToolbarPlugin} from './yasr-toolbar-plugin';
 import {EventService} from '../services/event-service';
@@ -94,6 +94,13 @@ export interface YasguiConfiguration {
     paginationOn: true,
     pageSize: 10,
     yasqe?: {
+      /**
+       * Setup yasqe editor. There are three options:
+       * 1. true - the query can be edited;
+       * 2. false - the editor is read-only, but the query can be copied;
+       * 3.'nocursor' - the editor is read-only and hte query can't be copied.
+       */
+      readOnly?: ReadonlyType;
       /**
        * Default query when a tab is opened.
        */
@@ -270,7 +277,8 @@ export const defaultYasqeConfig: Record<string, any> = {
   prefixes: {
 
   },
-  isVirtualRepository: false
+  isVirtualRepository: false,
+  showQueryButton: true
 }
 
 export const defaultYasrConfig: Record<string, any> = {

--- a/ontotext-yasgui-web-component/src/pages/actions/index.html
+++ b/ontotext-yasgui-web-component/src/pages/actions/index.html
@@ -24,6 +24,8 @@
     <button id="configureInferEnabled" onclick="configureInfer(true)">Set infer enabled</button>
     <button id="configureSameAsDisabled" onclick="configureSameAs(false)">Set same as disabled</button>
     <button id="configureSameAsEnabled" onclick="configureSameAs(true)">Set same as enabled</button>
+    <button id="showQueryButton" onclick="showQueryButton()">Show query button</button>
+    <button id="hideQueryButton" onclick="hideQueryButton()">Hide query button</button>
     <hr/>
     <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -45,6 +45,19 @@ if (query) {
   });
 }
 
+function hideQueryButton() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    showQueryButton: false
+  };
+}
+
+function showQueryButton() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    showQueryButton: true
+  };
+}
 
 function hideSaveQueryAction() {
   ontoElement.config = {

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
@@ -12,6 +12,7 @@
   </head>
   <body>
   <button id="setVirtualRepo" onclick="setVirtualRepository()">Set Virtual Repository</button>
+  <button id="hideRunButton" onclick="hideRunButton()">Hide Run button</button>
   <hr>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
 

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
@@ -6,6 +6,13 @@ ontoElement.addEventListener('output', (evt) => {
   }
 });
 
+function hideRunButton() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    showQueryButton: false
+  };
+}
+
 function setVirtualRepository() {
   ontoElement.config = {... ontoElement.config, isVirtualRepository: true}
 }

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -1,7 +1,8 @@
 import {KeyboardShortcutDescription, KeyboardShortcutName} from '../models/keyboard-shortcut-description';
+import {YasguiConfiguration} from '../models/yasgui-configuration';
 
 export class KeyboardShortcutService {
-  static initKeyboardShortcutMapping = (): KeyboardShortcutDescription[] => {
+  static initKeyboardShortcutMapping = (config: YasguiConfiguration): KeyboardShortcutDescription[] => {
     const keyboardShortcutDescriptions = [];
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createTriggerAutocomplete());
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createDeleteCurrentLine());
@@ -11,13 +12,15 @@ export class KeyboardShortcutService {
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createAutoFormat());
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createIndentMore());
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createIndentLess());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteQuery());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteExplainPlanForQuery());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createCreateTab());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createSavedQuery());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToNextTab());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToPreviousTab());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createCloseAllTabs());
+    if (config.yasguiConfig.yasqe.showQueryButton) {
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteQuery());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteExplainPlanForQuery());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createCreateTab());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSavedQuery());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToNextTab());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToPreviousTab());
+      keyboardShortcutDescriptions.push(KeyboardShortcutService.createCloseAllTabs());
+    }
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createF11());
     keyboardShortcutDescriptions.push(KeyboardShortcutService.createEscape());
     return keyboardShortcutDescriptions;

--- a/ontotext-yasgui-web-component/src/services/namespace-service.ts
+++ b/ontotext-yasgui-web-component/src/services/namespace-service.ts
@@ -2,6 +2,11 @@ import {NamespaceMapping, Namespaces} from "../models/yasgui-configuration";
 
 export class NamespaceService {
   static namespacesMapToArray(namespaceMapping: NamespaceMapping): Namespaces {
+
+    if (!namespaceMapping) {
+      return [];
+    }
+
     let hasOntoPrefix = false;
     const namespaces: Namespaces = Object.keys(namespaceMapping).map((prefix) => {
       if (prefix === 'onto') {

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -109,12 +109,16 @@ export class YasguiConfigurationBuilder {
     config.yasguiConfig.yasr.yasrToolbarPlugins = yasrToolbarElements;
 
     // prepare the yasqe config
-    this.initShortcuts(config);
     config.yasguiConfig.yasqe.value = externalConfiguration.query || defaultYasqeConfig.query;
     config.yasguiConfig.yasqe.prefixes = NamespaceService.namespacesMapToArray(config.yasguiConfig.yasr.prefixes);
     config.yasqeConfig = {};
     config.yasqeConfig.initialQuery = externalConfiguration.initialQuery || defaultYasqeConfig.initialQuery;
     config.yasguiConfig.yasqe.createShareableLink = externalConfiguration.createShareableLink || defaultYasqeConfig.createShareableLink;
+    if (externalConfiguration.readonly !== undefined) {
+      config.yasguiConfig.yasqe.readOnly = externalConfiguration.readonly;
+    }
+
+    config.yasguiConfig.yasqe.showQueryButton = externalConfiguration.showQueryButton !== undefined ? externalConfiguration.showQueryButton : defaultYasqeConfig.showQueryButton;
 
     config.yasguiConfig.yasqe.yasqeActionButtons =
       externalConfiguration.yasqeActionButtons !== undefined && externalConfiguration.yasqeActionButtons.length ?
@@ -124,11 +128,11 @@ export class YasguiConfigurationBuilder {
     config.yasguiConfig.yasqe.pluginButtons = (yasqe?: Yasqe) => {
       return this.getYasqeActionButtons(config, defaultYasqeConfig, yasqe);
     };
-    config.yasguiConfig.yasqe.showQueryButton = true;
 
     if (externalConfiguration.onQueryAborted instanceof Function) {
       config.yasguiConfig.yasqe.onQueryAborted = externalConfiguration.onQueryAborted;
     }
+    this.initShortcuts(config);
 
     // Register autocompleters
     this.registerCustomAutocompleters(config);
@@ -147,7 +151,7 @@ export class YasguiConfigurationBuilder {
   }
 
   private initShortcuts(config: YasguiConfiguration): void {
-    const keyboardShortcutDescriptions = KeyboardShortcutService.initKeyboardShortcutMapping();
+    const keyboardShortcutDescriptions = KeyboardShortcutService.initKeyboardShortcutMapping(config);
 
     config.yasguiConfig.yasqe.extraKeys = keyboardShortcutDescriptions
       .flatMap(description => description.keyboardShortcuts.map(keyboardShortcut => ({keyboardShortcut, executeFunction: description.executeFunction})))


### PR DESCRIPTION
## What
 - Can't hide "Run" query button;
 - Yasgui executes keyboard shortcuts update actions regardless run query button is hidden;
 - Expose new methods that can be used rom the clients.

## Why
 - There is not such configuration;
 - All keyboard shortcuts are initialized with component initialization.

## How
 - Exposed readonly configuration to external configurations;
 - Added a check that prevent initialization of keyboard shortcuts that trigger execution of query, when "Run" query button is disabled.