### PR TITLE
GDB-8598 reorganize ok/cancel button positions in dialogs and allow dialogs and menus to be close via [esc] keydown

### DIFF
--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
@@ -91,7 +91,6 @@
       background-color: $color-ontotext-orange;
       border-color: $color-ontotext-orange;
       color: #fff;
-      margin-right: 10px;
 
       &:hover, &:focus {
         background-color: $color-ontotext-orange-dark;
@@ -101,6 +100,7 @@
 
     .cancel-button {
       color: $color-onto-blue;
+      margin-right: 10px;
 
       &:hover, &:focus {
         background-color: #d4d4d4;

--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.tsx
@@ -1,4 +1,4 @@
-import {Component, Event, EventEmitter, h, Host, Prop} from '@stencil/core';
+import {Component, Event, EventEmitter, h, Host, Listen, Prop} from '@stencil/core';
 import {TranslationService} from "../../services/translation.service";
 
 export type ConfirmationDialogConfig = {
@@ -30,6 +30,17 @@ export class ConfirmationDialog {
    */
   @Event() internalConfirmationApprovedEvent: EventEmitter;
 
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.internalConfirmationRejectedEvent.emit();
+    }
+  }
+
   onClose(evt: MouseEvent): void {
     const target = evt.target as HTMLElement;
     evt.stopPropagation();
@@ -57,10 +68,10 @@ export class ConfirmationDialog {
             </div>
             <div class="dialog-body">{this.config.message}</div>
             <div class="dialog-footer">
-              <button class="confirm-button"
-                      onClick={(evt) => this.onConfirm(evt)}>{this.translationService.translate('confirmation.btn.confirm.label')}</button>
               <button class="cancel-button"
                       onClick={(evt) => this.onClose(evt)}>{this.translationService.translate('confirmation.btn.cancel.label')}</button>
+              <button class="confirm-button"
+                      onClick={(evt) => this.onConfirm(evt)}>{this.translationService.translate('confirmation.btn.confirm.label')}</button>
             </div>
           </div>
         </div>

--- a/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.scss
@@ -15,4 +15,12 @@
   .copy-link-form {
     @include formField;
   }
+
+  .copy-button {
+    margin-right: 0 !important;
+  }
+
+  .cancel-button {
+    margin-right: 10px;
+  }
 }

--- a/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.tsx
@@ -1,4 +1,4 @@
-import {Component, Element, h, Prop} from '@stencil/core';
+import {Component, Element, h, Listen, Prop} from '@stencil/core';
 import {DialogConfig} from "../ontotext-dialog-web-component/ontotext-dialog-web-component";
 import {ServiceFactory} from "../../services/service-factory";
 import {TranslationService} from "../../services/translation.service";
@@ -32,6 +32,17 @@ export class CopyLinkDialog {
   @Prop() copyLinkEventsObserver: CopyLinkObserver;
 
   @Prop() classes: string
+
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.copyLinkEventsObserver.onDialogClosed();
+    }
+  }
 
   buildDialogConfig(): DialogConfig {
     return {
@@ -121,10 +132,10 @@ export class CopyLinkDialog {
           </div>
         </div>
         <div slot="footer">
-          <button class="primary-button copy-button"
-                  onClick={(evt) => this.onCopy(evt)}>{this.translationService.translate('yasqe.share.copy_link.dialog.copy.btn.label')}</button>
           <button class="secondary-button cancel-button"
                   onClick={(evt) => this.onClose(evt)}>{this.translationService.translate('confirmation.btn.cancel.label')}</button>
+          <button class="primary-button copy-button"
+                  onClick={(evt) => this.onCopy(evt)}>{this.translationService.translate('yasqe.share.copy_link.dialog.copy.btn.label')}</button>
         </div>
       </ontotext-dialog-web-component>
     );

--- a/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
+++ b/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
@@ -1,4 +1,4 @@
-import {Component, Event, EventEmitter, h, Prop, State} from '@stencil/core';
+import {Component, Event, EventEmitter, h, Listen, Prop, State} from '@stencil/core';
 import {TranslationService} from '../../services/translation.service';
 import {DropdownOption} from '../../models/dropdown-option';
 import {InternalDropdownValueSelectedEvent} from '../../models/internal-events/internal-dropdown-value-selected-event';
@@ -20,6 +20,29 @@ export class Dropdown {
   @Prop() iconClass = '';
 
   @Event() valueChanged: EventEmitter<InternalDropdownValueSelectedEvent>;
+
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.closeMenu();
+    }
+  }
+
+  /**
+   * Handles the mouse click events and closes the menu when target is outside the menu.
+   * @param ev The mouse event.
+   */
+  @Listen('click', {target: 'window'})
+  mouseClickListener(ev: PointerEvent): void {
+    const target: HTMLElement = ev.target as HTMLElement;
+    if (!target.closest('.ontotext-dropdown')) {
+      this.closeMenu();
+    }
+  }
 
   render() {
     const showToolbar = this.tooltipLabelKey && window.innerWidth < 768;
@@ -47,6 +70,7 @@ export class Dropdown {
   private onSelect(value: string) {
     this.open = false;
     this.valueChanged.emit(new InternalDropdownValueSelectedEvent(value));
+    console.log('selected', value);
   }
 
   private toggleComponent(): void {
@@ -58,5 +82,9 @@ export class Dropdown {
       return this.translationService.translate(labelKey);
     }
     return '';
+  }
+
+  private closeMenu(): void {
+    this.open = false;
   }
 }

--- a/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.tsx
@@ -1,4 +1,4 @@
-import {Component, h, Host, Prop, State} from '@stencil/core';
+import {Component, h, Host, Listen, Prop, State} from '@stencil/core';
 import {TranslationService} from '../../services/translation.service';
 import {DialogConfig} from '../ontotext-dialog-web-component/ontotext-dialog-web-component';
 
@@ -14,6 +14,17 @@ export class KeyboardShortcutsDialog {
   @Prop() items: string[] = [];
 
   @Prop() translationService: TranslationService;
+
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.open = false;
+    }
+  }
 
   private openDialog() {
     this.open = true;

--- a/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.scss
@@ -154,7 +154,6 @@
       background-color: $color-ontotext-orange;
       border-color: $color-ontotext-orange;
       color: #fff;
-      margin-right: 10px;
 
       &:hover, &:focus {
         background-color: $color-ontotext-orange-dark;
@@ -164,6 +163,7 @@
 
     .cancel-button {
       color: $color-onto-blue;
+      margin-right: 10px;
 
       &:hover, &:focus {
         background-color: #d4d4d4;

--- a/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
@@ -4,7 +4,7 @@ import {
   EventEmitter,
   FunctionalComponent,
   h,
-  Host,
+  Host, Listen,
   Prop,
   State
 } from '@stencil/core';
@@ -55,6 +55,17 @@ export class SaveQueryDialog {
    * updated query data.
    */
   @Event() internalUpdateQueryEvent: EventEmitter<UpdateQueryData>;
+
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.internalSaveQueryDialogClosedEvent.emit();
+    }
+  }
 
   componentWillLoad(): void {
     // TranslationService is injected here because the service factory is not available
@@ -185,10 +196,10 @@ export class SaveQueryDialog {
 
             </div>
             <div class="dialog-footer">
-              <button class="ok-button" disabled={!this.isSaveAllowed}
-                      onClick={(evt) => this.onCreate(evt)}>{this.translationService.translate('yasqe.actions.save_query.dialog.create.button')}</button>
               <button class="cancel-button"
                       onClick={(evt) => this.onClose(evt)}>{this.translationService.translate('yasqe.actions.save_query.dialog.cancel.button')}</button>
+              <button class="ok-button" disabled={!this.isSaveAllowed}
+                      onClick={(evt) => this.onCreate(evt)}>{this.translationService.translate('yasqe.actions.save_query.dialog.create.button')}</button>
             </div>
           </div>
         </div>

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -50,6 +50,17 @@ export class SavedQueriesPopup {
     }
   }
 
+  /**
+   * Handles the Escape key keydown event and closes the dialog.
+   * @param ev The keyboard event.
+   */
+  @Listen('keydown', {target: "window"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Escape') {
+      this.internalCloseSavedQueriesPopupEvent.emit();
+    }
+  }
+
   onSelect(evt, selectedQuery: SaveQueryData): void {
     evt.stopPropagation();
     this.internalSaveQuerySelectedEvent.emit(selectedQuery);


### PR DESCRIPTION
## What
* Reorganized the order of ok/cancel buttons in all dialogs in a way that the primary action button to be always on the right.
* Allow all dialogs and menus to be closed by hitting the [esc] keyboard key.

## Why
A decision was taken for the Ontotext workbench application where those buttons must have a consistent order and position throughout the application. Given that decision, here we need to apply the same rules in order to comply with the entire look'n'feel of the workbench. Also it was identified that having the option to close any dialog or menu by clicking the [esc] key would lead to a better user experience.

## How
* Changed the buttons order.
* Implemented listeners allowing to close dialogs and menus on [esc] keydown event.