### PR TITLE
GDB-8194: Tab is not visible when execute "Close other tabs" command.

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -152,8 +152,7 @@ export class Tab extends EventEmitter {
   public close(confirm = true) {
     const closeTab = () => {
       if (this.yasqe) this.yasqe.abortQuery();
-      const tab = this.yasgui.getTab();
-      if (tab === this) {
+      if (this.yasgui.getTab() === this) {
         //it's the active tab
         //first select other tab
         const tabs = this.yasgui.persistentConfig.getTabs();
@@ -163,7 +162,6 @@ export class Tab extends EventEmitter {
         }
       }
 
-      tab?.destroy();
       this.yasgui._removePanel(this.rootEl);
       this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
       this.yasgui.emit("tabClose", this.yasgui, this);

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -82,7 +82,7 @@
   "yasqe.keyboard_shortcuts.dialog.item.switch_next_tab.description": "Switch to next tab",
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.label": "[Ctrl|Cmd]-Alt-Left",
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.description": "Switch to previous tab",
-  "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "Shift-Left-Mouse",
+  "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "Shift-Ctrl-F4",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.description": "Closes all the tabs except the current one",
   "yasqe.keyboard_shortcuts.dialog.item.f11.label": "F11",
   "yasqe.keyboard_shortcuts.dialog.item.f11.description": "Press F11 full screen/exit full screen",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -82,7 +82,7 @@
   "yasqe.keyboard_shortcuts.dialog.item.switch_next_tab.description": "Créer une requête sauvegardée à partir de l'état actuel",
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.label": "[Ctrl|Cmd]-Alt-Left",
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.description": "Passer à l'onglet suivant",
-  "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "Shift-Left-Mouse",
+  "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "Shift-Ctrl-F4",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.description": "Ferme tous les onglets sauf celui en cours",
   "yasqe.keyboard_shortcuts.dialog.item.f11.label": "F11",
   "yasqe.keyboard_shortcuts.dialog.item.f11.description": "Press F11 full screen/exit full screen",

--- a/yasgui-patches/2023-08-22-tab_is_not_visible_when_execute__Close_other_tabs__command_.patch
+++ b/yasgui-patches/2023-08-22-tab_is_not_visible_when_execute__Close_other_tabs__command_.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] GDB-8194: Tab is not visible when execute "Close other tabs" command.
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision fb2d443c126120bc80d12cbcee6995b20e979d39)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 005b6e2d7ce099a4d2c7ea0e0238a4bec7156092)
+@@ -152,8 +152,7 @@
+   public close(confirm = true) {
+     const closeTab = () => {
+       if (this.yasqe) this.yasqe.abortQuery();
+-      const tab = this.yasgui.getTab();
+-      if (tab === this) {
++      if (this.yasgui.getTab() === this) {
+         //it's the active tab
+         //first select other tab
+         const tabs = this.yasgui.persistentConfig.getTabs();
+@@ -163,7 +162,6 @@
+         }
+       }
+ 
+-      tab?.destroy();
+       this.yasgui._removePanel(this.rootEl);
+       this.yasgui.persistentConfig.deleteTab(this.persistentJson.id);
+       this.yasgui.emit("tabClose", this.yasgui, this);


### PR DESCRIPTION
## What
When the closeOtherTabs function is called, all other tabs are closed, but the YASQE and YASR sections of the active tab are dismissed. Only the tab with the tab name is left.

## Why
The close function of the Tab object has been changed during development. I don't know why, but destroying of active tab has been added, that removes all content of the active tab.

## How
The incorrect destruction of the active tab has been removed.

### Additional work
The description of the 'Close Other Tabs' keyboard shortcut has been changed.