### PR TITLE
Fixes Yasqe Shortcut Key Functionality

### DIFF
--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -109,6 +109,12 @@ export class Yasgui extends EventEmitter {
     parent.appendChild(this.rootEl);
 
     this.config = merge({}, Yasgui.defaults, config);
+
+    if (config.yasqe?.extraKeys) {
+      // We don't want to merge both shortcut configurations. If shortcuts are passed, we will use them.
+      this.config.yasqe.extraKeys = config.yasqe.extraKeys;
+    }
+
     this.translationService = this.config.translationService;
     this.notificationMessageService = this.config.notificationMessageService;
     this.eventService = this.config.eventService;

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -111,6 +111,12 @@ export class Yasqe extends CodeMirror {
     this.rootEl.className = "yasqe";
     parent.appendChild(this.rootEl);
     this.config = merge({}, Yasqe.defaults, conf);
+
+    if (conf.extraKeys) {
+      // We don't want to merge both shortcut configurations. If shortcuts are passed, we will use them.
+      this.config.extraKeys = conf.extraKeys;
+    }
+
     this.translationService = this.config.translationService;
     this.isVirtualRepository = this.config.isVirtualRepository;
     this.notificationMessageService = this.config.notificationMessageService;

--- a/cypress/e2e/keyboard-shortcuts.spec.cy.ts
+++ b/cypress/e2e/keyboard-shortcuts.spec.cy.ts
@@ -187,6 +187,18 @@ describe('Keyboard Shortcuts', () => {
       YasrSteps.getTableResults().should('have.length', 75);
     });
 
+    it('should not trigger "EXECUTE_QUERY_OR_UPDATE" action when run button is hidden', () => {
+      // Given: I visit a page with "ontotext-yasgui-web-component" in it,
+      // and a query is typed.
+      KeyboardShortcutPageSteps.hideRunButton();
+
+      // When press the "Run query button" keyboard shortcut.
+      KeyboardShortcutSteps.clickOnRunQueryShortcut();
+
+      // Then I expect the query to be executed.
+      YasrSteps.getEmptyResultElement().should('exist');
+    });
+
     it('should trigger "CREATE_TAB" action', () => {
       // Given: I visit a page with "ontotext-yasgui-web-component" in it.
       YasqeSteps.clearEditor();

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -189,4 +189,8 @@ export class YasrSteps {
   static getResponseTableTab() {
     return YasrSteps.getResultHeader().find('.select_extended_response');
   }
+
+  static getEmptyResultElement() {
+    return cy.get('.yasr_response_chip.empty');
+  }
 }

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -84,7 +84,10 @@ Add "CUSTOM_ELEMENTS_SCHEMA" to "@NgModule.schemas" in the module where componen
 ## Configuration
 
 The "config" value of "ngce-prop-config" or "[config]" is an object with following options:
-- <b>yasguiConfig</b>: this is yasgui original configuration as it is. [See how can be used it](https://triply.cc/docs/yasgui-api#yasgui-config)
+- **endpoint**: The sparql endpoint which will be used when a query request is made. It is important to note that if the endpoint
+  configuration is passed as string, it will be persisted when first time initializes the instance with specific componentId. Subsequent
+  query executions will use the endpoint stored in the persistence regardless if the configuration is changed. If the endpoint is defined as
+  a function, it will be called before each query execution.
 - <b>render</b>: Configure what part of the yasgui should be rendered. Supported values are:
    - mode-yasgui: default configuration. Shows the query editor and the results;
    - mode-yasqe: shows the query editor only;

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -59,8 +59,12 @@ export interface ExternalYasguiConfiguration {
 
   /**
    * The sparql endpoint which will be used when a query request is made.
+   * It is important to note that if the endpoint configuration is passed as string, it will be persisted when first time initializes
+   * the instance with specific {@link ExternalYasguiConfiguration#componentId}. Subsequent query executions will
+   * use the endpoint stored in the persistence regardless if the configuration is changed. If the endpoint is defined as a function, it will be called before each query execution.
    */
-  endpoint: string;
+  // @ts-ignore
+  endpoint: string | ((yasgui: Yasgui) => string);
 
   /**
    * Key -> value translations as JSON. If the language is supported, then not needed to pass all label values.

--- a/yasgui-patches/2023-08-15-make_external_extra_key_configuration_to_override_defaults.patch
+++ b/yasgui-patches/2023-08-15-make_external_extra_key_configuration_to_override_defaults.patch
@@ -1,0 +1,44 @@
+Subject: [PATCH] The behavior of the 'extraKeys' configuration is changed. The old implementation, which merged the external and default configurations, has been replaced with a new one where the external configuration overrides the internal one.
+---
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision 1b6adaba28846ba1f21b5cec28ecdf45eb98634f)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision 8b5d5a18700c44648b719ae47e2d9e07b2774a87)
+@@ -109,6 +109,12 @@
+     parent.appendChild(this.rootEl);
+ 
+     this.config = merge({}, Yasgui.defaults, config);
++
++    if (config.yasqe?.extraKeys) {
++      // We don't want to merge both shortcut configurations. If shortcuts are passed, we will use them.
++      this.config.yasqe.extraKeys = config.yasqe.extraKeys;
++    }
++
+     this.translationService = this.config.translationService;
+     this.notificationMessageService = this.config.notificationMessageService;
+     this.eventService = this.config.eventService;
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 1b6adaba28846ba1f21b5cec28ecdf45eb98634f)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 8b5d5a18700c44648b719ae47e2d9e07b2774a87)
+@@ -111,6 +111,12 @@
+     this.rootEl.className = "yasqe";
+     parent.appendChild(this.rootEl);
+     this.config = merge({}, Yasqe.defaults, conf);
++
++    if (conf.extraKeys) {
++      // We don't want to merge both shortcut configurations. If shortcuts are passed, we will use them.
++      this.config.extraKeys = conf.extraKeys;
++    }
++
+     this.translationService = this.config.translationService;
+     this.isVirtualRepository = this.config.isVirtualRepository;
+     this.notificationMessageService = this.config.notificationMessageService;


### PR DESCRIPTION
## What
When the component is configured to hide the query run button, some shortcut keys that execute queries remain active.

## Why
Yasqe has a default configuration of shortcut key functions, and those functions are merged with externally passed functions. However, when the external configuration doesn't provide an execution function, the default one is used.

## How
The behavior of the 'extraKeys' configuration is changed. The old implementation, which merged the external and default configurations, has been replaced with a new one where the external configuration overrides the internal one.