### PR TITLE
Extends the public Api of the component.

### DIFF
--- a/cypress/e2e-flaky/yasr/plugin-table.spec.cy.ts
+++ b/cypress/e2e-flaky/yasr/plugin-table.spec.cy.ts
@@ -1,10 +1,7 @@
-import {QueryStubDescription, QueryStubs, ResultType} from '../../stubs/query-stubs';
+import {QueryStubDescription, QueryStubs} from '../../stubs/query-stubs';
 import {YasrTablePluginSteps} from '../../steps/yasr-table-plugin-steps';
 import {YasqeSteps} from '../../steps/yasqe-steps';
-import DefaultViewPageSteps from '../../steps/default-view-page-steps';
 import {YasrSteps} from '../../steps/yasr-steps';
-import {PaginationPageSteps} from '../../steps/pages/pagination-page-steps';
-import {PaginationSteps} from '../../steps/pagination-steps';
 
 describe('Plugin: Table', () => {
 

--- a/cypress/e2e/public-api.spec.cy.ts
+++ b/cypress/e2e/public-api.spec.cy.ts
@@ -1,0 +1,62 @@
+import {PublicApiPageSteps} from '../steps/pages/public-api-page-steps';
+import {YasqeSteps} from '../steps/yasqe-steps';
+import {YasrSteps} from '../steps/yasr-steps';
+
+describe('Component public API', () => {
+  it('should show or hide yasqe buttons', () => {
+    // When I open a page, that contains "ontotext-yasgui-web-components",
+    PublicApiPageSteps.visit();
+    // and call functions to hide yasqe buttons.
+    PublicApiPageSteps.hideActionCreateSavedQuery();
+    PublicApiPageSteps.hideInferStatements();
+    PublicApiPageSteps.hideExpandResults();
+    PublicApiPageSteps.hideShareQuery();
+    PublicApiPageSteps.hideShowSavedQueries();
+
+    // Then I expect all buttons to be not visible.
+    YasqeSteps.getCreateSavedQueryButton().should('not.be.visible');
+    YasqeSteps.getIncludeInferredStatementsButton().should('not.be.visible');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('not.be.visible');
+    YasqeSteps.getShareQueryButton().should('not.be.visible');
+    YasqeSteps.getShowSavedQueriesButton().should('not.be.visible');
+
+    // When call functions to show yasqe buttons.
+    PublicApiPageSteps.showActionCreateSavedQuery();
+    PublicApiPageSteps.showInferStatements();
+    PublicApiPageSteps.showExpandResults();
+    PublicApiPageSteps.showShareQuery();
+    PublicApiPageSteps.showShowSavedQueries();
+
+    // Then I expect all buttons to be not visible.
+    YasqeSteps.getCreateSavedQueryButton().should('be.visible');
+    YasqeSteps.getIncludeInferredStatementsButton().should('be.visible');
+    YasqeSteps.getExpandResultsOverSameAsButton().should('be.visible');
+    YasqeSteps.getShareQueryButton().should('be.visible');
+    YasqeSteps.getShowSavedQueriesButton().should('be.visible');
+  });
+
+  it('should switch to different render mode', () => {
+    // When I open a page, that contains "ontotext-yasgui-web-components",
+    PublicApiPageSteps.visit();
+    // and switch to yasqe mode
+    PublicApiPageSteps.switchToYasqeMode();
+
+    // Then I expect to see only yasqe.
+    YasqeSteps.getYasqe().should('be.visible');
+    YasrSteps.getYasr().should('not.be.visible');
+
+    // When I switch to yasr mode.
+    PublicApiPageSteps.switchToYasrMode();
+
+    // Then I expect to see only yasr.
+    YasqeSteps.getYasqe().should('not.be.visible');
+    YasrSteps.getYasr().should('be.visible');
+
+    // When I switch to yasgui mode.
+    PublicApiPageSteps.switchToYasguiMode();
+
+    // Then I expect to see both yasr and yasqe.
+    YasqeSteps.getYasqe().should('be.visible');
+    YasrSteps.getYasr().should('be.visible');
+  });
+});

--- a/cypress/steps/pages/public-api-page-steps.ts
+++ b/cypress/steps/pages/public-api-page-steps.ts
@@ -1,0 +1,57 @@
+export class PublicApiPageSteps {
+  static visit() {
+    cy.visit('/pages/public-api');
+  }
+
+  static showActionCreateSavedQuery() {
+    cy.get('#showActionCreateSavedQuery').click();
+  }
+
+  static hideActionCreateSavedQuery() {
+    cy.get('#hideActionCreateSavedQuery').click();
+  }
+
+  static showShowSavedQueries() {
+    cy.get('#showShowSavedQueries').click();
+  }
+
+  static hideShowSavedQueries() {
+    cy.get('#hideShowSavedQueries').click();
+  }
+
+  static showShareQuery() {
+    cy.get('#showShareQuery').click();
+  }
+
+  static hideShareQuery() {
+    cy.get('#hideShareQuery').click();
+  }
+
+  static showExpandResults() {
+    cy.get('#showExpandResults').click();
+  }
+
+  static hideExpandResults() {
+    cy.get('#hideExpandResults').click();
+  }
+
+  static showInferStatements() {
+    cy.get('#showInferStatements').click();
+  }
+
+  static hideInferStatements() {
+    cy.get('#hideInferStatements').click();
+  }
+
+  static switchToYasguiMode() {
+    cy.get('#switchToYasguiMode').click();
+  }
+
+  static switchToYasqeMode() {
+    cy.get('#switchToYasqeMode').click();
+  }
+
+  static switchToYasrMode() {
+    cy.get('#switchToYasrMode').click();
+  }
+}

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -17,6 +17,7 @@ import { Page } from "./models/page";
 import { ExternalYasguiConfiguration, TabQueryModel } from "./models/external-yasgui-configuration";
 import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/saved-query-configuration";
 import { OutputEvent } from "./models/output-events/output-event";
+import { YasqeButtonType } from "./models/yasqe-button-name";
 import { ShareQueryDialogConfig } from "./components/share-query-dialog/share-query-dialog";
 export namespace Components {
     interface ConfirmationDialog {
@@ -86,6 +87,10 @@ export namespace Components {
      */
     interface OntotextYasgui {
         /**
+          * Aborts the running query if any.
+         */
+        "abortQuery": () => Promise<any>;
+        /**
           * Changes rendering mode of component.
           * @param newRenderMode - then new render mode of component.
          */
@@ -117,6 +122,11 @@ export namespace Components {
          */
         "getQueryType": () => Promise<string>;
         /**
+          * Hides the YASQE action button with the name <code>yasqeActionButtonNames</code>.
+          * @param yasqeActionButtonNames - the name of the action that needs to be hidden.
+         */
+        "hideYasqeActionButton": (yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]) => Promise<void>;
+        /**
           * Checks if query is valid.
          */
         "isQueryValid": () => Promise<boolean>;
@@ -142,6 +152,11 @@ export namespace Components {
           * @param query The query that should be set in the current focused tab.
          */
         "setQuery": (query: string) => Promise<void>;
+        /**
+          * Shows the YASQE action button with the name <code>yasqeActionButtonNames</code>.
+          * @param yasqeActionButtonNames - the name of the action that needs to be displayed.
+         */
+        "showYasqeActionButton": (yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]) => Promise<void>;
     }
     interface SaveQueryDialog {
         /**

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -23,6 +23,8 @@ import {InternalShowResourceCopyLinkDialogEvent} from '../../models/internal-eve
 import {InternalShowSavedQueriesEvent} from '../../models/internal-events/internal-show-saved-queries-event';
 import {InternalQueryExecuted} from '../../models/internal-events/internal-query-executed';
 import {InternalCountQueryResponseEvent} from '../../models/internal-events/internal-count-query-response-event';
+import {YasqeButtonType} from '../../models/yasqe-button-name';
+import {YasqeService} from '../../services/yasqe/yasqe-service';
 
 /**
  * This is the custom web component which is adapter for the yasgui library. It allows as to
@@ -328,6 +330,37 @@ export class OntotextYasguiWebComponent {
     return this.getOntotextYasgui().then((ontotextYasgui) => {
       return ontotextYasgui.getEmbeddedResultAsCSV();
     });
+  }
+
+  /**
+   * Hides the YASQE action button with the name <code>yasqeActionButtonNames</code>.
+   *
+   * @param yasqeActionButtonNames - the name of the action that needs to be hidden.
+   */
+  @Method()
+  hideYasqeActionButton(yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]): Promise<void> {
+    return this.getOntotextYasgui().then(() => YasqeService.hideYasqeActionButtons(yasqeActionButtonNames));
+  }
+
+  /**
+   * Shows the YASQE action button with the name <code>yasqeActionButtonNames</code>.
+   *
+   * @param yasqeActionButtonNames - the name of the action that needs to be displayed.
+   */
+  @Method()
+  showYasqeActionButton(yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]): Promise<void> {
+    return this.getOntotextYasgui().then(() => YasqeService.showYasqeActionButtons(yasqeActionButtonNames));
+  }
+
+  /**
+   * Aborts the running query if any.
+   */
+  @Method()
+  abortQuery(): Promise<any> {
+    return this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        ontotextYasgui.abortQuery();
+      });
   }
 
   /**

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -52,6 +52,16 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Methods
 
+### `abortQuery() => Promise<any>`
+
+Aborts the running query if any.
+
+#### Returns
+
+Type: `Promise<any>`
+
+
+
 ### `changeRenderMode(newRenderMode: any) => Promise<void>`
 
 Changes rendering mode of component.
@@ -118,6 +128,16 @@ Type: `Promise<string>`
 
 A promise which resolves with a string representing the query type.
 
+### `hideYasqeActionButton(yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]) => Promise<void>`
+
+Hides the YASQE action button with the name <code>yasqeActionButtonNames</code>.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `isQueryValid() => Promise<boolean>`
 
 Checks if query is valid.
@@ -153,6 +173,16 @@ Type: `Promise<any>`
 ### `setQuery(query: string) => Promise<void>`
 
 Allows the client to set a query in the current opened tab.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `showYasqeActionButton(yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]) => Promise<void>`
+
+Shows the YASQE action button with the name <code>yasqeActionButtonNames</code>.
 
 #### Returns
 

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -50,6 +50,10 @@ export class OntotextYasgui {
     return this.yasgui.getTab().getYasqe().query();
   }
 
+  abortQuery(): void {
+    this.yasgui.getTab().getYasqe().abortQuery();
+  }
+
   getQuery(): string {
     return this.yasgui.getTab().getYasqe().getValue();
   }

--- a/ontotext-yasgui-web-component/src/models/yasqe-button-name.ts
+++ b/ontotext-yasgui-web-component/src/models/yasqe-button-name.ts
@@ -1,0 +1,12 @@
+import {MessageCode} from './internal-events/internal-notification-message-event';
+
+export const YasqeButtonName = {
+  CREATE_SAVED_QUERY: 'createSavedQuery',
+  SHOW_SAVED_QUERIES: 'showSavedQueries',
+  SHARE_QUERY: 'shareQuery',
+  EXPANDS_RESULTS: 'expandResults',
+  INFER_STATEMENTS: 'inferStatements'
+}
+
+
+export type YasqeButtonType = (typeof MessageCode)[keyof typeof MessageCode];

--- a/ontotext-yasgui-web-component/src/pages/public-api/index.html
+++ b/ontotext-yasgui-web-component/src/pages/public-api/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Test component public API</title>
+
+    <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
+    <script src="./public-api/main.js" defer></script>
+  </head>
+  <body>
+  <button id="showActionCreateSavedQuery" onclick="changeActionButtonVisibility('createSavedQuery', false)">Show "Create Saved Query" button</button>
+  <button id="hideActionCreateSavedQuery" onclick="changeActionButtonVisibility('createSavedQuery', true)">Hide "Create Saved Query" button</button>
+  <button id="showShowSavedQueries" onclick="changeActionButtonVisibility('showSavedQueries', false)">Show "Show saved queries" button</button>
+  <button id="hideShowSavedQueries" onclick="changeActionButtonVisibility('showSavedQueries', true)">Hide "Show saved queries" button</button>
+  <button id="showShareQuery" onclick="changeActionButtonVisibility('shareQuery', false)">Show "Share Query" button</button>
+  <button id="hideShareQuery" onclick="changeActionButtonVisibility('shareQuery', true)">Hide "Share Query" button</button>
+  <button id="showExpandResults" onclick="changeActionButtonVisibility('expandResults', false)">Show "Expand Results" button</button>
+  <button id="hideExpandResults" onclick="changeActionButtonVisibility('expandResults', true)">Hide "Expand Results" button</button>
+  <button id="showInferStatements" onclick="changeActionButtonVisibility('inferStatements', false)">Show "Infer Statements" button</button>
+  <button id="hideInferStatements" onclick="changeActionButtonVisibility('inferStatements', true)">Hide "Infer Statements" button</button>
+
+  <button id="switchToYasguiMode" onclick="changeRenderMode('mode-yasgui')">Switch to YASGUI Mode</button>
+  <button id="switchToYasqeMode" onclick="changeRenderMode('mode-yasqe')">Switch to YASQE Mode</button>
+  <button id="switchToYasrMode" onclick="changeRenderMode('mode-yasr')">Switch to YASR Mode</button>
+  <hr/>
+  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  </body>
+</html>

--- a/ontotext-yasgui-web-component/src/pages/public-api/main.js
+++ b/ontotext-yasgui-web-component/src/pages/public-api/main.js
@@ -1,0 +1,13 @@
+let ontoElement = getOntotextYasgui();
+
+function changeActionButtonVisibility(actionButtonName, hide) {
+  if (hide) {
+    ontoElement.hideYasqeActionButton(actionButtonName);
+  } else {
+    ontoElement.showYasqeActionButton(actionButtonName);
+  }
+}
+
+function changeRenderMode(renderMode) {
+  ontoElement.changeRenderMode(renderMode);
+}

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -1,5 +1,7 @@
 import {KeyboardShortcutDescription, KeyboardShortcutName} from '../models/keyboard-shortcut-description';
 import {YasguiConfiguration} from '../models/yasgui-configuration';
+import {YasqeButtonName} from '../models/yasqe-button-name';
+import {YasqeService} from './yasqe/yasqe-service';
 
 export class KeyboardShortcutService {
   static initKeyboardShortcutMapping = (config: YasguiConfiguration): KeyboardShortcutDescription[] => {
@@ -203,7 +205,7 @@ export class KeyboardShortcutService {
     //@ts-ignore
     keyboardShortcut.executeFunction = (yasqe: Yasqe) => {
       const wrapperElement = yasqe.getWrapperElement();
-      const querySelector = wrapperElement.querySelector('.yasqe_createSavedQueryButton');
+      const querySelector = wrapperElement.querySelector(`.${YasqeService.getActionButtonClassName(YasqeButtonName.CREATE_SAVED_QUERY)}`);
       if (querySelector) {
         querySelector.click();
       }

--- a/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
@@ -40,7 +40,11 @@ export class YasqeService {
   }
 
   static getActionButtonClassName(actionButtonName: YasqeButtonType) {
-    return this.pluginButtonNameToClassNameMapping.get(actionButtonName);
+    if (this.pluginButtonNameToClassNameMapping.has(actionButtonName)) {
+      return this.pluginButtonNameToClassNameMapping.get(actionButtonName);
+    } else {
+      console.log(`The YASQE action with name: ${actionButtonName} doesn't exist!`);
+    }
   }
 
   static hideActionButton(actionButtonName: YasqeButtonType): void {


### PR DESCRIPTION
## What
- Expose new functions, that hides/shows action buttons.
- Expose a new function, that abort query.

## Why
Showing/Hiding of action buttons was previously possible through configuration changes, but this would result in destroying the instance and creating a new one. This is now avoided with the new functions, where if the client invokes them, the buttons will be shown/hidden without destroying the instance.

## How
- Expose new functions that show/hide yasqe action buttons.
- Expose a new function, that abort query.