### PR TITLE
Fixes npe when try to create a tab without pass query parameter

### DIFF
--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -114,11 +114,11 @@ export class OntotextYasgui {
   }
 
   openTab(queryModel: TabQueryModel): void {
-    const existingTab = this.getInstance().getTabByNameAndQuery(queryModel.queryName, queryModel.query);
+    const existingTab = this.getInstance().getTabByNameAndQuery(queryModel?.queryName, queryModel?.query);
     if (existingTab) {
       this.getInstance().selectTabId(existingTab.getId());
     } else {
-      this.createNewTab(queryModel.queryName, queryModel.query);
+      this.createNewTab(queryModel?.queryName, queryModel?.query);
     }
   }
 
@@ -126,7 +126,9 @@ export class OntotextYasgui {
     const tabInstance = this.getInstance().addTab(true, {
       name: queryName
     });
-    tabInstance.setQuery(query);
+    if (query) {
+      tabInstance.setQuery(query);
+    }
   }
 
   destroy() {


### PR DESCRIPTION
## What
A Null Pointer Exception (NPE) occurs when attempting to create a new tab without passing a TabQueryModel parameter.

## Why
There was no null check in the function.

## How
A null check has been added.