### PR TITLE
Extends the public Api of the component.

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -119,6 +119,10 @@ export namespace Components {
          */
         "openTab": (queryModel: TabQueryModel) => Promise<void>;
         /**
+          * Executes the yasqe query.
+         */
+        "query": () => Promise<any>;
+        /**
           * A configuration model related with all the saved queries actions.
          */
         "savedQueryConfig"?: SavedQueryConfig;

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
@@ -43,10 +43,14 @@ export class OntotextTooltipWebComponent {
   }
 
   private update() {
+    this.init();
     this.tooltip.setContent(this.dataTooltip);
   }
 
   private init() {
+    if (this.tooltip) {
+      return;
+    }
     const options = {
       content: this.dataTooltip,
       trigger: 'manual',

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -217,6 +217,17 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
+   * Executes the yasqe query.
+   */
+  @Method()
+  query(): Promise<any> {
+    return this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        return ontotextYasgui.query();
+      });
+  }
+
+  /**
    * Fetches the query from YASQE editor.
    */
   @Method()

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -130,6 +130,16 @@ Type: `Promise<void>`
 
 
 
+### `query() => Promise<any>`
+
+Executes the yasqe query.
+
+#### Returns
+
+Type: `Promise<any>`
+
+
+
 ### `setQuery(query: string) => Promise<void>`
 
 Allows the client to set a query in the current opened tab.

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -46,6 +46,10 @@ export class OntotextYasgui {
     this.yasgui.getTab().getYasqe().setValue(query);
   }
 
+  query(): void {
+    this.yasgui.getTab().getYasqe().query();
+  }
+
   getQuery(): string {
     return this.yasgui.getTab().getYasqe().getValue();
   }


### PR DESCRIPTION
## What
Expose a new method, which runs the yasqe query.

## Why
There are client flows where the query needs to be executed programmatically.

## How
Added a new method 'query', to run the yasqe query.

Additional work:
Fixed a null pointer exception (NPE) that occurs when trying to set content but the tooltip is not yet initialized.