### PR TITLE
GDB-8626 show error mark on yasgui a tab when query is invalid

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -63,6 +63,7 @@ export interface Tab {
   emit(event: "openNextTab", tab: Tab): void;
   emit(event: "openPreviousTab", tab: Tab): void;
   emit(event: "closeOtherTabs", tab: Tab): void;
+  emit(event: "queryStatus", tab: Tab, data: any): void;
 }
 export class Tab extends EventEmitter {
   private persistentJson: PersistedJson;
@@ -416,7 +417,9 @@ export class Tab extends EventEmitter {
     this.yasqe.on("openNextTab", this.handleOpenNextTab);
     this.yasqe.on("openPreviousTab", this.handleOpenPreviousTab);
     this.yasqe.on("closeOtherTabs", this.handlerCloseOtherTabs);
+    this.yasqe.on("queryStatus", this.handleQueryStatusChange);
   }
+
   private destroyYasqe() {
     // As Yasqe extends of CM instead of eventEmitter, it doesn't expose the removeAllListeners function, so we should unregister all events manually
     this.yasqe?.off("blur", this.handleYasqeBlur);
@@ -430,6 +433,7 @@ export class Tab extends EventEmitter {
     this.yasqe?.off("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
     this.yasqe?.off("openNewTab", this.handleOpenNewTab);
     this.yasqe?.off("openNextTab", this.handleOpenNextTab);
+    this.yasqe?.off("queryStatus", this.handleQueryStatusChange);
     this.yasqe?.on("openPreviousTab", this.handleOpenPreviousTab);
     this.yasqe?.on("closeOtherTabs", this.handlerCloseOtherTabs);
     this.yasqe?.destroy();
@@ -450,6 +454,10 @@ export class Tab extends EventEmitter {
 
   handlerCloseOtherTabs = () => {
     this.emit("closeOtherTabs", this);
+  };
+
+  handleQueryStatusChange = (...args: any[]) => {
+    this.emit('queryStatus', this, args[2]);
   };
 
   handleYasqeBlur = (yasqe: Yasqe) => {

--- a/Yasgui/packages/yasgui/src/TabElements.scss
+++ b/Yasgui/packages/yasgui/src/TabElements.scss
@@ -41,6 +41,10 @@ $minTabHeight: 35px;
       $activeColor: #337ab7;
       $hoverColor: lighten($activeColor, 30);
 
+      &.query-invalid a {
+        text-decoration: underline dotted red;
+      }
+
       .loader {
         display: none;
         background-color: lighten(#555, 50);

--- a/Yasgui/packages/yasgui/src/TabElements.ts
+++ b/Yasgui/packages/yasgui/src/TabElements.ts
@@ -54,6 +54,19 @@ export class TabListEl {
       this.nameEl.textContent = name;
     }
   }
+  public setAsValid(isValid: boolean) {
+    if (isValid) {
+      removeClass(this.tabEl, "query-invalid");
+      if (this.tabEl) {
+          this.tabEl.removeAttribute("title");
+      }
+    } else {
+      addClass(this.tabEl, "query-invalid");
+      if (this.tabEl) {
+          this.tabEl.setAttribute("title", this.translationService.translate("yasqe.tab_list.new_tab.query_invalid.warning.message"));
+      }
+    }
+  }
   public setAsQuerying(querying: boolean) {
     if (querying) {
       addClass(this.tabEl, "querying");
@@ -197,7 +210,18 @@ export class TabList {
         this._tabs[id].setAsQuerying(false);
       }
     });
+    this.yasgui.on("queryStatus", (tab, data) => this.queryStatusChangeHandler(tab, data));
+    this.yasgui.on("yasqeReady", (tab, yasqe) => this.yasqeReadyHandler(tab, yasqe));
   }
+
+  private yasqeReadyHandler(tab: any, yasqe: any) {
+    this._tabs[tab.getId()].setAsValid(yasqe.queryValid);
+  }
+
+  private queryStatusChangeHandler(tab: any, data: any) {
+    this._tabs[tab.getId()].setAsValid(data.valid);
+  }
+
   private getActiveIndex() {
     if (!this._selectedTab) return;
     const allTabs = Object.keys(this._tabs);

--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -89,6 +89,7 @@ export interface Yasgui {
   on(event: "autocompletionClose", listener: (instance: Yasgui, tab: Tab) => void): this;
   emit(event: "autocompletionClose", instance: Yasgui, tab: Tab): boolean;
   emit(event: "yasqeReady", tab: Tab, yasqe: Yasqe | undefined): boolean;
+  emit(event: "queryStatus", tab: Tab, data: any): void;
 }
 export class Yasgui extends EventEmitter {
   public rootEl: HTMLDivElement;
@@ -339,6 +340,7 @@ export class Yasgui extends EventEmitter {
     tab.on("queryResponse", (tab) => this.emit("queryResponse", this, tab));
     tab.on("autocompletionShown", (tab, widget) => this.emit("autocompletionShown", this, tab, widget));
     tab.on("autocompletionClose", (tab) => this.emit("autocompletionClose", this, tab));
+    tab.on("queryStatus", (tab, data) => this.emit("queryStatus", tab, data));
   }
 
   public openNextTab(tab: Tab) {

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -71,6 +71,8 @@ export interface Yasqe {
   off(eventName: "openPreviousTab", handler: () => void): void;
   on(eventName: "closeOtherTabs", handler: () => void): void;
   off(eventName: "closeOtherTabs", handler: () => void): void;
+  on(eventName: "queryStatus", handler: (instance: Yasqe, data: any) => void): void;
+  off(eventName: "queryStatus", handler: () => void): void;
 }
 
 export class Yasqe extends CodeMirror {
@@ -179,6 +181,7 @@ export class Yasqe extends CodeMirror {
   private handleChange() {
     this.checkSyntax();
     this.updateQueryButton();
+    this.emit("queryStatus", this, {valid: this.queryValid});
   }
   private handleBlur() {
     this.saveQuery();

--- a/cypress/e2e/yasgui-tabs.spec.cy.ts
+++ b/cypress/e2e/yasgui-tabs.spec.cy.ts
@@ -12,6 +12,24 @@ describe('Yasgui tabs', () => {
     QueryStubs.stubQueryResults(new QueryStubDescription().setPageSize(10).setTotalElements(6));
   });
 
+  it('Should mark tab as errorneous if query is invalid', () => {
+    // Given I have opened yasgui with a single opened tab
+    // And I have created a second tab
+    openNewTab(1, 2);
+    // Then I expect to have no error mark on the tab
+    YasguiSteps.getCurrentTab().should('not.have.class', 'query-invalid');
+    // When I write invalid query
+    YasqeSteps.writeInEditor("test");
+    // Then I expect that the tab will have an error mark and a title with an error message
+    YasguiSteps.getCurrentTab().should('have.class', 'query-invalid')
+      .and('have.attr', 'title', 'Query contains a syntax error. See the relevant line for more information.');
+    // When I switch the tab
+    YasguiSteps.openTab(0);
+    // Then I expect that the error mark should stay
+    YasguiSteps.getTab(1).should('have.class', 'query-invalid')
+      .and('have.attr', 'title', 'Query contains a syntax error. See the relevant line for more information.');
+  });
+
   it('Should ask for confirmation on tab close', () => {
     // Given I have opened yasgui with a single opened tab
     // And I have created a second tab

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -23,8 +23,12 @@ export class YasguiSteps {
     cy.get('button.addTab').click();
   }
 
+  static getTab(index: number) {
+    return this.getTabs().eq(index);
+  }
+
   static openTab(index: number) {
-    this.getTabs().eq(index).click();
+    this.getTab(index).click();
   }
 
   static closeTab(index: number) {

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -27,6 +27,7 @@
   "yasgui.tab_list.menu.rename_tab.btn.label": "Rename Tab",
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Undo close Tab",
   "yasqe.tab_list.new_tab.query_running.warning.message": "New tabs may not be opened while query or update is running.",
+  "yasqe.tab_list.new_tab.query_invalid.warning.message": "Query contains a syntax error. See the relevant line for more information.",
   "yasgui.toolbar.mode_yasgui.btn.label": "Editor and results",
   "yasgui.toolbar.mode_yasqe.btn.label": "Editor only",
   "yasgui.toolbar.mode_yasr.btn.label": "Results only",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -27,6 +27,7 @@
   "yasgui.tab_list.menu.rename_tab.btn.label": "Rename Tab",
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Undo close Tab",
   "yasqe.tab_list.new_tab.query_running.warning.message": "Il est impossible d'ouvrir de nouveaux onglets pendant l'exécution d'une requête ou d'une mise à jour.",
+  "yasqe.tab_list.new_tab.query_invalid.warning.message": "La requête contient une erreur de syntaxe. Consultez la ligne concernée pour plus d'informations.",
   "yasgui.toolbar.mode_yasgui.btn.label": "Éditeur et résultats",
   "yasgui.toolbar.mode_yasqe.btn.label": "Éditeur seulement",
   "yasgui.toolbar.mode_yasr.btn.label": "Résultats seulement",

--- a/yasgui-patches/2023-08-17-GDB-8626_show_error_mark_on_yasgui_a_tab_when_query_is_invalid.patch
+++ b/yasgui-patches/2023-08-17-GDB-8626_show_error_mark_on_yasgui_a_tab_when_query_is_invalid.patch
@@ -1,0 +1,160 @@
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision e0b14bada22f6c82a76e32b2a265a44c6522b99e)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision b3455e0e0a504e44a32c4d8ed988d7aa7349d995)
+@@ -63,6 +63,7 @@
+   emit(event: "openNextTab", tab: Tab): void;
+   emit(event: "openPreviousTab", tab: Tab): void;
+   emit(event: "closeOtherTabs", tab: Tab): void;
++  emit(event: "queryStatus", tab: Tab, data: any): void;
+ }
+ export class Tab extends EventEmitter {
+   private persistentJson: PersistedJson;
+@@ -416,7 +417,9 @@
+     this.yasqe.on("openNextTab", this.handleOpenNextTab);
+     this.yasqe.on("openPreviousTab", this.handleOpenPreviousTab);
+     this.yasqe.on("closeOtherTabs", this.handlerCloseOtherTabs);
++    this.yasqe.on("queryStatus", this.handleQueryStatusChange);
+   }
++
+   private destroyYasqe() {
+     // As Yasqe extends of CM instead of eventEmitter, it doesn't expose the removeAllListeners function, so we should unregister all events manually
+     this.yasqe?.off("blur", this.handleYasqeBlur);
+@@ -430,6 +433,7 @@
+     this.yasqe?.off("countAffectedRepositoryStatementsChanged", this.handleCountAffectedRepositoryStatementsChanged);
+     this.yasqe?.off("openNewTab", this.handleOpenNewTab);
+     this.yasqe?.off("openNextTab", this.handleOpenNextTab);
++    this.yasqe?.off("queryStatus", this.handleQueryStatusChange);
+     this.yasqe?.on("openPreviousTab", this.handleOpenPreviousTab);
+     this.yasqe?.on("closeOtherTabs", this.handlerCloseOtherTabs);
+     this.yasqe?.destroy();
+@@ -452,6 +456,10 @@
+     this.emit("closeOtherTabs", this);
+   };
+ 
++  handleQueryStatusChange = (...args: any[]) => {
++    this.emit('queryStatus', this, args[2]);
++  };
++
+   handleYasqeBlur = (yasqe: Yasqe) => {
+     this.updatePersistJson(yasqe);
+     this.emit("change", this, this.persistentJson);
+Index: Yasgui/packages/yasgui/src/TabElements.scss
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/TabElements.scss b/Yasgui/packages/yasgui/src/TabElements.scss
+--- a/Yasgui/packages/yasgui/src/TabElements.scss	(revision e0b14bada22f6c82a76e32b2a265a44c6522b99e)
++++ b/Yasgui/packages/yasgui/src/TabElements.scss	(revision b3455e0e0a504e44a32c4d8ed988d7aa7349d995)
+@@ -41,6 +41,10 @@
+       $activeColor: #337ab7;
+       $hoverColor: lighten($activeColor, 30);
+ 
++      &.query-invalid a {
++        text-decoration: underline dotted red;
++      }
++
+       .loader {
+         display: none;
+         background-color: lighten(#555, 50);
+Index: Yasgui/packages/yasgui/src/TabElements.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/TabElements.ts b/Yasgui/packages/yasgui/src/TabElements.ts
+--- a/Yasgui/packages/yasgui/src/TabElements.ts	(revision e0b14bada22f6c82a76e32b2a265a44c6522b99e)
++++ b/Yasgui/packages/yasgui/src/TabElements.ts	(revision b3455e0e0a504e44a32c4d8ed988d7aa7349d995)
+@@ -54,6 +54,19 @@
+       this.nameEl.textContent = name;
+     }
+   }
++  public setAsValid(isValid: boolean) {
++    if (isValid) {
++      removeClass(this.tabEl, "query-invalid");
++      if (this.tabEl) {
++          this.tabEl.removeAttribute("title");
++      }
++    } else {
++      addClass(this.tabEl, "query-invalid");
++      if (this.tabEl) {
++          this.tabEl.setAttribute("title", this.translationService.translate("yasqe.tab_list.new_tab.query_invalid.warning.message"));
++      }
++    }
++  }
+   public setAsQuerying(querying: boolean) {
+     if (querying) {
+       addClass(this.tabEl, "querying");
+@@ -197,7 +210,18 @@
+         this._tabs[id].setAsQuerying(false);
+       }
+     });
++    this.yasgui.on("queryStatus", (tab, data) => this.queryStatusChangeHandler(tab, data));
++    this.yasgui.on("yasqeReady", (tab, yasqe) => this.yasqeReadyHandler(tab, yasqe));
++  }
++
++  private yasqeReadyHandler(tab: any, yasqe: any) {
++    this._tabs[tab.getId()].setAsValid(yasqe.queryValid);
+   }
++
++  private queryStatusChangeHandler(tab: any, data: any) {
++    this._tabs[tab.getId()].setAsValid(data.valid);
++  }
++
+   private getActiveIndex() {
+     if (!this._selectedTab) return;
+     const allTabs = Object.keys(this._tabs);
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision e0b14bada22f6c82a76e32b2a265a44c6522b99e)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision b3455e0e0a504e44a32c4d8ed988d7aa7349d995)
+@@ -89,6 +89,7 @@
+   on(event: "autocompletionClose", listener: (instance: Yasgui, tab: Tab) => void): this;
+   emit(event: "autocompletionClose", instance: Yasgui, tab: Tab): boolean;
+   emit(event: "yasqeReady", tab: Tab, yasqe: Yasqe | undefined): boolean;
++  emit(event: "queryStatus", tab: Tab, data: any): void;
+ }
+ export class Yasgui extends EventEmitter {
+   public rootEl: HTMLDivElement;
+@@ -339,6 +340,7 @@
+     tab.on("queryResponse", (tab) => this.emit("queryResponse", this, tab));
+     tab.on("autocompletionShown", (tab, widget) => this.emit("autocompletionShown", this, tab, widget));
+     tab.on("autocompletionClose", (tab) => this.emit("autocompletionClose", this, tab));
++    tab.on("queryStatus", (tab, data) => this.emit("queryStatus", tab, data));
+   }
+ 
+   public openNextTab(tab: Tab) {
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision e0b14bada22f6c82a76e32b2a265a44c6522b99e)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision b3455e0e0a504e44a32c4d8ed988d7aa7349d995)
+@@ -71,6 +71,8 @@
+   off(eventName: "openPreviousTab", handler: () => void): void;
+   on(eventName: "closeOtherTabs", handler: () => void): void;
+   off(eventName: "closeOtherTabs", handler: () => void): void;
++  on(eventName: "queryStatus", handler: (instance: Yasqe, data: any) => void): void;
++  off(eventName: "queryStatus", handler: () => void): void;
+ }
+ 
+ export class Yasqe extends CodeMirror {
+@@ -179,6 +181,7 @@
+   private handleChange() {
+     this.checkSyntax();
+     this.updateQueryButton();
++    this.emit("queryStatus", this, {valid: this.queryValid});
+   }
+   private handleBlur() {
+     this.saveQuery();


### PR DESCRIPTION
## What
Show an error mark on the yasgui tab when the query inside its editor is invalid.

## Why
In the old implementation in the GDB workbench was implemented such behavior and we want it here as well.

## How
Implemented a new event queryStatus fired by yasqe and propagated to TabsList component where it's possible to update the respective tab by adding a marker css class and a title message.