### PR TITLE
GDB-8286 fixing yasgui results rendering performance issue

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -70,23 +70,22 @@ export class ExtendedTable extends Table {
   }
 
   /**
-   * Set-ups first column to be index column according official solution from DataTable.
-   * @see <a href="https://datatables.net/examples/api/counter_columns.html">Official solution from DataTable</a>
+   * Set-ups first column to be index column.
+   * 1. Listen for the event 'draw.dt'
+   * 2. Limit the nodes to just those on the page instead of all nodes.
+   * 3. Use an offset of the page info starting point for the index.
    * @private
    */
   private setupIndexColumn() {
     if (!this.dataTable) {
       return;
     }
-    const dataTable = this.dataTable;
-    // Set up first column to be index column according official solution from DataTable.
-    this.dataTable
-      .on("order.dt search.dt", function () {
-        let i = 1;
-        dataTable.cells(null, 0, { search: "applied", order: "applied" }).every(function (cell) {
-          this.data(i++);
-        });
-      })
-      .draw();
+    const table = this.dataTable;
+    table.on( 'draw.dt', function () {
+      const PageInfo = table.page.info();
+      table.column(0, { page: 'current' }).nodes().each( function (cell, i) {
+        cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
+      });
+    });
   }
 }

--- a/yasgui-patches/2023-07-07-GDB-8286_fixing_yasgui_results_rendering_performance_issue.patch
+++ b/yasgui-patches/2023-07-07-GDB-8286_fixing_yasgui_results_rendering_performance_issue.patch
@@ -1,0 +1,43 @@
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 9f3d678fbdd6a5924f55a6cb1441b52d274347f3)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision f1a47a976d22c19ee704543a4105e49abc178f26)
+@@ -70,23 +70,22 @@
+   }
+ 
+   /**
+-   * Set-ups first column to be index column according official solution from DataTable.
+-   * @see <a href="https://datatables.net/examples/api/counter_columns.html">Official solution from DataTable</a>
++   * Set-ups first column to be index column.
++   * 1. Listen for the event 'draw.dt'
++   * 2. Limit the nodes to just those on the page instead of all nodes.
++   * 3. Use an offset of the page info starting point for the index.
+    * @private
+    */
+   private setupIndexColumn() {
+     if (!this.dataTable) {
+       return;
+     }
+-    const dataTable = this.dataTable;
+-    // Set up first column to be index column according official solution from DataTable.
+-    this.dataTable
+-      .on("order.dt search.dt", function () {
+-        let i = 1;
+-        dataTable.cells(null, 0, { search: "applied", order: "applied" }).every(function (cell) {
+-          this.data(i++);
+-        });
+-      })
+-      .draw();
++    const table = this.dataTable;
++    table.on( 'draw.dt', function () {
++      const PageInfo = table.page.info();
++      table.column(0, { page: 'current' }).nodes().each( function (cell, i) {
++        cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
++      });
++    });
+   }
+ }


### PR DESCRIPTION
## What
Fixes the rendering performance issue in our table renderer plugin extension in yasgui.

## Why
We observed that when say 1000 results has to be rendered in the yasr table, then it struggles to do it in a responsive manner. We noticed that it takes around 8 seconds which is beyond ideal. That's why we need to find a fix for the bottleneck.

## How
* Reimplemented the setupIndexColumn function in the ExtendedTable plugin implementation to prevent redundant rerendering of the index column.