### PR TITLE
GDB-8438: YASR: Update error plugin

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+++ b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
@@ -1,7 +1,11 @@
 import Error from "./index";
 import Parser from "../../parsers";
 
+const COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN = 160;
 export default class ExtendedError extends Error {
+  private fullMessage = true;
+  private errorMessageElement: HTMLDivElement | undefined;
+
   async draw() {
     const error = this.yasr.results?.getError();
     if (error) {
@@ -11,50 +15,88 @@ export default class ExtendedError extends Error {
 
   private createErrorElement(error: Parser.ErrorSummary): HTMLDivElement {
     const errorResponseElement = document.createElement("div");
-    errorResponseElement.className = "error-response-plugin";
-    errorResponseElement.innerHTML = this.getErrorMessage(error);
+    errorResponseElement.classList.add("error-response-plugin");
+    errorResponseElement.appendChild(this.getErrorStatusElement(error));
+    this.errorMessageElement = this.createErrorMessageElement();
+    const isErrorMessageBig = error?.text?.length > COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN;
+    if (isErrorMessageBig) {
+      this.fullMessage = false;
+      errorResponseElement.appendChild(this.getShowMoreOrLessMessageElement());
+    }
+    errorResponseElement.appendChild(this.errorMessageElement);
+    this.updateErrorMessage();
     return errorResponseElement;
   }
 
-  private getErrorMessage(error: Parser.ErrorSummary): string {
-    const status = error.status;
-    const statusText = error.statusText
-      ? error.statusText
-      : this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
-    let errorBodyText;
+  private getShowMoreOrLessMessageElement(): HTMLAnchorElement {
+    const showFullErrorMessage = this.translationService.translate("yasr.plugin.error.show.full.message");
+    const showLessErrorMessage = this.translationService.translate("yasr.plugin.error.show.less.message");
+
+    const showMoreOrLessElement = document.createElement("a");
+    showMoreOrLessElement.classList.add("show-full-message-link");
+    showMoreOrLessElement.href = "#";
+    showMoreOrLessElement.innerText = showFullErrorMessage;
+
+    showMoreOrLessElement.onclick = () => {
+      this.fullMessage = !this.fullMessage;
+      if (this.fullMessage) {
+        showMoreOrLessElement.innerText = showLessErrorMessage;
+        showMoreOrLessElement.classList.add("show-less-message-link");
+        showMoreOrLessElement.classList.remove("show-full-message-link");
+      } else {
+        showMoreOrLessElement.classList.add("show-full-message-link");
+        showMoreOrLessElement.classList.remove("show-less-message-link");
+        showMoreOrLessElement.innerText = showFullErrorMessage;
+      }
+      this.updateErrorMessage();
+    };
+
+    return showMoreOrLessElement;
+  }
+
+  private createErrorMessageElement(): HTMLDivElement {
+    const errorMessageElement = document.createElement("div");
+    errorMessageElement.classList.add("error-response-plugin-body");
+    return errorMessageElement;
+  }
+
+  private updateErrorMessage(): void {
+    if (!this.errorMessageElement) {
+      return;
+    }
+
+    const error = this.yasr.results?.getError() || ({} as Parser.ErrorSummary);
+    let errorBodyText = "";
     if (error.text) {
       errorBodyText = error.text;
     } else if (error.messageLabelKey) {
       errorBodyText = this.yasr.translationService.translate(error.messageLabelKey, error.parameters);
     }
-    return this.createErrorMessageElement(status, statusText, errorBodyText);
+
+    this.errorMessageElement.innerText = this.fullMessage
+      ? errorBodyText
+      : errorBodyText.substring(0, COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN);
   }
 
-  private createErrorMessageElement(status: number | undefined, statusText = "", errorBodyText = "") {
-    let errorStatus = "";
-    if (status) {
-      errorStatus += status + ": ";
-    }
+  private getErrorStatusElement(error: Parser.ErrorSummary): HTMLDivElement {
+    const status = error.status ? error.status + ":" : "";
+    const statusText = error.statusText
+      ? error.statusText
+      : this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
 
-    if (statusText) {
-      errorStatus += statusText;
-    } else {
-      errorStatus += this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
-    }
+    const errorStatusElement = document.createElement("div");
+    errorStatusElement.classList.add("error-response-plugin-error-status");
+    errorStatusElement.innerText = `${status} ${statusText}`;
 
-    return (
-      '<div class="error-response-plugin-header">' +
-      '<div class="error-response-plugin-error-status">' +
-      errorStatus +
-      "</div>" +
-      '<div class="error-response-plugin-error-time-message">' +
-      this.getResultTimeMessage() +
-      "</div>" +
-      "</div>" +
-      '<div class="error-response-plugin-body">' +
-      errorBodyText +
-      "</div>"
-    );
+    const errorTimeMessageElement = document.createElement("div");
+    errorTimeMessageElement.classList.add("error-response-plugin-error-time-message");
+    errorTimeMessageElement.innerText = this.getResultTimeMessage();
+
+    const errorResponseHeaderElement = document.createElement("div");
+    errorResponseHeaderElement.classList.add("error-response-plugin-header");
+    errorResponseHeaderElement.appendChild(errorStatusElement);
+    errorResponseHeaderElement.appendChild(errorTimeMessageElement);
+    return errorResponseHeaderElement;
   }
 
   private getResultTimeMessage(): string {

--- a/Yasgui/packages/yasr/src/plugins/error/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/error/index.ts
@@ -9,7 +9,7 @@ require("./index.scss");
 
 export default class Error implements Plugin<never> {
   protected yasr: ExtendedYasr;
-  private readonly translationService: TranslationService;
+  protected readonly translationService: TranslationService;
   constructor(yasr: ExtendedYasr) {
     this.yasr = yasr;
     this.translationService = this.yasr.config.translationService;

--- a/cypress/e2e/yasr/plugins/error/error-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/error/error-plugin.spec.cy.ts
@@ -6,16 +6,18 @@ import {YasrSteps} from '../../../../steps/yasr-steps';
 
 describe('Error handling', () => {
 
+  const SHORT_ERROR_BODY = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore';
+  const LONG_ERROR_BODY = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+  const LESS_MESSAGE = LONG_ERROR_BODY.substring(0, 160);
+
   beforeEach(() => {
     DefaultViewPageSteps.visit();
   });
 
-  it('should show error when execute wrong query', () => {
+  it('should show error without show full message button when error message is les than 160 characters.', () => {
     // When I visit a page with "ontotext-yasgui-web-component" in it,
-    // and execute wrong query.
-    QueryStubs.stubLoadQueryErrorResponse()
-    YasqeSteps.clearEditor();
-    YasqeSteps.writeInEditor('LOAD <file:///datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq>\n INTO GRAPH <file:///datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq>');
+    // and execute wrong query that returns short error message (less thant 160).
+    QueryStubs.stubQueryErrorResponse(SHORT_ERROR_BODY);
     YasqeSteps.executeErrorQuery();
 
     // Then I expect to see a message that
@@ -24,10 +26,50 @@ describe('Error handling', () => {
     // and time when the query is executed,
     ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
     // and error message sent by server,
-    ErrorPluginSteps.getErrorPluginBody().contains('/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)');
+    ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', SHORT_ERROR_BODY);
     // and toolbar with plugins to not be visible,
     YasrSteps.getResultHeader().should('not.be.visible');
-    // and message info to not be visible
+    // and message info to not be visible,
     YasrSteps.getResponseInfo().should('not.be.visible');
+    // and show full/less error message not be visible
+    ErrorPluginSteps.getShowFullErrorMessage().should('not.exist');
+    ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
+  });
+
+  it('should show error with show full message button when error message is more than than 160 characters.', () => {
+    // When I visit a page with "ontotext-yasgui-web-component" in it,
+    // and execute wrong query.
+    QueryStubs.stubQueryErrorResponse(LONG_ERROR_BODY);
+    YasqeSteps.executeErrorQuery();
+
+    // Then I expect to see a message that
+    // describes error status and error text,
+    ErrorPluginSteps.getErrorPluginErrorStatus().contains('500: Internal Server Error');
+    // and time when the query is executed,
+    ErrorPluginSteps.getErrorPluginErrorTimeMessage().contains(/Query took \d{1}\.\d{1}s, moments ago\./);
+    // and error message sent by server,
+    ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+    // and toolbar with plugins to not be visible,
+    YasrSteps.getResultHeader().should('not.be.visible');
+    // and message info to not be visible,
+    YasrSteps.getResponseInfo().should('not.be.visible');
+    ErrorPluginSteps.getShowFullErrorMessage().should('be.visible');
+    ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
+
+    // When click on show full message
+    ErrorPluginSteps.getShowFullErrorMessage().click();
+
+    // Then I expect to see full message
+    ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LONG_ERROR_BODY);
+    ErrorPluginSteps.getShowFullErrorMessage().should('not.exist');
+    ErrorPluginSteps.getShowLessErrorMessage().should('be.visible');
+
+    // When click on show less message
+    ErrorPluginSteps.getShowLessErrorMessage().click();
+
+    // Then I expect to see first 160 characters of the error message
+    ErrorPluginSteps.getErrorPluginBody().invoke('text').should('eq', LESS_MESSAGE);
+    ErrorPluginSteps.getShowFullErrorMessage().should('be.visible');
+    ErrorPluginSteps.getShowLessErrorMessage().should('not.exist');
   });
 });

--- a/cypress/steps/error-plugin-steps.ts
+++ b/cypress/steps/error-plugin-steps.ts
@@ -19,4 +19,12 @@ export class ErrorPluginSteps {
   static getErrorPluginBody() {
     return ErrorPluginSteps.getErrorPlugin().find('.error-response-plugin-body');
   }
+
+  static getShowFullErrorMessage() {
+    return cy.get('.show-full-message-link');
+  }
+
+  static getShowLessErrorMessage() {
+    return cy.get('.show-less-message-link');
+  }
 }

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -46,10 +46,10 @@ export class QueryStubs {
     cy.intercept('/repositories/test-repo', {fixture, delay: withDelay}).as(alias);
   }
 
-  static stubLoadQueryErrorResponse() {
+  static stubQueryErrorResponse(errorBody = '', statusCode = 500) {
     cy.intercept('/repositories/test-repo', {
-      statusCode: 500,
-      body: '/datasets/bio2rdf/drugbank/bio2rdf-drugbank.nq (No such file or directory)'
+      statusCode,
+      body: errorBody
     }).as('loadQueryErrorResponse');
   }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -60,9 +60,12 @@
 
   .yasgui {
 
-    .yasqe-fullscreen  .CodeMirror {
+    .yasqe-fullscreen .CodeMirror {
       position: fixed;
-      top: 0; left: 0; right: 0; bottom: 0;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
       height: auto !important;
       z-index: 1015;
     }
@@ -117,6 +120,7 @@
         opacity: .65;
       }
     }
+
     .yasqe-footer-buttons {
       display: flex;
       justify-content: end;
@@ -294,6 +298,32 @@
           }
         }
 
+        .show-full-message-link, .show-less-message-link {
+          display: block;
+          font-weight: 400;
+          text-align: right;
+          text-decoration: none;
+        }
+
+        .show-full-message-link::after, .show-less-message-link::after {
+          font-family: 'icomoon', sans-serif !important;
+          content: "\e921";
+          display: inline-block;
+          width: auto;
+          height: auto;
+          border: none;
+          margin-left: 0;
+          font-size: 1.2em;
+          -moz-transition: all 0.2s ease-in; /* FF4+ */
+          -o-transition: all 0.2s ease-in; /* Opera 10.5+ */
+          -webkit-transition: all 0.2s ease-in; /* Saf3.2+, Chrome */
+          transition: all 0.2s ease-in;
+        }
+
+        .show-full-message-link::after {
+          transform: rotate(180deg);
+        }
+
         .error-response-plugin-body {
           white-space: pre-wrap;
         }
@@ -329,19 +359,20 @@
       th {
         background-position: calc(100% - 5px) center;
       }
+
       .sorting {
         background-size: 0.9em;
-        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z'/%3E%3C/svg%3E" );
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z'/%3E%3C/svg%3E");
       }
 
       .sorting_asc {
         background-size: 1em;
-        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm240-64H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 446.37V464a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 321.63V304a16 16 0 0 0-16-16zm31.06-85.38l-59.27-160A16 16 0 0 0 372.72 32h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 224h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 224H432a16 16 0 0 0 15.06-21.38zM335.61 144L352 96l16.39 48z'/%3E%3C/svg%3E" );
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm240-64H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 446.37V464a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 321.63V304a16 16 0 0 0-16-16zm31.06-85.38l-59.27-160A16 16 0 0 0 372.72 32h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 224h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 224H432a16 16 0 0 0 15.06-21.38zM335.61 144L352 96l16.39 48z'/%3E%3C/svg%3E");
       }
 
       .sorting_desc {
         background-size: 1em;
-        background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm112-128h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 65.63V48a16 16 0 0 0-16-16H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 190.37V208a16 16 0 0 0 16 16zm159.06 234.62l-59.27-160A16 16 0 0 0 372.72 288h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 480h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 480H432a16 16 0 0 0 15.06-21.38zM335.61 400L352 352l16.39 48z'/%3E%3C/svg%3E" );
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath d='M176 352h-48V48a16 16 0 0 0-16-16H80a16 16 0 0 0-16 16v304H16c-14.19 0-21.36 17.24-11.29 27.31l80 96a16 16 0 0 0 22.62 0l80-96C197.35 369.26 190.22 352 176 352zm112-128h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-56l61.26-70.45A32 32 0 0 0 432 65.63V48a16 16 0 0 0-16-16H288a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h56l-61.26 70.45A32 32 0 0 0 272 190.37V208a16 16 0 0 0 16 16zm159.06 234.62l-59.27-160A16 16 0 0 0 372.72 288h-41.44a16 16 0 0 0-15.07 10.62l-59.27 160A16 16 0 0 0 272 480h24.83a16 16 0 0 0 15.23-11.08l4.42-12.92h71l4.41 12.92A16 16 0 0 0 407.16 480H432a16 16 0 0 0 15.06-21.38zM335.61 400L352 352l16.39 48z'/%3E%3C/svg%3E");
       }
     }
   }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -152,6 +152,8 @@
   "yasr.plugin.error.incorrect_endpoint.error.label": "Incorrect endpoint URL",
   "yasr.plugin.error.new_window.btn.label": "Try query in new browser window",
   "yasr.plugin.error.no_response_possible_reason.error.label": "Unable to get response from endpoint. Possible reasons:",
+  "yasr.plugin.error.show.full.message": "Show full exception message",
+  "yasr.plugin.error.show.less.message": "Show less exception message",
   "yasr.plugin.response.download_result.btn.label": "Download result",
   "yasr.plugin.response.download_result.btn.tooltip": "Download result",
   "yasr.plugin.response.show_all.btn.label": "Show all",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -152,6 +152,8 @@
   "yasr.plugin.error.incorrect_endpoint.error.label": "URL de point d'accès incorrecte",
   "yasr.plugin.error.new_window.btn.label": "Essayez la requête dans une nouvelle fenêtre du navigateur",
   "yasr.plugin.error.no_response_possible_reason.error.label": "Unable to get response from endpoint. Possible reasons:",
+  "yasr.plugin.error.show.full.message": "Afficher le message d'exception complet",
+  "yasr.plugin.error.show.less.message": "Afficher moins de détails sur l'exception",
   "yasr.plugin.response.download_result.btn.label": "Télécharger le résultat",
   "yasr.plugin.response.download_result.btn.tooltip": "Télécharger le résultat",
   "yasr.plugin.response.show_all.btn.label": "Afficher tout",

--- a/yasgui-patches/2023-10-17-update_error_plugin.patch
+++ b/yasgui-patches/2023-10-17-update_error_plugin.patch
@@ -1,0 +1,161 @@
+Subject: [PATCH] GDB-8438: YASR: Update error plugin
+---
+Index: Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+--- a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts	(revision 464434946fd416ccb698a7cbfc90c9e155ef98c0)
++++ b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts	(revision 0ab32958e1d757c7f740303203886d90faec3784)
+@@ -1,7 +1,11 @@
+ import Error from "./index";
+ import Parser from "../../parsers";
+ 
++const COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN = 160;
+ export default class ExtendedError extends Error {
++  private fullMessage = true;
++  private errorMessageElement: HTMLDivElement | undefined;
++
+   async draw() {
+     const error = this.yasr.results?.getError();
+     if (error) {
+@@ -11,50 +15,88 @@
+ 
+   private createErrorElement(error: Parser.ErrorSummary): HTMLDivElement {
+     const errorResponseElement = document.createElement("div");
+-    errorResponseElement.className = "error-response-plugin";
+-    errorResponseElement.innerHTML = this.getErrorMessage(error);
++    errorResponseElement.classList.add("error-response-plugin");
++    errorResponseElement.appendChild(this.getErrorStatusElement(error));
++    this.errorMessageElement = this.createErrorMessageElement();
++    const isErrorMessageBig = error?.text?.length > COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN;
++    if (isErrorMessageBig) {
++      this.fullMessage = false;
++      errorResponseElement.appendChild(this.getShowMoreOrLessMessageElement());
++    }
++    errorResponseElement.appendChild(this.errorMessageElement);
++    this.updateErrorMessage();
+     return errorResponseElement;
+   }
+ 
+-  private getErrorMessage(error: Parser.ErrorSummary): string {
+-    const status = error.status;
+-    const statusText = error.statusText
+-      ? error.statusText
+-      : this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
+-    let errorBodyText;
++  private getShowMoreOrLessMessageElement(): HTMLAnchorElement {
++    const showFullErrorMessage = this.translationService.translate("yasr.plugin.error.show.full.message");
++    const showLessErrorMessage = this.translationService.translate("yasr.plugin.error.show.less.message");
++
++    const showMoreOrLessElement = document.createElement("a");
++    showMoreOrLessElement.classList.add("show-full-message-link");
++    showMoreOrLessElement.href = "#";
++    showMoreOrLessElement.innerText = showFullErrorMessage;
++
++    showMoreOrLessElement.onclick = () => {
++      this.fullMessage = !this.fullMessage;
++      if (this.fullMessage) {
++        showMoreOrLessElement.innerText = showLessErrorMessage;
++        showMoreOrLessElement.classList.add("show-less-message-link");
++        showMoreOrLessElement.classList.remove("show-full-message-link");
++      } else {
++        showMoreOrLessElement.classList.add("show-full-message-link");
++        showMoreOrLessElement.classList.remove("show-less-message-link");
++        showMoreOrLessElement.innerText = showFullErrorMessage;
++      }
++      this.updateErrorMessage();
++    };
++
++    return showMoreOrLessElement;
++  }
++
++  private createErrorMessageElement(): HTMLDivElement {
++    const errorMessageElement = document.createElement("div");
++    errorMessageElement.classList.add("error-response-plugin-body");
++    return errorMessageElement;
++  }
++
++  private updateErrorMessage(): void {
++    if (!this.errorMessageElement) {
++      return;
++    }
++
++    const error = this.yasr.results?.getError() || ({} as Parser.ErrorSummary);
++    let errorBodyText = "";
+     if (error.text) {
+       errorBodyText = error.text;
+     } else if (error.messageLabelKey) {
+       errorBodyText = this.yasr.translationService.translate(error.messageLabelKey, error.parameters);
+     }
+-    return this.createErrorMessageElement(status, statusText, errorBodyText);
+-  }
+ 
+-  private createErrorMessageElement(status: number | undefined, statusText = "", errorBodyText = "") {
+-    let errorStatus = "";
+-    if (status) {
+-      errorStatus += status + ": ";
+-    }
++    this.errorMessageElement.innerText = this.fullMessage
++      ? errorBodyText
++      : errorBodyText.substring(0, COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN);
++  }
+ 
+-    if (statusText) {
+-      errorStatus += statusText;
+-    } else {
+-      errorStatus += this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
+-    }
++  private getErrorStatusElement(error: Parser.ErrorSummary): HTMLDivElement {
++    const status = error.status ? error.status + ":" : "";
++    const statusText = error.statusText
++      ? error.statusText
++      : this.yasr.translationService.translate("yasr.plugin.extended_error.default_status.message");
++
++    const errorStatusElement = document.createElement("div");
++    errorStatusElement.classList.add("error-response-plugin-error-status");
++    errorStatusElement.innerText = `${status} ${statusText}`;
+ 
+-    return (
+-      '<div class="error-response-plugin-header">' +
+-      '<div class="error-response-plugin-error-status">' +
+-      errorStatus +
+-      "</div>" +
+-      '<div class="error-response-plugin-error-time-message">' +
+-      this.getResultTimeMessage() +
+-      "</div>" +
+-      "</div>" +
+-      '<div class="error-response-plugin-body">' +
+-      errorBodyText +
+-      "</div>"
+-    );
++    const errorTimeMessageElement = document.createElement("div");
++    errorTimeMessageElement.classList.add("error-response-plugin-error-time-message");
++    errorTimeMessageElement.innerText = this.getResultTimeMessage();
++
++    const errorResponseHeaderElement = document.createElement("div");
++    errorResponseHeaderElement.classList.add("error-response-plugin-header");
++    errorResponseHeaderElement.appendChild(errorStatusElement);
++    errorResponseHeaderElement.appendChild(errorTimeMessageElement);
++    return errorResponseHeaderElement;
+   }
+ 
+   private getResultTimeMessage(): string {
+Index: Yasgui/packages/yasr/src/plugins/error/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/error/index.ts b/Yasgui/packages/yasr/src/plugins/error/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/error/index.ts	(revision 464434946fd416ccb698a7cbfc90c9e155ef98c0)
++++ b/Yasgui/packages/yasr/src/plugins/error/index.ts	(revision 0ab32958e1d757c7f740303203886d90faec3784)
+@@ -9,7 +9,7 @@
+ 
+ export default class Error implements Plugin<never> {
+   protected yasr: ExtendedYasr;
+-  private readonly translationService: TranslationService;
++  protected readonly translationService: TranslationService;
+   constructor(yasr: ExtendedYasr) {
+     this.yasr = yasr;
+     this.translationService = this.yasr.config.translationService;


### PR DESCRIPTION
## What
When exception is thrown after executing of sparql query, the workbench shows the error. But if the error is too big the error area is too long. Most of the users do not need to see the entire message.

## Why
WB displays all error messages no matter of its length.

## How
Added functionality that checks error message length and if it is too long a small part of message is displayed accompanied by a 'Show full error message' button to expand it. When the button is clicked all error will be displayed accompanied by a 'Show less error message' button to show less part of message.