### PR TITLE
GDB-8185: Тhe button for "Copy URL to clipboard" is not visible on Browser Firefox

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -244,15 +244,10 @@
         hyphens: auto;
       }
 
-      /** Shows copy resource link when mouse is over a table row with resources of type uri */
-      .dataTable tbody td:hover:not(:has(.triple-cell)) div.uri-cell .resource-copy-link {
-        display: inline;
-        float: right;
-        padding-right: 10px;
-      }
-
-      /** Shows copy resource link when mouse is over a link with resource of type triple */
-      .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link {
+      /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
+      .dataTable tbody td div.uri-cell:hover .resource-copy-link, .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
+      .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link
+      {
         display: inline;
         padding-left: 10px;
         padding-right: 10px;

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -95,7 +95,7 @@ export class YasrService {
       `<li>${this.toCellContent(binding.value['s'], context)}</li>` +
       `<li>${this.toCellContent(binding.value['p'], context)}</li>` +
       `<li>${this.toCellContent(binding.value['o'], context)}</li>` +
-      '</ul><div class"triple-close">' +
+      '</ul><div class="triple-close">' +
       `<a title="${tripleLinkTitle}" class="triple-link triple-link-end" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_GREATER}</a>` +
       `<copy-resource-link-button class="resource-copy-link" uri="${HtmlUtil.encodeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
       '</div></div>'


### PR DESCRIPTION
## What
When hovering over a URI in Yasr, the "Copy URL to clipboard" button is not visible in the Firefox browser.

## Why
The CSS selector that displays the URI includes a ":has" selector, which is not supported by the Firefox browser.

## How
Simplify the selectors that display the copy button.