### PR TITLE
GDB-7730: integration with jdbc view.

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -624,6 +624,11 @@ export class Tab extends EventEmitter {
     yasrConf.tabId = this.getId();
 
     if (this.yasqe) {
+      if (this.yasgui.config.yasr.sparqlResponse) {
+        this.persistentJson.yasr.response = {
+          data: this.yasgui.config.yasr.sparqlResponse,
+        };
+      }
       this.yasr = new ExtendedYasr(this.yasqe, this.yasrWrapperEl, yasrConf, this.persistentJson);
 
       //populate our own persistent config

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -683,6 +683,7 @@ export interface Config {
   externalPluginsConfigurations?: Map<string, any>;
   yasrToolbarPlugins?: YasrToolbarPlugin[];
   downloadAsOptions?: { labelKey: string; value: any }[];
+  sparqlResponse?: string;
   /**
    * Custom renderers for errors.
    * Allow multiple to be able to add new custom renderers without having to

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -110,6 +110,8 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
    - READ - the editor is read-only, but the query can be copied;
    - PROTECTED - the editor is read-only and the query can't be copied.
 - **showQueryButton**: if false the "Run" query button will be hidden. Default value is true.
+- **getCellContent**: function that will be called for every one cell. It must return valid html as string.
+- **sparqlResponse**: response of a sparql query as string.
 
 ## Developers guide
 

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -111,7 +111,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
    - PROTECTED - the editor is read-only and the query can't be copied.
 - **showQueryButton**: if false the "Run" query button will be hidden. Default value is true.
 - **getCellContent**: function that will be called for every one cell. It must return valid html as string.
-- **sparqlResponse**: response of a sparql query as string.
+- **sparqlResponse**: a response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
 
 ## Developers guide
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -621,10 +621,14 @@ export class OntotextYasguiWebComponent {
 
   private getOntotextYasgui(): Promise<OntotextYasgui> {
     return new Promise((resolve, reject) => {
+      if (this.isOntotextYasguiInitialiazed()) {
+        return resolve(this.ontotextYasgui);
+      }
+
       let maxIterationsToComplete = 15;
       const timer = setInterval(() => {
         maxIterationsToComplete--;
-        if (this.ontotextYasgui && this.ontotextYasgui.getInstance()) {
+        if (this.isOntotextYasguiInitialiazed()) {
           clearInterval(timer);
           return resolve(this.ontotextYasgui);
         }
@@ -634,6 +638,10 @@ export class OntotextYasguiWebComponent {
         }
       }, 100);
     });
+  }
+
+  private isOntotextYasguiInitialiazed(): boolean {
+    return !!this.ontotextYasgui && !!this.ontotextYasgui.getInstance();
   }
 
   private afterInit(): void {
@@ -691,7 +699,7 @@ export class OntotextYasguiWebComponent {
     const classList = `yasgui-host-element ${this.getOrientationMode()} ${this.getRenderMode()}`;
     return (
       <Host class={classList}>
-        <div class="yasgui-toolbar">
+        <div class="yasgui-toolbar hidden">
           <button class="yasgui-btn btn-mode-yasqe"
                   onClick={() => VisualisationUtils.changeRenderMode(this.hostElement, RenderingMode.YASQE)}>
             {this.translationService.translate('yasgui.toolbar.mode_yasqe.btn.label')}

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -248,6 +248,16 @@ export interface ExternalYasguiConfiguration {
   onQueryAborted?: (req) => Promise<void>;
 
   yasrToolbarPlugins?: YasrToolbarPlugin[];
+
+  /**
+   * If this function is present, then it will be called on every one result cell.
+   * @param binding - binding value that will be shown into a cell.
+   * @param prefixes - Object with uris and their corresponding prefixes.
+   */
+  // @ts-ignore
+  getCellContent: (binding: Parser.BindingValue, prefixes?: Prefixes) => string;
+
+  sparqlResponse: string | undefined;
 }
 
 export type AutocompleteLoader = () => any;

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -257,6 +257,9 @@ export interface ExternalYasguiConfiguration {
   // @ts-ignore
   getCellContent: (binding: Parser.BindingValue, prefixes?: Prefixes) => string;
 
+  /**
+   * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
+   */
   sparqlResponse: string | undefined;
 }
 

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -204,6 +204,10 @@ export interface YasguiConfiguration {
       maxPersistentResponseSize?: number;
 
       yasrToolbarPlugins?: YasrToolbarPlugin[],
+
+      /**
+       * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
+       */
       sparqlResponse: string | undefined,
     }
   };

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -203,7 +203,8 @@ export interface YasguiConfiguration {
        */
       maxPersistentResponseSize?: number;
 
-      yasrToolbarPlugins?: YasrToolbarPlugin[]
+      yasrToolbarPlugins?: YasrToolbarPlugin[],
+      sparqlResponse: string | undefined,
     }
   };
 

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -73,10 +73,11 @@ export class YasguiConfigurationBuilder {
         getRepositoryStatementsCount: externalConfiguration.getRepositoryStatementsCount !== undefined ? externalConfiguration.getRepositoryStatementsCount : defaultYasqeConfig.getRepositoryStatementsCount
       },
       yasr: {
+        sparqlResponse: externalConfiguration.sparqlResponse,
         prefixes: {},
         defaultPlugin: '',
         pluginOrder: [],
-        externalPluginsConfigurations: YasrService.getPluginsConfigurations(),
+        externalPluginsConfigurations: YasrService.getPluginsConfigurations(externalConfiguration),
       }
     };
     config.yasguiConfig.requestConfig.endpoint = externalConfiguration.endpoint || defaultYasguiConfig.endpoint;
