### PR TITLE
Fixed issues caused by WB.

### DIFF
--- a/Yasgui/packages/yasqe/src/sparql.ts
+++ b/Yasgui/packages/yasqe/src/sparql.ts
@@ -65,7 +65,7 @@ export async function executeUpdateModeQuery(yasqe: Yasqe, config?: YasqeAjaxCon
     return yasqe.config.beforeUpdateQuery(yasqe.getValue(), yasqe.getTabId()).then((result) => {
       beforeUpdateQueryResult = result;
 
-      if (QueryResponseStatus.ERROR === beforeUpdateQueryResult.status) {
+      if (beforeUpdateQueryResult && QueryResponseStatus.ERROR === beforeUpdateQueryResult.status) {
         const error = new QueryError();
         error.messageLabelKey = beforeUpdateQueryResult.messageLabelKey;
         error.parameters = beforeUpdateQueryResult.parameters;

--- a/ontotext-yasgui-web-component/src/services/yasqe/autocompleter/local-names.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/autocompleter/local-names.ts
@@ -37,12 +37,15 @@ const getLocalNamesAutocompleter = (localNamesLoader: (term: string) => any) => 
       }
       // TODO: show toast warning on 204 or some error
       return localNamesLoader(query).then((data) => {
-        return data.suggestions.map((suggestion) => {
-          // TODO: should we sanitize and
-          // let description = suggestion.description.replaceAll('<b>', '<span class=\'CodeMirror-highlight\'>');
-          // description = description.replaceAll('</b>', '</span>');
-          return suggestion.description;
-        });
+        if (data && data.suggestions) {
+          return data.suggestions.map((suggestion) => {
+            // TODO: should we sanitize and
+            // let description = suggestion.description.replaceAll('<b>', '<span class=\'CodeMirror-highlight\'>');
+            // description = description.replaceAll('</b>', '</span>');
+            return suggestion.description;
+          });
+        }
+        return [];
       });
     },
     // Implementation taken from: Yasgui/packages/yasqe/src/autocompleters/index.ts

--- a/yasgui-patches/2023-07-04_Fixe_issues_caused_by_WB_.patch
+++ b/yasgui-patches/2023-07-04_Fixe_issues_caused_by_WB_.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] Fixe issues caused by WB.
+---
+Index: Yasgui/packages/yasqe/src/sparql.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/sparql.ts b/Yasgui/packages/yasqe/src/sparql.ts
+--- a/Yasgui/packages/yasqe/src/sparql.ts	(revision 46954f5d8a99bdfdc4dbc7512c6d6e977ba61d11)
++++ b/Yasgui/packages/yasqe/src/sparql.ts	(revision cb132eab696658afb4e60b1eddadc800b4fe99f4)
+@@ -65,7 +65,7 @@
+     return yasqe.config.beforeUpdateQuery(yasqe.getValue(), yasqe.getTabId()).then((result) => {
+       beforeUpdateQueryResult = result;
+ 
+-      if (QueryResponseStatus.ERROR === beforeUpdateQueryResult.status) {
++      if (beforeUpdateQueryResult && QueryResponseStatus.ERROR === beforeUpdateQueryResult.status) {
+         const error = new QueryError();
+         error.messageLabelKey = beforeUpdateQueryResult.messageLabelKey;
+         error.parameters = beforeUpdateQueryResult.parameters;


### PR DESCRIPTION
## What
 - When use local name autocompleter;
 - NPE when 'beforeUpdateQuery' returns no result.
 
## Why
 - When autocomplete functionality is off then "localNamesLoader(query)" promise don't return suggestions;
 - WB's beforeUpdateQuery implementation has rest call to backend server that can throw error in this case WB don't return  beforeUpdateQueryResult.
 
## How
 - added check if response contains suggestions;
 - added check if beforeUpdateQueryResult is not undefined.