### PR TITLE
GDB-8286: The `ontotext-yasgui-web-component` opens slowly when there are many results.

### DIFF
--- a/cypress/e2e/yasr/plugins/table/copy-link-dialog.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/copy-link-dialog.spec.cy.ts
@@ -1,7 +1,7 @@
-import {QueryStubDescription, QueryStubs} from '../../stubs/query-stubs';
-import {YasrTablePluginSteps} from '../../steps/yasr-table-plugin-steps';
-import {YasqeSteps} from '../../steps/yasqe-steps';
-import {YasrSteps} from '../../steps/yasr-steps';
+import {YasrTablePluginSteps} from '../../../../steps/yasr-table-plugin-steps';
+import {QueryStubDescription, QueryStubs} from '../../../../stubs/query-stubs';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
 
 describe('Plugin: Table', () => {
 
@@ -10,7 +10,7 @@ describe('Plugin: Table', () => {
     YasrTablePluginSteps.visit();
   });
 
-  describe('Copy resource link dialog', () => {
+  context('Copy resource link dialog', () => {
 
     it('Should open copy link dialog', () => {
       // When I execute a query which returns results of type is uri.

--- a/yasgui-patches/2023-08-16-fixes_slow_rendering_of_extended_table_plugin.patch
+++ b/yasgui-patches/2023-08-16-fixes_slow_rendering_of_extended_table_plugin.patch
@@ -1,0 +1,61 @@
+Subject: [PATCH] GDB-8286: The `ontotext-yasgui-web-component` opens slowly when there are many results.
+---
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 591ca74fb98ad5a4edd329b242e81c427b5aefd9)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 9cd0b6407f417287d27e164f2bcf5d9905033b7c)
+@@ -22,8 +22,8 @@
+     this.persistentJson = persistentJson;
+     this.externalPluginsConfigurations = conf.externalPluginsConfigurations;
+     if (yasqe.config.paginationOn) {
+-      this.yasqe.on("queryResponse", this.draw.bind(this));
+-      this.yasqe.on("totalElementsPersisted", this.draw.bind(this));
++      this.yasqe.on("queryResponse", this.updatePaginationRelatedElements.bind(this));
++      this.yasqe.on("totalElementsPersisted", this.updatePaginationRelatedElements.bind(this));
+     }
+     this.yasqe.on("countAffectedRepositoryStatementsPersisted", this.updateResponseInfo.bind(this));
+   }
+@@ -67,12 +67,12 @@
+   }
+ 
+   draw() {
+-    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery() || this.results?.hasError()) {
+-      this.hidePluginElementVisibility();
+-    } else {
+-      this.showPluginElementVisibility();
+-    }
+-    super.draw();
++    // The rendering of YASR is synchronous and can take time, especially when populating numerous results.
++    // Setting a timeout resolves the visualization of other components without waiting for YASR to finish drawing.
++    setTimeout(() => {
++      this.updatePluginElementVisibility();
++      super.draw();
++    }, 0);
+   }
+ 
+   updatePluginSelectorNames() {
+@@ -80,6 +80,20 @@
+     this.yasrToolbarManagers?.forEach((manager) => manager.updateElement(this));
+   }
+ 
++  private updatePaginationRelatedElements(): void {
++    this.updatePluginElementVisibility();
++    this.updateResponseInfo();
++    this.updatePluginSelectorNames();
++  }
++
++  private updatePluginElementVisibility(): void {
++    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery() || this.results?.hasError()) {
++      this.hidePluginElementVisibility();
++    } else {
++      this.showPluginElementVisibility();
++    }
++  }
++
+   private hidePluginElementVisibility() {
+     const pluginElement = this.getPluginSelectorsEl();
+     if (pluginElement) {


### PR DESCRIPTION
## What
- When the SPARQL view is opened, and the active tab contains a significant number of results, the page becomes unresponsive until YASR finishes rendering.
- When run a query the YASR results are rendered slowly.

## Why
- The rendering process of YASR is synchronous and can be time-consuming, particularly when handling a large volume of results.
- When the pagination functionality was implemented, two event listeners were registered to update the pagination. The implementation of these event handlers simply called the YASR draw function. However, this function is slow due to its rendering of the result table. As a result, for a single query execution, the function is called three times: once from the original YASGUI implementation and twice from both listeners.

## How
- To address this issue, the drawing method of YASR has been wrapped in a `setTimeout` function, enabling asynchronous execution. This modification allows other components to load and be visualized without waiting for YASR to finish rendering.
- Implements a function that updates only the affected elements when both events occur.