@@ -91,7 +92,7 @@ export class YasguiConfigurationBuilder {
     config.yasguiConfig.yasr.prefixes = externalConfiguration.prefixes || defaultYasrConfig.prefixes;
     config.yasguiConfig.yasr.defaultPlugin = externalConfiguration.defaultPlugin || defaultYasrConfig.defaultPlugin;
     config.yasguiConfig.yasr.pluginOrder = externalConfiguration.pluginOrder || defaultYasrConfig.pluginOrder;
-    if (externalConfiguration.maxPersistentResponseSize) {
+    if (externalConfiguration.maxPersistentResponseSize !== undefined) {
       config.yasguiConfig.yasr.maxPersistentResponseSize = externalConfiguration.maxPersistentResponseSize;
     }
 

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -1,4 +1,5 @@
 import {HtmlUtil} from '../utils/html-util';
+import {ExternalYasguiConfiguration} from '../../models/external-yasgui-configuration';
 
 export class YasrService {
 
@@ -17,15 +18,15 @@ export class YasrService {
    */
   static readonly ESCAPED_HTML_DOUBLE_GREATER = '&gt;&gt';
 
-  static getPluginsConfigurations(): Map<string, any> {
+  static getPluginsConfigurations(externalConfiguration: ExternalYasguiConfiguration): Map<string, any> {
     const pluginsConfigurations = new Map<string, any>();
-    this.addExtendedTableConfiguration(pluginsConfigurations);
+    this.addExtendedTableConfiguration(externalConfiguration, pluginsConfigurations);
     return pluginsConfigurations;
   }
 
-  private static addExtendedTableConfiguration(pluginsConfigurations: Map<string, any>) {
+  private static addExtendedTableConfiguration(externalConfiguration: ExternalYasguiConfiguration, pluginsConfigurations: Map<string, any>) {
     const configuration = {
-      getCellContent: YasrService.getCellContent().bind(this),
+      getCellContent: externalConfiguration.getCellContent ? externalConfiguration.getCellContent : YasrService.getCellContent().bind(this),
     };
     pluginsConfigurations.set('extended_table', configuration);
   }

--- a/yasgui-patches/2023-06-22_GDB-7730_Extends_yasgui_results_to_be_set_via_configuration.patch
+++ b/yasgui-patches/2023-06-22_GDB-7730_Extends_yasgui_results_to_be_set_via_configuration.patch
@@ -1,0 +1,38 @@
+Subject: [PATCH] Extends yasgui results to be set via configuration.
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision 1f6af41ed57431904d96d3fb5dcdf0592b56198f)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 111cff7a2a241ffad51cd119b39d2aad7e5eec80)
+@@ -624,6 +624,11 @@
+     yasrConf.tabId = this.getId();
+ 
+     if (this.yasqe) {
++      if (this.yasgui.config.yasr.sparqlResponse) {
++        this.persistentJson.yasr.response = {
++          data: this.yasgui.config.yasr.sparqlResponse,
++        };
++      }
+       this.yasr = new ExtendedYasr(this.yasqe, this.yasrWrapperEl, yasrConf, this.persistentJson);
+ 
+       //populate our own persistent config
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 1f6af41ed57431904d96d3fb5dcdf0592b56198f)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 111cff7a2a241ffad51cd119b39d2aad7e5eec80)
+@@ -683,6 +683,7 @@
+   externalPluginsConfigurations?: Map<string, any>;
+   yasrToolbarPlugins?: YasrToolbarPlugin[];
+   downloadAsOptions?: { labelKey: string; value: any }[];
++  sparqlResponse?: string;
+   /**
+    * Custom renderers for errors.
+    * Allow multiple to be able to add new custom renderers without having to


### PR DESCRIPTION
## What
- The OntotextYasguiWebComponent.getOntotextYasgui() function returns a promise with ontotextYasgui reference after 100ms without matter that the instance already exist.
- Expose getCellContent function to yasgui client;
- Expose yasrData

## Why
- The function uses "setInterval" with a time interval of 100ms, so the first check is after 100ms, and if instance exists, the promise with reference is returned.

## How
- Added initial check if instance exists, if yes return it, if not then "setInterval" is used.

Additional work:
- Fixes GDB-8382