### PR TITLE
GDB-8281 add ND-JSONLD rdf file format to download formats

### DIFF
--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -128,6 +128,7 @@
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Get HTML snippet to embed results on a web page",
   "yasr.plugin_control.download_as.sparql_results_json.label": "JSON",
   "yasr.plugin_control.download_as.sparql_results_json_ld.label": "JSON-LD",
+  "yasr.plugin_control.download_as.sparql_results_ndjson_ld.label": "NDJSON-LD",
   "yasr.plugin_control.download_as.x_sparqlstar_results_json.label": "JSON*",
   "yasr.plugin_control.download_as.x_sparqlstar_results_rdf_xml.label": "RDF-XML",
   "yasr.plugin_control.download_as.sparql_results_xml.label": "XML",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -128,6 +128,7 @@
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.plugin_control.download_as.sparql_results_json.label": "JSON",
   "yasr.plugin_control.download_as.sparql_results_json_ld.label": "JSON-LD",
+  "yasr.plugin_control.download_as.sparql_results_ndjson_ld.label": "NDJSON-LD",
   "yasr.plugin_control.download_as.x_sparqlstar_results_json.label": "JSON*",
   "yasr.plugin_control.download_as.x_sparqlstar_results_rdf_xml.label": "RDF-XML",
   "yasr.plugin_control.download_as.sparql_results_xml.label": "XML",

--- a/ontotext-yasgui-web-component/src/services/yasr/toolbar/download-as-yasr-toolbar-plugin.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/toolbar/download-as-yasr-toolbar-plugin.ts
@@ -195,6 +195,9 @@ class ExtendedTableDownloadAsConfiguration extends DownloadAsPluginConfiguration
           labelKey: "yasr.plugin_control.download_as.sparql_results_json_ld.label",
           value: "application/ld+json",
         }, {
+          labelKey: "yasr.plugin_control.download_as.sparql_results_ndjson_ld.label",
+          value: "application/x-ld+ndjson",
+        }, {
           labelKey: "yasr.plugin_control.download_as.x_sparqlstar_results_rdf_xml.label",
           value: "application/rdf+xml",
         }, {


### PR DESCRIPTION
## What
Added support for ND-JSONLD file formats

## Why
To enhance the download compatibility and usability, this commit introduces support for ND-JSONLD file format

## How
- added ND-JSONLD entry in the list of options