### PR TITLE
Extends the public Api of the component with new "changeRenderMode" function.

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -86,10 +86,21 @@ export namespace Components {
      */
     interface OntotextYasgui {
         /**
+          * Changes rendering mode of component.
+          * @param newRenderMode - then new render mode of component.
+         */
+        "changeRenderMode": (newRenderMode: any) => Promise<void>;
+        /**
           * An input object property containing the yasgui configuration.
          */
         "config": ExternalYasguiConfiguration;
+        /**
+          * Fetches the query result and return it as CSV.
+         */
         "getEmbeddedResultAsCSV": () => Promise<unknown>;
+        /**
+          * Fetches the query result and return it as JSON.
+         */
         "getEmbeddedResultAsJson": () => Promise<unknown>;
         /**
           * Fetches the query from YASQE editor.

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -205,6 +205,19 @@ export class OntotextYasguiWebComponent {
   @State() copiedResourceLink: string;
 
   /**
+   * Changes rendering mode of component.
+   *
+   * @param newRenderMode - then new render mode of component.
+   */
+  @Method()
+  changeRenderMode(newRenderMode): Promise<void> {
+    return this.getOntotextYasgui()
+      .then(() => {
+        VisualisationUtils.changeRenderMode(this.hostElement, newRenderMode);
+      });
+  }
+
+  /**
    * Allows the client to set a query in the current opened tab.
    * @param query The query that should be set in the current focused tab.
    */
@@ -297,6 +310,9 @@ export class OntotextYasguiWebComponent {
     })
   }
 
+  /**
+   * Fetches the query result and return it as JSON.
+   */
   @Method()
   getEmbeddedResultAsJson(): Promise<unknown> {
     return this.getOntotextYasgui().then((ontotextYasgui) => {
@@ -304,6 +320,9 @@ export class OntotextYasguiWebComponent {
     });
   }
 
+  /**
+   * Fetches the query result and return it as CSV.
+   */
   @Method()
   getEmbeddedResultAsCSV(): Promise<unknown> {
     return this.getOntotextYasgui().then((ontotextYasgui) => {
@@ -311,7 +330,11 @@ export class OntotextYasguiWebComponent {
     });
   }
 
-  @Listen('resize', { target: 'window' })
+  /**
+   * There are rendering problems when the window size is changed. To address this, we added a listener to the window resize event.
+   * When the event occurs, we refresh the component to recalculate and resolve the rendering issues.
+   */
+  @Listen('resize', {target: 'window'})
   onResize() {
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {
@@ -392,6 +415,7 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
+   * Handler for confirmation event fired when deletion of saved query is approved.
    */
   @Listen('internalConfirmationApprovedEvent')
   deleteSavedQueryHandler() {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -52,9 +52,19 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Methods
 
+### `changeRenderMode(newRenderMode: any) => Promise<void>`
+
+Changes rendering mode of component.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `getEmbeddedResultAsCSV() => Promise<unknown>`
 
-
+Fetches the query result and return it as CSV.
 
 #### Returns
 
@@ -64,7 +74,7 @@ Type: `Promise<unknown>`
 
 ### `getEmbeddedResultAsJson() => Promise<unknown>`
 
-
+Fetches the query result and return it as JSON.
 
 #### Returns
 

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -46,8 +46,8 @@ export class OntotextYasgui {
     this.yasgui.getTab().getYasqe().setValue(query);
   }
 
-  query(): void {
-    this.yasgui.getTab().getYasqe().query();
+  query(): Promise<any> {
+    return this.yasgui.getTab().getYasqe().query();
   }
 
   getQuery(): string {

--- a/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
@@ -6,7 +6,11 @@ export class VisualisationUtils {
   static changeRenderMode(hostElement: HTMLElement, newMode: RenderingMode): void {
     VisualisationUtils.unselectAllToolbarButtons(hostElement);
     const button = HtmlElementsUtil.getRenderModeButton(hostElement, newMode);
-    button.classList.add('btn-selected');
+
+    /** The button can be undefined if the render buttons are hidden and the {@see OntotextYasguiWebComponent#changeRenderMode} method is called.*/
+    if (button) {
+      button.classList.add('btn-selected');
+    }
 
     const modes: string[] = Object.values(RenderingMode);
     hostElement.classList.remove(...modes);


### PR DESCRIPTION
## What
Expose a new method, which changes the rendering mode.

## Why
Changing the render mode used to only be possible through configuration changes, but this would result in destroying the instance and creating a new one. This is now avoided with the new method, where if the client invokes it, it will change the render mode without destroying the instance.

## How
Expose a new method that changes the component render mode.

Additional work:
Fixes definition of "OntotextYasgui#query" function.