### PR TITLE
Extends component configuration

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -553,6 +553,7 @@ export class Tab extends EventEmitter {
 
   handleTotalElementsChanged = (_yasqe: Yasqe, totalElements = -1) => {
     if (this.yasr?.results) {
+      this.yasr.results.setTotalElements(totalElements);
       const response = this.persistentJson.yasr.response;
       if (response) {
         if (response.totalElements !== totalElements) {
@@ -621,6 +622,7 @@ export class Tab extends EventEmitter {
     yasrConf.externalPluginsConfigurations = this.yasgui.config.yasr.externalPluginsConfigurations;
     yasrConf.yasrToolbarPlugins = this.yasgui.config.yasr.yasrToolbarPlugins;
     yasrConf.downloadAsOptions = this.yasgui.config.yasr.downloadAsOptions;
+    yasrConf.showResultInfo = this.yasgui.config.yasr.showResultInfo;
     yasrConf.tabId = this.getId();
 
     if (this.yasqe) {

--- a/Yasgui/packages/yasr/src/defaults.ts
+++ b/Yasgui/packages/yasr/src/defaults.ts
@@ -3,6 +3,7 @@ import { TranslationService } from "@triply/yasgui-utils";
 export default function get(): Config {
   return {
     translationService: TranslationService.INSTANCE,
+    showResultInfo: true,
     persistenceId: function (yasr) {
       //Traverse parents untl we've got an id
       // Get matching parent elements

--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -161,7 +161,7 @@ export class ExtendedYasr extends Yasr {
 
     const pageSize = this.yasqe.getPageSize() || this.persistentJson?.yasqe.pageSize;
     const pageNumber = this.yasqe.getPageNumber() || this.persistentJson?.yasqe.pageNumber;
-    const totalElements = this.persistentJson?.yasr.response?.totalElements;
+    const totalElements = this.persistentJson?.yasr.response?.totalElements || this.results?.getTotalElements();
     const from = pageSize * (pageNumber - 1);
     let to = from + bindings.length;
 
@@ -178,11 +178,12 @@ export class ExtendedYasr extends Yasr {
   updateResponseInfo() {
     const responseInfoElement = this.getResponseInfoElement();
 
-    removeClass(responseInfoElement, "hidden");
-    if (this.results?.hasError()) {
+    if (!this.config.showResultInfo || this.results?.hasError()) {
       addClass(responseInfoElement, "hidden");
       return;
     }
+
+    removeClass(responseInfoElement, "hidden");
 
     const responseTime = this.results?.getResponseTime();
     const queryStartedTime = this.results?.getQueryStartedTime();

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -683,6 +683,8 @@ export interface Config {
   externalPluginsConfigurations?: Map<string, any>;
   yasrToolbarPlugins?: YasrToolbarPlugin[];
   downloadAsOptions?: { labelKey: string; value: any }[];
+
+  showResultInfo: boolean;
   sparqlResponse?: string;
   /**
    * Custom renderers for errors.

--- a/Yasgui/packages/yasr/src/parsers/index.ts
+++ b/Yasgui/packages/yasr/src/parsers/index.ts
@@ -82,6 +82,7 @@ class Parser {
   private readonly executionTime: number | undefined;
   private readonly queryStartedTime: number | undefined;
   private countAffectedRepositoryStatements?: number | undefined;
+  private totalElements?: number | undefined;
   private readonly possibleElementsCount?: number;
   private readonly hasMorePages?: boolean;
   private readonly customResultMessage?: CustomResultMessage;
@@ -241,6 +242,14 @@ class Parser {
 
   public getCountAffectedRepositoryStatements() {
     return this.countAffectedRepositoryStatements;
+  }
+
+  public setTotalElements(totalElements: number) {
+    this.totalElements = totalElements;
+  }
+
+  public getTotalElements() {
+    return this.totalElements;
   }
 
   private getParserFromContentType(): boolean {

--- a/cypress/e2e/view-configurations.spec.cy.ts
+++ b/cypress/e2e/view-configurations.spec.cy.ts
@@ -47,9 +47,10 @@ describe('View configurations', () => {
          // WHEN: set configuration property "showResultTabs" to false.
          ViewConfigurationsPageSteps.hideResultTabs();
 
-         // THEN: only result tabs have to be invisible.
+         // THEN: results tab have to not be visible.
          YasqeSteps.getQueryTabs().should('be.visible');
-         YasrSteps.getResultHeader().should('not.be.visible');
+         YasrSteps.getExtendedTableTab().should('not.be.visible');
+         YasrSteps.getResponseTableTab().should('not.be.visible');
 
          // WHEN: set configuration property "showResultTabs" to true.
          ViewConfigurationsPageSteps.showResultTabs();

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -181,4 +181,12 @@ export class YasrSteps {
   static getResultLiteralCell(rowIndex, columnIndex) {
     return YasrSteps.getResultCell(rowIndex, columnIndex).find('.literal-cell');
   }
+
+  static getExtendedTableTab() {
+    return YasrSteps.getResultHeader().find('.select_extended_table');
+  }
+
+  static getResponseTableTab() {
+    return YasrSteps.getResultHeader().find('.select_extended_response');
+  }
 }

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -97,6 +97,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - <b>defaultTabName?</b>: The default tab name when a new tab is created;
 - <b>showEditorTabs</b>: If the query editor tabs should be rendered or not;
 - <b>showResultTabs</b>: If the results tabs should be rendered or not;
+- **showResultInfo**: If the result message should be rendered or not;
 - <b>showToolbar</b>: If the toolbar with render mode buttons should be rendered or not;
 - <b>yasqePluginButtons</b>: Plugin definitions configurations for yasqe action buttons; 
 - <b>componentId</b>: An unique identifier of an instance of the component. This config is optional.

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -97,7 +97,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - <b>defaultTabName?</b>: The default tab name when a new tab is created;
 - <b>showEditorTabs</b>: If the query editor tabs should be rendered or not;
 - <b>showResultTabs</b>: If the results tabs should be rendered or not;
-- **showResultInfo**: If the result message should be rendered or not;
+- **showResultInfo**: If the result information header of YASR should be rendered or not;
 - <b>showToolbar</b>: If the toolbar with render mode buttons should be rendered or not;
 - <b>yasqePluginButtons</b>: Plugin definitions configurations for yasqe action buttons; 
 - <b>componentId</b>: An unique identifier of an instance of the component. This config is optional.

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -32,7 +32,7 @@ export interface ExternalYasguiConfiguration {
   showResultTabs: boolean;
 
   /**
-   * If the result info should be rendered or not
+   * If the result information header of YASR should be rendered or not.
    */
   showResultInfo: boolean;
 

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -32,6 +32,11 @@ export interface ExternalYasguiConfiguration {
   showResultTabs: boolean;
 
   /**
+   * If the result info should be rendered or not
+   */
+  showResultInfo: boolean;
+
+  /**
    * If the toolbar with render mode buttons should be rendered or not.
    */
   showToolbar: boolean;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -211,7 +211,7 @@ export interface YasguiConfiguration {
       sparqlResponse: string | undefined,
 
       /**
-       * If the result info should be rendered or not
+       * If the result information header of YASR should be rendered or not.
        */
       showResultInfo?: boolean;
     }

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -209,6 +209,11 @@ export interface YasguiConfiguration {
        * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
        */
       sparqlResponse: string | undefined,
+
+      /**
+       * If the result info should be rendered or not
+       */
+      showResultInfo?: boolean;
     }
   };
 
@@ -244,6 +249,7 @@ export const defaultOntotextYasguiConfig: Record<string, any> = {
   orientation: Orientation.VERTICAL,
   showEditorTabs: true,
   showResultTabs: true,
+  showResultInfo: true,
   showToolbar: false,
   showControlBar: false
 }

--- a/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
@@ -38,20 +38,15 @@ export class HtmlElementsUtil {
     return hostElement.querySelector('.yasgui .controlbar');
   }
 
-  static addHiddenClass(hostElement: HTMLElement, ...elementSelectors: string[]) {
-    elementSelectors.forEach((elementSelector) => {
-      const element = hostElement.querySelector(elementSelector);
-      if (element) {
-        element.classList.add('hidden');
-      }
-    });
+  static toggleHiddenByCondition(hostElement: HTMLElement, elementSelectors: string[], haveToExist: () => boolean) {
+    HtmlElementsUtil.toggleClassByCondition(hostElement, elementSelectors, 'hidden', haveToExist);
   }
 
-  static removeHiddenClass(hostElement: HTMLElement, ...elementSelectors: string[]) {
+  static toggleClassByCondition(hostElement: HTMLElement, elementSelectors: string[], className: string, haveToExist: () => boolean): void {
     elementSelectors.forEach((elementSelector) => {
       const element = hostElement.querySelector(elementSelector);
       if (element) {
-        element.classList.remove('hidden');
+        element.classList.toggle(className, haveToExist());
       }
     });
   }

--- a/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
@@ -37,4 +37,22 @@ export class HtmlElementsUtil {
   static getControlBar(hostElement: HTMLElement): HTMLElement {
     return hostElement.querySelector('.yasgui .controlbar');
   }
+
+  static addHiddenClass(hostElement: HTMLElement, ...elementSelectors: string[]) {
+    elementSelectors.forEach((elementSelector) => {
+      const element = hostElement.querySelector(elementSelector);
+      if (element) {
+        element.classList.add('hidden');
+      }
+    });
+  }
+
+  static removeHiddenClass(hostElement: HTMLElement, ...elementSelectors: string[]) {
+    elementSelectors.forEach((elementSelector) => {
+      const element = hostElement.querySelector(elementSelector);
+      if (element) {
+        element.classList.remove('hidden');
+      }
+    });
+  }
 }

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -95,6 +95,7 @@ export class YasguiConfigurationBuilder {
     if (externalConfiguration.maxPersistentResponseSize !== undefined) {
       config.yasguiConfig.yasr.maxPersistentResponseSize = externalConfiguration.maxPersistentResponseSize;
     }
+    config.yasguiConfig.yasr.showResultInfo = externalConfiguration.showResultInfo !== undefined ? externalConfiguration.showResultInfo : defaultOntotextYasguiConfig.showResultInfo;
 
     const yasrToolbarElements = externalConfiguration.yasrToolbarPlugins || [];
     if (externalConfiguration.downloadAsOn === undefined || externalConfiguration.downloadAsOn) {

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -45,19 +45,13 @@ export class OntotextYasguiService {
   }
 
   private static initResultTabs(hostElement: HTMLElement, config: YasguiConfiguration): void {
-    if (config.showResultTabs) {
-      HtmlElementsUtil.removeHiddenClass(hostElement, '.select_extended_table', '.select_extended_response');
-    } else {
-      HtmlElementsUtil.addHiddenClass(hostElement, '.select_extended_table', '.select_extended_response');
-    }
+    const pluginTabsElementsSelectors = ['.select_extended_table', '.select_extended_response'];
+    HtmlElementsUtil.toggleHiddenByCondition(hostElement, pluginTabsElementsSelectors, () => !config.showResultTabs);
   }
 
   private static initResultInfo(hostElement: HTMLElement, config: YasguiConfiguration): void {
-    if (config.yasguiConfig.yasr.showResultInfo) {
-      HtmlElementsUtil.removeHiddenClass(hostElement, '.yasr_response_chip', '#yasr_plugin_control');
-    } else {
-      HtmlElementsUtil.addHiddenClass(hostElement, '.yasr_response_chip', '#yasr_plugin_control');
-    }
+    const responseInfoMessageElementsSelectors = ['.yasr_response_chip', '#yasr_plugin_control'];
+    HtmlElementsUtil.toggleHiddenByCondition(hostElement, responseInfoMessageElementsSelectors, () => !config.yasguiConfig.yasr.showResultInfo);
   }
 
   private static initButtonsStyling(hostElement: HTMLElement, config: YasguiConfiguration): void {

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -16,6 +16,7 @@ export class OntotextYasguiService {
     OntotextYasguiService.initEditorTabs(hostElement, config);
     OntotextYasguiService.initControlBar(hostElement, config);
     OntotextYasguiService.initResultTabs(hostElement, config);
+    OntotextYasguiService.initResultInfo(hostElement, config);
     OntotextYasguiService.initButtonsStyling(hostElement, config);
     this.updateTranslation(config);
   }
@@ -45,9 +46,17 @@ export class OntotextYasguiService {
 
   private static initResultTabs(hostElement: HTMLElement, config: YasguiConfiguration): void {
     if (config.showResultTabs) {
-      hostElement.classList.remove('hidden-result-tabs');
+      HtmlElementsUtil.removeHiddenClass(hostElement, '.select_extended_table', '.select_extended_response');
     } else {
-      hostElement.classList.add('hidden-result-tabs');
+      HtmlElementsUtil.addHiddenClass(hostElement, '.select_extended_table', '.select_extended_response');
+    }
+  }
+
+  private static initResultInfo(hostElement: HTMLElement, config: YasguiConfiguration): void {
+    if (config.yasguiConfig.yasr.showResultInfo) {
+      HtmlElementsUtil.removeHiddenClass(hostElement, '.yasr_response_chip', '#yasr_plugin_control');
+    } else {
+      HtmlElementsUtil.addHiddenClass(hostElement, '.yasr_response_chip', '#yasr_plugin_control');
     }
   }
 

--- a/ontotext-yasgui-web-component/src/services/yasr/toolbar/pagination-yasr-toolbar-plugin.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/toolbar/pagination-yasr-toolbar-plugin.ts
@@ -19,7 +19,7 @@ export class PaginationYasrToolbarPlugin implements YasrToolbarPlugin {
     paginationElement.pageNumber = yasr.yasqe?.getPageNumber();
     paginationElement.pageSize = yasr.yasqe?.getPageSize();
     paginationElement.pageElements = yasr.results?.getBindings()?.length || 0;
-    paginationElement.totalElements = yasr.persistentJson?.yasr.response?.totalElements || -1;
+    paginationElement.totalElements = yasr.persistentJson?.yasr.response?.totalElements || yasr.results?.totalElements || -1;
     paginationElement.hasMorePages = yasr.results?.getHasMorePages();
     this.updateQueryResultPaginationVisibility(paginationElement, yasr);
   }

--- a/yasgui-patches/2023-07-21-added-total-elements-to-response-object.patch
+++ b/yasgui-patches/2023-07-21-added-total-elements-to-response-object.patch
@@ -1,0 +1,123 @@
+Subject: [PATCH] Fixes pagination
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision 8beb999aa15eee9b04ee04279a5e4892f1c80201)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 9c4f6abe00dd7dedfd8cf9b2a2b87de5ab54da38)
+@@ -553,6 +553,7 @@
+ 
+   handleTotalElementsChanged = (_yasqe: Yasqe, totalElements = -1) => {
+     if (this.yasr?.results) {
++      this.yasr.results.setTotalElements(totalElements);
+       const response = this.persistentJson.yasr.response;
+       if (response) {
+         if (response.totalElements !== totalElements) {
+@@ -621,6 +622,7 @@
+     yasrConf.externalPluginsConfigurations = this.yasgui.config.yasr.externalPluginsConfigurations;
+     yasrConf.yasrToolbarPlugins = this.yasgui.config.yasr.yasrToolbarPlugins;
+     yasrConf.downloadAsOptions = this.yasgui.config.yasr.downloadAsOptions;
++    yasrConf.showResultInfo = this.yasgui.config.yasr.showResultInfo;
+     yasrConf.tabId = this.getId();
+ 
+     if (this.yasqe) {
+Index: Yasgui/packages/yasr/src/defaults.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/defaults.ts b/Yasgui/packages/yasr/src/defaults.ts
+--- a/Yasgui/packages/yasr/src/defaults.ts	(revision 8beb999aa15eee9b04ee04279a5e4892f1c80201)
++++ b/Yasgui/packages/yasr/src/defaults.ts	(revision 9c4f6abe00dd7dedfd8cf9b2a2b87de5ab54da38)
+@@ -3,6 +3,7 @@
+ export default function get(): Config {
+   return {
+     translationService: TranslationService.INSTANCE,
++    showResultInfo: true,
+     persistenceId: function (yasr) {
+       //Traverse parents untl we've got an id
+       // Get matching parent elements
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 8beb999aa15eee9b04ee04279a5e4892f1c80201)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 9c4f6abe00dd7dedfd8cf9b2a2b87de5ab54da38)
+@@ -161,7 +161,7 @@
+ 
+     const pageSize = this.yasqe.getPageSize() || this.persistentJson?.yasqe.pageSize;
+     const pageNumber = this.yasqe.getPageNumber() || this.persistentJson?.yasqe.pageNumber;
+-    const totalElements = this.persistentJson?.yasr.response?.totalElements;
++    const totalElements = this.persistentJson?.yasr.response?.totalElements || this.results?.getTotalElements();
+     const from = pageSize * (pageNumber - 1);
+     let to = from + bindings.length;
+ 
+@@ -178,12 +178,13 @@
+   updateResponseInfo() {
+     const responseInfoElement = this.getResponseInfoElement();
+ 
+-    removeClass(responseInfoElement, "hidden");
+-    if (this.results?.hasError()) {
++    if (!this.config.showResultInfo || this.results?.hasError()) {
+       addClass(responseInfoElement, "hidden");
+       return;
+     }
+ 
++    removeClass(responseInfoElement, "hidden");
++
+     const responseTime = this.results?.getResponseTime();
+     const queryStartedTime = this.results?.getQueryStartedTime();
+ 
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 8beb999aa15eee9b04ee04279a5e4892f1c80201)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 9c4f6abe00dd7dedfd8cf9b2a2b87de5ab54da38)
+@@ -683,6 +683,8 @@
+   externalPluginsConfigurations?: Map<string, any>;
+   yasrToolbarPlugins?: YasrToolbarPlugin[];
+   downloadAsOptions?: { labelKey: string; value: any }[];
++
++  showResultInfo: boolean;
+   sparqlResponse?: string;
+   /**
+    * Custom renderers for errors.
+Index: Yasgui/packages/yasr/src/parsers/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/parsers/index.ts b/Yasgui/packages/yasr/src/parsers/index.ts
+--- a/Yasgui/packages/yasr/src/parsers/index.ts	(revision 8beb999aa15eee9b04ee04279a5e4892f1c80201)
++++ b/Yasgui/packages/yasr/src/parsers/index.ts	(revision 9c4f6abe00dd7dedfd8cf9b2a2b87de5ab54da38)
+@@ -82,6 +82,7 @@
+   private readonly executionTime: number | undefined;
+   private readonly queryStartedTime: number | undefined;
+   private countAffectedRepositoryStatements?: number | undefined;
++  private totalElements?: number | undefined;
+   private readonly possibleElementsCount?: number;
+   private readonly hasMorePages?: boolean;
+   private readonly customResultMessage?: CustomResultMessage;
+@@ -243,6 +244,14 @@
+     return this.countAffectedRepositoryStatements;
+   }
+ 
++  public setTotalElements(totalElements: number) {
++    this.totalElements = totalElements;
++  }
++
++  public getTotalElements() {
++    return this.totalElements;
++  }
++
+   private getParserFromContentType(): boolean {
+     const contentType = this.getContentType();
+     if (contentType) {


### PR DESCRIPTION
## What
- I can't configure only pagination to be displayed.
- Pagination pages and total elements are not displayed when the result data size is more than the configured length with the "maxPersistentResponseSize" property.

## Why
The configuration isn't granular enough.
- The calculation of pagination pages and the result info message is based on the total element value, which is fetched asynchronously with a second request. When the total element is ready, its value is persisted to the browser's local store. However, if the response size is larger, the result is not persisted. As a result, the pagination functionality fetches undefined value of the total element. As a result, the pages and result info are not correctly displayed..

## How
- Added a new configuration option "showResultInfo" to hide/show result information.
- Extends the response object to hold the value of total elements. The pagination logic was changed to read total elements from the local store. If there is no value, then it reads it from the extended response object.