### PR TITLE
GDB-8626 allow yasr table columns to be resized from any row

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -227,7 +227,7 @@ export default class Table implements Plugin<PluginConfig> {
       widths: this.persistentConfig.compact === true ? widths : [this.getSizeFirstColumn(), ...widths.slice(1)],
       partialRefresh: true,
       onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
-      headerOnly: true,
+      headerOnly: false,
     });
     // DataTables uses the rendered style to decide the widths of columns.
     // Before a draw remove the ellipseTable styling

--- a/yasgui-patches/2023-08-16-GDB-8626_allow_yasr_table_columns_to_be_resized_from_any_row.patch
+++ b/yasgui-patches/2023-08-16-GDB-8626_allow_yasr_table_columns_to_be_resized_from_any_row.patch
@@ -1,0 +1,17 @@
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 591ca74fb98ad5a4edd329b242e81c427b5aefd9)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 6b1fbb48a5fe6c30b1e971afd046da8819a50d87)
+@@ -227,7 +227,7 @@
+       widths: this.persistentConfig.compact === true ? widths : [this.getSizeFirstColumn(), ...widths.slice(1)],
+       partialRefresh: true,
+       onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+-      headerOnly: true,
++      headerOnly: false,
+     });
+     // DataTables uses the rendered style to decide the widths of columns.
+     // Before a draw remove the ellipseTable styling


### PR DESCRIPTION
## What
Allow yasr table columns to be resizable from any table row.

## Why
The old yasgui integrated in the GDB workbench was configured to allow such behavior and we want it to come as a default with the new component.

## How
Changed the configuration passed to the ColumnResizer plugin to the datatable.