### PR TITLE
Changed algorithm of opening tab

### DIFF
--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -201,6 +201,18 @@ export class Yasgui extends EventEmitter {
   public tabNameTaken(name: string) {
     return find(this._tabs, (tab) => tab.getName() === name);
   }
+
+  public getTabByNameAndQuery(name: string, query: string) {
+    return find(this._tabs, (tab) => {
+      if (tab.getName() === name) {
+        // We can't get the query directly from the tab because if the tab hasn't been opened before
+        // then the yasqe won't be initialized. That's why we get the query from the tab's persistence.
+        return tab.getPersistedJson()?.yasqe?.value === query;
+      }
+      return false;
+    });
+  }
+
   public getTab(tabId?: string): Tab | undefined {
     if (tabId) {
       return this._tabs[tabId];

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -114,12 +114,8 @@ export class OntotextYasgui {
   }
 
   openTab(queryModel: TabQueryModel): void {
-    const existingTab = this.getInstance().tabNameTaken(queryModel.queryName);
-    const config = existingTab?.getPersistedJson();
-    // We can't get the query directly from the tab because if the tab hasn't been opened before
-    // then the yasqe won't be initialized. That's why we get the query from the tab's persistence.
-    const isSameQuery = config?.yasqe?.value === queryModel.query;
-    if (existingTab && isSameQuery) {
+    const existingTab = this.getInstance().getTabByNameAndQuery(queryModel.queryName, queryModel.query);
+    if (existingTab) {
       this.getInstance().selectTabId(existingTab.getId());
     } else {
       this.createNewTab(queryModel.queryName, queryModel.query);

--- a/yasgui-patches/2023-08-10-changed_algorithm_of_opening_tab.patch
+++ b/yasgui-patches/2023-08-10-changed_algorithm_of_opening_tab.patch
@@ -1,0 +1,29 @@
+Subject: [PATCH] Changed algorithm of opening tab
+---
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision 87131b70c98643d4ced510dce1d2691918ecbe06)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision b646fc5ad45c684fa6b11e514a06f1fa4c1e073c)
+@@ -201,6 +201,18 @@
+   public tabNameTaken(name: string) {
+     return find(this._tabs, (tab) => tab.getName() === name);
+   }
++
++  public getTabByNameAndQuery(name: string, query: string) {
++    return find(this._tabs, (tab) => {
++      if (tab.getName() === name) {
++        // We can't get the query directly from the tab because if the tab hasn't been opened before
++        // then the yasqe won't be initialized. That's why we get the query from the tab's persistence.
++        return tab.getPersistedJson()?.yasqe?.value === query;
++      }
++      return false;
++    });
++  }
++
+   public getTab(tabId?: string): Tab | undefined {
+     if (tabId) {
+       return this._tabs[tabId];


### PR DESCRIPTION
## What
A new tab is opened although there is a tab with same name and query.

## Why
The algorithm of finding the tab with same name and query looking for first tab with same name checks the query and if query not same opens a new tab, but if there could be a second tab with same name and looked for query, in this case opening a new tab is wrong.

## How
Changed algorithm to not stop after first found tab with same name but different query.