### PR TITLE
GDB-7789 introduce google charts yasr plugin

### DIFF
--- a/cypress/e2e/yasr/plugins/charts/configure-charts.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/charts/configure-charts.spec.cy.ts
@@ -1,0 +1,78 @@
+import {YasrChartsPluginPageSteps} from "../../../../steps/pages/yasr-charts-plugin-page-steps";
+import {YasrSteps} from "../../../../steps/yasr-steps";
+import {YasqeSteps} from "../../../../steps/yasqe-steps";
+import {ChartsStubs} from "../../../../stubs/charts-stubs";
+import {GoogleChartsConfigSteps} from "../../../../steps/google-charts-config-steps";
+
+describe('Plugin: Charts', () => {
+
+  beforeEach(() => {
+    ChartsStubs.stubLoader();
+    ChartsStubs.stub_jsapi_compiled_annotatedtimeline_module();
+    ChartsStubs.stub_jsapi_compiled_annotationchart_module();
+    ChartsStubs.stub_jsapi_compiled_charteditor_module();
+    ChartsStubs.stub_jsapi_compiled_controls_module();
+    ChartsStubs.stub_jsapi_compiled_corechart_module();
+    ChartsStubs.stub_jsapi_compiled_default_module();
+    ChartsStubs.stub_jsapi_compiled_flashui_module();
+    ChartsStubs.stub_jsapi_compiled_gauge_module();
+    ChartsStubs.stub_jsapi_compiled_geo_module();
+    ChartsStubs.stub_jsapi_compiled_geochart_module();
+    ChartsStubs.stub_jsapi_compiled_graphics_module();
+    ChartsStubs.stub_jsapi_compiled_imagechart_module();
+    ChartsStubs.stub_jsapi_compiled_motionchart_module();
+    ChartsStubs.stub_jsapi_compiled_orgchart_module();
+    ChartsStubs.stub_jsapi_compiled_table_module();
+    ChartsStubs.stub_jsapi_compiled_ui_module();
+
+    // Given I have opened a page with the editor
+    YasrChartsPluginPageSteps.visit();
+  });
+
+  it('Should render results in a datatable by default', () => {
+    // When I open the yasr charts tab
+    YasrSteps.openChartsTab();
+    // Then I should not see results
+    YasrSteps.getRawResults().should('be.empty');
+    // And I should not see the chart config button
+    YasrSteps.getGoogleChartConfigButton().should('not.exist');
+    // When I execute a query
+    YasqeSteps.executeQuery();
+    // Then I should see results in a datatable
+    // TODO: check for rows and columns?
+    YasrSteps.getGoogleDataTable().should('be.visible');
+    // And I should see the chart config button
+    YasrSteps.getGoogleChartConfigButton().should('be.visible');
+  });
+
+  it('Should be able to configure a chart', () => {
+    // And I have opened the yasr charts tab
+    YasrSteps.openChartsTab();
+    // And I have results
+    YasqeSteps.executeQuery();
+    YasrSteps.getGoogleDataTable().should('be.visible');
+    // When I click on chart config button
+    YasrSteps.openGoogleChartsConfig();
+    // Then I expect to see the chart config dialog
+    GoogleChartsConfigSteps.getConfigDialog().should('be.visible');
+    // When I select the pie chart type
+    GoogleChartsConfigSteps.selectPieChart();
+    GoogleChartsConfigSteps.getPieChartPreview().should('be.visible');
+    // And I confirm
+    GoogleChartsConfigSteps.getConfirmSelectedChartButton().should('be.visible');
+    GoogleChartsConfigSteps.confirmSelectedChart();
+    // Then I expect to see the pie chart rendered in the results
+    YasrSteps.getGoogleChartVisualization().should('be.visible');
+    // And the config chart button should still be visible
+    YasrSteps.getGoogleChartConfigButton().should('be.visible');
+
+    // When I switch to line chart
+    YasrSteps.openGoogleChartsConfig();
+    GoogleChartsConfigSteps.getConfigDialog().should('be.visible');
+    GoogleChartsConfigSteps.selectLineChart();
+    GoogleChartsConfigSteps.getPieChartPreview().should('be.visible');
+    GoogleChartsConfigSteps.getConfirmSelectedChartButton().should('be.visible');
+    GoogleChartsConfigSteps.confirmSelectedChart();
+    YasrSteps.getGoogleChartVisualization().should('be.visible');
+  });
+});

--- a/cypress/fixtures/charts/jsapi_compiled_annotatedtimeline_module
+++ b/cypress/fixtures/charts/jsapi_compiled_annotatedtimeline_module
@@ -1,0 +1,7 @@
+gvjs_q(gvjs_2b, gvjs_nY, void 0);
+gvjs_nY.prototype.draw = gvjs_nY.prototype.draw;
+gvjs_nY.prototype.getSelection = gvjs_nY.prototype.getSelection;
+gvjs_nY.prototype.getVisibleChartRange = gvjs_nY.prototype.U$;
+gvjs_nY.prototype.setVisibleChartRange = gvjs_nY.prototype.setVisibleChartRange;
+gvjs_nY.prototype.showDataColumns = gvjs_nY.prototype.Nfa;
+gvjs_nY.prototype.hideDataColumns = gvjs_nY.prototype.Waa;

--- a/cypress/fixtures/charts/jsapi_compiled_annotationchart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_annotationchart_module
@@ -1,0 +1,1179 @@
+var gvjs_6X = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  , gvjs_7X = "allValuesSuffix"
+  , gvjs_8X = "annotationsContainer"
+  , gvjs_9X = "annotationsFilterContainer"
+  , gvjs_$X = "background-color"
+  , gvjs_aY = "chartContainer"
+  , gvjs_bY = "containerTable"
+  , gvjs_cY = "dateFormat"
+  , gvjs_dY = "displayAnnotations"
+  , gvjs_eY = "displayDateBarSeparator"
+  , gvjs_fY = "displayLegendDots"
+  , gvjs_gY = "displayLegendValues"
+  , gvjs_hY = "displayRangeSelector"
+  , gvjs_iY = "displayZoomButtons"
+  , gvjs_jY = "numberFormats"
+  , gvjs_kY = "outerChartContainer"
+  , gvjs_lY = "zoomButtons.";
+function gvjs_Eka(a) {
+  return void 0 !== a.lastElementChild ? a.lastElementChild : gvjs_nh(a.lastChild, !1)
+}
+function gvjs_mY(a, b, c) {
+  var d = a.W(c);
+  if (d !== gvjs_Lb && d !== gvjs_Mb)
+    throw Error(gvjs_wa + c + " must be of type date or datetime, but is " + (d + "."));
+  return a.getValue(b, c)
+}
+var gvjs_Fka = {
+  annotationsWidth: 25,
+  annotationsFilter: "off",
+  scaleValues: null,
+  dateFormat: "MMMM dd, yyyy",
+  displayRangeSelector: !0,
+  displayAnnotations: !0,
+  displayAnnotationsFilter: !1,
+  displayZoomButtons: !0,
+  zoomButtons: {
+    "1-second": {
+      label: "1s",
+      offset: [0, 0, 1]
+    },
+    "5-seconds": {
+      label: "5s",
+      offset: [0, 0, 5]
+    },
+    "10-seconds": {
+      label: "10s",
+      offset: [0, 0, 10]
+    },
+    "15-seconds": {
+      label: "15s",
+      offset: [0, 0, 15]
+    },
+    "1-minute": {
+      label: "1min",
+      offset: [0, 1, 0]
+    },
+    "5-minutes": {
+      label: "5min",
+      offset: [0, 5, 0]
+    },
+    "10-minutes": {
+      label: "10min",
+      offset: [0, 10, 0]
+    },
+    "15-minutes": {
+      label: "15min",
+      offset: [0, 15, 0]
+    },
+    "1-hour": {
+      label: "1h",
+      offset: [1, 0, 0]
+    },
+    "6-hours": {
+      label: "6h",
+      offset: [6, 0, 0]
+    },
+    "1-day": {
+      label: "1d",
+      offset: [1, 0, 0, 0, 0]
+    },
+    "5-days": {
+      label: "5d",
+      offset: [5, 0, 0, 0, 0]
+    },
+    "1-week": {
+      label: "1w",
+      offset: [7, 0, 0, 0, 0]
+    },
+    "1-month": {
+      label: "1m",
+      offset: [1, 0, 0, 0, 0, 0]
+    },
+    "3-months": {
+      label: "3m",
+      offset: [3, 0, 0, 0, 0, 0]
+    },
+    "6-months": {
+      label: "6m",
+      offset: [6, 0, 0, 0, 0, 0]
+    },
+    "1-year": {
+      label: "1y",
+      offset: [1, 0, 0, 0, 0, 0, 0]
+    },
+    max: {
+      label: gvjs_Gv,
+      range: {
+        start: null,
+        end: null
+      }
+    }
+  },
+  zoomButtonsOrder: ["1-hour", "1-day", "5-days", "1-week", "1-month", "3-months", "6-months", "1-year", gvjs_Gv],
+  displayLegendDots: !0,
+  displayDateBarSeparator: !0,
+  displayExactValues: !1,
+  fill: 0,
+  lclt: 0,
+  labelColors: null,
+  allowHtml: !1
+}
+  , gvjs_Gka = {
+  annotations: {
+    textStyle: {
+      fontSize: 10,
+      auraColor: gvjs_f
+    },
+    boxStyle: {
+      stroke: "#888888",
+      strokeWidth: .5,
+      rx: 2,
+      ry: 2,
+      gradient: {
+        color1: "#eeeeee",
+        color2: "#dddddd",
+        x1: gvjs_Ro,
+        y1: gvjs_Ro,
+        x2: gvjs_Ro,
+        y2: gvjs_So,
+        useObjectBoundingBoxUnits: !0
+      }
+    }
+  },
+  backgroundColor: gvjs_ea,
+  chartArea: {
+    width: gvjs_So,
+    backgroundColor: gvjs_ea
+  },
+  height: 200,
+  width: gvjs_So,
+  hAxis: {
+    baselineColor: gvjs_f,
+    slantedText: !1,
+    maxAlternation: 1,
+    gridlines: {
+      count: -1
+    },
+    textStyle: {
+      fontSize: 9
+    }
+  },
+  vAxis: {
+    baselineColor: "#ababab",
+    gridlines: {
+      count: -1,
+      color: "#ECECF7"
+    },
+    textPosition: gvjs_Fp,
+    inTextPosition: "high",
+    viewWindowMode: gvjs_Lv
+  },
+  legend: {
+    position: gvjs_f,
+    alignment: gvjs_R
+  },
+  colors: gvjs_MF,
+  targetAxisIndex: 1,
+  focusTarget: gvjs_Ht,
+  tooltip: {
+    trigger: gvjs_f
+  },
+  candlestick: {
+    hollowIsRising: !0
+  },
+  forceIFrame: !1,
+  animation: {
+    duration: 0
+  }
+}
+  , gvjs_Hka = {
+  filterColumnIndex: 0,
+  ui: {
+    chartType: gvjs_na,
+    chartOptions: {
+      chartArea: {
+        width: gvjs_So,
+        height: gvjs_So,
+        backgroundColor: {
+          fill: gvjs_ea,
+          stroke: "#ababab",
+          strokeWidth: .5
+        }
+      },
+      height: 40,
+      width: gvjs_So,
+      backgroundColor: gvjs_ea,
+      areaOpacity: .1,
+      lineWidth: 1,
+      forceIFrame: !1,
+      hAxis: {
+        baselineColor: gvjs_f,
+        slantedText: !1,
+        maxAlternation: 1,
+        gridlines: {},
+        textPosition: gvjs_Fp,
+        textStyle: {
+          fontSize: 9
+        }
+      },
+      vAxis: {
+        baselineColor: gvjs_f,
+        scaleType: gvjs_Vv
+      }
+    },
+    sideScreenColor: {
+      fill: "#f2f2f2",
+      fillOpacity: .75
+    },
+    zoomAroundSelection: !0,
+    chartView: {
+      columns: [0, 1]
+    }
+  }
+}
+  , gvjs_Ika = {
+  width: gvjs_So,
+  height: gvjs_So,
+  allowHtml: !0,
+  sortAscending: !1,
+  sortColumn: 0
+};
+function gvjs_nY(a) {
+  gvjs_Qn.call(this, a);
+  this.hb = null;
+  this.IH = !0;
+  this.ra = null;
+  this.Gj = 0;
+  this.$M = this.RV = this.Eu = this.Ri = this.Dx = this.Du = this.rh = this.aa = this.mG = this.im = this.Cc = this.K = this.m = this.su = null;
+  this.NI = {};
+  this.Wq = this.lO = this.IE = this.ig = null;
+  this.ea = new gvjs_KA;
+  this.zd = new gvjs_8q(this);
+  this.e_ = !1;
+  this.D = gvjs_Oh()
+}
+gvjs_o(gvjs_nY, gvjs_Qn);
+gvjs_ = gvjs_nY.prototype;
+gvjs_.He = function() {
+  this.ea.removeAll();
+  gvjs_E(this.zd);
+  this.zd = new gvjs_8q(this);
+  gvjs_E(this.ea);
+  this.ea = new gvjs_KA;
+  this.e_ = !1;
+  this.Ri && this.Ri.clear();
+  this.rh && this.rh.clear();
+  this.aa && this.aa.clear();
+  this.container && this.D.qc(this.container)
+}
+;
+gvjs_.uv = function() {
+  return this.aa.zf()
+}
+;
+gvjs_.getSelection = function() {
+  var a = this;
+  return this.uv().getSelection().map(function(b) {
+    b = gvjs_oY(a, b.row, b.column);
+    return {
+      row: b.row,
+      column: b.column
+    }
+  })
+}
+;
+gvjs_.setSelection = function(a) {
+  var b = this
+    , c = this.uv();
+  null == a || 0 === a.length ? c.setSelection([]) : (a = a.map(function(d) {
+    d = gvjs_pY(b, d.row, d.column);
+    return {
+      row: d.row,
+      column: d.column
+    }
+  }),
+    c.setSelection(a))
+}
+;
+gvjs_.U$ = function() {
+  return this.rh.getState().range
+}
+;
+gvjs_.setVisibleChartRange = function(a, b, c) {
+  this.rh.setState({
+    range: {
+      start: a,
+      end: b
+    }
+  });
+  this.rh.draw();
+  gvjs_qY(this, null == c ? !0 : c)
+}
+;
+gvjs_.Waa = function(a) {
+  gvjs_rY(this, a, !0)
+}
+;
+gvjs_.Nfa = function(a) {
+  gvjs_rY(this, a, !1)
+}
+;
+function gvjs_rY(a, b, c) {
+  Array.isArray(b) || (b = [b]);
+  for (var d = 0; d < b.length; d++)
+    a.NI[b[d]] = c;
+  a.Qt()
+}
+gvjs_.Qt = function() {
+  this.draw(this.ra, this.su, this.K)
+}
+;
+gvjs_.Rd = function(a, b, c, d) {
+  this.su = c || {};
+  this.K = d || {};
+  this.lM(b);
+  this.z_(b);
+  gvjs_Jka(this);
+  a = this.Ni = new gvjs_N(this.ra);
+  a.Hn(this.ig);
+  b = a.at([{
+    column: this.Gj,
+    test: function(e) {
+      return null != e
+    }
+  }]);
+  a.pp(b);
+  b = a.bn(this.Gj);
+  a.pp(b);
+  b = gvjs_mY(this.Ni, 0, this.Gj);
+  c = gvjs_mY(this.Ni, this.Ni.ca() - 1, this.Gj);
+  this.nO = {
+    min: b,
+    max: c
+  };
+  this.VO();
+  gvjs_Kka(this);
+  gvjs_sY(this);
+  gvjs_Lka(this);
+  gvjs_Mka(this);
+  gvjs_Nka(this);
+  gvjs_Oka(this);
+  gvjs_Pka(this);
+  gvjs_Qka(this);
+  this.aa.zh(a);
+  this.rh.zh(a);
+  this.rh.draw();
+  gvjs_qY(this, !1)
+}
+;
+gvjs_.z_ = function(a) {
+  this.ra = a;
+  this.Kt()
+}
+;
+gvjs_.lM = function(a) {
+  if (!a)
+    throw Error(gvjs_as);
+  var b = a.$();
+  if (2 > b)
+    throw Error(gvjs_$r);
+  if (a.W(0) != gvjs_Lb && a.W(0) != gvjs_Mb)
+    throw Error("First column must contain date, or date and time.");
+  for (var c, d, e = !1, f = 0, g = 1; g < b && !e; g++)
+    c = a.W(g),
+      c == gvjs_g ? f = 1 : 0 == f ? (e = !0,
+        d = g) : 1 == f ? c == gvjs_l ? f = 2 : (e = !0,
+        d = g) : 2 == f && (c == gvjs_l ? f = 0 : (e = !0,
+        d = g));
+  if (e)
+    throw Error("Each values column may be followed by one or two annotation columns. column number " + d + gvjs_fr + c);
+}
+;
+function gvjs_Kka(a) {
+  var b = a.hb;
+  b && b.AS && gvjs_C(b.AS, gvjs_ku, gvjs_f);
+  var c = a.getHeight(a.m)
+    , d = a.La(a.m);
+  if (b) {
+    gvjs_Cz(b.AS, d, c);
+    gvjs_C(b.AS, gvjs_ku, "");
+    var e = gvjs_Jh(b.GG);
+    a.Pa = c - (e.top + e.bottom);
+    a.ga = d - (e.left + e.right);
+    gvjs_Cz(b.GG, a.ga, a.Pa)
+  } else {
+    b = a.hb = {};
+    var f = a.D;
+    f.qc(a.container);
+    gvjs_WC(a.container, ["google-visualization-atl", "container"]);
+    var g = a.container.id + "_AnnotationChart_";
+    e = function(l, m, n) {
+      var p = f.createElement(gvjs_Ob);
+      l && (p.id = g + l);
+      p.className = m;
+      n.appendChild(p);
+      return p
+    }
+    ;
+    var h = b.AS = e("", "", a.container);
+    gvjs_C(h, gvjs_vd, gvjs_zd);
+    gvjs_Cz(h, d, c);
+    h = e("", "", h);
+    gvjs_C(h, gvjs_vd, gvjs_c);
+    gvjs_sz(h, 0, 0);
+    gvjs_Cz(h, gvjs_So, gvjs_So);
+    h = b.GG = e("borderDiv", "border", h);
+    h = b.wCa = e(gvjs_bY, gvjs_bY, h);
+    var k = gvjs_Jh(b.GG);
+    a.Pa = c - (k.top + k.bottom);
+    a.ga = d - (k.left + k.right);
+    gvjs_Cz(b.GG, a.ga, a.Pa);
+    a = b.rCa = e("chartTd", "td chartTdContainer", h);
+    c = b.SV = e("annotationsTd", "td annotationsTdContainer", h);
+    d = b.iEa = e(gvjs_kY, gvjs_kY, a);
+    h = b.vla = e("chartControlsContainer", "chartControls", d);
+    b.KF = e("zoomControlContainer", "zoomControls", h);
+    b.Lsa = e("legendContainer", gvjs_rv, h);
+    b.tla = e(gvjs_aY, gvjs_aY, d);
+    b.L2 = e("rangeControlContainer", "rangeControl", a);
+    b.nG = e(gvjs_9X, gvjs_9X, c);
+    b.QV = b.QV = e(gvjs_8X, gvjs_8X, c)
+  }
+}
+function gvjs_Nka(a) {
+  var b = 1 + gvjs_Oj(a.Cc, ["series.0.pointSize", gvjs_jw], 6)
+    , c = gvjs_Gh(a.hb.vla).height
+    , d = gvjs_K(a.m, gvjs_hY) ? gvjs_L(a.im, "ui.chartOptions.height") : 0;
+  c = a.Pa - (c + d);
+  var e = Math.max(b, gvjs_L(a.Cc, gvjs_2o, 0))
+    , f = Math.max(b, 2 + 2 * gvjs_L(a.Cc, "hAxis.textStyle.fontSize"));
+  f = Math.max(f, gvjs_L(a.Cc, gvjs_Zo, 0));
+  gvjs_hq(a.Cc, 1, {
+    height: c,
+    chartArea: {
+      top: e,
+      bottom: f,
+      height: c - (e + f)
+    }
+  });
+  gvjs_hq(a.im, 1, {
+    ui: {
+      chartOptions: {
+        chartArea: {
+          height: d
+        }
+      }
+    }
+  });
+  d = 0;
+  a.IH ? (d = a.mG.fa(gvjs_Xd, gvjs_ub),
+    gvjs_Bz(a.hb.SV, d),
+    d = gvjs_Dz(a.hb.SV).width,
+    d = Math.max(0, d)) : gvjs_Bz(a.hb.SV, 0);
+  d = a.ga - d;
+  c = Math.max(b, gvjs_L(a.Cc, gvjs_0o, 0));
+  b = Math.max(b, gvjs_L(a.Cc, gvjs_1o, 0));
+  e = d - (c + b);
+  gvjs_hq(a.Cc, 1, {
+    width: d,
+    chartArea: {
+      left: c,
+      right: b,
+      width: e
+    }
+  });
+  gvjs_hq(a.im, 1, {
+    ui: {
+      chartOptions: {
+        width: d,
+        chartArea: {
+          left: c + 1,
+          right: b + 2,
+          width: e - 3
+        }
+      }
+    }
+  })
+}
+function gvjs_Oka(a) {
+  a.aa || (a.aa = new gvjs_Q({
+    chartType: gvjs_GP,
+    container: a.hb.tla
+  }));
+  a.rh || (a.rh = new gvjs_P({
+    controlType: gvjs_YP,
+    container: a.hb.L2
+  }),
+    gvjs_si(a.rh, gvjs_i, function() {
+      gvjs_oi(a.rh, gvjs_Hd, a.Lqa.bind(a))
+    }));
+  if (a.IH) {
+    var b = gvjs_K(a.m, "displayAnnotationsFilter")
+      , c = function() {
+      var d = a.IH && b ? gvjs_Dz(a.hb.nG).height : 0;
+      a.hb.QV.style.height = gvjs_rz(a.Pa - d + gvjs_T, !0)
+    };
+    a.oG || (a.oG = new gvjs_P({
+      controlType: gvjs_gQ,
+      container: a.hb.nG,
+      options: {
+        filterColumnLabel: "Text",
+        matchType: "any",
+        useFormattedValue: !0,
+        ui: {
+          label: "Filter",
+          labelSeparator: ": "
+        }
+      }
+    }));
+    gvjs_C(a.hb.nG, gvjs_ku, b ? "" : gvjs_f);
+    a.Ri || (a.Ri = new gvjs_Q({
+      chartType: gvjs_hM,
+      container: a.hb.QV
+    }),
+      gvjs_si(a.Ri, gvjs_i, function() {
+        gvjs_oi(a.Ri, gvjs_k, a.Uqa.bind(a))
+      }));
+    a.Du ? c() : (a.Du = new gvjs_so(a.hb.nG),
+      a.Du.bind(a.oG, a.Ri),
+      gvjs_si(a.Du, gvjs_i, c))
+  } else
+    gvjs_cg(a.hb.nG, gvjs_9f),
+    a.Ri && (a.Ri.clear(),
+      a.Ri = null),
+    a.oG && (a.oG.clear(),
+      a.oG = null),
+    a.Du && (a.Du.clear(),
+      a.Du = null);
+  a.e_ || (a.e_ = !0,
+    gvjs_oi(a.aa, gvjs_i, a.w0.bind(a)),
+    gvjs_si(a.aa, gvjs_i, function() {
+      var d = a.uv();
+      gvjs_oi(d, gvjs_k, a.pqa.bind(a));
+      gvjs_oi(d, gvjs_7v, a.rqa.bind(a));
+      gvjs_oi(d, gvjs_6v, a.qqa.bind(a))
+    }))
+}
+gvjs_.w0 = function() {
+  this.zd && this.zd.dispatchEvent(gvjs_i)
+}
+;
+gvjs_.Lqa = function() {
+  var a = this.rh.getState();
+  gvjs_qY(this, !1);
+  this.zd.dispatchEvent(gvjs_8N, a.range)
+}
+;
+function gvjs_qY(a, b) {
+  var c = a.rh.getState();
+  a.aa.ba("hAxis.viewWindow", {
+    min: c.range.start,
+    max: c.range.end
+  });
+  c = a.aa.getOption(gvjs_Ws);
+  b && 0 === c && a.aa.ba(gvjs_Ws, 150);
+  a.aa.draw();
+  a.aa.ba(gvjs_Ws, c)
+}
+function gvjs_Jka(a) {
+  a.ig = [{
+    label: "Datetime",
+    type: a.ra.W(a.Gj),
+    calc: function(g, h) {
+      return {
+        v: g.getValue(h, a.Gj),
+        p: {
+          dataRow: h
+        }
+      }
+    }
+  }];
+  a.IE = [];
+  for (var b = 0, c = a.Gj + 1, d = a.ra.$(); c < d; ) {
+    var e = c
+      , f = {
+      label: a.ra.Ga(c) + "  ",
+      sourceColumn: c,
+      properties: {
+        dataColumn: e,
+        viewColumn: a.ig.length
+      }
+    };
+    a.NI[b] && (f.type = gvjs_g,
+        f.calc = function() {
+          return null
+        }
+    );
+    a.ig.push(f);
+    a.IE.push(f);
+    c++;
+    c < d && a.ra.W(c) === gvjs_l && (c++,
+    c < d && a.ra.W(c) === gvjs_l && c++,
+    a.NI[b] || a.ig.push({
+      calc: function(g) {
+        return function(h, k) {
+          return (h = gvjs_tY(a, k, g)) ? h.key : null
+        }
+      }(e),
+      type: gvjs_l,
+      role: gvjs_Zs,
+      properties: {
+        dataColumn: e
+      }
+    }));
+    b++
+  }
+  for (c = b = 0; c < a.IE.length; c++)
+    if (!a.NI[c]) {
+      b = c;
+      break
+    }
+  gvjs_hq(a.im, 1, {
+    ui: {
+      chartView: {
+        columns: [0, a.IE[b].properties.viewColumn]
+      }
+    }
+  });
+  gvjs_hq(a.im, 1, {
+    ui: {
+      chartOptions: {
+        colors: [a.Kb[b % a.Kb.length]]
+      }
+    }
+  })
+}
+gvjs_.VO = function() {
+  function a() {
+    return ("      " + b(f++)).substr(-e)
+  }
+  function b(n) {
+    return 26 <= n ? b(Math.floor(n / 26) - 1) + gvjs_6X[n % 26] : gvjs_6X[n]
+  }
+  var c = this.ra.$()
+    , d = this.ra.ca();
+  this.Eu = [];
+  this.RV = {};
+  for (var e = Math.ceil(Math.log(d) / Math.log(26)), f = 0, g = 0; g < d; g++)
+    for (var h = this.Gj + 1; h < c; ) {
+      var k = h;
+      h++;
+      if (h < c && this.ra.W(h) === gvjs_l) {
+        var l = h
+          , m = null;
+        h++;
+        h < c && this.ra.W(h) === gvjs_l && (m = h,
+          h++);
+        (k = gvjs_Rka(this, this.Eu.length, g, k, l, m, a)) && gvjs_Ska(this, k)
+      }
+    }
+  this.IH = gvjs_K(this.m, gvjs_dY) && 0 < this.Eu.length
+}
+;
+function gvjs_Rka(a, b, c, d, e, f, g) {
+  e = e && a.ra.getValue(c, e);
+  f = f && a.ra.getValue(c, f);
+  return e || f ? (g = g(),
+    a = a.ra.getValue(c, a.Gj),
+    {
+      idx: b,
+      key: g,
+      title: e,
+      text: f,
+      date: a,
+      EX: c,
+      Bs: d
+    }) : null
+}
+function gvjs_Tka(a) {
+  a.Dx = new gvjs_M;
+  a.Dx.xd(gvjs_l, "Key");
+  a.Dx.xd(gvjs_l, "Text");
+  a.$M = [];
+  for (var b = [], c = 0; c < a.Eu.length; c++) {
+    var d = a.Eu[c]
+      , e = '<button type="button" class="key">' + gvjs_dg(d.key) + "</button>"
+      , f = d.date;
+    a.lO && (f = gvjs_dg(a.lO.Ob(d.date)));
+    var g = d.title || "";
+    d = d.text || "";
+    gvjs_K(a.m, gvjs_Us) || (g = gvjs_dg(g),
+      d = gvjs_dg(d));
+    b.push([e, '<span class="title">' + g + '</span> <span class="description">' + d + '</span> <span class="date">' + f + "</span> "])
+  }
+  a.Dx.Yn(b);
+  var h = a.Dx.ca();
+  b.forEach(function(k, l) {
+    a.Dx.Gfa(l, "idx", h - l - 1);
+    a.$M[h - l - 1] = l
+  })
+}
+function gvjs_Pka(a) {
+  if (a.IH) {
+    gvjs_Tka(a);
+    var b = gvjs_jq(a.mG);
+    b.width = gvjs_So;
+    b.height = gvjs_So;
+    a.Ri.setOptions(b);
+    a.Du.draw(a.Dx)
+  }
+}
+gvjs_.Kt = function() {
+  this.m = new gvjs_Aj([this.su, gvjs_Fka]);
+  this.Cc = new gvjs_Aj([gvjs_my(this.m, gvjs_Bb), gvjs_Gka]);
+  this.im = new gvjs_Aj([gvjs_my(this.m, gvjs_sw), gvjs_Hka]);
+  this.mG = new gvjs_Aj([gvjs_my(this.m, gvjs_Ld), gvjs_Ika]);
+  var a = this.m.cb(gvjs_ht);
+  a && (gvjs_C(this.hb.GG, gvjs_$X, a),
+    gvjs_hq(this.Cc, 1, {
+      backgroundColor: a
+    }),
+    gvjs_hq(this.im, 1, {
+      ui: {
+        chartOptions: {
+          backgroundColor: a
+        }
+      }
+    }));
+  gvjs_hq(this.Cc, 1, {
+    colors: this.m.fa(gvjs_2t)
+  });
+  this.Kb = this.Cc.fa(gvjs_2t);
+  gvjs_hq(this.im, 1, {
+    ui: {
+      chartOptions: {
+        colors: [this.Kb[0]]
+      }
+    }
+  });
+  typeof this.m.fa(gvjs_np) === gvjs_g && gvjs_hq(this.Cc, 1, {
+    areaOpacity: gvjs_L(this.m, gvjs_np) / 100,
+    seriesType: gvjs_at
+  });
+  a = gvjs_K(this.m, gvjs_hv, !1);
+  gvjs_hq(this.Cc, 1, {
+    interpolateNulls: a
+  });
+  gvjs_hq(this.im, 1, {
+    ui: {
+      chartOptions: {
+        interpolateNulls: a
+      }
+    }
+  });
+  gvjs_hq(this.Cc, 1, {
+    vAxis: {
+      maxValue: this.m.fa(gvjs_Gv),
+      minValue: this.m.fa(gvjs_Ov)
+    }
+  });
+  if (a = this.m.fa("scaleColumns"))
+    if (0 === a.length)
+      gvjs_hq(this.Cc, 1, {
+        vAxis: {
+          textPosition: gvjs_f
+        }
+      });
+    else {
+      for (var b = 1 === a.length, c = {}, d = 0; d < a.length; d++)
+        c[a[d]] = b ? {
+          targetAxisIndex: 1
+        } : {
+          targetAxisIndex: d
+        };
+      gvjs_hq(this.Cc, 1, {
+        series: c
+      })
+    }
+  else
+    gvjs_hq(this.Cc, 1, {
+      vAxis: {
+        targetAxisIndex: 1
+      }
+    });
+  this.m.fa(gvjs_Ew) && (this.m.fa(gvjs_Ew) === gvjs_wu || "allfixed" === this.m.fa(gvjs_Ew)) && gvjs_hq(this.Cc, 1, {
+    vAxis: {
+      baseline: 0
+    }
+  });
+  this.ra.W(this.Gj) === gvjs_Mb ? gvjs_hq(this.m, 1, {
+    minDisplaySeconds: 60,
+    dateFormat: "HH:mm MMMM dd, yyyy",
+    minTimelineGranularity: 0
+  }) : gvjs_hq(this.m, 1, {
+    minDisplaySeconds: 86400,
+    dateFormat: "MMMM dd, yyyy",
+    minTimelineGranularity: 86400
+  });
+  a = this.m.fa(gvjs_cY);
+  a = typeof a === gvjs_l ? {
+    pattern: gvjs_J(this.m, gvjs_cY)
+  } : gvjs_my(this.m, gvjs_cY);
+  this.lO = new gvjs_Tj(a);
+  a = this.m.fa(gvjs_jY);
+  if (typeof a === gvjs_l)
+    a = {
+      pattern: gvjs_J(this.m, gvjs_jY)
+    },
+      this.Wq = new gvjs_gk(a);
+  else if (gvjs_r(a)) {
+    var e = [];
+    this.Wq = e;
+    gvjs_w(gvjs_my(this.m, gvjs_jY), function(f, g) {
+      f = {
+        pattern: f
+      };
+      g = parseInt(g, 10);
+      e[g] = new gvjs_gk(f)
+    })
+  } else
+    gvjs_K(this.m, "displayExactValues") ? this.Wq = null : this.Wq = new gvjs_gk({
+      pattern: "#.##"
+    });
+  a = gvjs_J(this.m, "scaleFormat", "#.########") + gvjs_J(this.m, gvjs_7X, "");
+  gvjs_hq(this.Cc, 1, {
+    vAxis: {
+      format: a
+    }
+  });
+  a = this.m.Aa("thickness");
+  gvjs_hq(this.Cc, 1, {
+    lineWidth: null != a ? Math.max(1, a) : 1
+  });
+  a = this.m.fa("annotationsWidth");
+  typeof a === gvjs_g ? gvjs_hq(this.mG, 1, {
+    width: a + "%"
+  }) : a && gvjs_hq(this.mG, 1, {
+    width: a
+  });
+  this.ula = "newRow" === gvjs_J(this.m, "legendPosition", "sameRow") ? "twoRows" : "oneRow";
+  gvjs_hq(this.im, 1, {
+    ui: {
+      chartOptions: {
+        width: this.Cc.fa(gvjs_Xd)
+      }
+    }
+  });
+  gvjs_hq(this.im, 1, {
+    ui: {
+      chartOptions: {
+        chartArea: {
+          width: this.Cc.fa(gvjs_3o)
+        }
+      }
+    }
+  });
+  this.m.fa("async", !1) && (gvjs_hq(this.Cc, 1, {
+    async: !0
+  }),
+    gvjs_hq(this.im, 1, {
+      ui: {
+        chartOptions: {
+          async: !0
+        }
+      }
+    }))
+}
+;
+function gvjs_Qka(a) {
+  var b = a.rh.getState() || {};
+  b.range = b.range || {};
+  var c = a.m.fa("zoomEndTime");
+  null != c && (b.range.end = c);
+  c = a.m.fa("zoomStartTime");
+  null != c && (b.range.start = c);
+  a.rh.setState(b);
+  gvjs_K(a.m, gvjs_hY) ? a.hb.L2.style.display = "" : a.hb.L2.style.display = gvjs_f;
+  b = gvjs_jq(a.Cc);
+  a.aa.setOptions(b);
+  b = gvjs_jq(a.im);
+  a.rh.setOptions(b)
+}
+function gvjs_Lka(a) {
+  if (gvjs_K(a.m, "displayAggregationButtons")) {
+    var b = [{
+      id: "daily",
+      label: "Daily",
+      modCalc: function(g) {
+        if (null != g)
+          return new Date(g.getFullYear(),g.getMonth(),g.getDate(),0)
+      }
+    }, {
+      id: "weekly",
+      label: "Weekly",
+      modCalc: function(g) {
+        if (null != g)
+          return new Date(g.getFullYear(),g.getMonth(),g.getDate() - g.getDay())
+      }
+    }, {
+      id: "monthly",
+      label: "Monthly",
+      modCalc: function(g) {
+        if (null != g)
+          return new Date(g.getFullYear(),g.getMonth(),1)
+      }
+    }, {
+      id: "year",
+      label: "Yearly",
+      modCalc: function(g) {
+        if (null != g)
+          return new Date(g.getFullYear(),0,1)
+      }
+    }]
+      , c = a.hb.KF.id;
+    var d = "Aggregate: ";
+    for (var e = 0; e < b.length; e++) {
+      var f = b[e];
+      d += ' <button type="button" id="' + (c + "_" + f.id) + '" href="#">' + gvjs_dg(f.label) + "</button>"
+    }
+    d += "<br />";
+    b = function(g) {
+      for (var h = 0; h < g.length; h++)
+        if (null !== g[h])
+          return g[h]
+    }
+    ;
+    c = [];
+    d = a.ra.$();
+    for (e = a.Gj + 1; e < d; )
+      c.push({
+        column: e,
+        type: gvjs_g,
+        label: a.ra.Ga(e),
+        aggregation: gvjs_Mo
+      }),
+        e++,
+      e < d && (c.push({
+        column: e,
+        type: gvjs_l,
+        label: a.ra.Ga(e),
+        aggregation: b
+      }),
+        e++,
+      e < d && (c.push({
+        column: e,
+        type: gvjs_l,
+        label: a.ra.Ga(e),
+        aggregation: b
+      }),
+        e++))
+  }
+}
+function gvjs_Mka(a) {
+  var b = a.hb.KF.id
+    , c = gvjs_K(a.m, gvjs_iY)
+    , d = gvjs_Fj(a.m, gvjs_Ij, [], "zoomButtonsOrder", void 0, void 0)
+    , e = a.D;
+  e.qc(a.hb.KF);
+  if (c) {
+    e.append(a.hb.KF, "Zoom: ");
+    c = {};
+    for (var f = 0; f < d.length; c = {
+      XF: c.XF,
+      hV: c.hV
+    },
+      f++) {
+      var g = d[f];
+      if (!a.m.pb(gvjs_lY + g))
+        break;
+      var h = gvjs_J(a.m, gvjs_lY + g + ".className", "zoomButton")
+        , k = gvjs_J(a.m, gvjs_lY + g + ".label", g);
+      h = gvjs_5f(gvjs_Bt, {
+        type: gvjs_Bt,
+        id: b + "_" + g,
+        "class": h,
+        href: "#"
+      }, k);
+      c.XF = gvjs_4x(e.dd, h);
+      e.append(a.hb.KF, c.XF);
+      c.XF = gvjs_Eka(a.hb.KF);
+      c.hV = gvjs_Uka(a, g).bind(a);
+      gvjs_si(a, gvjs_i, function(l) {
+        return function() {
+          a.ea.o(l.XF, gvjs_Wt, l.hV)
+        }
+      }(c))
+    }
+  }
+}
+function gvjs_Uka(a, b) {
+  var c = a.m.fa(gvjs_lY + b + ".offset"), d;
+  c && (d = gvjs_pk(c));
+  var e = a.m.pb(gvjs_lY + b + ".range");
+  return function() {
+    var f = a.rh.getState();
+    var g = f.range.end;
+    null == g && (g = a.nO.max);
+    if (c && null != g) {
+      g = gvjs_zA(g, d);
+      var h = a.nO.min;
+      g = g.getTime() > h.getTime() ? g : h;
+      h = {
+        start: g
+      }
+    } else
+      e && (h = e);
+    void 0 !== h.start && (f.range.start = h.start);
+    void 0 !== h.end && (f.range.end = h.end);
+    a.rh.setState(f);
+    a.rh.draw();
+    gvjs_qY(a, !0)
+  }
+}
+gvjs_.qqa = function(a) {
+  a = gvjs_oY(this, a.row, a.column);
+  this.zd.dispatchEvent(gvjs_6v, {
+    row: a.row,
+    column: a.column
+  });
+  var b;
+  a = this.getSelection();
+  0 < a.length && (b = a[0].row);
+  gvjs_sY(this, b || void 0)
+}
+;
+gvjs_.rqa = function(a) {
+  var b = gvjs_oY(this, a.row, a.column);
+  this.zd.dispatchEvent(gvjs_7v, {
+    row: b.row,
+    column: b.column
+  });
+  a = this.aa.mb().getProperty(a.row, this.Gj, "dataRow");
+  gvjs_sY(this, a)
+}
+;
+function gvjs_sY(a, b) {
+  for (var c = gvjs_9f, d = 0; d < a.IE.length; d++)
+    if (!a.NI[d]) {
+      var e = a.IE[d]
+        , f = e.properties.dataColumn
+        , g = a.Kb[d % a.Kb.length];
+      g && g.color && (g = g.color);
+      var h = gvjs_K(a.m, gvjs_fY) ? gvjs_5f(gvjs_Ob, {
+        "class": "legend-dot",
+        style: gvjs_Hf({
+          "background-color": g
+        })
+      }) : gvjs_9f;
+      c = gvjs_$f(c, gvjs_5f(gvjs_0w, {
+        style: gvjs_Hf({
+          color: g
+        })
+      }, gvjs_$f(h, e.label)));
+      null != b && gvjs_K(a.m, gvjs_gY, !0) && (f = a.ra.getValue(b, f),
+      null !== f && (e = f,
+        g = null,
+      a.Wq && (g = Array.isArray(a.Wq) ? a.Wq[d] : a.Wq),
+      g && (e = g.Ob(f)),
+      (f = a.m.cb(gvjs_7X)) && (e += f),
+        c = gvjs_$f(c, ": ", e)));
+      c = gvjs_$f(c, gvjs__y("&nbsp;&nbsp;"))
+    }
+  if (null != b) {
+    var k = a.ra.getValue(b, a.Gj);
+    k = a.lO.Ob(k)
+  }
+  "oneRow" === a.ula ? (b = a.m.fa(gvjs_eY),
+    b = !0 === b ? "|&nbsp;" : !1 === b ? "&nbsp; &nbsp;" : b.toString(),
+    c = k ? gvjs_$f(c, gvjs__y(b), k) : c) : c = gvjs_$f(k ? k : "", gvjs__y("&nbsp;&nbsp;"), gvjs_5f("br"), c);
+  gvjs_cg(a.hb.Lsa, c)
+}
+function gvjs_oY(a, b, c) {
+  var d = a.aa.mb();
+  return {
+    row: null != b ? d.getProperty(b, a.Gj, "dataRow") : null,
+    column: null != c ? d.Bd(c, "dataColumn") : null
+  }
+}
+function gvjs_pY(a, b, c) {
+  return {
+    row: null == b ? null : a.Ni.GZ(b),
+    column: null == c ? null : a.Ni.S$(c)
+  }
+}
+gvjs_.pqa = function() {
+  this.zd.dispatchEvent(gvjs_k);
+  if (this.Ri && !this.Laa) {
+    var a = this.Ri.zf();
+    if (a) {
+      var b;
+      if ((b = this.uv().getSelection()) && b.length) {
+        b = b[0];
+        var c = b.column;
+        b = !c || 1 > c ? null : b
+      } else
+        b = null;
+      b ? (b = gvjs_oY(this, b.row, b.column),
+        (b = gvjs_tY(this, b.row, b.column)) ? (c = this.Ri.mb(),
+          b = c.ca() - c.GZ(this.$M[b.idx]) - 1,
+          a.setSelection([{
+            row: b
+          }])) : a.setSelection([])) : a.setSelection([])
+    }
+  }
+}
+;
+function gvjs_tY(a, b, c) {
+  b = [String(b), String(c)].join();
+  return a.Eu[a.RV[b]]
+}
+function gvjs_Ska(a, b) {
+  var c = b.EX + "," + b.Bs
+    , d = b.idx;
+  a.Eu.push(b);
+  a.RV[c] = d
+}
+gvjs_.Uqa = function() {
+  var a = this
+    , b = this.uv()
+    , c = this.Ri.zf().getSelection()[0];
+  if (c) {
+    this.Laa = !0;
+    var d = this.Ri.mb();
+    c = d.ca() - d.fj(c.row) - 1;
+    var e = this.Eu[this.$M[c]];
+    c = function() {
+      var f = a.aa.Zc().hAxis.viewWindow
+        , g = f && f.min && f.min.getTime() || -Infinity;
+      f = f && f.max && f.max.getTime() || Infinity;
+      var h = e.date.getTime()
+        , k = gvjs_pY(a, e.EX, e.Bs);
+      return h >= g && h <= f ? (b.setSelection([{
+        row: k.row,
+        column: k.column + 1
+      }]),
+        a.Laa = !1,
+        !0) : !1
+    }
+    ;
+    c() || (d = gvjs_i,
+    gvjs_Oj(this.Cc, gvjs_Ws) && (d = gvjs_Ys),
+      gvjs_si(b, d, c),
+      gvjs_Vka(this, e.EX))
+  } else
+    b.setSelection([])
+}
+;
+function gvjs_Vka(a, b) {
+  var c = a.nO.min.getTime()
+    , d = a.nO.max.getTime()
+    , e = a.aa.Zc().hAxis.viewWindow
+    , f = e && e.min && e.min.getTime() || c;
+  e = e && e.max && e.max.getTime() || d;
+  b = a.ra.getValue(b, a.Gj).getTime();
+  f = e - f;
+  b = Math.max(c, b - Math.round(f / 2));
+  d = Math.min(d, b + f);
+  b = Math.max(c, d - f);
+  a.setVisibleChartRange(new Date(b), new Date(d), !0)
+}
+;gvjs_q(gvjs_3b, gvjs_nY, void 0);
+gvjs_nY.prototype.clearChart = gvjs_nY.prototype.Jb;
+gvjs_nY.prototype.draw = gvjs_nY.prototype.draw;
+gvjs_nY.prototype.getContainer = gvjs_nY.prototype.getContainer;
+gvjs_nY.prototype.getSelection = gvjs_nY.prototype.getSelection;
+gvjs_nY.prototype.getVisibleChartRange = gvjs_nY.prototype.U$;
+gvjs_nY.prototype.setVisibleChartRange = gvjs_nY.prototype.setVisibleChartRange;
+gvjs_nY.prototype.showDataColumns = gvjs_nY.prototype.Nfa;
+gvjs_nY.prototype.hideDataColumns = gvjs_nY.prototype.Waa;

--- a/cypress/fixtures/charts/jsapi_compiled_charteditor_module
+++ b/cypress/fixtures/charts/jsapi_compiled_charteditor_module
@@ -1,0 +1,13125 @@
+var gvjs_$pa = ' aria-disabled="true"'
+  , gvjs_o4 = ' aria-label="'
+  , gvjs_p4 = ' google-visualization-charteditor-float-end" data-tooltip-base="'
+  , gvjs_q4 = " google-visualization-charteditor-float-end\" data-tooltip-base='"
+  , gvjs_r4 = ' google-visualization-charteditor-float-end">'
+  , gvjs_aqa = ' google-visualization-charteditor-float-end"><div id="'
+  , gvjs_s4 = ' google-visualization-charteditor-float-end"><ul class="'
+  , gvjs_t4 = ' id="'
+  , gvjs_u4 = '" class="'
+  , gvjs_v4 = '" class="google-visualization-charteditor-color google-visualization-charteditor-float-end" data-tooltip-base=\''
+  , gvjs_w4 = '" class="google-visualization-charteditor-color" data-tooltip-base=\''
+  , gvjs_bqa = '" class="google-visualization-charteditor-input" data-tooltip-base=\''
+  , gvjs_cqa = '" class="google-visualization-charteditor-small-input"/>'
+  , gvjs_x4 = '" data-tooltip-base="'
+  , gvjs_y4 = "\" data-tooltip-base='"
+  , gvjs_z4 = '" style="display:none;">'
+  , gvjs_dqa = '" style="display:none;"><div class="'
+  , gvjs_eqa = '" tabIndex="0"><div class="google-visualization-charteditor-panel-navigation-cell '
+  , gvjs_fqa = '" type="text" class="google-visualization-charteditor-input" data-tooltip-base=\''
+  , gvjs_gqa = '" type="text" class="google-visualization-charteditor-small-input" data-tooltip-base="'
+  , gvjs_A4 = '" type="text" class="google-visualization-charteditor-small-input" data-tooltip-base=\''
+  , gvjs_B4 = '" type="text" class="google-visualization-charteditor-small-input"></td><td><div class="'
+  , gvjs_hqa = '" type="text" class="google-visualization-charteditor-small-input"><div><span><span id="'
+  , gvjs_C4 = '" value=""></li>'
+  , gvjs_D4 = '" value="0">'
+  , gvjs_iqa = '" value="0%">0%</li><li class="'
+  , gvjs_E4 = '" value="1">'
+  , gvjs_F4 = '" value="1">1px</li><li class="'
+  , gvjs_jqa = '" value="10%">10%</li><li class="'
+  , gvjs_G4 = '" value="2">2px</li><li class="'
+  , gvjs_kqa = '" value="20%">20%</li><li class="'
+  , gvjs_lqa = '" value="30%">30%</li><li class="'
+  , gvjs_H4 = '" value="4">4px</li><li class="'
+  , gvjs_mqa = '" value="40%">40%</li><li class="'
+  , gvjs_nqa = '" value="50%">50%</li></ul></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title '
+  , gvjs_oqa = '" value="50%">50%</li><li class="'
+  , gvjs_pqa = '" value="60%">60%</li><li class="'
+  , gvjs_qqa = '" value="70%">70%</li><li class="'
+  , gvjs_rqa = '" value="8">8px</li></ul></div>'
+  , gvjs_sqa = '" value="80%">80%</li><li class="'
+  , gvjs_tqa = '" value="90%">90%</li><li class="'
+  , gvjs_I4 = '" value="custom">'
+  , gvjs_uqa = '" value="exponential">'
+  , gvjs_vqa = '" value="linear">'
+  , gvjs_J4 = '" value="none">'
+  , gvjs_K4 = '" value="null">'
+  , gvjs_wqa = '" value="percent">'
+  , gvjs_L4 = '" value="value">'
+  , gvjs_M4 = '">&nbsp;</div>'
+  , gvjs_N4 = '"></div>'
+  , gvjs_xqa = '"></div></div>'
+  , gvjs_yqa = '"></div></div></div>'
+  , gvjs_O4 = '"></div><div class="'
+  , gvjs_P4 = '"></span>'
+  , gvjs_zqa = '"></span><span>'
+  , gvjs_Q4 = '"><div class="'
+  , gvjs_R4 = '"><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title '
+  , gvjs_S4 = '"><div class="google-visualization-charteditor-section">'
+  , gvjs_T4 = '"><div class="google-visualization-charteditor-section-title '
+  , gvjs_U4 = '"><div id="'
+  , gvjs_V4 = '"><li class="'
+  , gvjs_W4 = '"><ul class="'
+  , gvjs_X4 = "#222"
+  , gvjs_Y4 = "#3d85c6"
+  , gvjs_Z4 = "&nbsp;"
+  , gvjs__4 = "'></div></div>"
+  , gvjs_Aqa = "'></div></div></div></div>"
+  , gvjs_04 = "'></td><td><div class=\""
+  , gvjs_Bqa = "'><div class=\""
+  , gvjs_14 = "'><ul class=\""
+  , gvjs_24 = '-0"></div>'
+  , gvjs_34 = "-clickeditor"
+  , gvjs_44 = "-series-"
+  , gvjs_Cqa = '-x"></span></div></div>'
+  , gvjs_Dqa = ".formatOptions.source"
+  , gvjs_54 = ".useFormatFromData"
+  , gvjs_64 = "</div></div>"
+  , gvjs_Eqa = "</div></div></div>"
+  , gvjs_Fqa = '</div></div><div id="'
+  , gvjs_74 = '</div><div class="google-visualization-charteditor-float-end">'
+  , gvjs_Gqa = '</div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title '
+  , gvjs_Hqa = '</div><div id="'
+  , gvjs_84 = '</li><li class="'
+  , gvjs_94 = "</span>"
+  , gvjs_$4 = "</span></div>"
+  , gvjs_a5 = "</ul></div>"
+  , gvjs_b5 = '<div class="'
+  , gvjs_Iqa = '<div class="google-visualization-charteditor-inherit-color-header '
+  , gvjs_c5 = '<div class="google-visualization-charteditor-item-gap"></div>'
+  , gvjs_d5 = '<div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title '
+  , gvjs_Jqa = '<div class="google-visualization-charteditor-section">'
+  , gvjs_e5 = '<div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title '
+  , gvjs_f5 = '<div class="google-visualization-charteditor-section-title '
+  , gvjs_g5 = '<div class="google-visualization-charteditor-title-gap"></div><input id="'
+  , gvjs_Kqa = '<div class="jfk-button jfk-button-standard jfk-button-narrow '
+  , gvjs_h5 = '<div id="'
+  , gvjs_i5 = '<input id="'
+  , gvjs_j5 = '<input type="text" id="'
+  , gvjs_k5 = '<li class="'
+  , gvjs_l5 = '<p></p><div id="'
+  , gvjs_m5 = '<span style="width:auto"><span id="'
+  , gvjs_n5 = '<span><span id="'
+  , gvjs_Lqa = '<td><span><span id="'
+  , gvjs_o5 = '<ul class="'
+  , gvjs_p5 = '><div class="'
+  , gvjs_Mqa = "Aggregate Type"
+  , gvjs_q5 = "AnnotationChart"
+  , gvjs_r5 = "Area opacity"
+  , gvjs_Nqa = 'Auto</li><li class="'
+  , gvjs_Oqa = "Background color"
+  , gvjs_Pqa = "Candlestick chart"
+  , gvjs_s5 = "Chart title"
+  , gvjs_Qqa = 'Color</div><div class="google-visualization-charteditor-float-end">'
+  , gvjs_t5 = "Data series"
+  , gvjs_u5 = 'Default</li><li class="'
+  , gvjs_v5 = "Horizontal axis title"
+  , gvjs_w5 = "ImageChart"
+  , gvjs_x5 = "Left vertical axis title"
+  , gvjs_y5 = "Line thickness"
+  , gvjs_Rqa = 'Line thickness</div><div class="google-visualization-charteditor-float-end">'
+  , gvjs_z5 = 'Max<br><input id="'
+  , gvjs_A5 = 'Max<input id="'
+  , gvjs_Sqa = 'Min<br><input id="'
+  , gvjs_Tqa = 'None</div><div class="'
+  , gvjs_Uqa = "None</li></ul></div>"
+  , gvjs_B5 = 'None</li><li class="'
+  , gvjs_Vqa = "Organizational chart"
+  , gvjs_Wqa = 'Prefix<br><input id="'
+  , gvjs_C5 = "Right vertical axis title"
+  , gvjs_Xqa = "Stepped area chart"
+  , gvjs_Yqa = 'Suffix<br><input id="'
+  , gvjs_Zqa = 'Treat labels as text</div><div class="google-visualization-charteditor-section-title google-visualization-charteditor-float-end"><div><span id="'
+  , gvjs__qa = "goog-color-menu-button"
+  , gvjs_0qa = "goog-color-menu-button-indicator"
+  , gvjs_1qa = "goog-combo-button"
+  , gvjs_2qa = "goog-flat-menu-button"
+  , gvjs_D5 = "goog-tab"
+  , gvjs_E5 = "goog-tab-bar"
+  , gvjs_3qa = "goog-toolbar-button"
+  , gvjs_F5 = "goog-toolbar-color-menu-button"
+  , gvjs_4qa = "goog-toolbar-combo-button"
+  , gvjs_5qa = "goog-toolbar-menu-button"
+  , gvjs_6qa = "goog-toolbar-select"
+  , gvjs_G5 = "goog-toolbar-separator"
+  , gvjs_H5 = "aggregateFunction"
+  , gvjs_I5 = "animation.retry"
+  , gvjs_J5 = "applyAggregateData"
+  , gvjs_7qa = "areachart-stacked"
+  , gvjs_8qa = "barchart-stacked"
+  , gvjs_K5 = "before-draw"
+  , gvjs_L5 = "booleanRole"
+  , gvjs_9qa = "candlestickchart"
+  , gvjs_$qa = "chart_type_change_event"
+  , gvjs_M5 = "closeEditorCancel"
+  , gvjs_N5 = "closeEditorOK"
+  , gvjs_ara = "columnchart-stacked"
+  , gvjs_O5 = "combobox"
+  , gvjs_P5 = "custom"
+  , gvjs_Q5 = "data-name"
+  , gvjs_R5 = "data-tooltip"
+  , gvjs_S5 = "data-tooltip-base"
+  , gvjs_T5 = "data-tooltip-contained"
+  , gvjs_bra = "data-tooltip-disabled"
+  , gvjs_cra = "data-tooltip-value"
+  , gvjs_U5 = "dataLabel"
+  , gvjs_dra = "docs-icon-img docs-icon-fill-color"
+  , gvjs_era = "docs-icon-img docs-icon-line-color"
+  , gvjs_fra = "docs-icon-img docs-icon-line-width"
+  , gvjs_V5 = "docs-icon-img docs-icon-opacity"
+  , gvjs_gra = "docs-icon-img docs-icon-point-size"
+  , gvjs_W5 = "domainAxis.direction"
+  , gvjs_X5 = "errorBars.errorType"
+  , gvjs_Y5 = "errorBars.magnitude"
+  , gvjs_Z5 = "fontStyle"
+  , gvjs_hra = "formatOptions.source"
+  , gvjs_ira = "formatOptionsSource"
+  , gvjs_jra = "geochart-markers"
+  , gvjs_kra = "google-visualization-charteditor-axes-right"
+  , gvjs_lra = "google-visualization-charteditor-axes-select-div"
+  , gvjs_mra = "google-visualization-charteditor-axes-x"
+  , gvjs_nra = "google-visualization-charteditor-axes-y"
+  , gvjs__5 = "google-visualization-charteditor-axis-color-grid"
+  , gvjs_ora = "google-visualization-charteditor-axis-color-minor-grid"
+  , gvjs_pra = "google-visualization-charteditor-axis-icon-select-slant"
+  , gvjs_qra = "google-visualization-charteditor-axis-treat-labels-as-text"
+  , gvjs_05 = "google-visualization-charteditor-chart-type-categories"
+  , gvjs_15 = "google-visualization-charteditor-chart-type-subtypes"
+  , gvjs_rra = "google-visualization-charteditor-checkbox"
+  , gvjs_sra = "google-visualization-charteditor-checkbox-show-labels"
+  , gvjs_tra = "google-visualization-charteditor-color-background-clickeditor"
+  , gvjs_ura = "google-visualization-charteditor-color-chartarea-clickeditor"
+  , gvjs_vra = "google-visualization-charteditor-color-font-bubble"
+  , gvjs_25 = "google-visualization-charteditor-combo-background-opacity-clickeditor"
+  , gvjs_35 = "google-visualization-charteditor-combo-chartarea-opacity-clickeditor"
+  , gvjs_45 = "google-visualization-charteditor-combobox-closed"
+  , gvjs_wra = "google-visualization-charteditor-custom-data-input"
+  , gvjs_xra = "google-visualization-charteditor-data-preview"
+  , gvjs_55 = "google-visualization-charteditor-data-preview-arrow"
+  , gvjs_65 = "google-visualization-charteditor-display-none"
+  , gvjs_yra = "google-visualization-charteditor-font-style-axis-right"
+  , gvjs_zra = "google-visualization-charteditor-font-style-axisx"
+  , gvjs_Ara = "google-visualization-charteditor-font-style-axisy"
+  , gvjs_Bra = "google-visualization-charteditor-font-style-title"
+  , gvjs_Cra = "google-visualization-charteditor-font-style-title-clickeditor"
+  , gvjs_Dra = "google-visualization-charteditor-help-link"
+  , gvjs_75 = "google-visualization-charteditor-help-text"
+  , gvjs_Era = "google-visualization-charteditor-input-chart-name"
+  , gvjs_Fra = "google-visualization-charteditor-input-chart-title-clickeditor"
+  , gvjs_85 = "google-visualization-charteditor-input-data"
+  , gvjs_Gra = "google-visualization-charteditor-input-label"
+  , gvjs_95 = "google-visualization-charteditor-input-max"
+  , gvjs_$5 = "google-visualization-charteditor-input-min"
+  , gvjs_Hra = "google-visualization-charteditor-input-titlex-clickeditor"
+  , gvjs_Ira = "google-visualization-charteditor-input-titley-clickeditor"
+  , gvjs_Jra = "google-visualization-charteditor-menu"
+  , gvjs_a6 = "google-visualization-charteditor-mini"
+  , gvjs_b6 = "google-visualization-charteditor-options-panel"
+  , gvjs_c6 = "google-visualization-charteditor-panel-navigate-div"
+  , gvjs_Kra = "google-visualization-charteditor-panel-wrapper"
+  , gvjs_Lra = "google-visualization-charteditor-preview-div-chart"
+  , gvjs_d6 = "google-visualization-charteditor-preview-div-sample"
+  , gvjs_Mra = "google-visualization-charteditor-preview-div-wrapper"
+  , gvjs_Nra = "google-visualization-charteditor-preview-example-template"
+  , gvjs_e6 = "google-visualization-charteditor-radio-label-position"
+  , gvjs_f6 = "google-visualization-charteditor-radio-map-type"
+  , gvjs_g6 = "google-visualization-charteditor-radio-size"
+  , gvjs_Ora = "google-visualization-charteditor-select-font-name"
+  , gvjs_Pra = "google-visualization-charteditor-select-font-name-clickeditor"
+  , gvjs_Qra = "google-visualization-charteditor-select-font-size-tree"
+  , gvjs_h6 = "google-visualization-charteditor-select-legend-position"
+  , gvjs_Rra = "google-visualization-charteditor-select-series-color goog-inline-block"
+  , gvjs_Sra = "google-visualization-charteditor-series-annotations-div"
+  , gvjs_Tra = "google-visualization-charteditor-series-checkbox-dashed"
+  , gvjs_Ura = "google-visualization-charteditor-series-checkbox-markers"
+  , gvjs_i6 = "google-visualization-charteditor-series-color"
+  , gvjs_Vra = "google-visualization-charteditor-series-color-clickeditor"
+  , gvjs_j6 = "google-visualization-charteditor-series-color-items"
+  , gvjs_Wra = "google-visualization-charteditor-series-combo-line-size"
+  , gvjs_k6 = "google-visualization-charteditor-series-combo-line-size-clickeditor"
+  , gvjs_l6 = "google-visualization-charteditor-series-combo-opacity-area-clickeditor"
+  , gvjs_Xra = "google-visualization-charteditor-series-combo-opacity-area-series-global"
+  , gvjs_Yra = "google-visualization-charteditor-series-combo-point-size"
+  , gvjs_m6 = "google-visualization-charteditor-series-combo-point-size-clickeditor"
+  , gvjs_Zra = "google-visualization-charteditor-series-combo-trendline-degree"
+  , gvjs__ra = "google-visualization-charteditor-series-data-label-font-style"
+  , gvjs_0ra = "google-visualization-charteditor-series-font-style-annotations"
+  , gvjs_n6 = "google-visualization-charteditor-series-global"
+  , gvjs_1ra = "google-visualization-charteditor-series-icon-select-data-label-type-clickeditor"
+  , gvjs_2ra = "google-visualization-charteditor-series-input-error-magnitude"
+  , gvjs_3ra = "google-visualization-charteditor-series-input-max"
+  , gvjs_4ra = "google-visualization-charteditor-series-input-min"
+  , gvjs_5ra = "google-visualization-charteditor-series-input-trendline-label"
+  , gvjs_6ra = "google-visualization-charteditor-series-items"
+  , gvjs_o6 = "google-visualization-charteditor-series-items-clickeditor"
+  , gvjs_7ra = "google-visualization-charteditor-series-menu-add-trendline-clickeditor"
+  , gvjs_8ra = "google-visualization-charteditor-series-multi-icon-select-point-style-clickeditor"
+  , gvjs_9ra = "google-visualization-charteditor-series-point-shape"
+  , gvjs_$ra = "google-visualization-charteditor-series-select-div"
+  , gvjs_asa = "google-visualization-charteditor-series-select-error-type"
+  , gvjs_p6 = "google-visualization-charteditor-series-select-label-trendline"
+  , gvjs_bsa = "google-visualization-charteditor-series-select-target-axis"
+  , gvjs_q6 = "google-visualization-charteditor-series-select-trendline"
+  , gvjs_csa = "google-visualization-charteditor-series-select-visualization"
+  , gvjs_r6 = "google-visualization-charteditor-series-trendline-color"
+  , gvjs_dsa = "google-visualization-charteditor-series-trendline-color-clickeditor"
+  , gvjs_s6 = "google-visualization-charteditor-series-trendline-degree-wrapper"
+  , gvjs_t6 = "google-visualization-charteditor-series-trendline-opacity-clickeditor"
+  , gvjs_esa = "google-visualization-charteditor-series-trendline-opacity-series-global"
+  , gvjs_u6 = "google-visualization-charteditor-series-trendline-options"
+  , gvjs_v6 = "google-visualization-charteditor-series-trendline-showr2"
+  , gvjs_fsa = "google-visualization-charteditor-series-trendline-size"
+  , gvjs_w6 = "google-visualization-charteditor-series-trendline-size-clickeditor"
+  , gvjs_gsa = "google-visualization-charteditor-start-link-more-charts"
+  , gvjs_hsa = "google-visualization-charteditor-toggle-bold"
+  , gvjs_isa = "google-visualization-charteditor-toggle-italic"
+  , gvjs_x6 = "google-visualization-charteditor-trendline-series-color-items"
+  , gvjs_y6 = "google-visualization-charteditor-wrapper-aggregate-type"
+  , gvjs_z6 = "google-visualization-clickeditor-context-menu"
+  , gvjs_jsa = "google-visualization-clickeditor-edit-axis-right"
+  , gvjs_ksa = "google-visualization-clickeditor-edit-axis-x"
+  , gvjs_lsa = "google-visualization-clickeditor-edit-axis-y"
+  , gvjs_msa = "google-visualization-clickeditor-edit-legend"
+  , gvjs_nsa = "google-visualization-clickeditor-edit-series-"
+  , gvjs_osa = "google-visualization-clickeditor-edit-title"
+  , gvjs_psa = "google-visualization-clickeditor-edit-title-right"
+  , gvjs_qsa = "google-visualization-clickeditor-edit-title-x"
+  , gvjs_rsa = "google-visualization-clickeditor-edit-title-y"
+  , gvjs_ssa = "google-visualization-clickeditor-edit-trendline-"
+  , gvjs_tsa = "google-visualization-clickeditor-font-color"
+  , gvjs_usa = "google-visualization-clickeditor-font-size"
+  , gvjs_vsa = "google-visualization-clickeditor-open-editor"
+  , gvjs_A6 = "google-visualization-clickeditor-select"
+  , gvjs_B6 = "google-visualization-clickeditor-toggle"
+  , gvjs_wsa = "google-visualization-clickeditor-type"
+  , gvjs_xsa = "google-visualization-resizer-bar-center"
+  , gvjs_ysa = "google-visualization-resizer-bar-east"
+  , gvjs_zsa = "google-visualization-resizer-bar-north"
+  , gvjs_Asa = "google-visualization-resizer-bar-south"
+  , gvjs_Bsa = "google-visualization-resizer-bar-west"
+  , gvjs_C6 = "gridCount"
+  , gvjs_D6 = "gridWidth"
+  , gvjs_E6 = "hAxis."
+  , gvjs_F6 = "hAxis.logScale"
+  , gvjs_G6 = "hAxis.slantedText"
+  , gvjs_Csa = "hAxis.slantedTextAngle"
+  , gvjs_H6 = "hAxis.title"
+  , gvjs_I6 = "hasAnnotations"
+  , gvjs_J6 = "headers"
+  , gvjs_Dsa = "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=1"
+  , gvjs_Esa = "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=3"
+  , gvjs_Fsa = "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=5"
+  , gvjs_Gsa = "https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A7:F8&gid=0"
+  , gvjs_Hsa = "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:C5&gid=4&headers=1"
+  , gvjs_K6 = "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:H9&gid=2&headers=1"
+  , gvjs_Isa = "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A2:B54,D1:D54&gid=4&headers=0"
+  , gvjs_L6 = "iconSelect"
+  , gvjs_Jsa = "imageradarchart"
+  , gvjs_Ksa = "imagesparkline"
+  , gvjs_M6 = "inherit"
+  , gvjs_N6 = "inputUpdated"
+  , gvjs_Lsa = "jfk-button-standard"
+  , gvjs_O6 = "jfk-checkbox-checkmark"
+  , gvjs_P6 = "jfk-radiobutton"
+  , gvjs_Msa = "jfk-tooltip-hide"
+  , gvjs_Q6 = "labels"
+  , gvjs_R6 = "legacyContinuousAxisRemoved"
+  , gvjs_S6 = "legacyScatterChartLabels"
+  , gvjs_T6 = "legend.edit"
+  , gvjs_Nsa = "legendPositionLeft"
+  , gvjs_U6 = "legendPositionMaximized"
+  , gvjs_Osa = "legendPositionRight"
+  , gvjs_Psa = "linechart-smooth"
+  , gvjs_V6 = "maximize"
+  , gvjs_Qsa = "minorGridColor"
+  , gvjs_W6 = "multiIconSelect"
+  , gvjs_X6 = "noSlantForMaximize"
+  , gvjs_Rsa = "no_panel_redraw"
+  , gvjs_Y6 = "openeditor"
+  , gvjs_Ssa = "pointShape.rotation"
+  , gvjs_Tsa = "pointShape.sides"
+  , gvjs_Usa = "pointShape.type"
+  , gvjs_Z6 = "radio"
+  , gvjs_Vsa = "series.annotations.textStyle"
+  , gvjs_Wsa = "series_default"
+  , gvjs_Xsa = "series_default#"
+  , gvjs_Ysa = "showThousandsSeparator"
+  , gvjs_Zsa = "showValueLabels"
+  , gvjs__6 = "smoothLine"
+  , gvjs__sa = "steppedareachart"
+  , gvjs_0sa = "synthetic-keydown"
+  , gvjs_1sa = "synthetic-keypress"
+  , gvjs_2sa = "synthetic-keyup"
+  , gvjs_06 = "textarea"
+  , gvjs_16 = "theme"
+  , gvjs_26 = "title.edit"
+  , gvjs_36 = "toggle"
+  , gvjs_3sa = "toggleDataPreview"
+  , gvjs_46 = "treatLabelsAsText"
+  , gvjs_4sa = "trendline.showr2"
+  , gvjs_56 = "trendlines"
+  , gvjs_66 = "unsupported input type "
+  , gvjs_76 = "useFirstColumnAsDomain"
+  , gvjs_86 = "vAxes.0"
+  , gvjs_96 = "vAxes.0."
+  , gvjs_$6 = "vAxes.0.logScale"
+  , gvjs_a7 = "vAxes.0.title"
+  , gvjs_b7 = "vAxes.1"
+  , gvjs_c7 = "vAxes.1."
+  , gvjs_5sa = "vAxes.1.logScale"
+  , gvjs_d7 = "vAxes.1.title"
+  , gvjs_e7 = "xMark";
+function gvjs_f7(a, b) {
+  var c = b || document;
+  if (c.getElementsByClassName)
+    a = c.getElementsByClassName(a)[0];
+  else {
+    c = document;
+    var d = b || c;
+    a = d.querySelectorAll && d.querySelector && a ? d.querySelector(a ? "." + a : "") : gvjs_7g(c, "*", a, b)[0] || null
+  }
+  return a || null
+}
+gvjs_xE.prototype.Ov = gvjs_V(63, function() {
+  this.Kd(!1)
+});
+gvjs_xE.prototype.c4 = gvjs_V(62, function() {
+  this.Kd(!0)
+});
+gvjs_LD.prototype.AT = gvjs_V(61, function(a) {
+  if (this.Bb)
+    throw Error(gvjs_8r);
+  this.j() && (this.H = null);
+  this.F = a
+});
+gvjs_8D.prototype.AT = gvjs_V(60, function(a) {
+  if (this.j())
+    throw Error(gvjs_8r);
+  this.F = a
+});
+gvjs_fD.prototype.qT = gvjs_V(59, function(a) {
+  this.JH = a
+});
+gvjs_cB.prototype.QE = gvjs_V(39, function(a, b) {
+  this.UE = a;
+  this.ZC = b
+});
+gvjs_aD.prototype.QE = gvjs_V(38, function(a, b, c, d) {
+  this.gA = a;
+  this.fA = b;
+  this.GB = c;
+  this.FB = d
+});
+gvjs_cB.prototype.iT = gvjs_V(37, function(a) {
+  gvjs_dB(this);
+  this.y7 = a
+});
+gvjs_9h.prototype.EC = gvjs_V(13, function(a, b) {
+  a = this.Rh[a.toString()];
+  var c = [];
+  if (a)
+    for (var d = 0; d < a.length; ++d) {
+      var e = a[d];
+      e.capture == b && c.push(e)
+    }
+  return c
+});
+gvjs_H.prototype.EC = gvjs_V(12, function(a, b) {
+  return this.Jl.EC(String(a), b)
+});
+gvjs_4g.prototype.wX = gvjs_V(5, function(a, b) {
+  for (var c = this.dd, d = gvjs_ah(c, gvjs_ss), e = d.appendChild(gvjs_ah(c, gvjs_ts)), f = 0; f < a; f++) {
+    for (var g = gvjs_ah(c, gvjs_vs), h = 0; h < b; h++) {
+      var k = gvjs_ah(c, gvjs_us);
+      g.appendChild(k)
+    }
+    e.appendChild(g)
+  }
+  return d
+});
+gvjs_4g.prototype.yP = gvjs_V(4, function(a) {
+  return gvjs_f7(a, this.dd)
+});
+gvjs_MC.prototype.yP = gvjs_V(3, function(a) {
+  return this.hd(a)
+});
+gvjs_4g.prototype.hd = gvjs_V(2, function(a, b) {
+  return gvjs_f7(a, b || this.dd)
+});
+gvjs_MC.prototype.hd = gvjs_V(1, function(a) {
+  return this.H ? this.D.hd(a, this.H) : null
+});
+function gvjs_g7(a, b, c) {
+  b < a.tK ? a.array[b + a.qG] = c : (gvjs_Wg(a),
+    a.Kl[b] = c);
+  return a
+}
+function gvjs_h7(a, b, c) {
+  a.se || (a.se = {});
+  var d = c ? c.um() : c;
+  a.se[b] = c;
+  return gvjs_g7(a, b, d)
+}
+function gvjs_6sa(a, b) {
+  var c = [];
+  gvjs_0T(a, b, c, !1);
+  return c
+}
+function gvjs_7sa(a, b) {
+  a.CB(b);
+  a.qf = b;
+  a.anchor = b;
+  a.setPosition(a.uP(0));
+  a.setVisible(!0)
+}
+function gvjs_8sa(a) {
+  gvjs_kD(a);
+  return a.j()
+}
+function gvjs_9sa(a) {
+  return function() {
+    return a
+  }
+}
+function gvjs_$sa() {
+  return !0
+}
+function gvjs_ata(a) {
+  var b = b || 0;
+  return function() {
+    return a.apply(this, Array.prototype.slice.call(arguments, 0, b))
+  }
+}
+function gvjs_bta(a, b) {
+  for (var c = {}, d = 0; d < a.length; d++) {
+    var e = a[d]
+      , f = b.call(void 0, e, d, a);
+    void 0 !== f && (c[f] || (c[f] = [])).push(e)
+  }
+  return c
+}
+function gvjs_cta(a) {
+  var b = arguments.length;
+  if (1 == b && Array.isArray(arguments[0]))
+    return gvjs_cta.apply(null, arguments[0]);
+  if (b % 2)
+    throw Error(gvjs_kb);
+  for (var c = {}, d = 0; d < b; d += 2)
+    c[arguments[d]] = arguments[d + 1];
+  return c
+}
+var gvjs_dta = /^(ar|ckb|dv|he|iw|fa|nqo|ps|sd|ug|ur|yi|.*[-_](Adlm|Arab|Hebr|Nkoo|Rohg|Thaa))(?!.*[-_](Latn|Cyrl)($|-|_))($|-|_)/i;
+function gvjs_i7() {
+  return gvjs_dta.test(gvjs_Dm())
+}
+function gvjs_eta(a, b) {
+  b = b instanceof gvjs_vf ? b : gvjs_Wy(b);
+  a.href = gvjs_xf(b)
+}
+function gvjs_fta(a) {
+  try {
+    return gvjs_Oz(a).next()
+  } catch (b) {
+    if (b != gvjs_4i)
+      throw b;
+    return null
+  }
+}
+var gvjs_gta = /[?&]($|#)/;
+function gvjs_j7(a, b) {
+  for (var c = a.search(gvjs_Vm), d = 0, e, f = []; 0 <= (e = gvjs_Um(a, d, b, c)); )
+    f.push(a.substring(d, e)),
+      d = Math.min(a.indexOf("&", e) + 1 || c, c);
+  f.push(a.substr(d));
+  return f.join("").replace(gvjs_gta, "$1")
+}
+function gvjs_k7(a, b, c) {
+  a = gvjs_j7(a, b);
+  c = null != c ? "=" + encodeURIComponent(String(c)) : "";
+  if (b += c) {
+    c = a.indexOf("#");
+    0 > c && (c = a.length);
+    var d = a.indexOf("?");
+    if (0 > d || d > c) {
+      d = c;
+      var e = ""
+    } else
+      e = a.substring(d + 1, c);
+    a = [a.substr(0, d), e, a.substr(c)];
+    c = a[1];
+    a[1] = b ? c ? c + "&" + b : b : c;
+    a = a[0] + (a[1] ? "?" + a[1] : "") + a[2]
+  }
+  return a
+}
+function gvjs_hta(a) {
+  if (!gvjs_Lca.test(a))
+    return null;
+  a = a.toUpperCase();
+  for (var b, c = "", d = 0; d < a.length; d++) {
+    var e = a.charCodeAt(d);
+    if (65 > e || 90 < e) {
+      c = a.substring(0, d);
+      b = a.substring(d);
+      break
+    }
+  }
+  a = 0;
+  d = 1;
+  for (e = c.length - 1; 0 <= e; e--)
+    a += d * (c.charCodeAt(e) - 64),
+      d *= 26;
+  c = a;
+  b = Number(b);
+  return isNaN(b) || 0 >= b || 0 > c ? null : new gvjs_z(c,b)
+}
+var gvjs_ita = {}
+  , gvjs_jta = {};
+function gvjs_l7() {
+  var a = gvjs_i7();
+  this.D8 = typeof a == gvjs_g ? 0 < a ? 1 : 0 > a ? -1 : null : null == a ? null : a ? -1 : 1
+}
+gvjs_l7.prototype.Una = gvjs_mq;
+gvjs_l7.prototype.mark = function() {
+  switch (this.D8) {
+    case 1:
+      return "\u200e";
+    case -1:
+      return "\u200f";
+    default:
+      return ""
+  }
+}
+;
+function gvjs_8(a, b) {
+  return a && b && a.hsa && b.hsa ? a.eq !== b.eq ? !1 : a.toString() === b.toString() : a instanceof gvjs_qq && b instanceof gvjs_qq ? a.eq != b.eq ? !1 : a.toString() == b.toString() : a == b
+}
+function gvjs_m7(a, b) {
+  return -1 != a.indexOf(b)
+}
+function gvjs_9(a) {
+  return a instanceof gvjs_qq ? !!a.getContent() : !!a
+}
+function gvjs_n7(a) {
+  return a.replace(/<\//g, "<\\/").replace(/\]\]>/g, "]]\\>")
+}
+function gvjs_o7(a) {
+  null != a && a.eq === gvjs_ita && (a = a.getContent());
+  var b;
+  if (b = a)
+    b = !(1 <= a.length && " " === a.substring(0, 1));
+  return (b ? " " : "") + a
+}
+function gvjs_p7(a) {
+  for (var b = [], c = 0; c < arguments.length; ++c)
+    b[c - 0] = arguments[c];
+  return b
+}
+var gvjs_kta = /^(?!-*(?:expression|(?:moz-)?binding))(?:(?:[.#]?-?(?:[_a-z0-9-]+)(?:-[_a-z0-9-]+)*-?|(?:rgb|hsl)a?\([0-9.%,\u0020]+\)|[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:e-?[0-9]+)?(?:[a-z]{1,4}|%)?|!important)(?:\s*[,\u0020]\s*|$))*$/i;
+function gvjs_lta(a) {
+  null != a && a.eq === gvjs_jta ? a = gvjs_n7(a.getContent()) : null == a ? a = "" : a instanceof gvjs_Df ? a = gvjs_n7(gvjs_Ff(a)) : a instanceof gvjs_Mf ? a = gvjs_n7(gvjs_Pf(a)) : (a = String(a),
+    a = gvjs_kta.test(a) ? a : "zSoyz");
+  return a
+}
+var gvjs_mta = /^(?!on|src|(?:action|archive|background|cite|classid|codebase|content|data|dsync|href|http-equiv|longdesc|style|usemap)\s*$)(?:[a-z0-9_$:-]*)$/i;
+function gvjs_q7(a) {
+  null != a && a.eq === gvjs_ita ? a = a.getContent() : (a = String(a),
+    a = gvjs_mta.test(a) ? a : "zSoyz");
+  return a
+}
+function gvjs_r7(a, b) {
+  var c = gvjs_3g();
+  a = a(b || gvjs_JB, void 0);
+  a = gvjs_IB(a);
+  return gvjs_4x(c.dd, a)
+}
+var gvjs_nta = [gvjs_O5, gvjs_Pu, gvjs_Cp, "listbox", "menu", "menubar", "radiogroup", gvjs_Cd, "rowgroup", "tablist", "textbox", "toolbar", "tree", "treegrid"];
+function gvjs_s7(a, b, c, d, e) {
+  if (2 != b.length || 2 != c.length)
+    throw Error(gvjs__N);
+  gvjs_jO.call(this, a, b, c, d, e)
+}
+gvjs_t(gvjs_s7, gvjs_jO);
+gvjs_s7.prototype.aB = function() {
+  this.element.style.width = Math.round(this.coords[0]) + gvjs_T;
+  this.element.style.height = Math.round(this.coords[1]) + gvjs_T
+}
+;
+function gvjs_t7() {}
+gvjs_t7.prototype.equals = function(a) {
+  return Object.is(this, a) || null == this && null == a
+}
+;
+gvjs_t7.prototype.toString = function() {
+  var a = gvjs_u7(gvjs_ota(gvjs_pta(this.constructor))) + "@";
+  var b = ((this.n6 || (Object.defineProperties(this, {
+    n6: {
+      value: gvjs_qta = gvjs_qta + 1 | 0,
+      enumerable: !1
+    }
+  }),
+    this.n6)) >>> 0).toString(16);
+  return a + gvjs_u7(b)
+}
+;
+gvjs_t7.prototype.Rr = ["java.lang.Object", 0];
+/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+var gvjs_qta = 0;
+function gvjs_u7(a) {
+  return null == a ? gvjs_rd : a.toString()
+}
+;function gvjs_v7(a, b) {
+  this.pC = a;
+  this.XO = b
+}
+gvjs_o(gvjs_v7, gvjs_t7);
+function gvjs_ota(a) {
+  if (0 != a.XO) {
+    var b = 3 == a.pC.prototype.Rr[1] ? a.pC.prototype.Rr[2] : "L" + gvjs_u7(a.pC.prototype.Rr[0]) + ";";
+    a = a.XO;
+    for (var c = "", d = 0; d < a; d = d + 1 | 0)
+      c = gvjs_u7(c) + "[";
+    return gvjs_u7(c) + gvjs_u7(b)
+  }
+  return a.pC.prototype.Rr[0]
+}
+gvjs_v7.prototype.toString = function() {
+  return String(0 == this.XO && 1 == this.pC.prototype.Rr[1] ? "interface " : 0 == this.XO && 3 == this.pC.prototype.Rr[1] ? "" : "class ") + gvjs_u7(gvjs_ota(this))
+}
+;
+gvjs_v7.prototype.Rr = ["java.lang.Class", 0];
+function gvjs_pta(a) {
+  return gvjs_pg(a.prototype, "$$class/0", function() {
+    return new gvjs_v7(a,0)
+  })
+}
+;function gvjs_w7() {}
+gvjs_o(gvjs_w7, gvjs_t7);
+gvjs_w7.prototype.Rr = ["com.google.apps.docs.xplat.diagnostics.impressions.DiagnosticsData", 0];
+function gvjs_rta(a) {
+  gvjs_Ug(this, a, null)
+}
+gvjs_o(gvjs_rta, gvjs_Sg);
+function gvjs_sta(a) {
+  gvjs_Ug(this, a, gvjs_tta)
+}
+gvjs_o(gvjs_sta, gvjs_Sg);
+function gvjs_x7(a) {
+  gvjs_Ug(this, a, gvjs_uta)
+}
+gvjs_o(gvjs_x7, gvjs_Sg);
+gvjs_x7.prototype.ca = function() {
+  return gvjs_Xg(this, 1)
+}
+;
+gvjs_x7.prototype.$ = function() {
+  return gvjs_Xg(this, 2)
+}
+;
+var gvjs_tta = [2]
+  , gvjs_uta = [6];
+function gvjs_y7(a) {
+  gvjs_Ug(this, a, gvjs_vta)
+}
+gvjs_o(gvjs_y7, gvjs_Sg);
+gvjs_ = gvjs_y7.prototype;
+gvjs_.getTextColor = function() {
+  var a = gvjs_wta;
+  this.se || (this.se = {});
+  if (!this.se[4]) {
+    var b = gvjs_Xg(this, 4);
+    b && (this.se[4] = new a(b))
+  }
+  return this.se[4]
+}
+;
+gvjs_.setTextColor = function(a) {
+  return gvjs_h7(this, 4, a)
+}
+;
+gvjs_.getHeading = function() {
+  return gvjs_Xg(this, 8)
+}
+;
+gvjs_.setHeading = function(a) {
+  return gvjs_g7(this, 8, a)
+}
+;
+gvjs_.jZ = function() {
+  var a = gvjs_Xg(this, 31);
+  return null == a ? a : !!a
+}
+;
+gvjs_.bi = function(a) {
+  gvjs_g7(this, 31, a)
+}
+;
+gvjs_.setSelectionRange = function(a) {
+  return gvjs_h7(this, 116, a)
+}
+;
+function gvjs_wta(a) {
+  gvjs_Ug(this, a, null)
+}
+gvjs_o(gvjs_wta, gvjs_Sg);
+var gvjs_vta = [99];
+function gvjs_z7(a) {
+  gvjs_Ug(this, a, gvjs_xta)
+}
+gvjs_o(gvjs_z7, gvjs_Sg);
+gvjs_z7.prototype.A3 = function(a) {
+  return gvjs_h7(this, 4, a)
+}
+;
+var gvjs_xta = [3, 42];
+function gvjs_A7() {}
+gvjs_o(gvjs_A7, gvjs_t7);
+function gvjs_yta(a) {
+  var b = new gvjs_A7;
+  b.boa = a;
+  return b
+}
+gvjs_A7.prototype.A3 = function(a) {
+  this.EY = a;
+  null != this.EY && null != this.eI && gvjs_Xg(this.eI, 4);
+  return this
+}
+;
+gvjs_A7.prototype.cd = function() {
+  null != this.EY && (null == this.eI && (this.eI = new gvjs_z7),
+    this.eI.A3(this.EY));
+  return new gvjs_w7(this.boa,this.SCa,this.eDa,this.gDa,this.eI,this.dDa,this.mDa,this.kDa,this.bDa,this.sDa,this.lDa,this.oDa,this.KCa,this.UCa,this.tDa,this.NCa,this.uDa,this.TCa,this.iDa,this.XCa,this.PCa,this.hDa,this.nDa,this.qDa,this.pDa,this.rDa,this.VCa,this.ZCa,this.RCa,this.QCa,this.OCa,this.cDa,this.WCa,this.$Ca,this.aDa,this.jDa,this.YCa,this.LCa,this.MCa,this.fDa)
+}
+;
+gvjs_A7.prototype.Rr = ["com.google.apps.docs.xplat.diagnostics.impressions.DiagnosticsDataBuilder", 0];
+function gvjs_B7(a) {
+  return gvjs_W(gvjs_C7(gvjs_CB({
+    gva: !0,
+    PG: gvjs_sq("" + gvjs_D7(a.icon, a.Qla))
+  }, a)))
+}
+function gvjs_zta(a) {
+  return gvjs_W(gvjs_C7(gvjs_CB({
+    PG: gvjs_sq("" + gvjs_FB(a.textContent)),
+    ri: "docs-toolbar-text-button"
+  }, a)))
+}
+function gvjs_E7(a) {
+  var b = a.color
+    , c = a.sCa
+    , d = a.ri;
+  return gvjs_W(gvjs_C7(gvjs_CB({
+    ri: (c ? c + "-toolbar-color-menu-button " : "goog-toolbar-color-menu-button ") + (d ? "" + d + " " : ""),
+    PG: gvjs_sq(gvjs_b5 + gvjs_7(gvjs_0qa) + '"' + (b ? ' style="border-bottom-color: ' + gvjs_7(gvjs_lta(b)) + ';"' : "") + ">" + gvjs_D7(a.icon, a.Qla) + gvjs_a)
+  }, a)))
+}
+function gvjs_D7(a, b) {
+  return gvjs_W(gvjs_b5 + gvjs_7("docs-icon") + " " + gvjs_7(gvjs_Y) + " " + (b ? gvjs_7(b) : "") + gvjs_Q4 + gvjs_7("docs-icon-img-container") + " " + gvjs_7(a) + '" aria-hidden="true">&nbsp;</div></div>')
+}
+function gvjs_C7(a) {
+  a = (a = gvjs_CB({
+    X1: "goog-toolbar-menu-button-outer-box"
+  }, a)) || {};
+  a = gvjs_W(gvjs_Ata(gvjs_CB({
+    yX: gvjs_5qa,
+    E_: "goog-toolbar-menu-button-inner-box",
+    d8: "goog-toolbar-menu-button-caption",
+    G9: "goog-toolbar-menu-button-dropdown",
+    eN: a.eN
+  }, a)));
+  return gvjs_W(a)
+}
+function gvjs_Ata(a) {
+  var b = a.d8
+    , c = a.G9
+    , d = a.PG
+    , e = a.$k
+    , f = a.eN
+    , g = a.Bna;
+  return gvjs_W(gvjs_Bta(gvjs_CB({
+    C8: gvjs_sq((a.oCa ? "" : gvjs_b5 + gvjs_7(b) + " " + gvjs_7(gvjs_Y) + gvjs_X + gvjs_FB(d) + gvjs_a) + (f ? "" : gvjs_b5 + gvjs_7(c) + " " + (g ? gvjs_7("docs-gm-arrow") : "") + " " + gvjs_7(gvjs_Y) + ' ">' + (g ? gvjs_D7("docs-icon-img docs-icon-arrow-dropdown") : gvjs_Z4) + gvjs_a) + (e ? gvjs_FB(e) : ""))
+  }, a)))
+}
+function gvjs_Bta(a) {
+  var b = a.yX
+    , c = a.C8
+    , d = a.yka
+    , e = a.X1
+    , f = a.E_
+    , g = a.ri
+    , h = a.id
+    , k = a.hidden
+    , l = a.title
+    , m = a.attributes
+    , n = a.enabled
+    , p = a.backgroundColor;
+  a = a.gva;
+  d = d ? gvjs_o4 + gvjs_7(d) + '"' : l ? gvjs_o4 + gvjs_7(l) + '"' : "";
+  return gvjs_W("<div" + (h ? gvjs_t4 + gvjs_7(h) + '"' : "") + gvjs_dr + (g ? gvjs_7(g) + " " : "") + gvjs_7(b) + " " + gvjs_7(gvjs_Y) + (n ? "" : " " + gvjs_7(b) + "-" + gvjs_7("disabled")) + '"' + d + (gvjs_9(k) || gvjs_9(p) ? ' style="' + (k ? "display:none" : "") + (gvjs_9(k) && gvjs_9(p) ? " " : "") + (p ? gvjs_vb + gvjs_7(gvjs_lta(p)) : "") + '"' : "") + (l ? ' title="' + gvjs_7(l) + '"' : "") + ' role="button"' + (n ? ' tabindex="0"' : gvjs_$pa) + (m ? gvjs_o7(gvjs_q7(m)) : "") + gvjs_p5 + (e ? gvjs_7(e) : gvjs_7(b) + gvjs_Jr) + " " + gvjs_7(gvjs_Y) + '"' + (a ? ' aria-hidden="true"' : "") + gvjs_p5 + (f ? gvjs_7(f) : gvjs_7(b) + gvjs_Ir) + " " + gvjs_7(gvjs_Y) + gvjs_X + gvjs_FB(c) + gvjs_Eqa)
+}
+function gvjs_F7(a) {
+  a = a || {};
+  var b = gvjs_CB({
+    ri: "docs-toolbar-small-separator"
+  }, a);
+  b = b || {};
+  a = b.ri;
+  var c = b.hidden;
+  b = b.id;
+  a = gvjs_W(gvjs_b5 + (a ? gvjs_7(a) + " " : "") + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + '"' + (c ? ' style="display:none"' : "") + (b ? gvjs_t4 + gvjs_7(b) + '"' : "") + ">&nbsp;</div>");
+  return gvjs_W(a)
+}
+function gvjs_G7(a) {
+  a = a || {};
+  var b = a.id
+    , c = a.$k
+    , d = a.hidden
+    , e = a.QI
+    , f = a.eN;
+  return gvjs_W((e ? "" : gvjs_F7({
+    hidden: d ? gvjs_Rd : ""
+  })) + gvjs_Ata(gvjs_CB({
+    id: b,
+    yX: gvjs_4qa,
+    X1: "goog-toolbar-combo-button-outer-box",
+    E_: "goog-toolbar-combo-button-inner-box",
+    d8: "goog-toolbar-combo-button-caption",
+    G9: "goog-toolbar-combo-button-dropdown",
+    PG: gvjs_sq(gvjs_Z4),
+    hidden: d,
+    $k: c,
+    eN: f
+  }, a)) + (e ? "" : gvjs_F7({
+    hidden: d ? gvjs_Rd : ""
+  })))
+}
+;function gvjs_H7() {}
+gvjs_o(gvjs_H7, gvjs_nE);
+gvjs_ = gvjs_H7.prototype;
+gvjs_.createCaption = function(a, b) {
+  a = b.J(gvjs_Na, {
+    "class": this.sa() + "-input jfk-textinput",
+    autocomplete: "off",
+    value: a,
+    type: gvjs_m,
+    "aria-autocomplete": gvjs_ut,
+    tabIndex: -1
+  });
+  return gvjs_oE(a, this.sa(), b)
+}
+;
+gvjs_.sa = function() {
+  return gvjs_1qa
+}
+;
+gvjs_.ib = function(a) {
+  return a && this.bj(a)
+}
+;
+gvjs_.setContent = function(a, b) {
+  a && (a = gvjs_Cta(this, a)) && a.tagName == gvjs_Na && (a.value = b)
+}
+;
+function gvjs_Cta(a, b) {
+  var c = a.bj(b);
+  return c && c.firstChild && c.firstChild.tagName == gvjs_Na ? c.firstChild : c ? (b = gvjs_3g(b),
+    a = a.createCaption(gvjs_Z4, b),
+  (b = c.parentNode) && b.replaceChild(a, c),
+    c.firstChild) : null
+}
+gvjs_.bj = function(a) {
+  return gvjs_f7(gvjs_Y, gvjs_f7(gvjs_Y, gvjs_f7(gvjs_Y, a)))
+}
+;
+gvjs_le(gvjs_H7);
+function gvjs_I7(a) {
+  var b = 0;
+  if (gvjs_J7(a))
+    a.selectionStart = b;
+  else if (gvjs_y && !gvjs_Eg("9")) {
+    var c = gvjs_K7(a)
+      , d = c[0];
+    d.inRange(c[1]) && (b = gvjs_L7(a, b),
+      d.collapse(!0),
+      d.move(gvjs_Lt, b),
+      d.select())
+  }
+}
+function gvjs_M7(a, b) {
+  if (gvjs_J7(a))
+    a.selectionEnd = b;
+  else if (gvjs_y && !gvjs_Eg("9")) {
+    var c = gvjs_K7(a)
+      , d = c[1];
+    if (c[0].inRange(d)) {
+      b = gvjs_L7(a, b);
+      a: {
+        var e = 0
+          , f = 0;
+        if (gvjs_J7(a))
+          e = a.selectionStart,
+            f = -1;
+        else if (gvjs_y && !gvjs_Eg("9")) {
+          var g = gvjs_K7(a);
+          c = g[0];
+          g = g[1];
+          if (c.inRange(g)) {
+            c.setEndPoint("EndToStart", g);
+            if (a.type == gvjs_06) {
+              g.duplicate();
+              f = e = c.text;
+              for (g = !1; !g; )
+                0 == c.compareEndPoints("StartToEnd", c) ? g = !0 : (c.moveEnd(gvjs_Lt, -1),
+                  c.text == e ? f += "\r\n" : g = !0);
+              c = [f.length, -1];
+              break a
+            }
+            e = c.text.length;
+            f = -1
+          }
+        }
+        c = [e, f]
+      }
+      a = gvjs_L7(a, c[0]);
+      d.collapse(!0);
+      d.moveEnd(gvjs_Lt, b - a);
+      d.select()
+    }
+  }
+}
+function gvjs_K7(a) {
+  var b = a.ownerDocument || a.document
+    , c = b.selection.createRange();
+  a.type == gvjs_06 ? (b = b.body.createTextRange(),
+    b.moveToElementText(a)) : b = a.createTextRange();
+  return [b, c]
+}
+function gvjs_L7(a, b) {
+  a.type == gvjs_06 && (b = a.value.substring(0, b).replace(/(\r\n|\r|\n)/g, "\n").length);
+  return b
+}
+function gvjs_J7(a) {
+  try {
+    return typeof a.selectionStart == gvjs_g
+  } catch (b) {
+    return !1
+  }
+}
+;function gvjs_N7(a, b, c, d, e) {
+  c = void 0 === c ? gvjs_H7.Lc() : c;
+  gvjs_DE.call(this, a, b, c, d, e);
+  this.Yd = null;
+  this.Vv = !1;
+  this.gO = null;
+  this.AL = !1;
+  this.lha = gvjs_$sa;
+  this.$da = this.gka = gvjs_Wx;
+  this.x$ = gvjs_9sa("");
+  this.rD = this.uc = this.sQ = null;
+  this.N9 = !1;
+  this.H0 = gvjs_hf;
+  this.kQ = !1
+}
+gvjs_o(gvjs_N7, gvjs_DE);
+function gvjs_Dta(a) {
+  var b = a.$da(a.Yd.value);
+  if (a.AL) {
+    var c = gvjs_aE(a.Td());
+    null != c && (b = c.getValue());
+    a.AL = !1
+  }
+  return a.Wa(b) ? (a.dispatchEvent(gvjs_Ss),
+    !0) : !1
+}
+gvjs_ = gvjs_N7.prototype;
+gvjs_.Gb = function(a) {
+  gvjs_DE.prototype.Gb.call(this, a);
+  this.Yd && (this.Yd.disabled = !this.isEnabled())
+}
+;
+gvjs_.Wa = function(a) {
+  var b = this.lha(a);
+  return b || null == a ? (null != a && (a = this.gka(a)),
+    this.gO = a,
+    gvjs_DE.prototype.Wa.call(this, this.gO),
+    this.rO = this.x$(a),
+    gvjs_EE(this),
+    b) : !1
+}
+;
+gvjs_.getValue = function() {
+  return this.gO
+}
+;
+gvjs_.Iya = function() {
+  this.kQ = !1
+}
+;
+gvjs_.$S = function() {
+  this.Yd.select();
+  var a = this.Yd.value.length;
+  gvjs_I7(this.Yd);
+  gvjs_M7(this.Yd, a)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_DE.prototype.Nb.call(this);
+  gvjs_VB(this.H, gvjs_O5);
+  this.Yd = gvjs_Cta(this.Oa(), this.j());
+  this.sQ || (this.sQ = new gvjs_uD(this.Yd),
+    gvjs_6x(this, this.sQ));
+  this.hc().o(this.sQ, gvjs_kv, this.jqa).o(this.Yd, gvjs_Yo, this.fqa).o(this.Yd, gvjs_gd, this.gqa).o(this, "open", this.YZ).o(this.Yd, gvjs_xu, this.hqa);
+  this.N9 && this.Bb && (this.uc || (this.uc = new gvjs_0O(this.Yd),
+    gvjs_6x(this, this.uc)),
+    this.hc().o(this.uc, gvjs_fv, this.MP))
+}
+;
+gvjs_.YZ = function() {
+  this.Vv || this.Yd.focus();
+  var a = this.Td();
+  a && (a.j().id = a.getId(),
+    gvjs_WB(this.H, "owns", a.getId()),
+    gvjs_WB(this.Yd, gvjs_Ib, a.getId()))
+}
+;
+gvjs_.DI = function(a) {
+  gvjs_DE.prototype.DI.call(this, a);
+  a.target.j() && gvjs_WB(this.Yd, gvjs_Ts, a.target.j().id)
+}
+;
+gvjs_.Wj = function(a) {
+  var b = gvjs_DE.prototype.Wj.call(this, a);
+  if (!gvjs_FD(this, 64))
+    return b;
+  this.Vv && (38 == a.keyCode || 40 == a.keyCode) && (a = gvjs_aE(this.Td())) && (this.Yd.value = a.getValue(),
+    this.$S(),
+    b = !0);
+  return b
+}
+;
+gvjs_.Cf = function(a) {
+  gvjs_DE.prototype.Cf.call(this, a);
+  gvjs_FD(this, 64) && !this.Vv && this.Yd.focus()
+}
+;
+gvjs_.az = function(a) {
+  this.gl(a.target);
+  this.gO = this.Be().getValue();
+  gvjs_N7.G.az.call(this, a)
+}
+;
+gvjs_.jqa = function(a) {
+  if (this.Vv)
+    switch (a.keyCode) {
+      case 13:
+        gvjs_Dta(this) && (this.Yd.blur(),
+          this.Kd(!1));
+        a.stopPropagation();
+        break;
+      case 9:
+        gvjs_Dta(this);
+        this.Kd(!1);
+        break;
+      case 27:
+        this.AL = !1;
+        this.Yd.blur();
+        break;
+      case 38:
+      case 40:
+        this.AL = !0;
+        break;
+      case 39:
+      case 37:
+      case 35:
+      case 36:
+        a.stopPropagation();
+        break;
+      default:
+        this.AL = !1
+    }
+}
+;
+gvjs_.MP = function() {
+  var a = gvjs_kf(this.Yd.value.toLowerCase());
+  this.mL(a);
+  if (0 == a.length)
+    this.Td().Tg(-1);
+  else {
+    var b = gvjs_aE(this.Td());
+    b && b.isVisible() || this.vT(a)
+  }
+  this.rD = a
+}
+;
+gvjs_.gqa = function(a) {
+  this.Vv && a.stopPropagation()
+}
+;
+gvjs_.fqa = function() {
+  this.kQ || (this.Vv = !1,
+    gvjs_sg ? (gvjs_I7(this.Yd),
+      gvjs_M7(this.Yd, 0)) : gvjs_y && !gvjs_Eg("10.0") && this.Yd.setAttribute(gvjs_zx, "on"),
+    gvjs_EE(this),
+  gvjs_y && (this.kQ = !0,
+    gvjs_I7(this.Yd),
+    gvjs_M7(this.Yd, 0),
+    this.Yd.blur(),
+    gvjs_pl(this.Iya, 100, this)),
+    gvjs_WB(this.Yd, gvjs_Ts, ""),
+    gvjs_WB(this.Yd, gvjs_Ib, ""))
+}
+;
+gvjs_.hqa = function() {
+  if (!this.kQ && !this.Vv) {
+    this.Vv = !0;
+    gvjs_y ? (this.Yd.setAttribute(gvjs_zx, "off"),
+      this.$S()) : gvjs_sg ? this.$S() : gvjs_tg && gvjs_pl(this.$S, 0, this);
+    if (this.N9) {
+      var a = this.Td();
+      a && !a.isVisible() && this.mL("")
+    }
+    this.Kd(!0)
+  }
+}
+;
+gvjs_.mL = function(a) {
+  for (var b = !1, c = this.rD && !this.H0(a, this.rD), d = this.Td(), e = 0, f = d.ze(); e < f; e++) {
+    var g = d.Ye(e);
+    if (g.isEnabled())
+      if (g instanceof gvjs_ZD) {
+        if (g.isVisible() || c) {
+          var h = g.bj();
+          h = !gvjs_jf(h) && this.H0(h.toLowerCase(), a);
+          g.setVisible(!!h);
+          b = h || b
+        }
+      } else
+        b = g.isVisible() || b
+  }
+}
+;
+gvjs_.vT = function(a) {
+  for (var b = this.Td(), c = 0, d = b.ze(); c < d; c++) {
+    var e = b.Ye(c).bj();
+    if (e && this.H0(e.toLowerCase(), a)) {
+      b.Tg(c);
+      return
+    }
+  }
+  b.Tg(-1)
+}
+;
+gvjs_HD(gvjs_1qa, function() {
+  return new gvjs_N7(null)
+});
+function gvjs_O7() {}
+gvjs_o(gvjs_O7, gvjs_H7);
+gvjs_O7.prototype.sa = function() {
+  return gvjs_4qa
+}
+;
+gvjs_le(gvjs_O7);
+var gvjs_$ = {
+  Oi: {
+    o6: {
+      AnnotatedTimeLine: !0
+    },
+    yza: {
+      AnnotationChart: !0
+    },
+    lia: {
+      ComboChart: !0
+    },
+    uV: {
+      ImageSparkLine: !0
+    },
+    Map: {
+      Map: !0
+    },
+    x6: {
+      MotionChart: !0
+    },
+    B6: {
+      PieChart: !0
+    },
+    FBa: {
+      ScatterChart: !0
+    },
+    Table: {
+      Table: !0
+    },
+    OBa: {
+      Timeline: !0
+    },
+    Oja: {
+      TreeMap: !0
+    }
+  },
+  pV: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    CandlestickChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    PieChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    Histogram: !0
+  },
+  ZF: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    CandlestickChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    Histogram: !0
+  },
+  sfa: {
+    AreaChart: !0,
+    ComboChart: !0,
+    SteppedAreaChart: !0
+  },
+  GU: {
+    AreaChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  V9: {
+    AreaChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    SteppedAreaChart: !0,
+    ScatterChart: !0
+  },
+  Pla: {
+    AreaChart: !0,
+    BarChart: !0,
+    CandlestickChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    SteppedAreaChart: !0
+  },
+  U1: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    CandlestickChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    ImageChart: !0,
+    ImageRadarChart: !0,
+    ImageSparkLine: !0,
+    LineChart: !0,
+    PieChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    Histogram: !0
+  },
+  II: {
+    BubbleChart: !0
+  },
+  Lg: {
+    AreaChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0
+  },
+  ez: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    PieChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    ImageChart: !0,
+    ImageRadarChart: !0,
+    ImageSparkLine: !0,
+    Histogram: !0
+  },
+  Naa: {
+    AreaChart: !0,
+    BubbleChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    CandlestickChart: !0,
+    ImageChart: !0,
+    ImageRadarChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    Histogram: !0
+  },
+  Raa: {
+    AreaChart: !0,
+    BubbleChart: !0,
+    BarChart: !0,
+    CandlestickChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    ImageChart: !0,
+    ImageRadarChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0,
+    Histogram: !0
+  },
+  ira: {
+    AreaChart: !0,
+    BubbleChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    Histogram: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  Saa: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    Histogram: !0,
+    LineChart: !0,
+    CandlestickChart: !0,
+    ImageChart: !0,
+    ImageRadarChart: !0,
+    ScatterChart: !0,
+    SteppedAreaChart: !0
+  },
+  annotations: {
+    AreaChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    ComboChart: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  O: {},
+  v8: {},
+  YN: {
+    AreaChart: !0,
+    BarChart: !0,
+    BubbleChart: !0,
+    ColumnChart: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  Ima: {
+    LineChart: !0,
+    AreaChart: !0,
+    ScatterChart: !0
+  },
+  zma: {
+    AreaChart: !0,
+    BarChart: !0,
+    ColumnChart: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  lya: {
+    AreaChart: !0,
+    ColumnChart: !0,
+    LineChart: !0,
+    ScatterChart: !0
+  },
+  mya: {
+    BarChart: !0
+  }
+};
+gvjs_$.aoa = gvjs_$.ZF;
+gvjs_$.Ja = {
+  AreaChart: !0,
+  BarChart: !0,
+  BubbleChart: !0,
+  CandlestickChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0
+};
+gvjs_$.LJ = gvjs_$.pV;
+gvjs_$.scaleFactor = gvjs_$.ZF;
+gvjs_$.QT = gvjs_$.Oi.B6;
+gvjs_$.ufa = {
+  ImageChart: !0,
+  ImageRadarChart: !0
+};
+gvjs_$.N7 = {
+  AreaChart: !0,
+  LineChart: !0,
+  ScatterChart: !0
+};
+gvjs_$.Zj = {
+  ComboChart: !0,
+  LineChart: !0,
+  Histogram: !0
+};
+gvjs_$.Wwa = gvjs_$.Oi.uV;
+gvjs_$.cW = gvjs_$.ZF;
+gvjs_$.aW = gvjs_$.ZF;
+gvjs_$.Xfa = gvjs_$.ZF;
+gvjs_$.fill = gvjs_$.Oi.uV;
+gvjs_$.kea = {
+  AreaChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  ScatterChart: !0
+};
+gvjs_$.backgroundColor = {
+  AreaChart: !0,
+  BubbleChart: !0,
+  BarChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  CandlestickChart: !0,
+  GeoChart: !0,
+  ImageChart: !0,
+  ImageRadarChart: !0,
+  ImageSparkLine: !0,
+  SteppedAreaChart: !0,
+  Histogram: !0
+};
+gvjs_$.qg = {
+  AreaChart: !0,
+  BarChart: !0,
+  BubbleChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  Histogram: !0,
+  ImageChart: !0,
+  ImageRadarChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0
+};
+gvjs_$.Nsa = {
+  AreaChart: !0,
+  BarChart: !0,
+  BubbleChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0,
+  Histogram: !0
+};
+gvjs_$.Osa = gvjs_$.Oi.B6;
+gvjs_$.Msa = {
+  AreaChart: !0,
+  BarChart: !0,
+  BubbleChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0,
+  Histogram: !0
+};
+gvjs_$.PW = {
+  AreaChart: !0,
+  BubbleChart: !0,
+  BarChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  CandlestickChart: !0,
+  ImageChart: !0,
+  ImageRadarChart: !0,
+  ImageSparkLine: !0,
+  SteppedAreaChart: !0,
+  TreeMap: !0,
+  Histogram: !0
+};
+gvjs_$.yla = {
+  AreaChart: !0,
+  BubbleChart: !0,
+  BarChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  CandlestickChart: !0,
+  SteppedAreaChart: !0,
+  Histogram: !0
+};
+gvjs_$.UH = {
+  AreaChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  SteppedAreaChart: !0
+};
+gvjs_$.bb = gvjs_$.pV;
+gvjs_$.tfa = {
+  ImageChart: !0,
+  ImageRadarChart: !0
+};
+gvjs_$.z3 = {
+  AreaChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  ImageChart: !0,
+  ImageRadarChart: !0
+};
+gvjs_$.nwa = gvjs_$.Oi.uV;
+gvjs_$.owa = gvjs_$.Oi.lia;
+gvjs_$.Sxa = {
+  PieChart: !0
+};
+gvjs_$.aga = {
+  AreaChart: !0,
+  BarChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  Histogram: !0
+};
+gvjs_$.smooth = {
+  ComboChart: !0,
+  LineChart: !0
+};
+gvjs_$.Mva = {
+  AreaChart: !0,
+  BarChart: !0,
+  CandlestickChart: !0,
+  ComboChart: !0,
+  ColumnChart: !0,
+  LineChart: !0,
+  SteppedAreaChart: !0
+};
+gvjs_$.Mq = {
+  AreaChart: !0,
+  BarChart: !0,
+  BubbleChart: !0,
+  ComboChart: !0,
+  ColumnChart: !0,
+  LineChart: !0,
+  ScatterChart: !0
+};
+gvjs_$.hka = {
+  AreaChart: !0,
+  BarChart: !0,
+  ColumnChart: !0,
+  ComboChart: !0,
+  LineChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0
+};
+gvjs_$.V6 = {
+  GeoChart: !0,
+  PieChart: !0
+};
+gvjs_$.YO = {
+  AreaChart: !0,
+  BarChart: !0,
+  CandlestickChart: !0,
+  ComboChart: !0,
+  ColumnChart: !0,
+  ImageChart: !0,
+  ImageRadarChart: !0,
+  LineChart: !0,
+  PieChart: !0,
+  ScatterChart: !0,
+  SteppedAreaChart: !0,
+  Histogram: !0
+};
+gvjs_$.lfa = {
+  BubbleChart: !0
+};
+gvjs_$.EH = {
+  ScatterChart: !0
+};
+gvjs_$.ska = {
+  Histogram: !0
+};
+gvjs_$.Rba = {
+  BarChart: !0
+};
+gvjs_$.ixa = {
+  Map: !0,
+  TreeMap: !0
+};
+gvjs_$.rL = gvjs_$.Oi.Oja;
+gvjs_$.Dta = gvjs_$.Oi.Map;
+gvjs_$.hxa = gvjs_$.Oi.x6;
+gvjs_$.Zwa = gvjs_$.Oi.x6;
+gvjs_$.gxa = gvjs_$.Oi.Table;
+gvjs_$.qka = gvjs_$.Oi.Table;
+gvjs_$.sva = gvjs_$.Oi.o6;
+gvjs_$.qza = gvjs_$.Oi.o6;
+gvjs_$.Fsa = gvjs_$.Oi.Map;
+gvjs_$.zya = gvjs_$.Oi.Map;
+gvjs_$.bU = gvjs_$.pV;
+var gvjs_P7 = ["#3366CC", gvjs_vr, gvjs_wr, gvjs_lr, "#990099", "#0099C6", "#DD4477", "#66AA00", "#B82E2E", "#316395", gvjs_rr, "#22AA99", "#AAAA11", "#6633CC", "#E67300", "#8B0707", "#651067", "#329262", "#5574A6", "#3B3EAC", "#B77322", "#16D620", "#B91383", "#F4359E", "#9C5935", "#A9C413", "#2A778D", "#668D1C", "#BEA413", "#0C5922", "#743411"];
+var gvjs_Eta = ["x", gvjs_Xu]
+  , gvjs_Fta = ["y", gvjs_86];
+function gvjs_Q7(a, b, c, d) {
+  return gvjs_R7(a, b[1] + "." + c, d)
+}
+function gvjs_R7(a, b, c) {
+  b = Array.isArray(b) ? b[0] : b;
+  return a.getOption(b, c)
+}
+function gvjs_S7(a, b, c, d) {
+  gvjs_Gta(a, b[1] + "." + c, d)
+}
+function gvjs_Gta(a, b, c) {
+  b = Array.isArray(b) ? b : [b];
+  for (var d = 0; d < b.length; d++)
+    if (null == c) {
+      var e = a
+        , f = b[d];
+      e.ba(f, "dummy");
+      f = f.split(".");
+      var g = f.length;
+      e = e.Zc();
+      for (var h = 0; h < g - 1; h++)
+        e = e[f[h]];
+      e[f[g - 1]] = null
+    } else
+      a.ba(b[d], c)
+}
+function gvjs_T7(a, b, c, d) {
+  b = (a.Va() == gvjs_3a ? "slices" : gvjs_Mw) + "." + b + "." + c;
+  return a.getOption(b, d)
+}
+function gvjs_U7(a, b, c, d) {
+  b = (a.Va() == gvjs_3a ? "slices" : gvjs_Mw) + "." + b + "." + c;
+  a.ba(b, d)
+}
+function gvjs_V7(a, b) {
+  var c = gvjs_T7(a, b, gvjs_1);
+  null == c && (a = a.getOption(gvjs_2t)) && (c = a[b % a.length]);
+  null == c && (c = gvjs_P7[b % gvjs_P7.length]);
+  return c
+}
+function gvjs_W7(a) {
+  switch (a.Va()) {
+    case gvjs_Ha:
+      var b = a.getOption(gvjs_2t);
+      break;
+    case gvjs_hb:
+      b = [a.getOption(gvjs_Pv), a.getOption(gvjs_Mv), a.getOption(gvjs_Jv)]
+  }
+  return b
+}
+function gvjs_X7(a, b, c, d) {
+  var e = gvjs_W7(a);
+  switch (a.Va()) {
+    case gvjs_Ha:
+      a.ba(gvjs_2t, [b || e[0], c || e[1], d || e[2]]);
+      break;
+    case gvjs_hb:
+      a.ba(gvjs_Pv, b || e[0]),
+        a.ba(gvjs_Mv, c || e[1]),
+        a.ba(gvjs_Jv, d || e[2])
+  }
+}
+;function gvjs_Y7(a, b, c) {
+  this.Z = a;
+  this.aa = b;
+  this.rm = c;
+  this.ig = [];
+  this.PS = [];
+  this.dg = [];
+  this.RS = !1
+}
+gvjs_Y7.prototype.Do = function() {
+  return this.ig.length ? this.ig : null
+}
+;
+gvjs_Y7.prototype.Ry = function() {
+  return this.dg.length ? this.dg : null
+}
+;
+function gvjs_Hta(a) {
+  var b = gvjs_Z7(a, a.rm);
+  a.ig.unshift(gvjs__7(gvjs_Id, a.rm, gvjs_l));
+  a.ig.push(gvjs__7("mapFromSource", a.rm, gvjs_g, a.Z.Ga(a.rm), b));
+  a.dg.push(a.rm)
+}
+function gvjs_07(a, b, c) {
+  for (var d = {}, e = a.Z.ca(), f = 0; f < e; f++) {
+    var g = a.Z.getValue(f, a.rm)
+      , h = a.Z.getValue(f, c)
+      , k = c == a.rm;
+    (k && null != h || !k && typeof h === gvjs_g) && null != g && (g = g.toString(),
+    typeof d[g] === gvjs_g || a.RS || a.PS.push(f),
+      d[g] = b(h, d[g]))
+  }
+  a.RS = !0;
+  return d
+}
+function gvjs_Z7(a, b) {
+  return gvjs_07(a, function(c, d) {
+    return typeof d === gvjs_g ? d + 1 : 1
+  }, b)
+}
+function gvjs_Ita(a, b) {
+  return gvjs_07(a, function(c, d) {
+    return typeof d === gvjs_g ? Math.min(c, d) : c
+  }, b)
+}
+function gvjs_Jta(a, b) {
+  return gvjs_07(a, function(c, d) {
+    return typeof d === gvjs_g ? Math.max(c, d) : c
+  }, b)
+}
+function gvjs_Kta(a, b) {
+  return gvjs_07(a, function(c, d) {
+    return typeof d === gvjs_g ? c + d : c
+  }, b)
+}
+function gvjs__7(a, b, c, d, e) {
+  a = {
+    calc: a,
+    sourceColumn: b,
+    type: c
+  };
+  d && (a.label = d);
+  e && (a.mapping = e);
+  return a
+}
+;var gvjs_Lta = {
+  line: ["linechart", gvjs_Psa, "combochart", gvjs_Jsa],
+  area: ["areachart", gvjs_7qa, gvjs__sa],
+  column: ["columnchart", gvjs_ara, gvjs_4u],
+  bar: ["barchart", gvjs_8qa],
+  scatter: ["scatterchart", "bubblechart"],
+  pie: ["piechart", "piechart-3d", "donutchart"],
+  map: ["map", "map-street", gvjs_Ub, gvjs_jra],
+  trend: [gvjs_Ksa, gvjs_rb, gvjs_fd, gvjs_9qa],
+  network: [gvjs_Zd],
+  more: ["gauge", gvjs_sd, "treemap", gvjs_Ld, gvjs_Nd]
+}
+  , gvjs_Mta = {
+    annotationchart: {
+      type: gvjs_q5
+    },
+    annotatedtimeline: {
+      type: gvjs_q5
+    },
+    areachart: {
+      type: gvjs_na,
+      options: {
+        isStacked: !1
+      }
+    },
+    "areachart-stacked": {
+      type: gvjs_na,
+      options: {
+        isStacked: !0
+      }
+    },
+    barchart: {
+      type: gvjs_qa,
+      options: {
+        isStacked: !1
+      }
+    },
+    "barchart-stacked": {
+      type: gvjs_qa,
+      options: {
+        isStacked: !0
+      }
+    },
+    bubblechart: {
+      type: gvjs_ra
+    },
+    candlestickchart: {
+      type: gvjs_ua
+    },
+    columnchart: {
+      type: gvjs_xa,
+      options: {
+        isStacked: !1
+      }
+    },
+    "columnchart-stacked": {
+      type: gvjs_xa,
+      options: {
+        isStacked: !0
+      }
+    },
+    combochart: {
+      type: gvjs_ya
+    },
+    donutchart: {
+      type: gvjs_3a,
+      options: {
+        is3D: !1,
+        pieHole: .5
+      }
+    },
+    geochart: {
+      type: gvjs_Ha,
+      options: {
+        displayMode: gvjs_yd
+      }
+    },
+    "geochart-markers": {
+      type: gvjs_Ha,
+      options: {
+        displayMode: gvjs_bd
+      }
+    },
+    gauge: {
+      type: gvjs_Ga
+    },
+    histogram: {
+      type: gvjs_La
+    },
+    imageradarchart: {
+      type: gvjs_Oa
+    },
+    imagesparkline: {
+      type: gvjs_Pa
+    },
+    linechart: {
+      type: gvjs_Va,
+      options: {
+        curveType: ""
+      }
+    },
+    "linechart-smooth": {
+      type: gvjs_Va,
+      options: {
+        curveType: gvjs_d
+      }
+    },
+    map: {
+      type: gvjs_Wa,
+      options: {
+        mapType: gvjs_uT
+      }
+    },
+    "map-street": {
+      type: gvjs_Wa,
+      options: {
+        mapType: gvjs_0v
+      }
+    },
+    motionchart: {
+      type: gvjs_Za
+    },
+    orgchart: {
+      type: gvjs_2a
+    },
+    piechart: {
+      type: gvjs_3a,
+      options: {
+        is3D: !1,
+        pieHole: 0
+      }
+    },
+    "piechart-3d": {
+      type: gvjs_3a,
+      options: {
+        is3D: !0,
+        pieHole: 0
+      }
+    },
+    scatterchart: {
+      type: gvjs_9a
+    },
+    steppedareachart: {
+      type: gvjs_ab
+    },
+    table: {
+      type: gvjs_db
+    },
+    timeline: {
+      type: gvjs_fb
+    },
+    treemap: {
+      type: gvjs_hb
+    },
+    wordtree: {
+      type: gvjs_mb
+    }
+  };
+function gvjs_Nta(a) {
+  var b, c = {
+    charts: {}
+  };
+  for (b in gvjs_Mta) {
+    var d = gvjs_Mta[b];
+    if (null == a || gvjs_He(a, d.type))
+      c.charts[b] = d
+  }
+  c.groups = {};
+  for (b in gvjs_Lta) {
+    a = [];
+    d = gvjs_Lta[b];
+    for (var e = 0; e < d.length; e++) {
+      var f = d[e];
+      f in c.charts && a.push(f)
+    }
+    0 < a.length && (c.groups[b] = a)
+  }
+  c.names = [];
+  for (b in c.groups)
+    c.names.push(b);
+  return c
+}
+;var gvjs_Ota = {
+  uza: gvjs_Sra,
+  yia: gvjs_n6,
+  C6: gvjs_$ra,
+  A6: "google-visualization-charteditor-series-",
+  tV: gvjs_6ra,
+  MBa: gvjs_s6,
+  NBa: gvjs_u6,
+  Tza: gvjs_j6,
+  LBa: gvjs_x6,
+  Oza: gvjs_Tra,
+  Pza: gvjs_Ura,
+  Qza: gvjs_v6,
+  fia: "google-visualization-charteditor-series-combo-opacity-area",
+  eia: gvjs_Wra,
+  gia: gvjs_Yra,
+  hia: "google-visualization-charteditor-series-trendline-opacity",
+  iia: gvjs_fsa,
+  aia: gvjs_i6,
+  bia: gvjs_r6,
+  fAa: gvjs_0ra,
+  mBa: "google-visualization-charteditor-series-select-aggregate-type",
+  nBa: gvjs_asa,
+  pBa: gvjs_9ra,
+  bja: "google-visualization-charteditor-series-multi-icon-select-point-style",
+  qBa: gvjs_bsa,
+  sBa: gvjs_csa,
+  tAa: gvjs_2ra,
+  vAa: gvjs_4ra,
+  uAa: gvjs_3ra,
+  Lja: "google-visualization-charteditor-series-toggle-axis-left",
+  Mja: "google-visualization-charteditor-series-toggle-axis-right",
+  oBa: gvjs_p6,
+  wAa: gvjs_5ra,
+  Vza: gvjs_Zra,
+  rBa: gvjs_q6,
+  KAa: "google-visualization-charteditor-series-menu-add-trendline",
+  Nja: "google-visualization-charteditor-series-menu-trendline-showr2",
+  xja: "google-visualization-charteditor-series-select-data-label-type",
+  oAa: "google-visualization-charteditor-series-icon-select-data-label-type",
+  $za: gvjs__ra
+};
+var gvjs_Pta = {
+  tV: gvjs_o6,
+  C6: "google-visualization-charteditor-series-select-div-clickeditor",
+  fia: gvjs_l6,
+  eia: gvjs_k6,
+  gia: gvjs_m6,
+  bja: gvjs_8ra,
+  aia: gvjs_Vra,
+  Lja: "google-visualization-charteditor-series-toggle-axis-left-clickeditor",
+  Mja: "google-visualization-charteditor-series-toggle-axis-right-clickeditor",
+  LAa: gvjs_7ra,
+  iia: gvjs_w6,
+  hia: gvjs_t6,
+  bia: gvjs_dsa,
+  xja: gvjs_1ra,
+  Nja: "google-visualization-charteditor-series-menu-trendline-showr2-clickeditor"
+};
+function gvjs_Qta(a) {
+  return gvjs_Rta(a.Fna)
+}
+function gvjs_Rta(a) {
+  var b = "";
+  a ? (b += gvjs_h5 + gvjs_7(gvjs_c6) + gvjs_u4 + gvjs_7(gvjs_E5) + gvjs_eqa + gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X,
+    b = b + 'Recommendations</div><div class="google-visualization-charteditor-panel-navigation-cell ' + (gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X),
+    b = b + 'Chart types</div><div class="google-visualization-charteditor-panel-navigation-cell ' + (gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X),
+    b += "Customization") : (b += gvjs_h5 + gvjs_7(gvjs_c6) + gvjs_u4 + gvjs_7(gvjs_E5) + gvjs_eqa + gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X,
+    b = b + 'Start</div><div class="google-visualization-charteditor-panel-navigation-cell ' + (gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X),
+    b = b + 'Charts</div><div class="google-visualization-charteditor-panel-navigation-cell ' + (gvjs_7(gvjs_Y) + " " + gvjs_7(gvjs_D5) + gvjs_X),
+    b += "Customize");
+  return gvjs_W(b + gvjs_64)
+}
+function gvjs_Sta() {
+  return gvjs_W('<div style="width: 100%; height: 100%; text-align: center"><div style="position: relative; top: 50%;">No Data</div></div>')
+}
+function gvjs_17(a) {
+  a = "Data series " + gvjs_FB(a);
+  return gvjs_W(a)
+}
+function gvjs_Tta(a) {
+  var b = a.type
+    , c = '<div class="google-visualization-charteditor-data-mismatch"><div class="google-visualization-charteditor-data-mismatch-header"><div class="google-visualization-charteditor-mismatch-icon ' + gvjs_7(gvjs_Y) + '"></div> <span>' + gvjs_27(a.type) + "</span></div><div>";
+  a = "The required data format for the " + gvjs_27(a.type) + " doesn't match the current data.";
+  c = c + a + "</div><p></p>";
+  gvjs_8(b, gvjs_ma) || gvjs_8(b, gvjs_q5) ? c = c + "The first column should contain dates. Subsequently, all columns should contain numbers or text. Each numeric column may be followed by one or two text columns.<p></p>Here's an example:" + (gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_na) || gvjs_8(b, gvjs_Va) || gvjs_8(b, gvjs_9a) ? c += "The first column should contain the category label. Data values should appear as numeric columns. Each numeric column may be followed by one or two text columns. The text in the first column will be displayed as annotations above the data points. The text in the second column will be displayed in a hover-card when hovering over the point." : gvjs_8(b, gvjs_qa) || gvjs_8(b, gvjs_xa) ? c += "The first column in the table represents the label of a group of bars. Any number of columns can follow, all numeric, each representing the bars with the same color and relative position in each group.<p></p>The value at a given row and column determines the height of the single bar represented by this row and column." : gvjs_8(b, gvjs_La) ? c += "A histogram displays the distribution of a data set.<p></p>The first column in the table represents the label of a group of data. Any number of columns can follow, all numeric, each representing items in a distribution.<p></p>For each column, the values from all rows are grouped into numeric buckets. The histogram displays the number of values in each bucket, using the height of each bar to represent the count of values." : gvjs_8(b, gvjs_ra) ? c = c + "The first column in the table should be text, and represents the label of that bubble. The numbers in the second column are plotted on the x axis. The numbers in the third column are plotted on the y axis. The optional fourth column should be text, and determines the bubble color. The optional fifth column is numeric, and determines the size of the bubble.<p></p>Here's an example:" + (gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_ya) ? c += "The first column should contain the category label. Any number of columns can follow, all should be numeric." : gvjs_8(b, gvjs_Ga) ? c = c + "The first column should be the label text for the gauge. The second column should be the gauge value.<p></p>Here's an example:" + (gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_Ha) ? c = c + "The first column should contain location names or addresses. The second column should contain numeric values.<p></p>Here's an example:" + (gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_ua) ? c = c + "The first column should be the names of the stocks or categories. The second column represents the low or minimum value for the stock or category, the third column represents the opening or initial value for the stock or category, the fourth column represents the closing or final value for the stock or category, and the fifth column represents the high or maximum value for the stock or category. The optional sixth column contains tooltip text.<p></p>Here's an example:" + (gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_Oa) || gvjs_8(b, gvjs_ab) ? c += "The first column should contain the category label. Any number of columns can follow, all must be numeric. Each column is displayed as a separate line." : gvjs_8(b, gvjs_Pa) ? c += "All columns must be numeric." : gvjs_8(b, gvjs_Wa) ? (b = "The first column should contain location names or addresses. An optional second column may contain tooltip text.<p></p>Here's an example:<p></p><div id=\"" + (gvjs_7(gvjs_d6) + '-0"></div><p></p>The locations may also be given in latitude/longitude format:'),
+    c = c + b + (gvjs_l5 + gvjs_7(gvjs_d6) + '-1"></div>')) : gvjs_8(b, gvjs_Za) ? (c += "The first column should contain entities (e.g. countries) the second is time (e.g. years) followed by 2-4 numeric or string columns.<p></p>Here's an example:",
+    c += gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_2a) ? (c += "The first column is the name of an individual in the chart. The second column is the name of the individual's parent or manager. The optional third column is tooltip text.<p></p>Here's an example:",
+    c += gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_3a) ? c += "The first column should contain the slice label. The second column should be a number, and contain the slice value." : gvjs_8(b, gvjs_fb) ? c += "Four columns are required. The first is the name of the row. The second is the name of the bar in that row. The third and fourth columns are the start and end times for that bar." : gvjs_8(b, gvjs_hb) ? (c += "The first column should be the name of an entity in a hierarchy. Each entity is visualized by a box when the chart is rendered.<p></p>The second column should be the name of the entity's parent entity. (The value in the second column of each row should be found in the first column of some other row.)<p></p>The optional third and fourth columns should be numerical values associated with the entity. The third column is visualized as the size of the box (must be a positive number), and the fourth column is visualized as the color of the box (may be a negative number).<p></p>Here's an example:",
+    c += gvjs_l5 + gvjs_7(gvjs_d6) + gvjs_24) : gvjs_8(b, gvjs_mb) && (c += "The first column should contain text sentences. The optional second column should contain a weight or score for each sentence.");
+  c += gvjs_l5 + gvjs_7(gvjs_Nra) + '" style="display: none"><a target="_blank">';
+  c += " Try a live example ";
+  c += "</a></div></div>";
+  return gvjs_W(c)
+}
+function gvjs_37(a) {
+  return gvjs_W('<div style="position: relative;" id="' + gvjs_7("google-visualization-charteditor-thumbnail") + "-" + gvjs_7(a) + '" class="jfk-radiobutton google-visualization-charteditor-thumbnail ' + gvjs_7(gvjs_Gs) + '"><div class="jfk-radiobutton-radio jfk-radiobutton-label"><div></div></div></div>')
+}
+function gvjs_Uta(a) {
+  var b = "";
+  gvjs_8(a, gvjs_na) || gvjs_8(a, gvjs_ab) ? b += "Areas" : gvjs_8(a, gvjs_qa) ? b += "Bars" : gvjs_8(a, gvjs_ra) ? b += "Bubbles" : gvjs_8(a, gvjs_xa) ? b += "Columns" : gvjs_8(a, gvjs_ya) || gvjs_8(a, gvjs_La) ? b += gvjs_t5 : gvjs_8(a, gvjs_Va) ? b += gvjs_ks : gvjs_8(a, gvjs_3a) ? b += "Slices" : gvjs_8(a, gvjs_9a) ? b += "Points" : gvjs_8(a, gvjs_fb) ? b += "Tasks" : gvjs_8(a, gvjs_Oa) ? b += gvjs_ks : gvjs_8(a, gvjs_Pa) && (b += gvjs_ks);
+  return gvjs_W(b)
+}
+function gvjs_47(a) {
+  var b = "";
+  gvjs_8(a, gvjs_na) || gvjs_8(a, gvjs_ab) ? b += "Area" : gvjs_8(a, gvjs_qa) ? b += "Bars" : gvjs_8(a, gvjs_xa) ? b += "Column" : gvjs_8(a, gvjs_ya) || gvjs_8(a, gvjs_ra) || gvjs_8(a, gvjs_La) ? b += gvjs_t5 : gvjs_8(a, gvjs_Va) ? b += "Line" : gvjs_8(a, gvjs_3a) ? b += "Slice" : gvjs_8(a, gvjs_9a) ? b += gvjs_t5 : gvjs_8(a, gvjs_fb) ? b += "Task" : gvjs_8(a, gvjs_Oa) ? b += "Line" : gvjs_8(a, gvjs_Pa) && (b += "Line");
+  return b
+}
+function gvjs_27(a) {
+  var b = "";
+  gvjs_8(a, gvjs_ma) || gvjs_8(a, gvjs_q5) ? b += "Time line" : gvjs_8(a, gvjs_na) ? b += "Area chart" : gvjs_8(a, gvjs_qa) ? b += "Bar chart" : gvjs_8(a, gvjs_ra) ? b += "Bubble chart" : gvjs_8(a, gvjs_ua) ? b += gvjs_Pqa : gvjs_8(a, gvjs_xa) ? b += "Column chart" : gvjs_8(a, gvjs_ya) ? b += "Combo chart" : gvjs_8(a, gvjs_Va) ? b += "Line chart" : gvjs_8(a, gvjs_Ga) ? b += gvjs_Ga : gvjs_8(a, gvjs_Ha) ? b += "Geo chart" : gvjs_8(a, gvjs_La) ? b += gvjs_La : gvjs_8(a, gvjs_Oa) ? b += "Radar chart" : gvjs_8(a, gvjs_Pa) ? b += "Spark line" : gvjs_8(a, gvjs_Wa) ? b += gvjs_Wa : gvjs_8(a, gvjs_Za) ? b += "Motion chart" : gvjs_8(a, gvjs_2a) ? b += gvjs_Vqa : gvjs_8(a, gvjs_3a) ? b += "Pie chart" : gvjs_8(a, gvjs_9a) ? b += "Scatter chart" : gvjs_8(a, gvjs_ab) ? b += gvjs_Xqa : gvjs_8(a, gvjs_db) ? b += gvjs_db : gvjs_8(a, gvjs_fb) ? b += gvjs_fb : gvjs_8(a, gvjs_hb) ? b += "Tree map" : gvjs_8(a, gvjs_mb) && (b += "Word tree");
+  return gvjs_W(b)
+}
+function gvjs_Vta(a) {
+  a = a.Gxa;
+  var b = "";
+  gvjs_8(a, gvjs_qb) || gvjs_8(a, gvjs_rb) ? b += "Time line" : gvjs_8(a, "areachart") ? b += "Area chart" : gvjs_8(a, gvjs_7qa) ? b += "Stacked area chart" : gvjs_8(a, "barchart") ? b += "Bar chart" : gvjs_8(a, gvjs_8qa) ? b += "Stacked bar chart" : gvjs_8(a, "bubblechart") ? b += "Bubble chart" : gvjs_8(a, gvjs_9qa) ? b += gvjs_Pqa : gvjs_8(a, "combochart") ? b += "Combo chart" : gvjs_8(a, "columnchart") ? b += "Column chart" : gvjs_8(a, gvjs_ara) ? b += "Stacked column chart" : gvjs_8(a, "donutchart") ? b += "Donut chart" : gvjs_8(a, gvjs_Ub) ? b += "Geo chart - regions" : gvjs_8(a, gvjs_jra) ? b += "Geo chart - markers" : gvjs_8(a, "gauge") ? b += gvjs_Ga : gvjs_8(a, gvjs_4u) ? b += gvjs_La : gvjs_8(a, gvjs_Jsa) ? b += "Radar chart" : gvjs_8(a, gvjs_Ksa) ? b += "Spark line" : gvjs_8(a, "linechart") ? b += "Line chart" : gvjs_8(a, gvjs_Psa) ? b += "Smooth line chart" : gvjs_8(a, "map") ? b += gvjs_Wa : gvjs_8(a, "map-street") ? b += "Simple map" : gvjs_8(a, gvjs_fd) ? b += "Motion chart" : gvjs_8(a, gvjs_sd) ? b += gvjs_Vqa : gvjs_8(a, "piechart") ? b += "Pie chart" : gvjs_8(a, "piechart-3d") ? b += "3d pie chart" : gvjs_8(a, "scatterchart") ? b += "Scatter chart" : gvjs_8(a, gvjs__sa) ? b += gvjs_Xqa : gvjs_8(a, gvjs_Ld) ? b += gvjs_db : gvjs_8(a, gvjs_Nd) ? b += gvjs_fb : gvjs_8(a, "treemap") ? b += "Tree map" : gvjs_8(a, gvjs_Zd) && (b += "Word tree");
+  return gvjs_W(b)
+}
+function gvjs_Wta(a) {
+  return a.Zea ? "Chart Editor - (Sample data)" : "Chart Editor"
+}
+function gvjs_Xta(a) {
+  a = a.key;
+  var b = "";
+  gvjs_8(a, "donut3d") ? b += "The donut hole feature is not available when the chart is 3D." : gvjs_8(a, gvjs_ira) ? b += "Number format from the data is not supported for log scale." : gvjs_8(a, gvjs_C6) ? b += "Grid count is not supported for time based axis." : gvjs_8(a, "logStack") ? b += "Log scale is not supported for stacked charts." : gvjs_8(a, gvjs_Nsa) ? b += "The left legend position is not supported for this chart,<br/>either because the chart is maximized,<br/>or because it has data on the left axis." : gvjs_8(a, gvjs_U6) ? b += "This legend position is not supported when the chart is maximized." : gvjs_8(a, gvjs_Osa) ? b += "The right legend position is not supported for this chart,<br/>either because the chart is maximized,<br/>or because it has data on the right axis." : gvjs_8(a, gvjs_Qsa) ? b += "No minor gridlines" : gvjs_8(a, gvjs_X6) ? b += "Slanted labels are not available when the chart is maximized." : gvjs_8(a, gvjs_gw) ? b += "Pie slice border color is not available when the chart is 3D." : gvjs_8(a, "scale") ? b += "Scale is not supported for time based axis." : gvjs_8(a, gvjs_Ew) ? b += 'The min and max for this chart are currently fixed to always show zero.<br/>To enter your own values, uncheck the "show zero" box below.' : gvjs_8(a, gvjs_2w) ? b += "Stacking is not supported for this chart, either because the chart is in log scale, or because the chart has two Y axes." : gvjs_8(a, gvjs_$w) && (b += "Dual axis mode is not supported for stacked charts.");
+  return gvjs_W(b)
+}
+function gvjs_57(a) {
+  a = '<span dir="' + gvjs_7(gvjs_Dv) + '" class="google-visualization-charteditor-tooltip">' + gvjs_FB(a) + gvjs_94;
+  return gvjs_W(a)
+}
+;function gvjs_Yta(a, b) {
+  return "Trendline for " + (gvjs_47(a) + " " + b)
+}
+function gvjs_67(a, b, c) {
+  var d = a.getOption("chxs") || "";
+  d = d.split("*");
+  d[0] = d[0].replace("1N", "");
+  d[b] = c;
+  d[0] = "1N" + d[0];
+  a.ba("chxs", d.join("*"))
+}
+function gvjs_77(a, b) {
+  var c = gvjs_$.ira[a];
+  return gvjs_$.Rba[a] ? c : b && c
+}
+function gvjs_87(a, b) {
+  var c = gvjs_$.Saa[a];
+  return gvjs_$.Rba[a] ? b && c : c
+}
+function gvjs_97(a, b) {
+  a = a.getOption(gvjs_16);
+  return gvjs_ne(a) ? gvjs_He(a, b) : a == b
+}
+function gvjs_Zta(a, b) {
+  if (!gvjs_97(a, b)) {
+    var c = a.getOption(gvjs_16);
+    gvjs_ne(c) ? (c.push(b),
+      a.ba(gvjs_16, c)) : c ? a.ba(gvjs_16, [c, b]) : a.ba(gvjs_16, b)
+  }
+}
+function gvjs__ta(a, b) {
+  if (gvjs_97(a, b)) {
+    var c = a.getOption(gvjs_16);
+    gvjs_ne(c) ? (gvjs_Ie(c, b),
+      a.ba(gvjs_16, c)) : c && a.ba(gvjs_16, null)
+  }
+}
+;function gvjs_$7(a, b, c) {
+  this.JO = c;
+  gvjs_0ta(this, a, b)
+}
+gvjs_ = gvjs_$7.prototype;
+gvjs_.aa = null;
+gvjs_.Z = null;
+gvjs_.qA = null;
+gvjs_.pha = null;
+gvjs_.HE = null;
+gvjs_.g_ = !1;
+gvjs_.bC = null;
+gvjs_.mb = function() {
+  return this.Z
+}
+;
+gvjs_.wZ = function(a) {
+  var b = this.aa.Va()
+    , c = ""
+    , d = this.Z;
+  switch (b) {
+    case gvjs_ra:
+      b = gvjs_1ta(d);
+      Array.isArray(b) && a < b.length && (c = b && b[a]);
+      break;
+    case gvjs_3a:
+      2 == d.$() && (c = d.Ha(a, 0));
+      break;
+    default:
+      c = d.Ga(this.qA[a])
+  }
+  return c
+}
+;
+function gvjs_a8(a) {
+  var b = a.aa.Va()
+    , c = a.Z;
+  if (!gvjs_$.ez[b] || null == c)
+    return 0;
+  switch (b) {
+    case gvjs_ra:
+      return 3 < c.$() && c.W(3) == gvjs_l ? gvjs_1ta(c).length : 1;
+    case gvjs_3a:
+      return (a = a.bC.rows) ? a.length : c.ca()
+  }
+  return a.qA.length
+}
+gvjs_.VP = function() {
+  return this.g_
+}
+;
+function gvjs_b8(a) {
+  var b = a.aa.Va();
+  return gvjs_$.ez[b] && gvjs_$.annotations[b] && null !== a.bC && null !== a.Z ? gvjs_Ue(a.HE, function(c) {
+    return c
+  }) : !1
+}
+function gvjs_2ta(a) {
+  var b = a.aa.Va();
+  return gvjs_$.ez[b] && gvjs_$.annotations[b] && null !== a.bC && null !== a.Z && null !== a.HE ? a.HE : {}
+}
+function gvjs_c8(a, b) {
+  var c = b.$();
+  if (2 > c)
+    return !1;
+  if (b.W(0) != gvjs_g)
+    return !0;
+  if (!gvjs_$.YO[a])
+    return !1;
+  if (a == gvjs_3a && 2 == c)
+    return !0;
+  for (var d = a = 0; d < c; d++)
+    if (b.W(d) == gvjs_g && a++,
+    1 < a)
+      return null;
+  return !1
+}
+function gvjs_0ta(a, b, c) {
+  a.aa = c;
+  a.Z = b;
+  a.qA = [];
+  b = a.aa;
+  var d = a.Z;
+  c = b.Va();
+  c == gvjs_w5 && (c = gvjs_Oa);
+  var e = gvjs_c8(c, d);
+  null === e && (e = b.getOption(gvjs_76, gvjs_$.EH[c]));
+  d = b.getOption(gvjs_46);
+  var f = gvjs_$.YO[c];
+  gvjs_$.YN[c] ? (d = e && d,
+    e = !e) : (d = f && e,
+    e = f && !e);
+  if (f = b.getOption(gvjs_J5))
+    d = e = !1;
+  var g = gvjs_$.V9[c];
+  b = {
+    applyAggregateData: f,
+    booleanRole: b.getOption(gvjs_L5),
+    stringifyFirstColumn: d,
+    emptyLabelsColumn: e,
+    errorBars: g,
+    series: b.getOption(gvjs_Mw),
+    isSparkLine: c == gvjs_Pa
+  };
+  a.pha = b;
+  a.HE = {};
+  a.g_ = !1;
+  b = a.mb();
+  c = a.pha;
+  d = a.Z.$();
+  d = (e = a.aa.pba) && e.columns && gvjs_3ta(e.columns) < d ? e.columns : a.Ua(0, d);
+  if (c.isSparkLine)
+    a.qA = d;
+  else {
+    e = d;
+    1 > b.$() || (c.stringifyFirstColumn && b.W(0) != gvjs_l ? e[0] = {
+      calc: gvjs_Id,
+      sourceColumn: 0,
+      type: gvjs_l
+    } : c.emptyLabelsColumn && e.unshift({
+      calc: "emptyString",
+      sourceColumn: 0,
+      type: gvjs_l
+    }));
+    if (typeof c.applyAggregateData === gvjs_g) {
+      e = new gvjs_Y7(b,a.aa,c.applyAggregateData);
+      var h = e.Z.$();
+      if (1 == h)
+        gvjs_Hta(e);
+      else if (1 < h) {
+        h = 0;
+        f = gvjs_$.V6[e.aa.Va()];
+        for (g = 0; g < e.Z.$(); g++)
+          if (e.rm != g) {
+            if (f && 0 < h)
+              break;
+            if (e.Z.W(g) == gvjs_g) {
+              var k = f ? e.aa.getOption(gvjs_H5) : gvjs_T7(e.aa, h, gvjs_H5);
+              h++;
+              switch (k) {
+                case "average":
+                  k = void 0;
+                  var l = e
+                    , m = g
+                    , n = gvjs_Z7(l, l.rm);
+                  l = gvjs_Kta(l, m);
+                  m = {};
+                  for (k in n)
+                    m[k] = l[k] / n[k];
+                  k = m;
+                  break;
+                case gvjs_Ov:
+                  k = gvjs_Ita(e, g);
+                  break;
+                case gvjs_Gv:
+                  k = gvjs_Jta(e, g);
+                  break;
+                case "count":
+                  k = gvjs_Z7(e, e.rm);
+                  break;
+                case "median":
+                  k = e;
+                  l = g;
+                  n = {};
+                  m = k.Z.ca();
+                  for (var p = 0; p < m; p++) {
+                    var q = k.Z.getValue(p, k.rm)
+                      , r = k.Z.getValue(p, l);
+                    typeof r === gvjs_g && (Array.isArray(n[q]) ? n[q].push(r) : (k.RS || k.PS.push(p),
+                      n[q] = [r]))
+                  }
+                  l = {};
+                  for (q in n)
+                    m = n[q],
+                      gvjs_Qe(m),
+                      p = m.length,
+                      l[q] = 1 == p % 2 ? m[(p - 1) / 2] : (m[p / 2] + m[p / 2 - 1]) / 2;
+                  k.RS = !0;
+                  k = l;
+                  break;
+                default:
+                  k = gvjs_Kta(e, g)
+              }
+              e.dg.push(g);
+              e.ig.push(gvjs__7("mapFromSource", e.rm, gvjs_g, e.Z.Ga(g), k))
+            }
+          }
+        e.ig.length ? e.ig.unshift(gvjs__7(gvjs_Id, e.rm, gvjs_l)) : gvjs_Hta(e)
+      }
+      d = e.Do() || d;
+      h = e.PS.length ? e.PS : null;
+      a.qA = e.Ry() || a.qA
+    }
+    q = d;
+    d = [];
+    e = 0;
+    f = -1;
+    0 < q.length && d.push(q[0]);
+    for (g = 1; g < q.length; g++)
+      if (k = q[g],
+      typeof k === gvjs_g && b.W(k) === gvjs_l)
+        e++,
+          d.push({
+            sourceColumn: k,
+            properties: {
+              role: 1 !== e || a.JO && null != t && t !== gvjs_P5 ? gvjs_jQ : gvjs_Zs
+            },
+            label: b.Ga(k)
+          }),
+          0 <= f ? a.HE[f] = !0 : a.g_ = !0;
+      else if (e = 0,
+        d.push(k),
+      typeof k === gvjs_g && b.W(k) === gvjs_g && (f++,
+        a.qA.push(k),
+        a.JO)) {
+        var t = gvjs_T7(a.aa, f, gvjs_U5);
+        null != t && t === gvjs_Vd && (d.push({
+          calc: gvjs_Id,
+          type: gvjs_l,
+          sourceColumn: k,
+          properties: {
+            role: gvjs_Zs
+          }
+        }),
+          e++)
+      }
+    t = d;
+    for (q = 0; q < t.length; q++)
+      e = t[q],
+      typeof e === gvjs_g && b.W(e) == gvjs_zb && (t[q] = {
+        sourceColumn: e,
+        role: c.booleanRole || gvjs_kQ,
+        label: b.Ga(e)
+      });
+    c.errorBars && gvjs_4ta(d, b, c.series)
+  }
+  a: {
+    for (t = 0; t < d.length; t++)
+      if (d[t] != t) {
+        t = !1;
+        break a
+      }
+    t = !0
+  }
+  a.bC = {
+    columns: t ? null : d,
+    rows: h ? h : null
+  }
+}
+function gvjs_3ta(a) {
+  return gvjs_Ee(a, function(b, c) {
+    return Math.max(b, gvjs_r(c) ? c.sourceColumn : c)
+  }, 0)
+}
+function gvjs_1ta(a) {
+  if (a && 3 < a.$() && 0 < a.ca() && a.W(3) == gvjs_l) {
+    for (var b = a.ca(), c = {}, d = [], e = 0; e < b; e++) {
+      var f = a.Ha(e, 3);
+      c[f] || (d.push(f),
+        c[f] = !0)
+    }
+    return d
+  }
+  return []
+}
+gvjs_.Ua = function(a, b) {
+  for (var c = []; a < b; a++)
+    c.push(a);
+  return c
+}
+;
+function gvjs_4ta(a, b, c) {
+  var d = 1
+    , e = 0;
+  c = c || {};
+  for (c = gvjs_Ny(c, function(k) {
+    return k && k.errorBars
+  }); d < a.length; ) {
+    var f = a[d];
+    if (typeof f === gvjs_g && b.W(f) == gvjs_g) {
+      var g = c[e] || {}
+        , h = g.magnitude;
+      h = null != h ? h : 10;
+      g = g.errorType || gvjs_f;
+      0 < h && g != gvjs_f && (d++,
+        gvjs_fq(a, {
+          type: gvjs_g,
+          calc: gvjs_Rb,
+          sourceColumn: f,
+          magnitude: -1 * h,
+          errorType: g,
+          role: gvjs_iv
+        }, d),
+        d++,
+        gvjs_fq(a, {
+          type: gvjs_g,
+          calc: gvjs_Rb,
+          sourceColumn: f,
+          magnitude: h,
+          errorType: g,
+          role: gvjs_iv
+        }, d));
+      e++
+    }
+    d++
+  }
+}
+;function gvjs_d8(a, b) {
+  return gvjs_e8(a, 0, b) && gvjs_e8(a, 1, b)
+}
+function gvjs_e8(a, b, c) {
+  var d = a.Va();
+  if (d == gvjs_ua)
+    return 0 == b;
+  if (gvjs_$.ez[d] && (0 == b || gvjs_$.UH[d])) {
+    a = a.getOption(gvjs_Mw) || {};
+    for (d = 0; d < c; d++)
+      if (((a[d] || {}).targetAxisIndex || 0) == b)
+        return !0;
+    if (0 == b)
+      return 0 == c
+  }
+  return !1
+}
+function gvjs_f8(a, b, c) {
+  b = b.split(".");
+  for (var d = 0; d < b.length - 1; d++)
+    a[b[d]] = a[b[d]] || {},
+      a = a[b[d]];
+  b = b[b.length - 1];
+  a[b] = null != a[b] ? a[b] : c
+}
+function gvjs_5ta(a, b, c) {
+  var d = a.Va();
+  switch (d) {
+    case "FunctionChart":
+      d = gvjs_ya;
+      break;
+    case gvjs_Oa:
+      d = gvjs_w5
+  }
+  a.cc(d);
+  gvjs_6ta(a);
+  d = a.Va();
+  var e = a.Zc();
+  switch (d) {
+    case gvjs_na:
+      gvjs_f8(e, gvjs_jv, !1);
+      break;
+    case gvjs_qa:
+      gvjs_f8(e, gvjs_jv, !1);
+      break;
+    case gvjs_xa:
+      gvjs_f8(e, gvjs_jv, !1);
+      break;
+    case gvjs_Ha:
+      gvjs_f8(e, "displayMode", gvjs_yd);
+      break;
+    case gvjs_Va:
+      gvjs_f8(e, gvjs_8t, "");
+      break;
+    case gvjs_3a:
+      gvjs_f8(e, "is3D", !1),
+        gvjs_f8(e, "pieHole", 0)
+  }
+  a.setOptions(e);
+  a.oL(null);
+  switch (a.Va()) {
+    case gvjs_ma:
+      a.ba("wmode", "opaque");
+      break;
+    case gvjs_ua:
+      a.ba(gvjs_rv, gvjs_f);
+      break;
+    case gvjs_ya:
+      a.ba(gvjs_Sd, gvjs_e);
+      break;
+    case gvjs_w5:
+      a.ba("cht", "rs");
+      d = a.getOption(gvjs_mw) || [];
+      e = a.getOption(gvjs_2t) || [];
+      for (var f = [], g = 0; g < d.length; g++)
+        if (d[g]) {
+          var h = d[g]
+            , k = e[g] || gvjs_ca;
+          k = k.replace("#", "");
+          h = [h.shape, k, g, -1, h.size];
+          h = h.join(",");
+          f.push(h)
+        }
+      a.ba("chm", f.join("|"));
+      break;
+    case gvjs_2a:
+      a.ba("allowCollapse", !0);
+      break;
+    case gvjs_9a:
+      a.ba(gvjs_Bv, 0);
+      break;
+    case gvjs_mb:
+      a.oL(gvjs_Zd)
+  }
+  e = a.Va();
+  d = a.Zc();
+  gvjs_f8(d, gvjs_L5, gvjs_kQ);
+  f = [gvjs_vr, "#EFE6DC", gvjs_lr];
+  switch (e) {
+    case gvjs_q5:
+      gvjs_f8(d, gvjs_dY, !0);
+      break;
+    case gvjs_ma:
+      gvjs_f8(d, gvjs_dY, !0);
+      break;
+    case gvjs_ra:
+      gvjs_f8(d, gvjs_2t, gvjs_Le(gvjs_P7));
+      break;
+    case gvjs_ya:
+      gvjs_f8(d, gvjs_Mw, [{
+        type: gvjs_lt
+      }]);
+      break;
+    case gvjs_Ha:
+      gvjs_f8(d, gvjs_2t, f);
+      e = a.getOption(gvjs_rT) || "#f5f5f5";
+      gvjs_f8(d, gvjs_sT, e);
+      break;
+    case gvjs_La:
+      gvjs_f8(d, gvjs_6u, !0);
+      break;
+    case gvjs_w5:
+      gvjs_f8(d, gvjs_2t, gvjs_Le(gvjs_P7));
+      break;
+    case gvjs_Pa:
+      gvjs_f8(d, gvjs_2t, gvjs_Le(gvjs_P7));
+      gvjs_f8(d, "labelPosition", gvjs_j);
+      break;
+    case gvjs_Va:
+      gvjs_f8(d, gvjs_Bv, 2);
+      break;
+    case gvjs_Wa:
+      gvjs_f8(d, gvjs_vT, gvjs_uT);
+      gvjs_f8(d, "showTip", !0);
+      break;
+    case gvjs_9a:
+      gvjs_f8(d, gvjs_jw, 7);
+      break;
+    case gvjs_hb:
+      gvjs_f8(d, gvjs_Du, gvjs_Br),
+        gvjs_f8(d, gvjs_zp, "14"),
+        gvjs_f8(d, gvjs_Zu, gvjs_Y4),
+        gvjs_f8(d, gvjs_Kv, 2),
+        gvjs_f8(d, gvjs__u, 40),
+        gvjs_f8(d, gvjs_Vw, !1),
+        gvjs_f8(d, gvjs_Pv, f[0]),
+        gvjs_f8(d, gvjs_Mv, f[1]),
+        gvjs_f8(d, gvjs_Jv, f[2])
+  }
+  a.setOptions(d);
+  if (b) {
+    b = new gvjs_$7(b,a,!!c);
+    c = b.bC || {};
+    a.RE(c);
+    e = gvjs_Rk(b.mb(), c).W(0) == gvjs_g;
+    c = a.Va();
+    f = a.getOption(gvjs_Hx) || [];
+    d = f[0] || {};
+    f = f[1] || {};
+    g = a.getOption(gvjs_Xu) || {};
+    e = gvjs_$.YO[c] && gvjs_$.zma[c] && !e;
+    c == gvjs_qa ? (gvjs_7ta(d, e),
+      gvjs_g8(g)) : (gvjs_7ta(g, e),
+      gvjs_g8(d),
+      gvjs_g8(f));
+    a.ba(gvjs_Hx, [d, f]);
+    a.ba(gvjs_Xu, g);
+    for (c = 0; c < gvjs_a8(b); c++) {
+      d = c;
+      if (e = gvjs_b8(b))
+        e = b,
+          f = c,
+          e = gvjs_b8(e) && !!e.HE[f];
+      gvjs_U7(a, d, gvjs_I6, e ? !0 : null)
+    }
+    a.ba(gvjs_1s, b.VP() ? gvjs_e : null);
+    f = gvjs_a8(b);
+    b = a.getOption(gvjs_rv);
+    c = a.getOption(gvjs_16) == gvjs_Lv;
+    d = gvjs_e8(a, 0, f);
+    e = gvjs_e8(a, 1, f);
+    f = gvjs_d8(a, f);
+    a.Va() == gvjs_3a ? c && gvjs_He([null, gvjs_vt, gvjs_vx], b) && a.ba(gvjs_rv, gvjs_j) : c ? gvjs_He([null, gvjs_vt, gvjs_$c, gvjs_j, gvjs_vx], b) && a.ba(gvjs_rv, gvjs_Fp) : f ? gvjs_He([null, gvjs_j, gvjs_$c], b) && a.ba(gvjs_rv, gvjs_vx) : e ? gvjs_He([null, gvjs_j], b) && a.ba(gvjs_rv, gvjs_$c) : d && gvjs_He([null, gvjs_$c], b) && a.ba(gvjs_rv, gvjs_j);
+    if (a.getOption(gvjs_jv))
+      if (a.Va() == gvjs_qa)
+        a.ba(gvjs_F6, !1);
+      else if (a.ba(gvjs_$6, !1),
+        a.ba(gvjs_5sa, !1),
+        f) {
+        b = a.getOption(gvjs_Mw) || {};
+        for (var l in b)
+          b[l].targetAxisIndex = 0
+      }
+  }
+  gvjs_8ta(a)
+}
+function gvjs_8ta(a) {
+  a.Va();
+  gvjs_u([gvjs_Xu, gvjs_86, gvjs_b7], function(b) {
+    var c = !!a.getOption(b + ".logScale")
+      , d = b + gvjs_Dqa;
+    c && a.getOption(d, gvjs_$t) == gvjs_$t && a.ba(d, gvjs_ev);
+    switch (a.getOption(b + gvjs_Dqa, gvjs_$t)) {
+      case gvjs_$t:
+        a.ba(b + gvjs_ja, null);
+        a.ba(b + gvjs_54, !0);
+        break;
+      case gvjs_f:
+        a.ba(b + gvjs_ja, null);
+        a.ba(b + gvjs_54, !1);
+        break;
+      case gvjs_ev:
+        a.ba(b + gvjs_ja, "0.##"),
+          a.ba(b + gvjs_54, !1)
+    }
+  })
+}
+function gvjs_g8(a) {
+  var b = a.viewWindow || {}
+    , c = typeof b.min === gvjs_g ? b.min : null;
+  b = typeof b.max === gvjs_g ? b.max : null;
+  var d = typeof a.minValue === gvjs_g ? a.minValue : null
+    , e = typeof a.maxValue === gvjs_g ? a.maxValue : null
+    , f = a.viewWindowMode != gvjs_su;
+  c = typeof d === gvjs_g ? d : f ? c : null;
+  b = typeof e === gvjs_g ? e : f ? b : null;
+  null == b && null == c ? delete a.viewWindowMode : gvjs_f8(a, gvjs_Lx, gvjs_su);
+  a.viewWindow = {
+    max: b,
+    min: c
+  };
+  a.minValue = c;
+  a.maxValue = b
+}
+function gvjs_9ta(a) {
+  var b = a.getOption(gvjs_ht)
+    , c = typeof b === gvjs_l;
+  gvjs_$.bU[a.Va()] ? c && (a.ba(gvjs_ht, null),
+    a.ba(gvjs_it, b)) : c || (b = a.getOption(gvjs_it),
+    a.ba(gvjs_ht, b))
+}
+function gvjs_6ta(a) {
+  var b = a.Va();
+  if (null == a.getOption(gvjs_Hx) && (b == gvjs_na || b == gvjs_xa || b == gvjs_ya || b == gvjs_Va)) {
+    var c = {};
+    c.title = a.getOption(gvjs_jx);
+    c.minValue = a.getOption(gvjs_Ov);
+    c.maxValue = a.getOption(gvjs_Gv);
+    a.ba(gvjs_Hx, [c]);
+    a.ba(gvjs_jx, null);
+    a.ba(gvjs_Ov, null);
+    a.ba(gvjs_Gv, null)
+  }
+  c = a.getOption(gvjs__6);
+  a.ba(gvjs__6, null);
+  typeof c === gvjs_zb && c && a.ba(gvjs_8t, gvjs_d);
+  c = a.getOption(gvjs_xw);
+  typeof c === gvjs_zb && (a.ba(gvjs_W5, c ? -1 : 1),
+    a.ba(gvjs_ww, null),
+    a.ba(gvjs_xw, null));
+  c = a.getOption(gvjs_3c);
+  typeof c === gvjs_zb && (a.ba(gvjs_76, c),
+    a.ba(gvjs_3c, null));
+  c = a.getOption(gvjs_S6);
+  b !== gvjs_9a || c || a.ba(gvjs_46, !1);
+  a.ba(gvjs_S6, !0);
+  (c = a.getOption(gvjs_R6)) ? typeof a.getOption(gvjs_46) !== gvjs_zb && b && a.ba(gvjs_46, !gvjs_$.Ima[b]) : !1 === c && (a.ba(gvjs_R6, !0),
+    a.ba(gvjs_46, !1));
+  gvjs_u(["", gvjs_96, gvjs_c7, gvjs_E6], function(d) {
+    a.getOption(d + gvjs_hx) && a.ba(d + "titleFontStyle.fontSize", a.getOption(d + gvjs_hx))
+  });
+  a.getOption(gvjs_Cv) && (b == gvjs_qa ? a.ba(gvjs_F6, !0) : a.ba(gvjs_$6, !0));
+  a.ba(gvjs_Cv, null);
+  gvjs_9ta(a)
+}
+function gvjs_7ta(a, b) {
+  b ? gvjs_u([gvjs_ed, gvjs_cd, "viewWindow", gvjs_Lx], function(c) {
+    a[c] = null
+  }) : gvjs_g8(a)
+}
+;function gvjs_h8(a) {
+  for (var b in gvjs_$ta) {
+    var c = gvjs_$ta[b]
+      , d = gvjs_0e(c);
+    d.name = a[1] + "." + c.name;
+    gvjs_r(c.defaultValue) && (d.defaultValue = c.defaultValue[a[0]]);
+    gvjs_r(c.handler) && (typeof c.handler.get === gvjs_d && (d.handler.get = gvjs_re(c.handler.get, a)),
+    typeof c.handler.set === gvjs_d && (d.handler.set = gvjs_re(c.handler.set, a)));
+    gvjs_r(c.L) && typeof c.L.nl === gvjs_d && (d.L.nl = gvjs_re(c.L.nl, a));
+    gvjs_r(c.L) && typeof c.L.ub === gvjs_d && (d.L.ub = gvjs_re(c.L.ub, a));
+    gvjs_i8[b + "-" + a[0]] = d
+  }
+}
+var gvjs_aua = {
+  get: function(a, b, c) {
+    a = gvjs_T7(c, b, gvjs_9s, {});
+    a = gvjs_x(a);
+    a.color = a.color || gvjs_M6;
+    a.fontSize = a.fontSize || 12;
+    return a
+  },
+  set: function(a, b, c, d) {
+    d.color = d.color != gvjs_M6 ? d.color : null;
+    gvjs_U7(c, b, gvjs_3s, null === d.color);
+    gvjs_U7(c, b, gvjs_9s, d)
+  }
+}
+  , gvjs_bua = {
+  get: function(a, b, c) {
+    a = gvjs_T7(c, b, gvjs_I6, !1) ? gvjs_P5 : gvjs_f;
+    return gvjs_T7(c, b, gvjs_U5, a)
+  },
+  set: function(a, b, c, d) {
+    gvjs_U7(c, b, gvjs_6s, d === gvjs_P5 ? null : gvjs_f);
+    gvjs_U7(c, b, gvjs_U5, d)
+  }
+}
+  , gvjs_cua = {
+  get: function(a, b, c) {
+    a = gvjs_T7(c, b, gvjs_Usa, gvjs_4o);
+    var d = gvjs_T7(c, b, gvjs_Tsa, 5);
+    gvjs_T7(c, b, gvjs_Ssa, 0);
+    a === gvjs_pw ? 5 === d ? a = "pentagon" : 6 === d && (a = "hexagon") : a === gvjs_3w && 4 === d && (a = gvjs_e7);
+    return a
+  },
+  set: function(a, b, c, d) {
+    a = null;
+    "hexagon" === d ? a = 6 : d === gvjs_e7 && (a = 4);
+    gvjs_U7(c, b, gvjs_Tsa, a);
+    gvjs_U7(c, b, gvjs_Ssa, d === gvjs_e7 ? 45 : null);
+    gvjs_U7(c, b, "pointShape.dent", d === gvjs_e7 ? .15 : null);
+    switch (d) {
+      case "pentagon":
+      case "hexagon":
+        d = gvjs_pw;
+        break;
+      case gvjs_e7:
+        d = gvjs_3w
+    }
+    gvjs_U7(c, b, gvjs_Usa, d);
+    gvjs_T7(c, b, gvjs_jw) || gvjs_U7(c, b, gvjs_jw, 10)
+  }
+}
+  , gvjs_dua = {
+  get: function(a, b, c) {
+    a = gvjs_T7(c, b, gvjs_jw);
+    return typeof a === gvjs_g ? a : a = c.Va() == gvjs_9a ? 7 : 0
+  },
+  set: function(a, b, c) {
+    typeof value === gvjs_l && (value = Number(value));
+    gvjs_U7(c, b, gvjs_jw, value)
+  }
+}
+  , gvjs_eua = {
+  get: gvjs_9sa(void 0),
+  set: function(a, b, c, d, e) {
+    e === gvjs_Xw ? gvjs_dua.set(a, b, c, d) : e === gvjs_Rw && gvjs_cua.set(a, b, c, d)
+  }
+}
+  , gvjs_fua = {
+  get: function(a, b, c) {
+    a = c.getOption(gvjs_56);
+    var d;
+    a && (d = a[b]);
+    return d ? d.type : gvjs_f
+  },
+  set: function(a, b, c, d) {
+    a = c.getOption(gvjs_56) || {};
+    var e = gvjs_Yta(c.getType(), b + 1)
+      , f = void 0;
+    d && -1 != d.indexOf("-") && (f = Number(d.substr(d.indexOf("-") + 1)),
+      d = d.substr(0, d.indexOf("-")));
+    d == gvjs_f ? gvjs_Qy(a, b) : (a[b] = a[b] || {},
+      a[b].type = d,
+      a[b].pointSize = 0,
+      a[b].visibleInLegend = void 0 !== a[b].visibleInLegend ? a[b].visibleInLegend : !0,
+      a[b].lineWidth = a[b].lineWidth || 2,
+      a[b].opacity = a[b].opacity || .4,
+      a[b].labelInLegend = void 0 !== a[b].labelInLegend ? a[b].labelInLegend : e,
+      a[b].showR2 = a[b].showR2 || !1,
+      a[b].degree = f || a[b].degree || 2);
+    b = gvjs_Oh();
+    (e = b.hd(gvjs_u6)) && gvjs_6(e, d != gvjs_f);
+    (b = b.hd(gvjs_s6)) && gvjs_6(b, "polynomial" === d);
+    c.ba(gvjs_56, a)
+  }
+}
+  , gvjs_gua = {
+  get: function(a, b, c) {
+    return (a = c.getOption(gvjs_56)) && a[b] ? a[b].showR2 || !1 : !1
+  },
+  set: function(a, b, c, d) {
+    (a = c.getOption(gvjs_56)) && a[b] && (a[b].showR2 = d,
+      c.ba(gvjs_56, a))
+  }
+}
+  , gvjs_hua = {
+  get: function(a) {
+    var b = a.getOption(gvjs_G6);
+    a = a.getOption(gvjs_Csa);
+    return null === b ? null : b ? a : 0
+  },
+  set: function(a, b) {
+    var c;
+    null === b ? b = c = null : "0" == b ? (c = !1,
+      b = null) : (c = !0,
+      b = parseFloat(b));
+    a.ba(gvjs_Csa, b);
+    a.ba(gvjs_G6, c)
+  }
+};
+function gvjs_j8(a, b, c) {
+  var d = b.Va() == gvjs_qa ? gvjs_Fta : gvjs_Eta;
+  if (a != d)
+    return !0;
+  if (!c)
+    return !1;
+  a = gvjs_Rk(c, b.Ni || {}).W(0);
+  return a == gvjs_g || a == gvjs_l
+}
+function gvjs_iua(a, b) {
+  return gvjs_Q7(b, a, gvjs_hra) == gvjs_ev
+}
+function gvjs_jua(a, b) {
+  if (a.Va() == gvjs_qa)
+    return !a.getOption(gvjs_F6);
+  b = (b = b ? new gvjs_$7(b,a,!1) : null) ? gvjs_a8(b) : 0;
+  return gvjs_d8(a, b) ? !1 : gvjs_e8(a, 0, b) ? !a.getOption(gvjs_$6) : gvjs_e8(a, 1, b) ? !a.getOption(gvjs_5sa) : !0
+}
+function gvjs_kua(a) {
+  return !a.getOption("is3D")
+}
+function gvjs_lua(a) {
+  return !!a.getOption(gvjs_zT)
+}
+function gvjs_k8(a, b) {
+  var c = b.Va() === gvjs_ya;
+  a = gvjs_T7(b, a, gvjs_Sd);
+  return !c || !a || a === gvjs_e || a === gvjs_at
+}
+function gvjs_mua(a) {
+  return a.Va() == gvjs_ma || a.Va() == gvjs_q5 ? a.getOption(gvjs_Ew) == gvjs_V6 : !0
+}
+function gvjs_l8(a) {
+  return a.getOption(gvjs_Zsa, !0)
+}
+function gvjs_nua(a) {
+  return !gvjs_97(a, gvjs_Lv)
+}
+function gvjs_oua(a) {
+  return a.getOption(gvjs_hw) != gvjs_f
+}
+function gvjs_pua(a, b) {
+  return (b = b.getOption(gvjs_56)) && b[a] && b[a].visibleInLegend
+}
+var gvjs_i8 = {
+  "google-visualization-charteditor-comparison-mode": {
+    type: gvjs_Ut,
+    name: gvjs_yu,
+    handler: {
+      get: function(a) {
+        return a.getOption(gvjs_yu) == gvjs_Ht
+      },
+      set: function(a, b) {
+        a.ba(gvjs_yu, b ? gvjs_Ht : null)
+      }
+    },
+    L: {
+      N: 1387
+    }
+  },
+  "google-visualization-charteditor-checkbox-trendlines": {
+    type: gvjs_Ut,
+    name: gvjs_pb,
+    L: {
+      N: 1420
+    }
+  },
+  "google-visualization-charteditor-checkbox-3d": {
+    type: gvjs_Ut,
+    name: "is3D",
+    defaultValue: !1,
+    L: {
+      N: 1383
+    }
+  },
+  "google-visualization-charteditor-checkbox-headers": {
+    type: gvjs_Ut,
+    handler: {
+      set: function(a, b) {
+        var c = a.cf || "";
+        c = gvjs_k7(c, gvjs_J6, !0 === b ? "1" : "0");
+        a.yh(c)
+      },
+      get: function(a) {
+        return "1" == gvjs_Wm(a.cf || "", gvjs_J6)
+      }
+    },
+    L: {
+      N: 1392,
+      ub: function(a, b) {
+        return 0 < (b && b.ca() || 0)
+      }
+    }
+  },
+  "google-visualization-charteditor-checkbox-maximize": {
+    type: gvjs_Ut,
+    handler: {
+      get: function(a) {
+        return gvjs_97(a, gvjs_Lv)
+      },
+      set: function(a, b) {
+        b ? (a.ba(gvjs_3o, null),
+          a.ba(gvjs__o, null),
+          a.ba(gvjs_2o, null),
+          a.ba(gvjs_0o, null),
+          gvjs_Zta(a, gvjs_Lv)) : gvjs__ta(a, gvjs_Lv)
+      }
+    },
+    L: {
+      N: 1399
+    }
+  },
+  "google-visualization-charteditor-checkbox-plot-nulls": {
+    type: gvjs_Ut,
+    name: gvjs_hv,
+    defaultValue: !1,
+    L: {
+      N: 1401
+    }
+  },
+  "google-visualization-charteditor-checkbox-reverse-axis": {
+    type: gvjs_Ut,
+    name: gvjs_W5,
+    defaultValue: 1,
+    handler: {
+      get: function(a) {
+        return -1 == a.getOption(gvjs_W5)
+      },
+      set: function(a, b) {
+        a.ba(gvjs_W5, b ? -1 : 1)
+      }
+    },
+    L: {
+      N: 1403
+    }
+  },
+  "google-visualization-charteditor-checkbox-smooth": {
+    type: gvjs_Ut,
+    name: gvjs__6,
+    defaultValue: !1,
+    handler: {
+      set: function(a, b) {
+        a.ba(gvjs_8t, b ? gvjs_d : null)
+      },
+      get: function(a) {
+        return a.getOption(gvjs_8t) == gvjs_d
+      }
+    },
+    L: {
+      N: 1416
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-scale": {
+    type: gvjs_Ut,
+    name: "showScale",
+    defaultValue: !1,
+    L: {
+      N: 1411
+    }
+  },
+  "google-visualization-charteditor-checkbox-transpose": {
+    type: gvjs_Ut,
+    handler: {
+      set: function(a, b) {
+        var c = a.cf || "";
+        c = gvjs_k7(c, "transpose", !0 === b ? "1" : "0");
+        a.yh(c)
+      },
+      get: function(a) {
+        return "1" == gvjs_Wm(a.cf || "", "transpose")
+      }
+    },
+    L: {
+      N: 1419
+    }
+  },
+  "google-visualization-charteditor-checkbox-quantum-lite-theme": {
+    type: gvjs_Ut,
+    handler: {
+      get: function(a) {
+        return gvjs_97(a, gvjs_Fv)
+      },
+      set: function(a, b) {
+        b ? gvjs_Zta(a, gvjs_Fv) : gvjs__ta(a, gvjs_Fv)
+      }
+    }
+  },
+  "google-visualization-charteditor-checkox-labels-column": {
+    type: gvjs_Ut,
+    name: gvjs_76,
+    defaultValue: !1,
+    handler: {
+      get: function(a) {
+        var b = a.Va();
+        return a.getOption(gvjs_76, gvjs_$.EH[b])
+      },
+      set: function(a, b) {
+        a.ba(gvjs_76, b)
+      }
+    },
+    L: {
+      N: 1394,
+      ub: function(a, b) {
+        if (!b)
+          return !1;
+        a = a.Va();
+        return null == gvjs_c8(a, b)
+      }
+    }
+  },
+  "google-visualization-charteditor-checkbox-fill": {
+    type: gvjs_Ut,
+    name: gvjs_np,
+    defaultValue: null,
+    L: {
+      N: 1391
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-labels": {
+    type: gvjs_Ut,
+    name: gvjs_Zsa,
+    defaultValue: !0,
+    L: {
+      N: 1408
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-separator": {
+    type: gvjs_Ut,
+    name: gvjs_Ysa,
+    defaultValue: !1,
+    handler: {
+      set: function(a, b) {
+        a.ba(gvjs_Ysa, b);
+        gvjs_67(a, 1, b ? "s" : "")
+      }
+    },
+    L: {
+      N: 1412,
+      ub: gvjs_l8
+    }
+  },
+  "google-visualization-charteditor-checkbox-stack": {
+    type: gvjs_Ut,
+    name: gvjs_jv,
+    defaultValue: !1,
+    L: {
+      Lk: gvjs_2w,
+      N: 1418,
+      ub: gvjs_jua
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-tip": {
+    type: gvjs_Ut,
+    name: ["showTip", gvjs_Vw],
+    defaultValue: !1,
+    L: {
+      N: 1413
+    }
+  },
+  "google-visualization-charteditor-checkbox-item-divisions": {
+    type: gvjs_Ut,
+    name: [gvjs_6u],
+    defaultValue: !0,
+    L: {
+      N: 1393
+    }
+  },
+  "google-visualization-charteditor-color-background": {
+    type: gvjs_1,
+    name: gvjs_ht,
+    defaultValue: gvjs_xr,
+    handler: {
+      get: function(a) {
+        a = a.getOption(gvjs_ht);
+        gvjs_r(a) && (a = a.fill);
+        return a || gvjs_xr
+      },
+      set: function(a, b) {
+        typeof a.getOption(gvjs_ht) === gvjs_l ? a.ba(gvjs_ht, b) : a.ba(gvjs_it, b)
+      }
+    },
+    L: {
+      N: 1423
+    }
+  },
+  "google-visualization-charteditor-color-chartarea": {
+    type: gvjs_1,
+    name: "chartArea.backgroundColor.fill",
+    defaultValue: gvjs_xr,
+    L: {
+      N: 1424
+    }
+  },
+  "google-visualization-charteditor-color-line-domain-annotations": {
+    type: gvjs_1,
+    name: gvjs_0s,
+    defaultValue: gvjs_sr,
+    L: {
+      N: 1430
+    }
+  },
+  "google-visualization-charteditor-color-font-bubble": {
+    type: gvjs_1,
+    name: "bubble.textStyle.color",
+    defaultValue: gvjs_X4,
+    L: {
+      N: 1425
+    }
+  },
+  "google-visualization-charteditor-color-stroke-bubble": {
+    type: gvjs_1,
+    name: "bubble.stroke",
+    defaultValue: "#666",
+    L: {
+      N: 1440
+    }
+  },
+  "google-visualization-charteditor-color-font-slice": {
+    type: gvjs_1,
+    name: "pieSliceTextStyle.color",
+    defaultValue: gvjs_Br,
+    L: {
+      N: 1426,
+      ub: gvjs_oua
+    }
+  },
+  "google-visualization-charteditor-color-slice-border": {
+    type: gvjs_1,
+    name: gvjs_gw,
+    defaultValue: gvjs_Br,
+    L: {
+      Lk: gvjs_gw,
+      N: 1439,
+      ub: gvjs_kua
+    }
+  },
+  "google-visualization-charteditor-color-min": {
+    type: gvjs_1,
+    name: gvjs_Pv,
+    defaultValue: gvjs_yr,
+    handler: {
+      get: function(a) {
+        return gvjs_W7(a)[0]
+      },
+      set: function(a, b) {
+        gvjs_X7(a, b, null, null)
+      }
+    },
+    L: {
+      N: 1433
+    }
+  },
+  "google-visualization-charteditor-color-mid": {
+    type: gvjs_1,
+    name: gvjs_Mv,
+    defaultValue: "#36c",
+    handler: {
+      get: function(a) {
+        return gvjs_W7(a)[1]
+      },
+      set: function(a, b) {
+        gvjs_X7(a, null, b, null)
+      }
+    },
+    L: {
+      N: 1432
+    }
+  },
+  "google-visualization-charteditor-color-max": {
+    type: gvjs_1,
+    name: gvjs_Jv,
+    defaultValue: gvjs_X4,
+    handler: {
+      get: function(a) {
+        return gvjs_W7(a)[2]
+      },
+      set: function(a, b) {
+        gvjs_X7(a, null, null, b)
+      }
+    },
+    L: {
+      N: 1431
+    }
+  },
+  "google-visualization-charteditor-color-no-value": {
+    type: gvjs_1,
+    name: [gvjs_rT, gvjs_sT],
+    defaultValue: "#F5F5F5",
+    L: {
+      N: 1436
+    }
+  },
+  "google-visualization-charteditor-font-style-legend": {
+    type: gvjs_Z5,
+    name: gvjs_yv,
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12
+    },
+    L: {
+      N: 1464,
+      ub: function(a) {
+        return a.getOption(gvjs_rv) != gvjs_f
+      },
+      Ve: {
+        min: 1,
+        max: 20,
+        Og: !0
+      }
+    }
+  },
+  "google-visualization-charteditor-font-style-title": {
+    type: gvjs_Z5,
+    name: gvjs_ix,
+    defaultValue: {
+      color: gvjs_kr,
+      fontSize: 12,
+      bold: !0
+    },
+    L: {
+      N: 1465,
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      }
+    }
+  },
+  "google-visualization-charteditor-font-style-domain-annotations": {
+    type: gvjs_Z5,
+    name: gvjs_2s,
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1463
+    }
+  },
+  "google-visualization-charteditor-font-style-axisx": {
+    type: gvjs_Z5,
+    name: "hAxis.textStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1461
+    }
+  },
+  "google-visualization-charteditor-font-style-axisy": {
+    type: gvjs_Z5,
+    name: "vAxes.0.textStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1462
+    }
+  },
+  "google-visualization-charteditor-font-style-axis-right": {
+    type: gvjs_Z5,
+    name: "vAxes.1.textStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1460
+    }
+  },
+  "google-visualization-charteditor-font-style-titlex": {
+    type: gvjs_Z5,
+    name: "hAxis.titleTextStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12,
+      italic: !0
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1467
+    }
+  },
+  "google-visualization-charteditor-font-style-titley": {
+    type: gvjs_Z5,
+    name: "vAxes.0.titleTextStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12,
+      italic: !0
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1468
+    }
+  },
+  "google-visualization-charteditor-font-style-title-right": {
+    type: gvjs_Z5,
+    name: "vAxes.1.titleTextStyle",
+    defaultValue: {
+      color: gvjs_X4,
+      fontSize: 12,
+      italic: !0
+    },
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      },
+      N: 1466
+    }
+  },
+  "google-visualization-charteditor-input-bucket-size": {
+    type: gvjs_m,
+    name: gvjs_5u,
+    defaultValue: null,
+    L: {
+      N: 1471,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-bucket-outlier-percentile": {
+    type: gvjs_m,
+    name: gvjs_7u,
+    defaultValue: null,
+    L: {
+      N: 1470,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-max": {
+    type: gvjs_m,
+    name: gvjs_Gv,
+    defaultValue: null,
+    L: {
+      Lk: gvjs_Ew,
+      N: 1482,
+      isNumeric: !0,
+      ub: gvjs_mua
+    }
+  },
+  "google-visualization-charteditor-input-min": {
+    type: gvjs_m,
+    name: gvjs_Ov,
+    defaultValue: null,
+    L: {
+      Lk: gvjs_Ew,
+      N: 1489,
+      isNumeric: !0,
+      ub: gvjs_mua
+    }
+  },
+  "google-visualization-charteditor-input-max-color-value": {
+    type: gvjs_m,
+    name: "maxColorValue",
+    defaultValue: null,
+    L: {
+      N: 1485,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-min-color-value": {
+    type: gvjs_m,
+    name: "minColorValue",
+    defaultValue: null,
+    L: {
+      N: 1490,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-titlex": {
+    type: gvjs_m,
+    name: gvjs_H6,
+    defaultValue: null,
+    L: {
+      N: 1497
+    }
+  },
+  "google-visualization-charteditor-input-titley": {
+    type: gvjs_m,
+    name: gvjs_a7,
+    defaultValue: null,
+    L: {
+      N: 1498
+    }
+  },
+  "google-visualization-charteditor-input-title-right": {
+    type: gvjs_m,
+    name: gvjs_d7,
+    defaultValue: null,
+    L: {
+      N: 1496
+    }
+  },
+  "google-visualization-charteditor-input-height": {
+    type: gvjs_m,
+    name: gvjs_4c,
+    defaultValue: null,
+    L: {
+      N: 1481,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-width": {
+    type: gvjs_m,
+    name: gvjs_Xd,
+    defaultValue: null,
+    L: {
+      N: 1501,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-chart-name": {
+    type: gvjs_m,
+    name: gvjs_Zv,
+    defaultValue: "",
+    handler: {
+      get: function(a) {
+        return a.iZ()
+      },
+      set: function(a, b) {
+        a.C3(b)
+      }
+    },
+    L: {
+      MI: gvjs_wh(gvjs_r7(function(a) {
+        a = a.key;
+        var b = "";
+        gvjs_8(a, "from") ? b += "From" : gvjs_8(a, "to") ? b += "To" : gvjs_8(a, "chartName") ? b += "Chart name" : gvjs_8(a, "chartTitle") ? b += gvjs_s5 : gvjs_8(a, "horizontalTitle") ? b += "Horizontal title" : gvjs_8(a, "verticalTitle") ? b += "Vertical title" : gvjs_8(a, "millionsExample") ? b += 'e.g., "M"' : gvjs_8(a, "dollarsExample") ? b += "e.g., $" : gvjs_8(a, "rangeExample") && (b += "0-100");
+        return gvjs_W(b)
+      }, {
+        key: "chartName"
+      })),
+      N: 1472
+    }
+  },
+  "google-visualization-charteditor-input-chart-title": {
+    type: gvjs_m,
+    name: gvjs_fx,
+    defaultValue: "",
+    L: {
+      N: 1473
+    }
+  },
+  "google-visualization-charteditor-input-prefix": {
+    type: gvjs_m,
+    name: "valuesPrefix",
+    defaultValue: "",
+    handler: {
+      set: function(a, b) {
+        a.ba("valuesPrefix", b);
+        gvjs_67(a, 0, b)
+      }
+    },
+    L: {
+      N: 1492,
+      ub: gvjs_l8
+    }
+  },
+  "google-visualization-charteditor-input-suffix": {
+    type: gvjs_m,
+    name: "valuesSuffix",
+    defaultValue: "",
+    handler: {
+      set: function(a, b) {
+        a.ba("valuesSuffix", b);
+        gvjs_67(a, 2, b)
+      }
+    },
+    L: {
+      N: 1495,
+      ub: gvjs_l8
+    }
+  },
+  "google-visualization-charteditor-combo-background-opacity": {
+    type: gvjs_O5,
+    name: "backgroundColor.fillOpacity",
+    defaultValue: 1,
+    L: {
+      Ve: {
+        min: 0,
+        max: 1,
+        suffix: "%",
+        scale: 100
+      },
+      N: 1443
+    }
+  },
+  "google-visualization-charteditor-combo-chartarea-opacity": {
+    type: gvjs_O5,
+    name: "chartArea.backgroundColor.fillOpacity",
+    defaultValue: 1,
+    L: {
+      Ve: {
+        min: 0,
+        max: 1,
+        suffix: "%",
+        scale: 100
+      },
+      N: 1444
+    }
+  },
+  "google-visualization-charteditor-combo-donut-hole": {
+    type: gvjs_O5,
+    name: "pieHole",
+    L: {
+      Ve: {
+        min: 0,
+        max: 1,
+        suffix: "%",
+        scale: 100
+      },
+      Lk: "donut3d",
+      N: 1445,
+      ub: gvjs_kua
+    }
+  },
+  "google-visualization-charteditor-combo-opacity-bubble": {
+    type: gvjs_O5,
+    name: gvjs_zt,
+    defaultValue: "1",
+    L: {
+      Ve: {
+        min: -0,
+        max: 1,
+        suffix: "%",
+        scale: 100
+      },
+      N: 1453
+    }
+  },
+  "google-visualization-charteditor-combo-font-size-bubble": {
+    type: gvjs_O5,
+    name: "bubble.textStyle.fontSize",
+    defaultValue: 12,
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0,
+        suffix: gvjs_T
+      },
+      N: 1446
+    }
+  },
+  "google-visualization-charteditor-combo-font-size-slice": {
+    type: gvjs_O5,
+    name: "pieSliceTextStyle.fontSize",
+    defaultValue: 12,
+    L: {
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0,
+        suffix: gvjs_T
+      },
+      N: 1447,
+      ub: gvjs_oua
+    }
+  },
+  "google-visualization-charteditor-select-visual-semantics": {
+    type: gvjs_k,
+    name: gvjs_L5,
+    defaultValue: gvjs_kQ,
+    L: {
+      N: 1508
+    }
+  },
+  "google-visualization-charteditor-select-chart-area-height": {
+    type: gvjs_k,
+    name: gvjs__o,
+    defaultValue: null,
+    L: {
+      N: 1509
+    }
+  },
+  "google-visualization-charteditor-select-chart-area-left": {
+    type: gvjs_k,
+    name: gvjs_0o,
+    defaultValue: null,
+    L: {
+      N: 1510
+    }
+  },
+  "google-visualization-charteditor-select-chart-area-width": {
+    type: gvjs_k,
+    name: gvjs_3o,
+    defaultValue: null,
+    L: {
+      N: 1512
+    }
+  },
+  "google-visualization-charteditor-select-chart-area-top": {
+    type: gvjs_k,
+    name: gvjs_2o,
+    defaultValue: null,
+    L: {
+      N: 1511
+    }
+  },
+  "google-visualization-charteditor-select-font-name": {
+    type: gvjs_k,
+    name: gvjs_yp,
+    defaultValue: gvjs_2r,
+    L: {
+      N: 1514
+    }
+  },
+  "google-visualization-charteditor-select-legend-position": {
+    type: gvjs_k,
+    name: gvjs_rv,
+    defaultValue: gvjs_j,
+    L: {
+      u9: {
+        bottom: gvjs_U6,
+        left: gvjs_Nsa,
+        right: gvjs_Osa,
+        top: gvjs_U6
+      },
+      N: 1519,
+      ub: function(a, b) {
+        var c = gvjs_97(a, gvjs_Lv);
+        if (a.Va() == gvjs_3a)
+          return c ? [gvjs_$c, gvjs_f, gvjs_j] : !0;
+        if (c)
+          return [gvjs_Fp, gvjs_f];
+        b = (b = b ? new gvjs_$7(b,a,!1) : null) ? gvjs_a8(b) : 0;
+        return gvjs_d8(a, b) ? [gvjs_vt, gvjs_Fp, gvjs_f, gvjs_vx] : gvjs_e8(a, 0, b) ? [gvjs_vt, gvjs_Fp, gvjs_f, gvjs_j, gvjs_vx] : gvjs_e8(a, 1, b) ? [gvjs_vt, gvjs_Fp, gvjs_$c, gvjs_f, gvjs_vx] : !0
+      }
+    }
+  },
+  "google-visualization-charteditor-select-slice-text": {
+    type: gvjs_k,
+    name: gvjs_hw,
+    defaultValue: gvjs_ew,
+    L: {
+      N: 1525
+    }
+  },
+  "google-visualization-charteditor-select-slant": {
+    type: gvjs_k,
+    name: gvjs_G6,
+    defaultValue: null,
+    handler: gvjs_hua,
+    L: {
+      Lk: gvjs_X6,
+      N: 1524,
+      isNumeric: !0,
+      ub: gvjs_nua
+    }
+  },
+  "google-visualization-charteditor-axis-icon-select-slant": {
+    type: gvjs_L6,
+    name: gvjs_G6,
+    defaultValue: null,
+    handler: gvjs_hua,
+    L: {
+      Lk: gvjs_X6,
+      N: 1469,
+      isNumeric: !0,
+      ub: gvjs_nua
+    }
+  },
+  "google-visualization-charteditor-checkbox-hidden-dimension": {
+    type: gvjs_Ut,
+    handler: {
+      set: function(a, b) {
+        var c = a.cf || "";
+        c = gvjs_k7(c, "hds", !0 === b ? 3 : 0);
+        a.yh(c)
+      },
+      get: function(a) {
+        return 3 == gvjs_Wm(a.cf || "", "hds")
+      }
+    },
+    L: {
+      N: 2100,
+      nl: function(a) {
+        return a.getOption("hasHiddenData")
+      }
+    }
+  },
+  "google-visualization-charteditor-select-aggregate-type": {
+    type: gvjs_k,
+    name: gvjs_H5,
+    handler: {
+      get: function(a) {
+        return a.getOption(gvjs_H5, "sum")
+      },
+      set: function(a, b) {
+        a.ba(gvjs_H5, b)
+      }
+    },
+    L: {
+      N: 21E3,
+      ub: function(a) {
+        a = typeof a.getOption(gvjs_J5) === gvjs_g;
+        var b = gvjs_f7(gvjs_y6);
+        b && gvjs_6(b, a);
+        return a
+      }
+    }
+  },
+  "google-visualization-charteditor-select-stacked": {
+    type: gvjs_k,
+    name: gvjs_jv,
+    defaultValue: !1,
+    L: {
+      Lk: gvjs_2w,
+      N: 1418,
+      ub: gvjs_jua
+    }
+  }
+};
+gvjs_2e(gvjs_i8, {
+  "google-visualization-charteditor-checkbox-date-separator": {
+    type: gvjs_Ut,
+    name: gvjs_eY,
+    defaultValue: !0,
+    L: {
+      N: 1389
+    }
+  },
+  "google-visualization-charteditor-checkbox-legend-dots": {
+    type: gvjs_Ut,
+    name: gvjs_fY,
+    defaultValue: !0,
+    L: {
+      N: 1395
+    }
+  },
+  "google-visualization-charteditor-checkbox-legend-values": {
+    type: gvjs_Ut,
+    name: gvjs_gY,
+    defaultValue: !0,
+    L: {
+      N: 1396
+    }
+  },
+  "google-visualization-charteditor-checkbox-range-selector": {
+    type: gvjs_Ut,
+    name: gvjs_hY,
+    defaultValue: !0,
+    L: {
+      N: 1402
+    }
+  },
+  "google-visualization-charteditor-checkbox-scale-type": {
+    type: gvjs_Ut,
+    name: gvjs_Ew,
+    defaultValue: gvjs_Rd,
+    handler: {
+      get: function(a) {
+        return a.getOption(gvjs_Ew) != gvjs_V6
+      },
+      set: function(a, b) {
+        a.ba(gvjs_Ew, b ? gvjs_wu : gvjs_V6)
+      }
+    },
+    L: {
+      N: 1405
+    }
+  },
+  "google-visualization-charteditor-checkbox-zoom-button": {
+    type: gvjs_Ut,
+    name: gvjs_iY,
+    defaultValue: !0,
+    L: {
+      N: 1422
+    }
+  },
+  "google-visualization-charteditor-combo-thickness": {
+    type: gvjs_O5,
+    name: "thickness",
+    defaultValue: 1,
+    L: {
+      Ve: {
+        min: 1,
+        max: 10,
+        Og: !0,
+        suffix: gvjs_T
+      },
+      N: 1455
+    }
+  },
+  "google-visualization-charteditor-input-values-suffix": {
+    type: gvjs_m,
+    name: gvjs_7X,
+    defaultValue: null,
+    L: {
+      N: 1500
+    }
+  },
+  "google-visualization-charteditor-input-fill": {
+    type: gvjs_m,
+    name: gvjs_np,
+    defaultValue: null,
+    L: {
+      N: 1476,
+      isNumeric: !0,
+      min: 0,
+      max: 100
+    }
+  },
+  "google-visualization-charteditor-input-date-format": {
+    type: gvjs_k,
+    name: gvjs_cY,
+    defaultValue: null,
+    L: {
+      N: 1474
+    }
+  }
+}, {
+  "google-visualization-charteditor-input-green-from": {
+    type: gvjs_m,
+    name: "greenFrom",
+    defaultValue: null,
+    L: {
+      N: 1479,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-green-to": {
+    type: gvjs_m,
+    name: "greenTo",
+    defaultValue: null,
+    L: {
+      N: 1480,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-red-from": {
+    type: gvjs_m,
+    name: "redFrom",
+    defaultValue: null,
+    L: {
+      N: 1493,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-red-to": {
+    type: gvjs_m,
+    name: "redTo",
+    defaultValue: null,
+    L: {
+      N: 1494,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-yellow-from": {
+    type: gvjs_m,
+    name: "yellowFrom",
+    defaultValue: null,
+    L: {
+      N: 1502,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-input-yellow-to": {
+    type: gvjs_m,
+    name: "yellowTo",
+    defaultValue: null,
+    L: {
+      N: 1503,
+      isNumeric: !0
+    }
+  }
+}, {
+  "google-visualization-charteditor-checkbox-color-legend": {
+    type: gvjs_Ut,
+    name: "showLegend",
+    defaultValue: !0,
+    L: {
+      N: 1386
+    }
+  },
+  "google-visualization-charteditor-select-region": {
+    type: gvjs_k,
+    name: gvjs_xT,
+    defaultValue: gvjs_CT,
+    handler: {
+      set: function(a, b) {
+        a.ba(gvjs_xT, b);
+        "US" == b ? a.ba(gvjs_yT, gvjs_wT) : a.ba(gvjs_yT, gvjs_qT)
+      }
+    },
+    L: {
+      N: 1522
+    }
+  }
+}, {
+  "google-visualization-charteditor-radio-map-type": {
+    type: gvjs_Z6,
+    name: gvjs_vT,
+    defaultValue: gvjs_uT,
+    L: {
+      N: 1506
+    }
+  },
+  "google-visualization-charteditor-select-zoom": {
+    type: gvjs_k,
+    name: "zoomLevel",
+    defaultValue: null,
+    L: {
+      N: 1530,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-checkbox-scroll": {
+    type: gvjs_Ut,
+    name: gvjs_tT,
+    defaultValue: !1,
+    L: {
+      N: 1406
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-line": {
+    type: gvjs_Ut,
+    name: gvjs_zT,
+    defaultValue: !1,
+    L: {
+      N: 1410
+    }
+  },
+  "google-visualization-charteditor-color-line": {
+    type: gvjs_1,
+    name: "lineColor",
+    defaultValue: "blue",
+    L: {
+      N: 1429,
+      ub: gvjs_lua
+    }
+  },
+  "google-visualization-charteditor-combo-line-weight": {
+    type: gvjs_O5,
+    name: "lineWeight",
+    defaultValue: 10,
+    L: {
+      N: 1450,
+      ub: gvjs_lua,
+      Ve: {
+        min: 1,
+        max: 20,
+        Og: !0,
+        suffix: gvjs_T
+      }
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-large-control": {
+    type: gvjs_Ut,
+    name: gvjs_AT,
+    defaultValue: !1,
+    L: {
+      N: 1409
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-type-control": {
+    type: gvjs_Ut,
+    name: gvjs_BT,
+    defaultValue: !1,
+    L: {
+      N: 1414
+    }
+  }
+}, {
+  "google-visualization-charteditor-checkbox-side-panel": {
+    type: gvjs_Ut,
+    name: "showSidePanel",
+    defaultValue: !0,
+    L: {
+      N: 1415
+    }
+  },
+  "google-visualization-charteditor-checkbox-chart-buttons": {
+    type: gvjs_Ut,
+    name: gvjs_Tw,
+    defaultValue: !0,
+    L: {
+      N: 1385
+    }
+  }
+}, {
+  "google-visualization-charteditor-color-node": {
+    type: gvjs_1,
+    name: gvjs_1,
+    defaultValue: "#edf7ff",
+    L: {
+      N: 1435
+    }
+  },
+  "google-visualization-charteditor-color-selected-node": {
+    type: gvjs_1,
+    name: "selectionColor",
+    defaultValue: "#d6e9f8",
+    L: {
+      N: 1437
+    }
+  },
+  "google-visualization-charteditor-radio-size": {
+    type: gvjs_Z6,
+    name: gvjs_Xw,
+    defaultValue: gvjs_dd,
+    L: {
+      N: 1507
+    }
+  }
+}, {
+  "google-visualization-charteditor-series-checkbox-dashed": {
+    type: gvjs_Ut,
+    name: "chls",
+    defaultValue: !1,
+    handler: {
+      get: function(a, b, c) {
+        a = c.getOption(a.name);
+        a = typeof a === gvjs_l ? a.split("|") : [];
+        return !!(a[b] ? a[b].split(",") : [])[2]
+      },
+      set: function(a, b, c, d) {
+        var e = c.getOption(a.name);
+        e = typeof e === gvjs_l ? e.split("|") : [];
+        for (var f = 0; f <= b; f++)
+          e[f] = e[f] ? e[f] : "1";
+        f = e[b].split(",");
+        var g = f[0];
+        d ? (f[1] = (3 * g).toString(),
+          f[2] = (2 * g).toString(),
+          f = f.join(",")) : f = g;
+        e[b] = f;
+        e = e.join("|");
+        c.ba(a.name, e)
+      }
+    },
+    L: {
+      N: 1388
+    }
+  },
+  "google-visualization-charteditor-series-checkbox-markers": {
+    type: gvjs_Ut,
+    name: gvjs_mw,
+    defaultValue: !1,
+    handler: {
+      get: function(a, b, c) {
+        return !!(c.getOption(a.name) || [])[b]
+      },
+      set: function(a, b, c, d) {
+        var e = c.getOption(a.name) || [];
+        d ? (d = e[b] || {},
+          d.shape = "o",
+          d.size = 10,
+          e[b] = d) : e[b] = null;
+        c.ba(a.name, e)
+      }
+    },
+    L: {
+      N: 1398
+    }
+  },
+  "google-visualization-charteditor-series-trendline-showr2": {
+    type: gvjs_Ut,
+    name: gvjs_4sa,
+    defaultValue: !1,
+    handler: gvjs_gua,
+    L: {
+      N: 1421,
+      nl: gvjs_pua
+    }
+  },
+  "google-visualization-charteditor-series-menu-trendline-showr2": {
+    type: gvjs_36,
+    name: gvjs_4sa,
+    handler: gvjs_gua,
+    L: {
+      N: 1533,
+      nl: gvjs_pua
+    }
+  },
+  "google-visualization-charteditor-series-color": {
+    type: gvjs_1,
+    name: gvjs_2t,
+    handler: {
+      get: function(a, b, c) {
+        return gvjs_V7(c, b)
+      },
+      set: function(a, b, c, d) {
+        a = d;
+        d = c.Va();
+        if (d == gvjs_w5 || d == gvjs_Pa)
+          a = a == gvjs_f ? gvjs_UT : a;
+        d == gvjs_w5 || d == gvjs_Pa || d == gvjs_ra ? (d = c.getOption(gvjs_2t),
+          d[b % d.length] = a,
+          c.ba(gvjs_2t, d)) : gvjs_U7(c, b, gvjs_1, a)
+      }
+    },
+    L: {
+      N: 1438
+    }
+  },
+  "google-visualization-charteditor-series-trendline-color": {
+    type: gvjs_1,
+    name: gvjs_1,
+    handler: {
+      get: function(a, b, c) {
+        a = c.getOption(gvjs_56);
+        c = (c = c.getOption(gvjs_Mw)) && c[b] && c[b].color ? gvjs_5F(c[b].color).jh : gvjs_5F(gvjs_P7[b % gvjs_P7.length]).jh;
+        return a && a[b] ? a[b].color || c : c
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (a[b].color = d,
+          c.ba(gvjs_56, a))
+      }
+    },
+    L: {
+      N: 1442
+    }
+  },
+  "google-visualization-charteditor-series-combo-line-size": {
+    type: gvjs_O5,
+    name: "chls",
+    defaultValue: null,
+    L: {
+      N: 1449,
+      isNumeric: !0,
+      ub: function(a, b) {
+        var c = b.Va() == gvjs_ya;
+        a = gvjs_T7(b, a, gvjs_Sd);
+        return !c || !a || a != gvjs_lt
+      },
+      Ve: {
+        min: 0,
+        max: 10,
+        Og: !0,
+        suffix: gvjs_T
+      }
+    },
+    handler: {
+      get: function(a, b, c) {
+        if (c.Va() == gvjs_w5)
+          return a = c.getOption(a.name),
+            a = typeof a === gvjs_l ? a.split("|") : [],
+            b = a[b] ? a[b].split(",") : [],
+            b[0] ? Number(b[0]) : 1;
+        b = gvjs_T7(c, b, gvjs_Bv);
+        return typeof b === gvjs_g ? b : 2
+      },
+      set: function(a, b, c, d) {
+        if (c.Va() == gvjs_w5) {
+          var e = c.getOption(a.name);
+          e = typeof e === gvjs_l ? e.split("|") : [];
+          var f = e[b] ? e[b].split(",") : [];
+          f[0] = d;
+          f = f.join(",");
+          e[b] = f;
+          for (d = 0; d < b; d++)
+            e[d] = e[d] || "1";
+          e = e.join("|");
+          c.ba(a.name, e)
+        } else
+          gvjs_U7(c, b, gvjs_Bv, d)
+      }
+    }
+  },
+  "google-visualization-charteditor-series-combo-opacity-area": {
+    type: gvjs_O5,
+    name: "series.areaOpacity",
+    defaultValue: "1",
+    handler: {
+      get: function(a, b, c) {
+        return gvjs_T7(c, b, gvjs_bt, .3)
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_bt, d)
+      }
+    },
+    L: {
+      Ve: {
+        min: 0,
+        max: 1,
+        suffix: "%",
+        scale: 100
+      },
+      N: 1452,
+      ub: function(a, b) {
+        var c = b.Va() == gvjs_ya;
+        a = gvjs_T7(b, a, gvjs_Sd);
+        return !c || a == gvjs_at || a == gvjs_4w
+      }
+    }
+  },
+  "google-visualization-charteditor-series-trendline-opacity": {
+    type: gvjs_O5,
+    name: "trendline.opacity",
+    defaultValue: "0.4",
+    handler: {
+      get: function(a, b, c) {
+        return (a = c.getOption(gvjs_56)) && a[b] ? a[b].opacity || .4 : .4
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (a[b].opacity = gvjs_jg(d),
+          c.ba(gvjs_56, a))
+      }
+    },
+    L: {
+      N: 1457
+    }
+  },
+  "google-visualization-charteditor-series-trendline-size": {
+    type: gvjs_O5,
+    name: gvjs_Bv,
+    defaultValue: "2",
+    handler: {
+      get: function(a, b, c) {
+        return (a = c.getOption(gvjs_56)) && a[b] ? a[b].lineWidth || 2 : 2
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (a[b].lineWidth = gvjs_jg(d),
+          c.ba(gvjs_56, a))
+      }
+    },
+    L: {
+      N: 1458
+    }
+  },
+  "google-visualization-charteditor-series-combo-point-size": {
+    type: gvjs_O5,
+    name: gvjs_jw,
+    L: {
+      N: 1454,
+      isNumeric: !0,
+      ub: gvjs_k8,
+      Ve: {
+        min: 0,
+        max: 20,
+        Og: !0,
+        suffix: gvjs_T
+      }
+    },
+    handler: gvjs_dua
+  },
+  "google-visualization-charteditor-series-font-style-annotations": {
+    type: gvjs_Z5,
+    name: gvjs_Vsa,
+    defaultValue: {
+      color: "",
+      fontSize: 12
+    },
+    handler: gvjs_aua,
+    L: {
+      N: 1459,
+      ub: function(a, b) {
+        return !!gvjs_T7(b, a, gvjs_I6)
+      },
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      }
+    }
+  },
+  "google-visualization-charteditor-series-input-error-magnitude": {
+    type: gvjs_m,
+    name: gvjs_Y5,
+    handler: {
+      get: function(a, b, c) {
+        return gvjs_T7(c, b, gvjs_Y5, 10)
+      },
+      set: function(a, b, c, d) {
+        d = gvjs_jf(gvjs_gg(d)) ? 0 : d;
+        d = parseFloat(d);
+        !isNaN(d) && 0 <= d && gvjs_U7(c, b, gvjs_Y5, d)
+      }
+    },
+    L: {
+      N: 1475,
+      isNumeric: !0,
+      ub: function(a, b) {
+        return (a = gvjs_T7(b, a, "errorBars")) && a.errorType && a.errorType != gvjs_f
+      }
+    }
+  },
+  "google-visualization-charteditor-series-select-aggregate-type": {
+    type: gvjs_k,
+    name: gvjs_H5,
+    handler: {
+      get: function(a, b, c) {
+        return gvjs_T7(c, b, gvjs_H5, "sum")
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_H5, d)
+      }
+    },
+    L: {
+      N: 21001,
+      ub: function(a, b) {
+        a = typeof b.getOption(gvjs_J5) === gvjs_g;
+        (b = gvjs_f7(gvjs_y6)) && gvjs_6(b, a);
+        return a
+      }
+    }
+  },
+  "google-visualization-charteditor-series-select-data-label-type": {
+    type: gvjs_k,
+    name: "dataLabels.type",
+    handler: gvjs_bua,
+    L: {
+      N: 2099
+    }
+  },
+  "google-visualization-charteditor-series-icon-select-data-label-type": {
+    type: gvjs_L6,
+    name: "icon.dataLabels.type",
+    handler: gvjs_bua,
+    L: {
+      N: 2099
+    }
+  },
+  "google-visualization-charteditor-series-data-label-font-style": {
+    type: gvjs_Z5,
+    name: gvjs_Vsa,
+    defaultValue: {
+      color: "",
+      fontSize: 12
+    },
+    handler: gvjs_aua,
+    L: {
+      N: 1459,
+      ub: function(a, b) {
+        var c = !!gvjs_T7(b, a, gvjs_I6);
+        return gvjs_T7(b, a, gvjs_U5, c ? gvjs_P5 : gvjs_f) != gvjs_f
+      },
+      Ve: {
+        min: 1,
+        max: 50,
+        Og: !0
+      }
+    }
+  },
+  "google-visualization-charteditor-series-select-error-type": {
+    type: gvjs_k,
+    name: gvjs_X5,
+    handler: {
+      get: function(a, b, c) {
+        return gvjs_T7(c, b, gvjs_X5, gvjs_f)
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_X5, d)
+      }
+    },
+    L: {
+      N: 1513
+    }
+  },
+  "google-visualization-charteditor-series-point-shape": {
+    type: gvjs_k,
+    defaultValue: gvjs_4o,
+    handler: gvjs_cua,
+    L: {
+      N: 1938,
+      ub: gvjs_k8
+    }
+  },
+  "google-visualization-charteditor-series-multi-icon-select-point-style": {
+    type: gvjs_W6,
+    handler: gvjs_eua,
+    L: {
+      N: 1976,
+      ub: gvjs_k8
+    }
+  },
+  "google-visualization-charteditor-series-select-target-axis": {
+    type: gvjs_k,
+    name: gvjs_$w,
+    L: {
+      Lk: gvjs_$w,
+      N: 1527,
+      isNumeric: !0,
+      ub: function(a, b) {
+        return !b.getOption(gvjs_jv)
+      }
+    },
+    handler: {
+      get: function(a, b, c) {
+        a = gvjs_T7(c, b, gvjs_$w);
+        return typeof a === gvjs_g ? a : 0
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_$w, d)
+      }
+    }
+  },
+  "google-visualization-charteditor-series-select-visualization": {
+    type: gvjs_k,
+    name: gvjs_Mw,
+    defaultValue: [{
+      type: gvjs_lt
+    }],
+    handler: {
+      get: function(a, b, c) {
+        (a = gvjs_T7(c, b, gvjs_Sd)) || (a = 0 == b ? gvjs_lt : gvjs_e);
+        return a
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_Sd, d)
+      }
+    },
+    L: {
+      N: 1529
+    }
+  },
+  "google-visualization-charteditor-series-select-trendline": {
+    type: gvjs_k,
+    name: "addTrendline",
+    handler: gvjs_fua,
+    L: {
+      N: 1528
+    }
+  },
+  "google-visualization-charteditor-series-menu-add-trendline": {
+    type: gvjs_L6,
+    name: "menuAddTrendline",
+    handler: gvjs_fua,
+    L: {
+      N: 1504
+    }
+  },
+  "google-visualization-charteditor-series-select-label-trendline": {
+    type: gvjs_k,
+    name: "label-trendline",
+    handler: {
+      get: function(a, b, c) {
+        return (a = c.getOption(gvjs_56)) && a[b] ? (c = !!a[b].labelInLegend,
+          a[b].visibleInLegend ? c ? gvjs_P5 : "equation" : gvjs_f) : null
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (d == gvjs_f ? (a[b].visibleInLegend = !1,
+          a[b].labelInLegend = null) : "equation" == d ? (a[b].visibleInLegend = !0,
+          a[b].labelInLegend = null) : (a[b].visibleInLegend = !0,
+          a[b].labelInLegend = gvjs_Yta(c.getType(), b + 1)));
+        c.ba(gvjs_56, a)
+      }
+    },
+    L: {
+      N: 1518
+    }
+  },
+  "google-visualization-charteditor-series-input-trendline-label": {
+    type: gvjs_m,
+    name: gvjs_nv,
+    handler: {
+      get: function(a, b, c) {
+        return (a = c.getOption(gvjs_56)) && a[b] ? a[b].labelInLegend : null
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (a[b].visibleInLegend = !0,
+          a[b].labelInLegend = d,
+          c.ba(gvjs_56, a))
+      }
+    },
+    L: {
+      N: 1499,
+      nl: function(a, b) {
+        return (b = b.getOption(gvjs_56)) && b[a] && b[a].visibleInLegend && b[a].labelInLegend
+      }
+    }
+  },
+  "google-visualization-charteditor-series-combo-trendline-degree": {
+    type: gvjs_O5,
+    name: "trendline.degree",
+    defaultValue: 2,
+    handler: {
+      get: function(a, b, c) {
+        return (a = c.getOption(gvjs_56)) && a[b] ? a[b].degree || 2 : 2
+      },
+      set: function(a, b, c, d) {
+        (a = c.getOption(gvjs_56)) && a[b] && (a[b].degree = d,
+          c.ba(gvjs_56, a))
+      }
+    },
+    L: {
+      N: 1456,
+      isNumeric: !0,
+      nl: function(a, b) {
+        return (b = b.getOption(gvjs_56)) && b[a] && "polynomial" == b[a].type
+      },
+      Ve: {
+        Og: !0
+      }
+    }
+  },
+  "google-visualization-charteditor-series-toggle-axis-left": {
+    type: gvjs_36,
+    name: gvjs_$w,
+    handler: {
+      get: function(a, b, c) {
+        a = gvjs_T7(c, b, gvjs_$w);
+        return 0 == (typeof a === gvjs_g ? a : 0)
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_$w, d ? 0 : 1)
+      }
+    },
+    L: {
+      N: 1531
+    }
+  },
+  "google-visualization-charteditor-series-toggle-axis-right": {
+    type: gvjs_36,
+    name: gvjs_$w,
+    handler: {
+      get: function(a, b, c) {
+        a = gvjs_T7(c, b, gvjs_$w);
+        return 1 == (typeof a === gvjs_g ? a : 0)
+      },
+      set: function(a, b, c, d) {
+        gvjs_U7(c, b, gvjs_$w, d ? 1 : 0)
+      }
+    },
+    L: {
+      N: 1532
+    }
+  }
+}, {
+  "google-visualization-charteditor-series-input-max": {
+    type: gvjs_m,
+    name: gvjs_Gv,
+    defaultValue: [],
+    L: {
+      N: 1482,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-series-input-min": {
+    type: gvjs_m,
+    name: gvjs_Ov,
+    defaultValue: [],
+    L: {
+      N: 1489,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-checkbox-show-axis-lines": {
+    type: gvjs_Ut,
+    name: "showAxisLines",
+    defaultValue: !0,
+    L: {
+      N: 1407
+    }
+  },
+  "google-visualization-charteditor-radio-label-position": {
+    type: gvjs_Z6,
+    name: "labelPosition",
+    defaultValue: gvjs_j,
+    L: {
+      N: 1505
+    }
+  }
+}, {
+  "google-visualization-charteditor-checkbox-alter-row": {
+    type: gvjs_Ut,
+    name: gvjs_Vs,
+    defaultValue: !0,
+    L: {
+      N: 1384
+    }
+  },
+  "google-visualization-charteditor-checkbox-row-number": {
+    type: gvjs_Ut,
+    name: "showRowNumber",
+    defaultValue: !1,
+    L: {
+      N: 1404
+    }
+  },
+  "google-visualization-charteditor-select-sort-column": {
+    type: gvjs_k,
+    name: gvjs__w,
+    defaultValue: null,
+    L: {
+      N: 1526,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-checkbox-ascending": {
+    type: gvjs_Ut,
+    name: "sortAscending",
+    defaultValue: !0,
+    L: {
+      N: 1417,
+      ub: function(a) {
+        return null != a.getOption(gvjs__w)
+      }
+    }
+  },
+  "google-visualization-charteditor-checkbox-page": {
+    type: gvjs_Ut,
+    name: gvjs_cw,
+    defaultValue: gvjs_ju,
+    handler: {
+      get: function(a) {
+        return a.getOption(gvjs_cw) == gvjs_qu
+      },
+      set: function(a, b) {
+        a.ba(gvjs_cw, b ? gvjs_qu : gvjs_ju)
+      }
+    },
+    L: {
+      N: 1400
+    }
+  },
+  "google-visualization-charteditor-select-page-size": {
+    type: gvjs_k,
+    name: "pageSize",
+    defaultValue: 10,
+    L: {
+      N: 1521,
+      isNumeric: !0,
+      ub: function(a) {
+        return a.getOption(gvjs_cw) == gvjs_qu
+      }
+    }
+  }
+}, {
+  "google-visualization-charteditor-color-font-tree": {
+    type: gvjs_1,
+    name: gvjs_Du,
+    defaultValue: gvjs_Br,
+    L: {
+      N: 1427
+    }
+  },
+  "google-visualization-charteditor-color-tree-header": {
+    type: gvjs_1,
+    name: gvjs_Zu,
+    defaultValue: gvjs_Y4,
+    L: {
+      N: 1441,
+      ub: function(a) {
+        return 0 < a.getOption(gvjs__u)
+      }
+    }
+  },
+  "google-visualization-charteditor-select-font-size-tree": {
+    type: gvjs_k,
+    name: gvjs_zp,
+    defaultValue: "14",
+    L: {
+      N: 1515
+    }
+  },
+  "google-visualization-charteditor-select-levels": {
+    type: gvjs_k,
+    name: gvjs_Kv,
+    defaultValue: 2,
+    L: {
+      N: 1520,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-select-header-height": {
+    type: gvjs_k,
+    name: gvjs__u,
+    defaultValue: 40,
+    L: {
+      N: 1517,
+      isNumeric: !0
+    }
+  }
+});
+var gvjs_$ta = {
+  "google-visualization-charteditor-axis-checkbox-explicit-view-window": {
+    type: gvjs_Ut,
+    handler: {
+      get: function(a, b) {
+        return gvjs_Q7(b, a, gvjs_Lx) == gvjs_su
+      },
+      set: function(a, b, c) {
+        gvjs_S7(b, a, gvjs_Lx, c ? gvjs_su : gvjs_qw)
+      }
+    },
+    L: {
+      N: 1390,
+      ub: function(a, b) {
+        var c = gvjs_Q7(b, a, gvjs_ed);
+        a = gvjs_Q7(b, a, gvjs_cd);
+        return typeof c === gvjs_g || typeof a === gvjs_g
+      }
+    }
+  },
+  "google-visualization-charteditor-axis-checkbox-log-scale": {
+    type: gvjs_Ut,
+    name: gvjs_Cv,
+    defaultValue: !1,
+    L: {
+      N: 1397,
+      ub: function(a, b) {
+        return !b.getOption(gvjs_jv)
+      },
+      Lk: "logStack"
+    }
+  },
+  "google-visualization-charteditor-axis-treat-labels-as-text": {
+    type: gvjs_Ut,
+    handler: {
+      get: function(a, b) {
+        return b.getOption(gvjs_46)
+      },
+      set: function(a, b, c) {
+        b.ba(gvjs_46, c)
+      }
+    },
+    L: {
+      N: 1937,
+      ub: function(a, b, c) {
+        if (!c)
+          return !1;
+        a = b.Va();
+        var d = c.W(0);
+        c = gvjs_c8(a, c);
+        return null === c ? b.getOption(gvjs_76, gvjs_$.EH[a]) : c && d !== gvjs_l
+      }
+    }
+  },
+  "google-visualization-charteditor-axis-color-grid": {
+    type: gvjs_1,
+    name: gvjs_Su,
+    defaultValue: {
+      x: gvjs_yr,
+      y: gvjs_yr,
+      right: gvjs_f
+    },
+    L: {
+      N: 1428
+    }
+  },
+  "google-visualization-charteditor-axis-color-minor-grid": {
+    type: gvjs_1,
+    name: gvjs_Qv,
+    defaultValue: null,
+    handler: {
+      get: function(a, b) {
+        return gvjs_Q7(b, a, gvjs_Qv, gvjs_M6)
+      },
+      set: function(a, b, c) {
+        gvjs_S7(b, a, gvjs_Qv, c != gvjs_M6 ? c : null)
+      }
+    },
+    L: {
+      Lk: gvjs_Qsa,
+      N: 1434,
+      ub: function(a, b) {
+        return 0 < b.getOption(a[1] + ".minorGridlines.count")
+      }
+    }
+  },
+  "google-visualization-charteditor-axis-combo-gridline-count": {
+    type: gvjs_O5,
+    name: gvjs_Tu,
+    defaultValue: 5,
+    L: {
+      Ve: {
+        min: 2,
+        max: 100,
+        Og: !0
+      },
+      Lk: gvjs_C6,
+      N: 1448,
+      ub: gvjs_j8
+    }
+  },
+  "google-visualization-charteditor-axis-combo-minor-gridline-count": {
+    type: gvjs_O5,
+    name: gvjs_Rv,
+    defaultValue: 0,
+    L: {
+      Ve: {
+        min: 0,
+        max: 100,
+        Og: !0
+      },
+      Lk: gvjs_C6,
+      N: 1451,
+      ub: gvjs_j8
+    }
+  },
+  "google-visualization-charteditor-axis-input-format-options-prefix": {
+    type: gvjs_m,
+    name: gvjs_Gu,
+    defaultValue: "",
+    L: {
+      N: 1477,
+      ub: gvjs_iua
+    }
+  },
+  "google-visualization-charteditor-axis-input-format-options-suffix": {
+    type: gvjs_m,
+    name: gvjs_Iu,
+    defaultValue: "",
+    L: {
+      N: 1478,
+      ub: gvjs_iua
+    }
+  },
+  "google-visualization-charteditor-axis-input-max": {
+    type: gvjs_m,
+    name: gvjs_cd,
+    defaultValue: null,
+    L: {
+      N: 1482,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-axis-input-min": {
+    type: gvjs_m,
+    name: gvjs_ed,
+    defaultValue: null,
+    L: {
+      N: 1489,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-axis-input-max-explicit": {
+    type: gvjs_m,
+    name: gvjs_cd,
+    defaultValue: null,
+    handler: {
+      get: function(a, b) {
+        return gvjs_Q7(b, a, gvjs_cd)
+      },
+      set: function(a, b, c) {
+        gvjs_S7(b, a, gvjs_Lx, gvjs_su);
+        gvjs_S7(b, a, gvjs_cd, c);
+        gvjs_S7(b, a, gvjs_Jx, c)
+      }
+    },
+    L: {
+      N: 1486,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-axis-input-min-explicit": {
+    type: gvjs_m,
+    name: gvjs_ed,
+    defaultValue: null,
+    handler: {
+      get: function(a, b) {
+        return gvjs_Q7(b, a, gvjs_ed)
+      },
+      set: function(a, b, c) {
+        gvjs_S7(b, a, gvjs_Lx, gvjs_su);
+        gvjs_S7(b, a, gvjs_ed, c);
+        gvjs_S7(b, a, gvjs_Kx, c)
+      }
+    },
+    L: {
+      N: 1491,
+      isNumeric: !0
+    }
+  },
+  "google-visualization-charteditor-axis-select-format-options-source": {
+    type: gvjs_k,
+    name: gvjs_hra,
+    defaultValue: gvjs_$t,
+    L: {
+      N: 1516,
+      ub: function(a, b) {
+        return gvjs_Q7(b, a, gvjs_Cv) ? [gvjs_ev, gvjs_f] : !0
+      },
+      u9: {
+        data: gvjs_ira
+      }
+    }
+  },
+  "google-visualization-charteditor-axis-select-scale": {
+    type: gvjs_k,
+    name: gvjs_Hu,
+    defaultValue: null,
+    L: {
+      N: 1523,
+      ub: gvjs_j8,
+      Lk: "scale"
+    }
+  }
+};
+gvjs_h8(gvjs_Eta);
+gvjs_h8(gvjs_Fta);
+gvjs_h8([gvjs_j, gvjs_b7]);
+function gvjs_m8(a) {
+  var b = gvjs_i7() ? gvjs_Up : gvjs_Dv;
+  gvjs_8g(a, {
+    dir: b
+  })
+}
+;function gvjs_n8(a, b) {
+  this.ps = a;
+  this.Tma = !!b;
+  this.s7 = {
+    0: this.ps + "-arrowright",
+    1: this.ps + "-arrowup",
+    2: this.ps + "-arrowdown",
+    3: this.ps + "-arrowleft"
+  }
+}
+gvjs_o(gvjs_n8, gvjs_2A);
+gvjs_ = gvjs_n8.prototype;
+gvjs_.hL = function(a) {
+  this.Bx = a
+}
+;
+gvjs_.FT = function(a) {
+  this.Wg = a
+}
+;
+gvjs_.setPosition = function(a, b, c, d) {
+  null != a && (this.oW = a);
+  null != b && (this.VV = b);
+  typeof c === gvjs_g && (this.t7 = Math.max(c, 15));
+  typeof d === gvjs_g && (this.K1 = d)
+}
+;
+gvjs_.Mf = function(a, b, c) {
+  a = this.VV;
+  2 == a && (a = 0);
+  gvjs_qua(this, this.oW, a, 2 == this.VV ? gvjs_o8(this.oW) ? this.Em.offsetHeight / 2 : this.Em.offsetWidth / 2 : this.t7, 0, c)
+}
+;
+gvjs_.iL = function(a) {
+  this.yba = a
+}
+;
+function gvjs_qua(a, b, c, d, e, f) {
+  if (a.Bx) {
+    var g = gvjs_rua(b, c);
+    var h = a.Bx;
+    var k = a.Em
+      , l = a.Wg
+      , m = gvjs_Dz(h);
+    a: {
+      m = (gvjs_o8(b) ? m.height / 2 : m.width / 2) - d;
+      var n = gvjs_5A(h, g);
+      if (l)
+        l = l.clone(),
+        k && (k = gvjs_4A(k),
+          l.left += k.x,
+          l.right += k.x,
+          l.top += k.y,
+          l.bottom += k.y);
+      else if (l = gvjs_wz(h),
+        !l) {
+        h = m;
+        break a
+      }
+      h = gvjs_oz(gvjs_Ez(h));
+      gvjs_o8(b) ? h.top < l.top && !(n & 1) ? m -= l.top - h.top : h.bottom > l.bottom && n & 1 && (m -= h.bottom - l.bottom) : h.left < l.left && !(n & 4) ? m -= l.left - h.left : h.right > l.right && n & 4 && (m -= h.right - l.right);
+      h = m
+    }
+    h = gvjs_o8(b) ? new gvjs_z(a.K1,h) : new gvjs_z(h,a.K1);
+    m = gvjs_o8(b) ? 6 : 9;
+    a.XM && 2 == e && (m = gvjs_o8(b) ? 4 : 1);
+    n = b ^ 3;
+    gvjs_o8(b) && a.Bx.dir == gvjs_Up && (n = b);
+    g = gvjs_7A(a.Bx, gvjs_rua(n, c), a.Em, g, h, f, a.yba ? m : 0, void 0, a.Wg);
+    if (2 != e && g & 496) {
+      gvjs_qua(a, b ^ 3, c, d, a.XM && 0 == e ? 1 : 2, f);
+      return
+    }
+    !a.Tma || g & 496 || (e = parseFloat(a.Em.style.left),
+      f = parseFloat(a.Em.style.top),
+    gvjs_1g(e) && gvjs_1g(f) || gvjs_sz(a.Em, Math.round(e), Math.round(f)))
+  }
+  gvjs_sua(a, b, c, d)
+}
+function gvjs_sua(a, b, c, d) {
+  var e = a.XV;
+  gvjs_w(a.s7, function(f) {
+    gvjs_ZC(e, f, !1)
+  }, a);
+  gvjs_VC(e, a.s7[b]);
+  e.style.top = e.style.left = e.style.right = e.style.bottom = "";
+  a.Bx ? (c = gvjs_Az(a.Bx, a.Em),
+    d = gvjs_tua(a.Bx, b),
+    gvjs_o8(b) ? e.style.top = gvjs_uua(c.y + d.y, a.Em.offsetHeight - 15) + gvjs_T : e.style.left = gvjs_uua(c.x + d.x, a.Em.offsetWidth - 15) + gvjs_T) : e.style[0 == c ? gvjs_o8(b) ? gvjs_vx : gvjs_$c : gvjs_o8(b) ? gvjs_vt : gvjs_j] = d + gvjs_T
+}
+function gvjs_uua(a, b) {
+  return 15 > b ? 15 : gvjs_0g(a, 15, b)
+}
+function gvjs_rua(a, b) {
+  switch (a) {
+    case 2:
+      return 0 == b ? 1 : 5;
+    case 1:
+      return 0 == b ? 0 : 4;
+    case 0:
+      return 0 == b ? 12 : 13;
+    default:
+      return 0 == b ? 8 : 9
+  }
+}
+function gvjs_tua(a, b) {
+  var c = 0
+    , d = 0;
+  a = gvjs_Dz(a);
+  switch (b) {
+    case 2:
+      c = a.width / 2;
+      break;
+    case 1:
+      c = a.width / 2;
+      d = a.height;
+      break;
+    case 0:
+      d = a.height / 2;
+      break;
+    case 3:
+      c = a.width,
+        d = a.height / 2
+  }
+  return new gvjs_z(c,d)
+}
+function gvjs_o8(a) {
+  return 0 == a || 3 == a
+}
+gvjs_.yba = !1;
+gvjs_.VV = 2;
+gvjs_.t7 = 20;
+gvjs_.oW = 3;
+gvjs_.Wg = null;
+gvjs_.K1 = -5;
+gvjs_.XM = !1;
+function gvjs_p8(a) {
+  gvjs_F.call(this);
+  this.MH = a || gvjs_3g()
+}
+gvjs_o(gvjs_p8, gvjs_F);
+gvjs_p8.prototype.nba = function() {
+  gvjs_VB(this.j(), this.Qk());
+  gvjs_WB(this.j(), "live", "polite")
+}
+;
+gvjs_p8.prototype.Qk = function() {
+  return gvjs_Pd
+}
+;
+function gvjs_q8(a) {
+  gvjs_p8.call(this, a);
+  this.Gk = this.MH.J(gvjs_b, gvjs_r8() + "-contentId");
+  this.WV = this.MH.J(gvjs_b, gvjs_r8() + "-arrow", this.MH.J(gvjs_b, gvjs_r8() + "-arrowimplbefore"), this.MH.J(gvjs_b, gvjs_r8() + "-arrowimplafter"));
+  this.Qn = this.MH.J(gvjs_b, {
+    "class": gvjs_r8(),
+    role: gvjs_Pd
+  }, this.Gk, this.WV);
+  this.nba()
+}
+gvjs_o(gvjs_q8, gvjs_p8);
+function gvjs_r8() {
+  return "jfk-tooltip"
+}
+gvjs_q8.prototype.j = function() {
+  return this.Qn
+}
+;
+gvjs_q8.prototype.ib = function() {
+  return this.Gk
+}
+;
+gvjs_q8.prototype.M = function() {
+  gvjs_p8.prototype.M.call(this);
+  this.Qn && gvjs_kh(this.Qn)
+}
+;
+function gvjs_s8(a) {
+  gvjs_q8.call(this, a)
+}
+gvjs_o(gvjs_s8, gvjs_q8);
+gvjs_s8.prototype.nba = function() {
+  gvjs_VB(this.j(), this.Qk())
+}
+;
+function gvjs_vua(a) {
+  return gvjs__y(gvjs_kf(a.replace(gvjs_wua, function(b, c) {
+    return gvjs_xua.test(c) ? "" : " "
+  }).replace(/[\t\n ]+/g, " ")))
+}
+var gvjs_xua = /^(?:abbr|acronym|address|b|em|i|small|strong|su[bp]|u)$/i
+  , gvjs_wua = /<[!\/]?([a-z0-9]+)([\/ ][^>]*)?>/gi;
+function gvjs_t8(a) {
+  a = a || gvjs_3g();
+  var b = gvjs_pe(a.kc());
+  gvjs_yua[b] || (gvjs_yua[b] = new gvjs_u8(a))
+}
+function gvjs_zua(a, b) {
+  gvjs_v8(a, b, void 0)
+}
+function gvjs_v8(a, b, c) {
+  c || (c = b instanceof gvjs_Zf ? gvjs_vua(gvjs_0f(b)) : b);
+  a.removeAttribute(gvjs_fx);
+  a.removeAttribute(gvjs_T5);
+  a.removeAttribute(gvjs_R5);
+  b ? (b instanceof gvjs_Zf ? a.qJ = b : (a.setAttribute(gvjs_R5, b),
+    a.qJ = null),
+    a.setAttribute(gvjs_et, c)) : (a.qJ = null,
+    a.removeAttribute(gvjs_et));
+  gvjs_t8(gvjs_3g(a))
+}
+var gvjs_yua = {};
+function gvjs_u8(a) {
+  gvjs_KA.call(this);
+  this.El = a;
+  this.Pm = new gvjs_SE(this.Txa,0,this);
+  gvjs_6x(this, this.Pm);
+  var b = gvjs_3x();
+  this.KR = typeof b.MutationObserver === gvjs_d ? new b.MutationObserver(gvjs_s(this.qpa, this)) : null;
+  a = a.kc();
+  this.o(a, [gvjs_kd, gvjs_gd, gvjs_Wt, gvjs_Yo, gvjs_Au, gvjs_lv], this.Cla, !0);
+  this.o(a, [gvjs_ld, gvjs_xu, gvjs_zu], this.pwa, !0)
+}
+gvjs_o(gvjs_u8, gvjs_KA);
+gvjs_ = gvjs_u8.prototype;
+gvjs_.M = function() {
+  gvjs_Aua(this);
+  gvjs_KA.prototype.M.call(this)
+}
+;
+function gvjs_Bua(a, b) {
+  switch (b.type) {
+    case gvjs_gd:
+    case gvjs_ld:
+    case gvjs_kd:
+    case gvjs_Wt:
+      a.Hba = !1;
+      break;
+    case gvjs_lv:
+      a.Hba = !0
+  }
+}
+gvjs_.pwa = function(a) {
+  this.KR && this.KR.disconnect();
+  gvjs_Bua(this, a);
+  var b = a.target;
+  a = a.type == gvjs_xu || a.type == gvjs_zu;
+  var c = this.xa && gvjs_rh(this.xa.ib(), b);
+  if (this.Hba || !a || c) {
+    this.dsa = a;
+    if (a = b && b.getAttribute && this.KR)
+      a = b.getAttribute(gvjs_Bd) || null,
+        a = gvjs_He(gvjs_nta, a);
+    a && (this.KR.observe(b, {
+      attributes: !0
+    }),
+    (a = gvjs_YB(b)) && (b = a));
+    this.qf = b
+  } else
+    this.qf = null;
+  gvjs_w8(this)
+}
+;
+gvjs_.Cla = function(a) {
+  gvjs_Bua(this, a);
+  var b = a.target;
+  a = a.type == gvjs_gd || a.type == gvjs_Wt;
+  b = this.xa && gvjs_rh(this.xa.ib(), b);
+  a && b || (this.qf = null,
+    gvjs_w8(this))
+}
+;
+gvjs_.qpa = function(a) {
+  gvjs_u(a, gvjs_s(function(b) {
+    var c = gvjs_YB(b.target);
+    c && b.attributeName == gvjs_ct && (this.qf = c,
+      gvjs_w8(this))
+  }, this))
+}
+;
+function gvjs_w8(a) {
+  if (!(a.Pm.ak() && a.hn && a.SL)) {
+    gvjs_Aua(a);
+    var b = null != a.SL ? a.SL : 50;
+    a.Pm.start(a.hn ? b : 300)
+  }
+}
+function gvjs_Aua(a) {
+  a.YS && (gvjs_ql(a.YS),
+    a.YS = 0,
+    a.hn = null)
+}
+gvjs_.Txa = function() {
+  if (!this.qf)
+    gvjs_x8(this),
+      this.SL = this.hn = null;
+  else if (!(this.hn && this.xa && gvjs_rh(this.xa.j(), this.qf)) || this.hn.getAttribute("data-tooltip-unhoverable")) {
+    var a = gvjs_yh(this.qf, function(h) {
+      return h.getAttribute && (h.getAttribute(gvjs_T5) || h.getAttribute(gvjs_R5) || h.qJ) && !h.getAttribute("data-tooltip-suspended")
+    }, !0)
+      , b = !1;
+    this.hn && this.hn != a && (gvjs_x8(this),
+      this.SL = this.hn = null,
+      b = !0);
+    if (!this.hn && a && (this.hn = a,
+      gvjs_Cua(this, a))) {
+      var c = gvjs_9f;
+      if (a.getAttribute(gvjs_T5))
+        for (var d = gvjs_Px("jfk-tooltip-data", a), e = 0; e < d.length; e++) {
+          if (d[e].parentNode == a) {
+            c = d[e].cloneNode(!0);
+            break
+          }
+        }
+      else
+        c = a.qJ ? a.qJ : gvjs__T(a.getAttribute(gvjs_R5));
+      d = a.getAttribute("data-tooltip-align");
+      e = a.getAttribute("data-tooltip-class");
+      var f = a.getAttribute("data-tooltip-offset");
+      f = gvjs_jf(gvjs_gg(f)) ? -1 : Number(f);
+      var g = a.getAttribute("data-tooltip-hide-delay");
+      g = gvjs_jf(gvjs_gg(g)) ? null : Number(g);
+      if (!b && (a = a.getAttribute("data-tooltip-delay"),
+        a = Math.max(0, a - 300))) {
+        this.YS = gvjs_pl(gvjs_re(this.Rfa, this.hn, c, d, f, e, g), a, this);
+        return
+      }
+      this.Rfa(this.hn, c, d, f, e, g)
+    }
+  }
+}
+;
+function gvjs_Cua(a, b) {
+  return b.getAttribute("data-tooltip-only-on-overflow") && b.offsetWidth >= b.scrollWidth && b.offsetHeight >= b.scrollHeight || a.dsa && "mouse" == b.getAttribute("data-tooltip-trigger") ? !1 : !0
+}
+function gvjs_Dua(a) {
+  if (a)
+    switch (a.toLowerCase().split(",")[0]) {
+      case "l":
+        return 0;
+      case "t":
+        return 2;
+      case "r":
+        return 3
+    }
+  return 1
+}
+gvjs_.Rfa = function(a, b, c, d, e, f) {
+  this.YS = 0;
+  this.SL = f;
+  if (!this.xa) {
+    this.xa = new gvjs_s8(this.El);
+    gvjs_x8(this);
+    f = this.El.kc().body;
+    var g = this.xa.j();
+    f.appendChild(g);
+    gvjs_6x(this, this.xa);
+    this.sF = new gvjs_n8(gvjs_r8(),!0);
+    this.sF.iL(!0);
+    this.sF.XM = !0;
+    f = this.sF;
+    g = this.xa.j();
+    var h = this.xa.WV;
+    f.Em = g;
+    f.XV = h
+  }
+  a: {
+    if (c)
+      switch (c.toLowerCase().split(",")[1]) {
+        case "l":
+          f = 0;
+          break a;
+        case "r":
+          f = 1;
+          break a
+      }
+    f = 2
+  }
+  this.sF.setPosition(gvjs_Dua(c), f, void 0, d);
+  gvjs_XC(this.xa.j(), gvjs_Msa);
+  this.BU != e && (this.BU && !gvjs_jf(gvjs_gg(this.BU)) && gvjs_XC(this.xa.j(), this.BU),
+  gvjs_jf(gvjs_gg(e)) || gvjs_VC(this.xa.j(), e),
+    this.BU = e);
+  gvjs_sz(this.xa.j(), 0, 0);
+  if (b instanceof gvjs_Zf)
+    c = this.xa.ib(),
+      gvjs_cg(c, b);
+  else
+    for (gvjs_hh(this.xa.ib()); c = b.firstChild; )
+      this.xa.ib().appendChild(c);
+  this.sF.hL(a);
+  this.sF.Mf(null, 0)
+}
+;
+function gvjs_x8(a) {
+  a.xa && gvjs_VC(a.xa.j(), gvjs_Msa)
+}
+;function gvjs_Eua(a, b) {
+  a.setAttribute(gvjs_S5, b || a.title || "");
+  a.title = ""
+}
+function gvjs_Fua(a, b) {
+  a.setAttribute(gvjs_cra, b || a.title || "");
+  a.title = ""
+}
+function gvjs_y8(a) {
+  a = gvjs_xQ(a.toString());
+  a = gvjs_57(a);
+  return gvjs_wy(a)
+}
+function gvjs_Gua(a, b) {
+  b = gvjs_4(gvjs_6a, {
+    dir: b ? gvjs_Up : gvjs_Dv
+  });
+  a = gvjs_xQ(a);
+  gvjs_cg(b, a);
+  return gvjs_4(gvjs_b, null, b).innerHTML
+}
+;function gvjs_z8() {}
+gvjs_o(gvjs_z8, gvjs_O7);
+gvjs_z8.prototype.il = function(a, b) {
+  gvjs_O7.prototype.il.call(this, a, b);
+  a && gvjs_Fua(a)
+}
+;
+gvjs_z8.prototype.setContent = function(a, b) {
+  gvjs_O7.prototype.setContent.call(this, a, b);
+  a && this.il(a, typeof b === gvjs_l ? b : "")
+}
+;
+function gvjs_A8() {
+  gvjs_N7.call(this, null, null, gvjs_zG(gvjs_z8))
+}
+gvjs_o(gvjs_A8, gvjs_N7);
+function gvjs_Hua(a, b, c, d) {
+  if (!c || gvjs_Yy(d))
+    if (d = parseFloat(d),
+      !isNaN(d))
+      return (typeof a === gvjs_g ? d >= a : !0) && (typeof b === gvjs_g ? d <= b : !0);
+  return !1
+}
+function gvjs_Iua(a, b, c) {
+  return String(parseFloat(c) / b).replace(new RegExp(a + "$"), "")
+}
+function gvjs_Jua(a, b, c) {
+  return String(parseFloat(c) * b) + a
+}
+function gvjs_Kua(a, b) {
+  var c = gvjs_re(gvjs_Iua, b.suffix || "", b.scale || 1);
+  a.$da = c;
+  c = gvjs_re(gvjs_Hua, b.min, b.max, !!b.Og);
+  a.lha = c;
+  b = gvjs_re(gvjs_Jua, b.suffix || "", b.scale || 1);
+  a.x$ = b
+}
+;var gvjs_Lua = {
+  8: "backspace",
+  9: "tab",
+  13: "enter",
+  16: "shift",
+  17: "ctrl",
+  18: "alt",
+  19: "pause",
+  20: "caps-lock",
+  27: "esc",
+  32: "space",
+  33: "pg-up",
+  34: "pg-down",
+  35: gvjs_R,
+  36: "home",
+  37: gvjs_$c,
+  38: "up",
+  39: gvjs_j,
+  40: "down",
+  45: "insert",
+  46: "delete",
+  48: "0",
+  49: "1",
+  50: "2",
+  51: "3",
+  52: "4",
+  53: "5",
+  54: "6",
+  55: "7",
+  56: "8",
+  57: "9",
+  59: "semicolon",
+  61: "equals",
+  65: "a",
+  66: "b",
+  67: "c",
+  68: "d",
+  69: "e",
+  70: "f",
+  71: "g",
+  72: "h",
+  73: "i",
+  74: "j",
+  75: "k",
+  76: "l",
+  77: "m",
+  78: "n",
+  79: "o",
+  80: "p",
+  81: "q",
+  82: "r",
+  83: "s",
+  84: "t",
+  85: "u",
+  86: "v",
+  87: "w",
+  88: "x",
+  89: "y",
+  90: "z",
+  93: "context",
+  96: "num-0",
+  97: "num-1",
+  98: "num-2",
+  99: "num-3",
+  100: "num-4",
+  101: "num-5",
+  102: "num-6",
+  103: "num-7",
+  104: "num-8",
+  105: "num-9",
+  106: "num-multiply",
+  107: "num-plus",
+  109: "num-minus",
+  110: "num-period",
+  111: "num-division",
+  112: "f1",
+  113: "f2",
+  114: "f3",
+  115: "f4",
+  116: "f5",
+  117: "f6",
+  118: "f7",
+  119: "f8",
+  120: "f9",
+  121: "f10",
+  122: "f11",
+  123: "f12",
+  186: "semicolon",
+  187: "equals",
+  189: gvjs_9t,
+  188: ",",
+  190: ".",
+  191: "/",
+  192: "`",
+  219: "open-square-bracket",
+  220: "\\",
+  221: "close-square-bracket",
+  222: "single-quote",
+  224: "win"
+};
+function gvjs_Mua(a, b, c, d, e, f, g, h, k, l) {
+  this.ih = a;
+  this.xz = b;
+  this.IT = c;
+  this.Mp = d;
+  this.YB = e;
+  this.PJ = f;
+  this.IL = g;
+  this.OS = h;
+  this.jA = k;
+  this.ZT = l
+}
+gvjs_Mua.prototype.getKey = function() {
+  return this.xz
+}
+;
+function gvjs_B8(a) {
+  var b = a.$i;
+  b = (b = b && "composed"in b && b && "composedPath"in b && b.composed && b.composedPath()) && 0 < b.length ? b[0] : a.target;
+  return gvjs_Nua(gvjs_Oua(gvjs_Pua((new gvjs_Qua).keyCode(a.keyCode || 0).key(a.key || "").shiftKey(!!a.shiftKey).altKey(!!a.altKey).ctrlKey(!!a.ctrlKey).metaKey(!!a.metaKey).target(a.target), b), function() {
+    return a.preventDefault()
+  }), function() {
+    return a.stopPropagation()
+  }).cd()
+}
+function gvjs_Qua() {
+  this.ih = null;
+  this.xz = "";
+  this.ZT = this.jA = this.OS = this.IL = this.PJ = this.YB = this.Mp = this.IT = null
+}
+gvjs_ = gvjs_Qua.prototype;
+gvjs_.keyCode = function(a) {
+  this.ih = a;
+  return this
+}
+;
+gvjs_.key = function(a) {
+  this.xz = a;
+  return this
+}
+;
+gvjs_.shiftKey = function(a) {
+  this.IT = a;
+  return this
+}
+;
+gvjs_.altKey = function(a) {
+  this.Mp = a;
+  return this
+}
+;
+gvjs_.ctrlKey = function(a) {
+  this.YB = a;
+  return this
+}
+;
+gvjs_.metaKey = function(a) {
+  this.PJ = a;
+  return this
+}
+;
+gvjs_.target = function(a) {
+  this.IL = a;
+  return this
+}
+;
+function gvjs_Pua(a, b) {
+  a.OS = b;
+  return a
+}
+function gvjs_Oua(a, b) {
+  a.jA = b;
+  return a
+}
+function gvjs_Nua(a, b) {
+  a.ZT = b;
+  return a
+}
+gvjs_.cd = function() {
+  return new gvjs_Mua(this.ih,this.xz,this.IT,this.Mp,this.YB,this.PJ,this.IL,this.OS,this.jA,this.ZT)
+}
+;
+function gvjs_C8(a, b, c) {
+  gvjs_1h.call(this, a, c);
+  this.identifier = b
+}
+gvjs_t(gvjs_C8, gvjs_1h);
+function gvjs_D8(a) {
+  gvjs_H.call(this);
+  this.wH = this.qL = {};
+  this.NQ = 0;
+  this.Yoa = gvjs_lq(gvjs_Rua);
+  this.Pxa = gvjs_lq(gvjs_Sua);
+  this.tka = !0;
+  this.lka = this.uka = !1;
+  this.yta = !0;
+  this.pka = !1;
+  this.HV = null;
+  this.am = a;
+  gvjs_G(this.am, gvjs_lv, this.gaa, void 0, this);
+  gvjs_G(this.am, gvjs_0sa, this.Daa, void 0, this);
+  gvjs_vg && (gvjs_G(this.am, gvjs_7c, this.Iaa, void 0, this),
+    gvjs_G(this.am, gvjs_1sa, this.Jaa, void 0, this));
+  gvjs_G(this.am, gvjs_mv, this.haa, void 0, this);
+  gvjs_G(this.am, gvjs_2sa, this.Eaa, void 0, this)
+}
+var gvjs_E8;
+gvjs_t(gvjs_D8, gvjs_H);
+function gvjs_Tua(a) {
+  this.Y3 = a || null;
+  this.next = a ? null : {}
+}
+var gvjs_Rua = [27, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 19]
+  , gvjs_Sua = [gvjs_1, gvjs_Lb, gvjs_Mb, "datetime-local", "email", "month", gvjs_g, "password", "search", "tel", gvjs_m, "time", "url", "week"];
+gvjs_ = gvjs_D8.prototype;
+gvjs_.Gea = function(a, b) {
+  gvjs_Uua(this.qL, gvjs_Vua(arguments), a)
+}
+;
+function gvjs_Vua(a) {
+  if (typeof a[1] === gvjs_l)
+    a = gvjs_Wua(a[1]).map(function(d) {
+      return gvjs_F8(d.key || "", d.keyCode, d.modifiers)
+    });
+  else {
+    var b = a
+      , c = 1;
+    Array.isArray(a[1]) && (b = a[1],
+      c = 0);
+    for (a = []; c < b.length; c += 2)
+      a.push(gvjs_F8("", b[c], b[c + 1]))
+  }
+  return a
+}
+gvjs_.M = function() {
+  gvjs_D8.G.M.call(this);
+  this.qL = {};
+  gvjs_ji(this.am, gvjs_lv, this.gaa, !1, this);
+  gvjs_ji(this.am, gvjs_0sa, this.Daa, !1, this);
+  gvjs_vg && (gvjs_ji(this.am, gvjs_7c, this.Iaa, !1, this),
+    gvjs_ji(this.am, gvjs_1sa, this.Jaa, !1, this));
+  gvjs_ji(this.am, gvjs_mv, this.haa, !1, this);
+  gvjs_ji(this.am, gvjs_2sa, this.Eaa, !1, this);
+  this.am = null
+}
+;
+function gvjs_Wua(a) {
+  a = a.replace(/[ +]*\+[ +]*/g, "+").replace(/[ ]+/g, " ").toLowerCase();
+  a = a.split(" ");
+  for (var b = [], c, d = 0; c = a[d]; d++) {
+    var e = c.split("+")
+      , f = null
+      , g = null;
+    c = 0;
+    for (var h, k = 0; h = e[k]; k++) {
+      switch (h) {
+        case "shift":
+          c |= 1;
+          continue;
+        case "ctrl":
+          c |= 2;
+          continue;
+        case "alt":
+          c |= 4;
+          continue;
+        case "meta":
+          c |= 8;
+          continue
+      }
+      e = void 0;
+      f = h;
+      if (!gvjs_E8) {
+        g = {};
+        for (e in gvjs_Lua)
+          g[gvjs_Lua[e]] = gvjs_aB(parseInt(e, 10));
+        gvjs_E8 = g
+      }
+      g = gvjs_E8[f];
+      f = h;
+      break
+    }
+    b.push({
+      key: f,
+      keyCode: g,
+      modifiers: c
+    })
+  }
+  return b
+}
+gvjs_.haa = function(a) {
+  a = gvjs_B8(a);
+  gvjs_sg && gvjs_Xua(this, a);
+  gvjs_vg && !this.yQ && gvjs_G8(a) && this.gn(a, !0)
+}
+;
+gvjs_.Eaa = function(a) {
+  a = a.getData();
+  gvjs_sg && gvjs_Xua(this, a);
+  gvjs_vg && !this.yQ && gvjs_G8(a) && this.gn(a, !0)
+}
+;
+function gvjs_Xua(a, b) {
+  32 == a.HV && 32 == b.ih && (0,
+    b.jA)();
+  a.HV = null
+}
+function gvjs_G8(a) {
+  return gvjs_vg && a.YB && a.Mp
+}
+gvjs_.Iaa = function(a) {
+  a = gvjs_B8(a);
+  32 < a.ih && gvjs_G8(a) && (this.yQ = !0)
+}
+;
+gvjs_.Jaa = function(a) {
+  a = a.getData();
+  32 < a.ih && gvjs_G8(a) && (this.yQ = !0)
+}
+;
+function gvjs_Uua(a, b, c) {
+  var d = b.shift();
+  d.forEach(function(e) {
+    if ((e = a[e]) && (0 == b.length || e.Y3))
+      throw Error("Keyboard shortcut conflicts with existing shortcut: " + e.Y3);
+  });
+  b.length ? d.forEach(function(e) {
+    e = gvjs_Ty(a, e.toString(), new gvjs_Tua);
+    var f = b.slice(0);
+    gvjs_Uua(e.next, f, c)
+  }) : d.forEach(function(e) {
+    a[e] = new gvjs_Tua(c)
+  })
+}
+function gvjs_Yua(a, b) {
+  for (var c = 0; c < b.length; c++) {
+    var d = a[b[c]];
+    if (d)
+      return d
+  }
+}
+function gvjs_F8(a, b, c) {
+  c = c || 0;
+  b = ["c_" + b + "_" + c];
+  "" != a && b.push("n_" + a + "_" + c);
+  return b
+}
+gvjs_.gaa = function(a) {
+  this.gn(gvjs_B8(a))
+}
+;
+gvjs_.Daa = function(a) {
+  this.gn(a.getData())
+}
+;
+gvjs_.gn = function(a, b) {
+  a: {
+    var c = a.ih;
+    if ("" != a.getKey()) {
+      var d = a.getKey();
+      if ("Control" == d || "Shift" == d || "Meta" == d || "AltGraph" == d) {
+        c = !1;
+        break a
+      }
+    } else if (16 == c || 17 == c || 18 == c) {
+      c = !1;
+      break a
+    }
+    d = a.OS;
+    var e = d.tagName == gvjs_Vo || d.tagName == gvjs_Na || d.tagName == gvjs_To || d.tagName == gvjs_Uo
+      , f = !e && (d.isContentEditable || d.ownerDocument && "on" == d.ownerDocument.designMode);
+    c = !e && !f || this.Yoa[c] || this.lka ? !0 : f ? !1 : this.yta && (a.Mp || a.YB || a.PJ) ? !0 : d.tagName == gvjs_Na && this.Pxa[d.type] ? 13 == c : d.tagName == gvjs_Na || d.tagName == gvjs_To ? this.pka ? !0 : 32 != c : !1
+  }
+  if (c)
+    if (!b && gvjs_G8(a))
+      this.yQ = !1;
+    else {
+      b = gvjs_aB(a.ih);
+      c = a.getKey();
+      c = gvjs_F8(c, b, (a.IT ? 1 : 0) | (a.YB ? 2 : 0) | (a.Mp ? 4 : 0) | (a.PJ ? 8 : 0));
+      d = gvjs_Yua(this.wH, c);
+      if (!d || 1500 <= Date.now() - this.NQ)
+        this.wH = this.qL,
+          this.NQ = Date.now();
+      (d = gvjs_Yua(this.wH, c)) && d.next && (this.wH = d.next,
+        this.NQ = Date.now());
+      d && (d.next ? (0,
+        a.jA)() : (this.wH = this.qL,
+        this.NQ = Date.now(),
+      this.tka && (0,
+        a.jA)(),
+      this.uka && (0,
+        a.ZT)(),
+        c = d.Y3,
+        d = this.dispatchEvent(new gvjs_C8("shortcut",c,a.IL)),
+      (d &= this.dispatchEvent(new gvjs_C8("shortcut_" + c,c,a.IL))) || (0,
+        a.jA)(),
+      gvjs_sg && (this.HV = b)))
+    }
+}
+;
+var gvjs_Zua = null;
+function gvjs__ua(a) {
+  var b = gvjs_Zua || new gvjs_H;
+  a = new gvjs_D8(a);
+  a.Gea("undo", [90, gvjs_ug ? 8 : 2]);
+  a.Gea("repeat-last-action", [89, gvjs_ug ? 8 : 2]);
+  gvjs_G(a, "shortcut", function(c) {
+    b.dispatchEvent(c)
+  });
+  gvjs_H8.push(a)
+}
+function gvjs_0ua() {
+  gvjs_u(gvjs_H8, function(a) {
+    gvjs_E(a)
+  });
+  gvjs_Fy(gvjs_H8)
+}
+var gvjs_H8 = [];
+function gvjs_I8(a) {
+  return a ? "light red berry " + a : "light red berry"
+}
+function gvjs_J8(a) {
+  return a ? "dark red berry " + a : "dark red berry"
+}
+function gvjs_K8(a) {
+  return a ? "light red " + a : "light red"
+}
+function gvjs_L8(a) {
+  return a ? "dark red " + a : "dark red"
+}
+function gvjs_M8(a) {
+  return a ? "light orange " + a : "light orange"
+}
+function gvjs_N8(a) {
+  return a ? "dark orange " + a : "dark orange"
+}
+function gvjs_O8(a) {
+  return a ? "light yellow " + a : "light yellow"
+}
+function gvjs_P8(a) {
+  return a ? "dark yellow " + a : "dark yellow"
+}
+function gvjs_Q8(a) {
+  return a ? "light green " + a : "light green"
+}
+function gvjs_R8(a) {
+  return a ? "dark green " + a : "dark green"
+}
+function gvjs_S8(a) {
+  return a ? "light cyan " + a : "light cyan"
+}
+function gvjs_T8(a) {
+  return a ? "dark cyan " + a : "dark cyan"
+}
+function gvjs_U8(a) {
+  return a ? "light cornflower blue " + a : "light cornflower blue"
+}
+function gvjs_V8(a) {
+  return a ? "dark cornflower blue " + a : "dark cornflower blue"
+}
+function gvjs_W8(a) {
+  return a ? "light blue " + a : "light blue"
+}
+function gvjs_X8(a) {
+  return a ? "dark blue " + a : "dark blue"
+}
+function gvjs_Y8(a) {
+  return a ? "light purple " + a : "light purple"
+}
+function gvjs_Z8(a) {
+  return a ? "dark purple " + a : "dark purple"
+}
+function gvjs__8(a) {
+  return a ? "light magenta " + a : "light magenta"
+}
+function gvjs_08(a) {
+  return a ? "dark magenta " + a : "dark magenta"
+}
+function gvjs_18(a) {
+  return a ? "light gray " + a : "light gray"
+}
+function gvjs_28(a) {
+  return a ? "dark gray " + a : "dark gray"
+}
+var gvjs_38 = {
+  "#000000": gvjs_rt,
+  "#434343": gvjs_28(4),
+  "#666666": gvjs_28(3),
+  "#999999": gvjs_28(2),
+  "#b7b7b7": gvjs_28(1),
+  "#cccccc": "gray",
+  "#d9d9d9": gvjs_18(1),
+  "#efefef": gvjs_18(2),
+  "#f3f3f3": gvjs_18(3),
+  "#ffffff": gvjs_Ox,
+  "#980000": "red berry",
+  "#e6b8af": gvjs_I8(3),
+  "#dd7e6b": gvjs_I8(2),
+  "#cc4125": gvjs_I8(1),
+  "#a61c00": gvjs_J8(1),
+  "#85200c": gvjs_J8(2),
+  "#5b0f00": gvjs_J8(3),
+  "#ff0000": "red",
+  "#f4cccc": gvjs_K8(3),
+  "#ea9999": gvjs_K8(2),
+  "#e06666": gvjs_K8(1),
+  "#cc0000": gvjs_L8(1),
+  "#990000": gvjs_L8(2),
+  "#660000": gvjs_L8(3),
+  "#ff9900": "orange",
+  "#fce5cd": gvjs_M8(3),
+  "#f9cb9c": gvjs_M8(2),
+  "#f6b26b": gvjs_M8(1),
+  "#e69138": gvjs_N8(1),
+  "#b45f06": gvjs_N8(2),
+  "#783f04": gvjs_N8(3),
+  "#ffff00": "yellow",
+  "#fff2cc": gvjs_O8(3),
+  "#ffe599": gvjs_O8(2),
+  "#ffd966": gvjs_O8(1),
+  "#f1c232": gvjs_P8(1),
+  "#bf9000": gvjs_P8(2),
+  "#7f6000": gvjs_P8(3),
+  "#00ff00": "green",
+  "#d9ead3": gvjs_Q8(3),
+  "#b6d7a8": gvjs_Q8(2),
+  "#93c47d": gvjs_Q8(1),
+  "#6aa84f": gvjs_R8(1),
+  "#38761d": gvjs_R8(2),
+  "#274e13": gvjs_R8(3),
+  "#00ffff": "cyan",
+  "#d0e0e3": gvjs_S8(3),
+  "#a2c4c9": gvjs_S8(2),
+  "#76a5af": gvjs_S8(1),
+  "#45818e": gvjs_T8(1),
+  "#134f5c": gvjs_T8(2),
+  "#0c343d": gvjs_T8(3),
+  "#4a86e8": "cornflower blue",
+  "#c9daf8": gvjs_U8(3),
+  "#a4c2f4": gvjs_U8(2),
+  "#6d9eeb": gvjs_U8(1),
+  "#3c78d8": gvjs_V8(1),
+  "#1155cc": gvjs_V8(2),
+  "#1c4587": gvjs_V8(3),
+  "#0000ff": "blue",
+  "#cfe2f3": gvjs_W8(3),
+  "#9fc5e8": gvjs_W8(2),
+  "#6fa8dc": gvjs_W8(1),
+  "#3d85c6": gvjs_X8(1),
+  "#0b5394": gvjs_X8(2),
+  "#073763": gvjs_X8(3),
+  "#9900ff": "purple",
+  "#d9d2e9": gvjs_Y8(3),
+  "#b4a7d6": gvjs_Y8(2),
+  "#8e7cc3": gvjs_Y8(1),
+  "#674ea7": gvjs_Z8(1),
+  "#351c75": gvjs_Z8(2),
+  "#20124d": gvjs_Z8(3),
+  "#ff00ff": "magenta",
+  "#ead1dc": gvjs__8(3),
+  "#d5a6bd": gvjs__8(2),
+  "#c27ba0": gvjs__8(1),
+  "#a64d79": gvjs_08(1),
+  "#741b47": gvjs_08(2),
+  "#4c1130": gvjs_08(3),
+  "#333333": gvjs_28(30),
+  "#808080": gvjs_28(20),
+  "#969696": gvjs_28(10),
+  "#c0c0c0": gvjs_18(10),
+  "#dddddd": gvjs_18(20),
+  "#99cc00": "yellow 11",
+  "#339966": "green 11",
+  "#33cccc": "blue 11",
+  "#3366ff": "blue 21",
+  "#800080": "purple 11",
+  "#ffcc00": gvjs_M8(12),
+  "#00ccff": gvjs_W8(12),
+  "#993366": gvjs_Y8(12),
+  "#ff99cc": gvjs_K8(13),
+  "#fadcb3": gvjs_M8(13),
+  "#ffff99": gvjs_O8(13),
+  "#ccffcc": gvjs_Q8(13),
+  "#ccffff": gvjs_W8(13),
+  "#c2d1f0": gvjs_W8(23),
+  "#e1c7e1": gvjs_Y8(13),
+  "#e69999": gvjs_K8(14),
+  "#ffcc99": gvjs_M8(14),
+  "#ebd780": gvjs_P8(14),
+  "#b3d580": gvjs_Q8(14),
+  "#bde6e1": gvjs_W8(14),
+  "#99ccff": gvjs_W8(14),
+  "#cc99ff": gvjs_Y8(14),
+  "#ff6600": gvjs_N8(15),
+  "#808000": gvjs_P8(15),
+  "#008000": gvjs_R8(15),
+  "#008080": gvjs_X8(15),
+  "#6666cc": gvjs_Z8(15),
+  "#800000": gvjs_L8(16),
+  "#993300": gvjs_N8(16),
+  "#330000": gvjs_P8(16),
+  "#003300": gvjs_R8(16),
+  "#003366": gvjs_X8(16),
+  "#000080": gvjs_X8(26),
+  "#333399": gvjs_Z8(16)
+};
+function gvjs_48() {}
+gvjs_t(gvjs_48, gvjs_cP);
+gvjs_le(gvjs_48);
+gvjs_ = gvjs_48.prototype;
+gvjs_.J = function(a) {
+  var b = this.Rl(a);
+  b = a.wa().J(gvjs_b, gvjs_Is + b.join(" "), [this.createCaption(a.getContent(), a.wa()), this.cO(a.wa())]);
+  this.il(b, a.en());
+  return b
+}
+;
+gvjs_.ib = function(a) {
+  return a && a.firstChild
+}
+;
+gvjs_.fb = function(a, b) {
+  var c = gvjs_gz("*", gvjs_Z, b)[0];
+  if (c) {
+    gvjs_6(c, !1);
+    a.wa().kc().body.appendChild(c);
+    var d = new gvjs_kE;
+    d.fb(c);
+    a.lp(d)
+  }
+  gvjs_gz("*", this.sa() + gvjs_Dr, b)[0] || b.appendChild(this.createCaption(b.childNodes, a.wa()));
+  gvjs_gz("*", this.sa() + gvjs_Hr, b)[0] || b.appendChild(this.cO(a.wa()));
+  return gvjs_48.G.fb.call(this, a, b)
+}
+;
+gvjs_.createCaption = function(a, b) {
+  return b.J(gvjs_b, gvjs_Is + (this.sa() + gvjs_Dr), a)
+}
+;
+gvjs_.cO = function(a) {
+  return a.J(gvjs_b, {
+    "class": gvjs_Is + (this.sa() + gvjs_Hr),
+    "aria-hidden": !0
+  }, "\u00a0")
+}
+;
+gvjs_.sa = function() {
+  return gvjs_2qa
+}
+;
+gvjs_HD(gvjs_2qa, function() {
+  return new gvjs_xE(null,null,gvjs_48.Lc())
+});
+function gvjs_58() {}
+gvjs_o(gvjs_58, gvjs_48);
+gvjs_58.prototype.createCaption = function(a, b) {
+  return gvjs_48.prototype.createCaption.call(this, b.J(gvjs_b, "goog-flat-menu-button-indicator", a), b)
+}
+;
+gvjs_58.prototype.Wa = function(a, b) {
+  if (a && (a = this.ib(a)) && a.firstChild) {
+    try {
+      var c = gvjs_qj(b).hex
+    } catch (d) {
+      c = gvjs_Qd
+    }
+    a.firstChild.style.backgroundColor = c
+  }
+}
+;
+var gvjs_1ua = !gvjs_y && !gvjs_Wf();
+function gvjs_2ua(a) {
+  if (/-[a-z]/.test(gvjs_D6))
+    return null;
+  if (gvjs_1ua && a.dataset) {
+    if (gvjs_Yf() && !(gvjs_D6 in a.dataset))
+      return null;
+    a = a.dataset.gridWidth;
+    return void 0 === a ? null : a
+  }
+  return a.getAttribute("data-" + gvjs_2y(gvjs_D6))
+}
+;function gvjs_68() {}
+gvjs_t(gvjs_68, gvjs_zD);
+gvjs_le(gvjs_68);
+var gvjs_3ua = 0;
+gvjs_ = gvjs_68.prototype;
+gvjs_.J = function(a) {
+  var b = this.Rl(a)
+    , c = a.wa()
+    , d = c.J;
+  var e = a.getContent();
+  for (var f = a.Tb(), g = a.wa(), h = [], k = 0, l = 0; k < f.height; k++) {
+    for (var m = [], n = 0; n < f.width; n++) {
+      var p = e && e[l++];
+      m.push(gvjs_78(this, p, g))
+    }
+    h.push(gvjs_88(this, m, g))
+  }
+  e = this.wX(h, g);
+  b = d.call(c, gvjs_b, b, e);
+  a = a.Tb().width;
+  if (gvjs_1ua && b.dataset)
+    b.dataset.gridWidth = a;
+  else {
+    if (/-[a-z]/.test(gvjs_D6))
+      throw Error("");
+    b.setAttribute("data-" + gvjs_2y(gvjs_D6), a)
+  }
+  return b
+}
+;
+gvjs_.wX = function(a, b) {
+  a = b.J(gvjs_ss, this.sa() + "-table", b.J(gvjs_ts, this.sa() + "-body", a));
+  gvjs_VB(a, gvjs_Pu);
+  a.cellSpacing = "0";
+  a.cellPadding = "0";
+  return a
+}
+;
+function gvjs_88(a, b, c) {
+  a = c.J(gvjs_vs, a.sa() + "-row", b);
+  gvjs_VB(a, gvjs_Cd);
+  return a
+}
+function gvjs_78(a, b, c) {
+  a = c.J(gvjs_us, {
+    "class": a.sa() + "-cell",
+    id: a.sa() + "-cell" + gvjs_3ua++
+  }, b);
+  gvjs_VB(a, "gridcell");
+  gvjs_WB(a, gvjs_Iw, !1);
+  gvjs_4ua(a);
+  return a
+}
+function gvjs_4ua(a) {
+  if (!gvjs_wh(a) && !gvjs__B(a)) {
+    for (var b = new gvjs_wQ(a), c = "", d; !c && (d = gvjs_fta(b)); )
+      1 == d.nodeType && (c = gvjs__B(d) || d.title);
+    c && gvjs_0B(a, c)
+  }
+}
+gvjs_.Fh = function() {
+  return !1
+}
+;
+gvjs_.fb = function() {
+  return null
+}
+;
+gvjs_.setContent = function(a, b) {
+  if (a) {
+    var c = gvjs_gz(gvjs_ts, this.sa() + "-body", a)[0];
+    if (c) {
+      var d = 0;
+      Array.prototype.forEach.call(c.rows, function(k) {
+        gvjs_u(k.cells, function(l) {
+          gvjs_hh(l);
+          l.removeAttribute(gvjs_et);
+          if (b) {
+            var m = b[d++];
+            m && (l.appendChild(m),
+              gvjs_4ua(l))
+          }
+        }, this)
+      }, this);
+      if (d < b.length) {
+        for (var e = [], f = gvjs_3g(a), g = gvjs_2ua(a); d < b.length; ) {
+          var h = b[d++];
+          e.push(gvjs_78(this, h, f));
+          e.length == g && (h = gvjs_88(this, e, f),
+            c.appendChild(h),
+            e.length = 0)
+        }
+        if (0 < e.length) {
+          for (; e.length < g; )
+            e.push(gvjs_78(this, "", f));
+          h = gvjs_88(this, e, f);
+          c.appendChild(h)
+        }
+      }
+    }
+    gvjs_Hz(a, !0, gvjs_sg)
+  }
+}
+;
+function gvjs_98(a, b, c) {
+  for (b = b.j(); c && 1 == c.nodeType && c != b; ) {
+    if (c.tagName == gvjs_us && gvjs_UC(c, a.sa() + "-cell"))
+      return c.firstChild;
+    c = c.parentNode
+  }
+  return null
+}
+gvjs_.sa = function() {
+  return "goog-palette"
+}
+;
+function gvjs_$8(a, b, c) {
+  gvjs_LD.call(this, a, b || gvjs_68.Lc(), c);
+  this.cs &= -89;
+  this.uH = new gvjs_5ua;
+  this.uH.uA(this);
+  this.h0 = -1
+}
+gvjs_t(gvjs_$8, gvjs_LD);
+gvjs_ = gvjs_$8.prototype;
+gvjs_.ya = null;
+gvjs_.fe = -1;
+gvjs_.Ca = null;
+gvjs_.M = function() {
+  gvjs_$8.G.M.call(this);
+  this.Ca && (this.Ca.pa(),
+    this.Ca = null);
+  this.ya = null;
+  this.uH.pa()
+}
+;
+gvjs_.JE = function(a) {
+  gvjs_$8.G.JE.call(this, a);
+  gvjs_6ua(this);
+  this.Ca ? (this.Ca.clear(),
+    gvjs_CE(this.Ca, a)) : (this.Ca = new gvjs_BE(a),
+    a = gvjs_s(this.BE, this),
+    this.Ca.bT = a,
+    this.hc().o(this.Ca, gvjs_k, this.b_));
+  this.fe = -1
+}
+;
+gvjs_.bj = function() {
+  return ""
+}
+;
+gvjs_.Lo = function(a) {
+  gvjs_$8.G.Lo.call(this, a);
+  var b = gvjs_98(this.Oa(), this, a.target);
+  b && a.relatedTarget && gvjs_rh(b, a.relatedTarget) || b != gvjs_a9(this) && gvjs_7ua(this, b)
+}
+;
+gvjs_.Cf = function(a) {
+  gvjs_$8.G.Cf.call(this, a);
+  this.ak() && (a = gvjs_98(this.Oa(), this, a.target),
+  a != gvjs_a9(this) && gvjs_7ua(this, a))
+}
+;
+gvjs_.$h = function(a) {
+  var b = gvjs_a9(this);
+  if (b) {
+    var c;
+    if (c = a)
+      c = this.Be() ? a.type != gvjs_md ? !0 : !!gvjs_98(this.Oa(), this, a.target) : !0;
+    c && this.gl(b);
+    return gvjs_$8.G.$h.call(this, a)
+  }
+  return !1
+}
+;
+gvjs_.gj = function(a) {
+  var b = this.getContent();
+  b = b ? b.length : 0;
+  var c = this.ya.width;
+  if (0 == b || !this.isEnabled())
+    return !1;
+  if (13 == a.keyCode || 32 == a.keyCode)
+    return this.$h(a);
+  if (36 == a.keyCode)
+    return gvjs_b9(this, 0, !0),
+      !0;
+  if (35 == a.keyCode)
+    return gvjs_b9(this, b - 1, !0),
+      !0;
+  var d = 0 > this.fe ? this.Vl() : this.fe;
+  switch (a.keyCode) {
+    case 37:
+      if (-1 == d || 0 == d)
+        d = b;
+      gvjs_b9(this, d - 1, !0);
+      a.preventDefault();
+      return !0;
+    case 39:
+      return d == b - 1 && (d = -1),
+        gvjs_b9(this, d + 1, !0),
+        a.preventDefault(),
+        !0;
+    case 38:
+      -1 == d && (d = b + c - 1);
+      if (d >= c)
+        return gvjs_b9(this, d - c, !0),
+          a.preventDefault(),
+          !0;
+      break;
+    case 40:
+      if (-1 == d && (d = -c),
+      d < b - c)
+        return gvjs_b9(this, d + c, !0),
+          a.preventDefault(),
+          !0
+  }
+  return !1
+}
+;
+gvjs_.b_ = function() {}
+;
+gvjs_.Tb = function() {
+  return this.ya
+}
+;
+gvjs_.wg = function(a, b) {
+  if (this.j())
+    throw Error(gvjs_8r);
+  this.ya = typeof a === gvjs_g ? new gvjs_A(a,b) : a;
+  gvjs_6ua(this)
+}
+;
+function gvjs_a9(a) {
+  var b = a.getContent();
+  return b && b[a.fe]
+}
+function gvjs_8ua(a) {
+  a.Oa();
+  return (a = gvjs_a9(a)) ? a.parentNode : null
+}
+gvjs_.Tg = function(a) {
+  gvjs_b9(this, a, !1)
+}
+;
+function gvjs_b9(a, b, c) {
+  b != a.fe && (gvjs_9ua(a, a.fe, !1),
+    a.h0 = a.fe,
+    a.fe = b,
+    gvjs_9ua(a, b, !0),
+  c && (b = gvjs_8ua(a),
+    gvjs_Iz(b, a.getParent().H)),
+    a.dispatchEvent("h"))
+}
+function gvjs_7ua(a, b) {
+  var c = a.getContent();
+  a.Tg(c && b ? c.indexOf(b) : -1)
+}
+gvjs_.Vl = function() {
+  return this.Ca ? this.Ca.Vl() : -1
+}
+;
+gvjs_.Be = function() {
+  return this.Ca ? this.Ca.Be() : null
+}
+;
+gvjs_.rk = function(a) {
+  this.Ca && this.Ca.rk(a)
+}
+;
+gvjs_.gl = function(a) {
+  this.Ca && this.Ca.gl(a)
+}
+;
+function gvjs_9ua(a, b, c) {
+  if (a.j()) {
+    var d = a.getContent();
+    if (d && 0 <= b && b < d.length) {
+      var e = gvjs_8ua(a);
+      a.uH.j() != e && (a.uH.H = e);
+      e = a.uH;
+      e.ci(c);
+      gvjs_FD(e, 2) == c && (e = a.Oa(),
+        b = d[b]) && (b = b ? b.parentNode : null,
+        gvjs_ZC(b, e.sa() + "-cell-hover", c),
+        c ? gvjs_WB(a.H, gvjs_Ts, b.id) : b.id == gvjs_XB(a.H, gvjs_Ts) && a.H.removeAttribute(gvjs_ct))
+    }
+  }
+}
+gvjs_.ci = function(a) {
+  a && -1 == this.fe ? this.Tg(-1 < this.h0 ? this.h0 : 0) : a || this.Tg(-1);
+  gvjs_$8.G.ci.call(this, a)
+}
+;
+gvjs_.BE = function(a, b) {
+  if (this.j()) {
+    var c = this.Oa();
+    a && (a = a.parentNode,
+      gvjs_ZC(a, c.sa() + "-cell-selected", b),
+      gvjs_WB(a, gvjs_Iw, b))
+  }
+}
+;
+function gvjs_6ua(a) {
+  var b = a.getContent();
+  if (b)
+    if (a.ya && a.ya.width) {
+      if (b = Math.ceil(b.length / a.ya.width),
+      typeof a.ya.height !== gvjs_g || a.ya.height < b)
+        a.ya.height = b
+    } else
+      b = Math.ceil(Math.sqrt(b.length)),
+        a.ya = new gvjs_A(b,b);
+  else
+    a.ya = new gvjs_A(0,0)
+}
+function gvjs_5ua() {
+  gvjs_LD.call(this, null);
+  this.ju |= 2
+}
+gvjs_t(gvjs_5ua, gvjs_LD);
+function gvjs_c9(a, b, c) {
+  this.Kb = a || [];
+  gvjs_$8.call(this, null, b || gvjs_68.Lc(), c);
+  this.ip(this.Kb)
+}
+gvjs_t(gvjs_c9, gvjs_$8);
+gvjs_ = gvjs_c9.prototype;
+gvjs_.NR = null;
+gvjs_.Kq = null;
+gvjs_.getColors = function() {
+  return this.Kb
+}
+;
+gvjs_.ip = function(a, b) {
+  this.Kb = a;
+  this.Kq = b || null;
+  this.NR = null;
+  this.setContent(gvjs_$ua(this))
+}
+;
+gvjs_.Av = function() {
+  var a = this.Be();
+  return a ? (a = gvjs_qz(a, gvjs_$X),
+    gvjs_d9(a)) : null
+}
+;
+gvjs_.tr = function(a) {
+  a = gvjs_d9(a);
+  this.NR || (this.NR = this.Kb.map(function(b) {
+    return gvjs_d9(b)
+  }));
+  this.rk(a ? this.NR.indexOf(a) : -1)
+}
+;
+function gvjs_$ua(a) {
+  return a.Kb.map(function(b, c) {
+    var d = this.wa().J(gvjs_b, {
+      "class": this.Oa().sa() + "-colorswatch",
+      style: gvjs_vb + b
+    });
+    d.title = this.Kq && this.Kq[c] ? this.Kq[c] : "#" == b.charAt(0) ? "RGB (" + gvjs_vj(b).join(gvjs_ha) + ")" : b;
+    return d
+  }, a)
+}
+function gvjs_d9(a) {
+  if (a)
+    try {
+      return gvjs_qj(a).hex
+    } catch (b) {}
+  return null
+}
+;function gvjs_e9(a, b) {
+  gvjs_c9.call(this, [gvjs_M6], a);
+  this.Ira = b;
+  this.Xr("google-visualization-charteditor-inherit-color")
+}
+gvjs_o(gvjs_e9, gvjs_c9);
+gvjs_e9.prototype.Av = function() {
+  return 0 == this.Vl() ? gvjs_M6 : null
+}
+;
+gvjs_e9.prototype.tr = function(a) {
+  this.rk(a == gvjs_M6 ? 0 : -1)
+}
+;
+gvjs_e9.prototype.J = function() {
+  gvjs_c9.prototype.J.call(this);
+  var a = this.j()
+    , b = this.wa()
+    , c = this.Oa().sa() + "-table";
+  a = b.hd(c, a);
+  gvjs_VC(a, gvjs_Y);
+  b.Sra(this.Ira, a)
+}
+;
+function gvjs_f9(a) {
+  gvjs_ZD.call(this, a);
+  this.Xr("google-visualization-charteditor-none-color");
+  this.eg(8, !0)
+}
+gvjs_o(gvjs_f9, gvjs_ZD);
+gvjs_f9.prototype.Av = function() {
+  return this.CQ() ? gvjs_f : null
+}
+;
+gvjs_f9.prototype.tr = function(a) {
+  this.qp(a == gvjs_f)
+}
+;
+var gvjs_g9 = [[gvjs_ca, "#434343", gvjs_pr, gvjs_tr, "#b7b7b7", gvjs_zr, "#d9d9d9", "#efefef", "#f3f3f3", gvjs_ea], "#980000 #f00 #f90 #ff0 #0f0 #0ff #4a86e8 #00f #90f #f0f".split(" "), ["#e6b8af", "#f4cccc", "#fce5cd", "#fff2cc", "#d9ead3", "#d0e0e3", "#c9daf8", "#cfe2f3", "#d9d2e9", "#ead1dc", "#dd7e6b", "#ea9999", "#f9cb9c", "#ffe599", "#b6d7a8", "#a2c4c9", "#a4c2f4", "#9fc5e8", "#b4a7d6", "#d5a6bd", "#cc4125", "#e06666", "#f6b26b", "#ffd966", "#93c47d", "#76a5af", "#6d9eeb", "#6fa8dc", "#8e7cc3", "#c27ba0", "#a61c00", "#cc0000", "#e69138", "#f1c232", "#6aa84f", "#45818e", "#3c78d8", gvjs_Y4, "#674ea7", "#a64d79", "#85200c", gvjs_iQ, "#b45f06", "#bf9000", "#38761d", "#134f5c", "#1155cc", "#0b5394", "#351c75", "#741b47", "#5b0f00", "#660000", "#783f04", "#7f6000", "#274e13", "#0c343d", "#1c4587", "#073763", "#20124d", "#4c1130"]]
+  , gvjs_ava = gvjs_Ke(gvjs_g9[0], gvjs_g9[1], gvjs_g9[2]);
+gvjs_lq(gvjs_v(gvjs_ava, gvjs_sj));
+function gvjs_bva() {
+  return gvjs_W('<div class="google-visualization-charteditor-panel google-visualization-charteditor-panel-scroll" id="' + gvjs_7(gvjs_b6) + gvjs_N4)
+}
+function gvjs_cva(a, b) {
+  var c = "Min: ";
+  var d = a.v8[b] ? gvjs_j5 + gvjs_7("google-visualization-charteditor-input-min-color-value") + gvjs_cqa : "";
+  c += gvjs_b5 + gvjs_7(gvjs_Y) + gvjs_r4 + d + gvjs_h5 + gvjs_7("google-visualization-charteditor-color-min") + gvjs_w4;
+  c += gvjs_GB("Min color");
+  c = c + '\'></div></div><div class="google-visualization-charteditor-item-gap"></div>Mid: <div class="' + (gvjs_7(gvjs_Y) + gvjs_aqa + gvjs_7("google-visualization-charteditor-color-mid") + gvjs_w4);
+  c += gvjs_GB("Mid color");
+  c += '\'></div></div><div class="google-visualization-charteditor-item-gap"></div>Max: ';
+  a = a.v8[b] ? gvjs_j5 + gvjs_7("google-visualization-charteditor-input-max-color-value") + gvjs_cqa : "";
+  c += gvjs_b5 + gvjs_7(gvjs_Y) + gvjs_r4 + a + gvjs_h5 + gvjs_7("google-visualization-charteditor-color-max") + gvjs_w4;
+  c += gvjs_GB("Max color");
+  return gvjs_W(c + gvjs__4)
+}
+function gvjs_dva(a) {
+  var b = a.features
+    , c = a.type
+    , d = "";
+  b.U1[c] && (d += '<div role="group" aria-labelledby="google-visualization-charteditor-chart-title"><div class="google-visualization-charteditor-multi-section-title" id="google-visualization-charteditor-chart-title">Chart</div>');
+  var e = a.features;
+  var f = a.type
+    , g = a.Ywa
+    , h = a.exa
+    , k = a.VP
+    , l = "";
+  if (gvjs_9(e.qg[f]) || gvjs_9(e.PW[f])) {
+    l += gvjs_Jqa;
+    if (e.PW[f]) {
+      l += '<div role="group" aria-labelledby="google-visualization-charteditor-title-label"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-title-label">';
+      l += "Title";
+      var m = e.yla[f] ? gvjs_h9(gvjs_Bra) : "";
+      l += gvjs_a + m + '<div class="google-visualization-charteditor-title-gap"></div><input type="text" id="' + gvjs_7("google-visualization-charteditor-input-chart-title") + gvjs_bqa;
+      l += gvjs_GB(gvjs_s5);
+      l += '\'/><div class="google-visualization-charteditor-item-gap"></div></div>'
+    }
+    gvjs_9(e.qg[f]) && gvjs_9(h) && (l += '<div role="group" aria-labelledby="google-visualization-charteditor-chart-title-legend"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-chart-title-legend">',
+      l += "Legend",
+      a = e.Msa[f] ? gvjs_la + gvjs_i9(gvjs_CB({
+        r0: gvjs_h6
+      }, a)) + gvjs_h9("google-visualization-charteditor-font-style-legend") : '<div class="google-visualization-charteditor-float-end ' + gvjs_7(gvjs_Y) + gvjs_X + gvjs_i9(gvjs_CB({
+        r0: gvjs_h6
+      }, a)) + gvjs_a,
+      l += gvjs_a + a + gvjs_a);
+    l += gvjs_a
+  }
+  if (gvjs_9(e.bb[f]) || gvjs_9(e.backgroundColor[f]) || gvjs_9(e.N7[f]) || gvjs_9(e.annotations[f]))
+    l += gvjs_Jqa,
+    e.bb[f] && (l += gvjs_f5 + gvjs_7(gvjs_Y) + gvjs_X,
+      l = l + 'Font</div><div id="' + (gvjs_7(gvjs_Ora) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_p4 + gvjs_7("Font") + gvjs_X + gvjs_eva() + '</div><div class="google-visualization-charteditor-item-gap"></div>')),
+    gvjs_9(e.N7[f]) && gvjs_9(g) && (l += gvjs_f5 + gvjs_7(gvjs_Y) + '" style="width: 125px">',
+      l = l + 'Effects</div><div id="' + (gvjs_7("google-visualization-charteditor-select-visual-semantics") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="certainty">'),
+      l = l + 'Dashes</li><li class="' + (gvjs_7(gvjs__) + '" value="scope">'),
+      l = l + 'Gray out</li><li class="' + (gvjs_7(gvjs__) + '" value="emphasis">'),
+      l += 'Emphasis</li></ul></div><div class="google-visualization-charteditor-item-gap"></div>'),
+    e.backgroundColor[f] && (a = "" + gvjs_j9(gvjs_ht),
+      l += gvjs_f5 + gvjs_7(gvjs_Y) + gvjs_X,
+      l = l + 'Background</div><div id="' + (gvjs_7("google-visualization-charteditor-color-background") + '" class="google-visualization-charteditor-color google-visualization-charteditor-float-end" data-tooltip-base="' + gvjs_7(a) + gvjs_N4)),
+      l += gvjs_a,
+    gvjs_9(e.annotations[f]) && gvjs_9(k) && (l += '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-chart-line-annotation"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-chart-line-annotation">',
+      l = l + 'Line annotations</div><div class="google-visualization-charteditor-color google-visualization-charteditor-float-end ' + (gvjs_7(gvjs_Y) + gvjs_ir + gvjs_7("google-visualization-charteditor-color-line-domain-annotations") + gvjs_x4 + gvjs_7(gvjs_7r) + '"></div><div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualization-charteditor-chart-line-annotation-font"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-chart-line-annotation-font">'),
+      l = l + "Font</div>" + (gvjs_h9("google-visualization-charteditor-font-style-domain-annotations") + gvjs_64));
+  k = l;
+  e.QT[f] ? (l = gvjs_e5 + gvjs_7(gvjs_Y) + gvjs_X,
+    l = l + 'Slice</div><div class="google-visualization-charteditor-float-end"><div id="' + (gvjs_7("google-visualization-charteditor-select-slice-text") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="percentage">'),
+    l = l + 'Percentage</li><li class="' + (gvjs_7(gvjs__) + gvjs_L4),
+    l = l + 'Value</li><li class="' + (gvjs_7(gvjs__) + '" value="label">'),
+    l = l + 'Label</li><li class="' + (gvjs_7(gvjs__) + gvjs_J4),
+    l = l + gvjs_Uqa + (gvjs_k9("google-visualization-charteditor-combo-font-size-slice") + gvjs_h5 + gvjs_7("google-visualization-charteditor-color-font-slice") + '" class="google-visualization-charteditor-color"></div></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X),
+    l = l + 'Border</div><div id="' + (gvjs_7("google-visualization-charteditor-color-slice-border") + '" class="google-visualization-charteditor-color google-visualization-charteditor-float-end"></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X),
+    l = l + 'Donut hole</div><div id="' + (gvjs_7("google-visualization-charteditor-combo-donut-hole") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_D4),
+    l = l + gvjs_B5 + (gvjs_7(gvjs__) + '" value="0.25">25%</li><li class="' + gvjs_7(gvjs__) + '" value="0.5">50%</li><li class="' + gvjs_7(gvjs__) + '" value="0.75">75%</li></ul></div></div>'),
+    l = gvjs_W(l)) : l = "";
+  e.O[f] ? (e = gvjs_e5 + gvjs_7(gvjs_Y) + gvjs_X,
+    e = e + 'Left margin</div><div id="' + (gvjs_7("google-visualization-charteditor-select-chart-area-left") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4),
+    e = e + gvjs_u5 + (gvjs_7(gvjs__) + gvjs_iqa + gvjs_7(gvjs__) + gvjs_jqa + gvjs_7(gvjs__) + gvjs_kqa + gvjs_7(gvjs__) + gvjs_lqa + gvjs_7(gvjs__) + gvjs_mqa + gvjs_7(gvjs__) + gvjs_nqa + gvjs_7(gvjs_Y) + gvjs_X),
+    e = e + 'Top margin</div><div id="' + (gvjs_7("google-visualization-charteditor-select-chart-area-top") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4),
+    e = e + gvjs_u5 + (gvjs_7(gvjs__) + gvjs_iqa + gvjs_7(gvjs__) + gvjs_jqa + gvjs_7(gvjs__) + gvjs_kqa + gvjs_7(gvjs__) + gvjs_lqa + gvjs_7(gvjs__) + gvjs_mqa + gvjs_7(gvjs__) + gvjs_nqa + gvjs_7(gvjs_Y) + gvjs_X),
+    e = e + 'Width</div><div id="' + (gvjs_7("google-visualization-charteditor-select-chart-area-width") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4),
+    e = e + gvjs_u5 + (gvjs_7(gvjs__) + gvjs_oqa + gvjs_7(gvjs__) + gvjs_pqa + gvjs_7(gvjs__) + gvjs_qqa + gvjs_7(gvjs__) + gvjs_sqa + gvjs_7(gvjs__) + gvjs_tqa + gvjs_7(gvjs__) + '" value="100%">100%</li></ul></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X),
+    e = e + 'Height</div><div id="' + (gvjs_7("google-visualization-charteditor-select-chart-area-height") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_s4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4),
+    e = e + gvjs_u5 + (gvjs_7(gvjs__) + gvjs_oqa + gvjs_7(gvjs__) + gvjs_pqa + gvjs_7(gvjs__) + gvjs_qqa + gvjs_7(gvjs__) + gvjs_sqa + gvjs_7(gvjs__) + gvjs_tqa + gvjs_7(gvjs__) + '" value="100%">100%</li></ul></div></div>'),
+    e = gvjs_W(e)) : e = "";
+  e = gvjs_W(k + (l + e));
+  d += e + (b.U1[c] ? gvjs_a : "");
+  return gvjs_W(d)
+}
+function gvjs_fva(a) {
+  a = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-features-title"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-features-title">Features</div><div class="google-visualization-charteditor-checkbox-container">' + (gvjs_FB(a.options) + gvjs_64);
+  return gvjs_W(a)
+}
+function gvjs_gva(a, b, c) {
+  return gvjs_W('<div class="google-visualization-charteditor-multi-section-gap"> </div><div class="google-visualization-charteditor-multi-section-title"><div class="google-visualization-charteditor-multi-section-title-text ' + gvjs_7(gvjs_Y) + '"' + (c ? gvjs_t4 + gvjs_7(c) + '"' : "") + ">" + gvjs_FB(a) + '</div><div class="google-visualization-charteditor-multi-section-chooser">' + gvjs_FB(b) + gvjs_64)
+}
+function gvjs_hva(a) {
+  var b = "";
+  if (0 < a.J1) {
+    b += '<div role="group" aria-labelledby="google-visualization-charteditor-series-title">';
+    var c = a.type
+      , d = a.features
+      , e = a.oq
+      , f = a.J1;
+    var g = "";
+    if (0 < f) {
+      g += gvjs_h5 + gvjs_7(gvjs_$ra) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_X;
+      if (gvjs_9(d.II[c]) || gvjs_9(e) && gvjs_9(d.Lg[c]) && 1 < f)
+        g += gvjs_k5 + gvjs_7(gvjs__) + ' google-visualization-charteditor-menu-item-global">',
+          c = "All " + gvjs_Uta(a.type),
+          g = g + c + gvjs_Yr;
+      f = Math.max(0, Math.ceil(f - 0));
+      for (c = 0; c < f; c++)
+        d = 1 * c,
+          g += gvjs_k5 + gvjs_7(gvjs__) + gvjs_X + gvjs_17(d) + gvjs_Yr;
+      g += gvjs_a5
+    }
+    g = gvjs_W(g);
+    b += gvjs_gva("Series", gvjs_sq("" + g), "google-visualization-charteditor-series-title");
+    g = a.J1;
+    f = a.type;
+    c = a.features;
+    var h = a.kC
+      , k = a.MO
+      , l = a.hra
+      , m = a.annotations
+      , n = a.vo
+      , p = a.ksa
+      , q = a.$ra;
+    d = a.oq;
+    var r = a.qY;
+    e = "";
+    if (0 < g) {
+      if (c.II[f]) {
+        var t = gvjs_h5 + gvjs_7(gvjs_n6) + '" class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X;
+        t = t + 'Labels</div><div class="google-visualization-charteditor-float-end">' + (gvjs_k9("google-visualization-charteditor-combo-font-size-bubble") + gvjs_h5 + gvjs_7(gvjs_vra) + '" class="google-visualization-charteditor-color"> </div></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X);
+        t = t + 'Border color</div><div id="' + (gvjs_7("google-visualization-charteditor-color-stroke-bubble") + '" class="google-visualization-charteditor-color google-visualization-charteditor-float-end"> </div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X);
+        t = t + 'Opacity</div><div class="google-visualization-charteditor-float-end">' + (gvjs_l9("google-visualization-charteditor-combo-opacity-bubble") + gvjs_64);
+        t = gvjs_W(t)
+      } else
+        t = "";
+      e += t + gvjs_h5 + gvjs_7(gvjs_6ra) + '"><div class="google-visualization-charteditor-section"><div class="' + gvjs_7(gvjs_j6) + gvjs_T4 + gvjs_7(gvjs_Y) + gvjs_X;
+      e += gvjs_Qqa;
+      t = Math.max(0, Math.ceil(g - 0));
+      for (var u = 0; u < t; u++) {
+        var v = 1 * u;
+        e += gvjs_h5 + gvjs_7(gvjs_i6) + gvjs_44 + gvjs_7(v) + gvjs_w4;
+        e += gvjs_GB(gvjs_7r);
+        e += "'> </div>"
+      }
+      e += gvjs_64;
+      if (c.z3[f]) {
+        e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + gvjs_Rqa + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_iva(gvjs_Lu) : "");
+        t = Math.max(0, Math.ceil(g - 0));
+        for (u = 0; u < t; u++)
+          e += gvjs_iva(1 * u);
+        e += gvjs_a
+      }
+      if (c.sfa[f]) {
+        e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e += gvjs_r5;
+        t = gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_m9(gvjs_Xra) : "";
+        e += gvjs_74 + t;
+        t = Math.max(0, Math.ceil(g - 0));
+        for (u = 0; u < t; u++)
+          e += gvjs_m9("google-visualization-charteditor-series-combo-opacity-area-series-" + 1 * u);
+        e += gvjs_a
+      }
+      if (c.kea[f]) {
+        e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + 'Point size</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_jva({
+          Ud: gvjs_Lu
+        }) : "");
+        t = Math.max(0, Math.ceil(g - 0));
+        for (u = 0; u < t; u++)
+          e += gvjs_jva({
+            Ud: 1 * u
+          });
+        e += gvjs_a;
+        if (h) {
+          e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+          e = e + 'Point shape</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_kva({
+            Ud: gvjs_Lu
+          }) : "");
+          h = Math.max(0, Math.ceil(g - 0));
+          for (t = 0; t < h; t++)
+            e += gvjs_kva({
+              Ud: 1 * t
+            });
+          e += gvjs_a
+        }
+      }
+      if (c.owa[f]) {
+        e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + 'Type</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_lva(gvjs_Lu) : "");
+        h = Math.max(0, Math.ceil(g - 0));
+        for (t = 0; t < h; t++)
+          e += gvjs_lva(1 * t);
+        e += gvjs_a
+      }
+      if (c.UH[f]) {
+        e += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + 'Axis</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_mva(gvjs_Lu) : "");
+        h = Math.max(0, Math.ceil(g - 0));
+        for (t = 0; t < h; t++)
+          e += gvjs_mva(1 * t);
+        e += gvjs_a
+      }
+      if (c.nwa[f]) {
+        e += '<div class="google-visualization-charteditor-item-gap"></div><div class="' + gvjs_7(gvjs_Y) + gvjs_X;
+        e += "Min<br>";
+        h = Math.max(0, Math.ceil(g - 0));
+        for (t = 0; t < h; t++)
+          u = 1 * t,
+            e += gvjs_i5 + gvjs_7(gvjs_4ra) + gvjs_44 + gvjs_7(u) + gvjs_A4,
+            e += gvjs_GB("Min"),
+            e += "'>";
+        e += '</div><div class="google-visualization-charteditor-float-end">Max<br>';
+        h = Math.max(0, Math.ceil(g - 0));
+        for (t = 0; t < h; t++)
+          u = 1 * t,
+            e += gvjs_i5 + gvjs_7(gvjs_3ra) + gvjs_44 + gvjs_7(u) + gvjs_A4,
+            e += gvjs_GB("Max"),
+            e += "'>";
+        e += gvjs_a
+      }
+      if (gvjs_9(c.tfa[f]) || gvjs_9(c.ufa[f])) {
+        e += gvjs_c5;
+        if (c.tfa[f])
+          for (h = Math.max(0, Math.ceil(g - 0)),
+                 t = 0; t < h; t++)
+            u = 1 * t,
+              e += gvjs_n5 + gvjs_7(gvjs_Tra) + gvjs_44 + gvjs_7(u) + gvjs_P4,
+              e += "Dashed line",
+              e += gvjs_94;
+        if (c.ufa[f])
+          for (e += gvjs_c5,
+                 h = Math.max(0, Math.ceil(g - 0)),
+                 t = 0; t < h; t++)
+            u = 1 * t,
+              e += gvjs_n5 + gvjs_7(gvjs_Ura) + gvjs_44 + gvjs_7(u) + gvjs_P4,
+              e += "Show points",
+              e += gvjs_94
+      }
+      if (gvjs_9(c.annotations[f]) && gvjs_9(n)) {
+        e += '<div class="google-visualization-charteditor-item-gap"></div><div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X;
+        e += "Data labels";
+        h = gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_nva(gvjs_CB({
+          c9: "google-visualization-charteditor-series-select-data-label-type-series-global",
+          hT: gvjs_Lu,
+          Maa: m.global
+        }, a)) + gvjs_h9("google-visualization-charteditor-series-data-label-font-style-series-global") : "";
+        e += "</div><br/>" + h;
+        h = Math.max(0, Math.ceil(g - 0));
+        for (t = 0; t < h; t++)
+          u = 1 * t,
+            e += gvjs_nva(gvjs_CB({
+              c9: "google-visualization-charteditor-series-select-data-label-type-series-" + u,
+              hT: u,
+              Maa: m[u]
+            }, a)) + gvjs_h9("google-visualization-charteditor-series-data-label-font-style-series-" + u);
+        e += gvjs_a
+      }
+      if (c.V9[f]) {
+        e = e + '<div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualization-charteditor-errorbars"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-errorbars">Error bars</div>' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_ova(gvjs_Lu) : "");
+        a = Math.max(0, Math.ceil(g - 0));
+        for (m = 0; m < a; m++)
+          e += gvjs_ova(1 * m);
+        e += gvjs_a
+      }
+      if (gvjs_9(c.hka[f]) && gvjs_9(k)) {
+        e += gvjs_b5 + gvjs_7(gvjs_y6) + gvjs_R4 + gvjs_7(gvjs_Y) + gvjs_X;
+        e += gvjs_Mqa;
+        a = gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_n9("google-visualization-charteditor-series-select-aggregate-type-series-global", !0) : "";
+        e += gvjs_74 + a;
+        a = Math.max(0, Math.ceil(g - 0));
+        for (k = 0; k < a; k++)
+          e += gvjs_n9("google-visualization-charteditor-series-select-aggregate-type-series-" + 1 * k, !1);
+        e += gvjs_64
+      }
+      if (gvjs_9(c.annotations[f]) && gvjs_9(l) && !n)
+        for (a = Math.max(0, Math.ceil(g - 0)),
+               l = 0; l < a; l++)
+          n = 1 * l,
+            e += gvjs_h5 + gvjs_7(gvjs_Sra) + gvjs_44 + gvjs_7(n) + gvjs_R4 + gvjs_7(gvjs_Y) + gvjs_X,
+            e += "Annotations",
+            e += gvjs_a + gvjs_h9("google-visualization-charteditor-series-font-style-annotations-series-" + n) + gvjs_a;
+      e += gvjs_a;
+      if (gvjs_9(c.GU[f]) && (!c.YN[f] || gvjs_9(p) || gvjs_9(q) || gvjs_9(r))) {
+        e += gvjs_e5 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + 'Trendline</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_pva(gvjs_Lu) : "");
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          e += gvjs_pva(1 * p);
+        e += '</div><div class="' + gvjs_7(gvjs_u6) + gvjs_dqa + gvjs_7(gvjs_s6) + gvjs_R4 + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + "Degree</div>" + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_qva(gvjs_Lu) : "");
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          e += gvjs_qva(1 * p);
+        e += gvjs_Gqa + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + 'Label</div><div class="google-visualization-charteditor-float-end">' + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_rva(gvjs_Lu) : "");
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          e += gvjs_rva(1 * p);
+        e += '</div><div class="google-visualization-charteditor-title-gap"></div>';
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          q = 1 * p,
+            e += gvjs_j5 + gvjs_7(gvjs_5ra) + gvjs_44 + gvjs_7(q) + gvjs_bqa,
+            e += gvjs_GB("Label"),
+            e += "'/>";
+        e += '<div class="google-visualization-charteditor-title-gap"></div>';
+        gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g && (e += gvjs_m5 + gvjs_7(gvjs_v6) + '-series-global"></span>',
+          e += "Show R&sup2;</span>");
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          q = 1 * p,
+            e += gvjs_m5 + gvjs_7(gvjs_v6) + gvjs_44 + gvjs_7(q) + gvjs_P4,
+            e += "Show R&sup2;",
+            e += gvjs_94;
+        e += gvjs_b5 + gvjs_7(gvjs_x6) + gvjs_R4 + gvjs_7(gvjs_Y) + gvjs_X;
+        e += gvjs_Qqa;
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          q = 1 * p,
+            e += gvjs_h5 + gvjs_7(gvjs_r6) + gvjs_44 + gvjs_7(q) + gvjs_w4,
+            e += gvjs_GB(gvjs_7r),
+            e += "'> </div>";
+        e += '</div></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + gvjs_X;
+        e += "Opacity";
+        a = gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_l9(gvjs_esa) : "";
+        e += gvjs_74 + a;
+        a = Math.max(0, Math.ceil(g - 0));
+        for (p = 0; p < a; p++)
+          e += gvjs_l9("google-visualization-charteditor-series-trendline-opacity-series-" + 1 * p);
+        e += gvjs_Gqa + gvjs_7(gvjs_Y) + gvjs_X;
+        e = e + gvjs_Rqa + (gvjs_9(d) && gvjs_9(c.Lg[f]) && 1 < g ? gvjs_sva(gvjs_Lu) : "");
+        g = Math.max(0, Math.ceil(g - 0));
+        for (f = 0; f < g; f++)
+          e += gvjs_sva(1 * f);
+        e += gvjs_Eqa
+      }
+      e += gvjs_a
+    }
+    g = gvjs_W(e);
+    b += g + gvjs_a
+  }
+  return gvjs_W(b)
+}
+function gvjs_nva(a) {
+  var b = a.hT
+    , c = a.Maa;
+  a = gvjs_h5 + gvjs_7(a.c9) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + '" style="margin-left:0;" data-tooltip-base="' + gvjs_7("Data label") + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(b, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_J4;
+  a = a + gvjs_B5 + (gvjs_7(gvjs__) + gvjs_L4);
+  a += "Value</li>";
+  c && (a += gvjs_k5 + gvjs_7(gvjs__) + gvjs_I4,
+    a += "Custom</li>");
+  return gvjs_W(a + gvjs_a5)
+}
+function gvjs_i9(a) {
+  var b = a.type
+    , c = a.features;
+  a = gvjs_h5 + gvjs_7(a.r0) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_x4 + gvjs_7("Position") + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="right">';
+  a = a + 'Right</li><li class="' + (gvjs_7(gvjs__) + '" value="left">');
+  a = a + 'Left</li><li class="' + (gvjs_7(gvjs__) + '" value="top">');
+  a = a + 'Top</li><li class="' + (gvjs_7(gvjs__) + '" value="bottom">');
+  a += "Bottom</li>";
+  c.Nsa[b] && (a += gvjs_k5 + gvjs_7(gvjs__) + '" value="in">',
+    a += "Inside</li>");
+  c.Osa[b] && (a += gvjs_k5 + gvjs_7(gvjs__) + '" value="labeled">',
+    a += "Labeled</li>");
+  a += gvjs_k5 + gvjs_7(gvjs__) + gvjs_J4;
+  return gvjs_W(a + gvjs_Uqa)
+}
+function gvjs_tva() {
+  var a = gvjs_Iqa + gvjs_7(gvjs_Y) + gvjs_X;
+  return gvjs_W(a + "Use color from series</div>")
+}
+function gvjs_uva() {
+  var a = gvjs_Iqa + gvjs_7(gvjs_Y) + gvjs_X;
+  return gvjs_W(a + "Match major lines</div>")
+}
+function gvjs_k9(a, b) {
+  var c = "" + gvjs_j9(gvjs_zp);
+  a = (a ? gvjs_h5 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_x4 + gvjs_7(c) + gvjs_X : gvjs_b5 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_x4 + gvjs_7(c) + gvjs_X) + gvjs_vva(b) + gvjs_a;
+  return gvjs_W(a)
+}
+function gvjs_vva(a) {
+  var b = gvjs_8(a, gvjs_Bra);
+  b || (b = gvjs_8(a, gvjs_Cra));
+  return gvjs_W(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_o9(b ? gvjs_p7(10, 12, 14, 16, 18, 20, 24, 30, 36) : gvjs_p7(7, 8, 9, 10, 11, 12, 13, 14, 15, 20)) + gvjs_a)
+}
+function gvjs_l9(a) {
+  var b = gvjs_h5 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4;
+  b += gvjs_GB("Opacity");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_esa) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "");
+  a = gvjs_p7(0, 20, 40, 60, 80, 100);
+  for (var c = Math.max(0, Math.ceil(a.length - 0)), d = 0; d < c; d++) {
+    var e = 1 * d;
+    b += gvjs_k5 + gvjs_7(gvjs__) + gvjs_jr + gvjs_7(a[e] / 100) + gvjs_X + gvjs_FB(a[e]) + "%</li>"
+  }
+  return gvjs_W(b + gvjs_a5)
+}
+function gvjs_m9(a) {
+  var b = gvjs_h5 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4;
+  b += gvjs_GB(gvjs_r5);
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Xra) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "");
+  a = gvjs_p7(0, 10, 30, 50, 70, 90, 100);
+  for (var c = Math.max(0, Math.ceil(a.length - 0)), d = 0; d < c; d++) {
+    var e = 1 * d;
+    b += gvjs_k5 + gvjs_7(gvjs__) + gvjs_jr + gvjs_7(a[e] / 100) + gvjs_X + gvjs_FB(a[e]) + "%</li>"
+  }
+  return gvjs_W(b + gvjs_a5)
+}
+function gvjs_o9(a, b) {
+  for (var c = "", d = Math.max(0, Math.ceil(a.length - 0)), e = 0; e < d; e++) {
+    var f = 1 * e;
+    c += gvjs_b5 + gvjs_7(gvjs__) + gvjs_jr + gvjs_7(a[f]) + gvjs_X + gvjs_FB(a[f]) + (b ? gvjs_FB(b) : "") + gvjs_a
+  }
+  return gvjs_W(c)
+}
+function gvjs_wva() {
+  for (var a = gvjs_p7("Auto", 2, 3, 4, 5, 6, 7, 8, 9, 10), b = gvjs_p7(-1), c = "", d = Math.max(0, Math.ceil(a.length - 0)), e = 0; e < d; e++) {
+    var f = 1 * e;
+    c += gvjs_b5 + gvjs_7(gvjs__) + gvjs_jr + (b[f] ? gvjs_7(b[f]) : gvjs_7(a[f])) + gvjs_X + gvjs_FB(a[f]) + gvjs_a
+  }
+  return gvjs_W(c)
+}
+function gvjs_h9(a) {
+  var b = gvjs_h5 + gvjs_7(a) + '" class="google-visualization-charteditor-float-end ' + gvjs_7(gvjs_Y) + gvjs_X
+    , c = "" + gvjs_j9(gvjs_Du)
+    , d = "" + gvjs_j9(gvjs_st)
+    , e = "" + gvjs_j9(gvjs_Gp);
+  b += '<div class="google-visualization-charteditor-toggle google-visualization-charteditor-toggle-bold jfk-button ' + gvjs_7(gvjs_Y) + gvjs_x4 + gvjs_7(d) + '"><div class="google-visualization-charteditor-toggle-bold-content ' + gvjs_7(gvjs_Y) + '">&nbsp;</div></div><div class="google-visualization-charteditor-toggle google-visualization-charteditor-toggle-italic jfk-button ' + gvjs_7(gvjs_Y) + gvjs_x4 + gvjs_7(e) + '"><div class="google-visualization-charteditor-toggle-italic-content ' + gvjs_7(gvjs_Y) + '">&nbsp;</div></div>' + gvjs_k9("", a) + '<div class="google-visualization-charteditor-color" data-tooltip-base="' + gvjs_7(c) + gvjs_xqa;
+  return gvjs_W(b)
+}
+function gvjs_eva() {
+  return gvjs_W(gvjs_o5 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" style="font-family:Arial;" value="Arial">Arial</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:sans-serif;" value="sans-serif">Sans Serif</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:serif;" value="Serif">Serif</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Arial black;" value="Arial black">Wide</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Arial Narrow;" value="Arial Narrow">Narrow</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Comic Sans MS;" value="Comic Sans MS">Comic Sans MS</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Courier New;" value="Courier New">Courier New</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Garamond;" value="Garamond">Garamond</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Georgia;" value="Georgia">Georgia</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Tahoma;" value="Tahoma">Tahoma</li><li class="' + gvjs_7(gvjs__) + '" style="font-family:Verdana;" value="Verdana">Verdana</li></ul>')
+}
+function gvjs_j9(a) {
+  var b = "";
+  gvjs_8(a, gvjs_zp) ? b += "Font size" : gvjs_8(a, gvjs_st) ? b += "Bold" : gvjs_8(a, gvjs_Gp) ? b += "Italic" : gvjs_8(a, gvjs_Du) ? b += "Font color" : gvjs_8(a, gvjs_ht) && (b += gvjs_Oqa);
+  return b
+}
+function gvjs_iva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_Wra) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB(gvjs_y5);
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_F4 + gvjs_7(gvjs__) + gvjs_G4 + gvjs_7(gvjs__) + gvjs_H4 + gvjs_7(gvjs__) + gvjs_rqa;
+  return gvjs_W(b)
+}
+function gvjs_jva(a) {
+  var b = a.Ud;
+  b = gvjs_h5 + gvjs_7(gvjs_Yra) + gvjs_44 + gvjs_7(b) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4;
+  b += gvjs_GB("Point size");
+  b += "'>" + gvjs_p9(a.Ud) + gvjs_a;
+  return gvjs_W(b)
+}
+function gvjs_p9(a) {
+  a = gvjs_o5 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + '" optionType="size" value="0">';
+  a = a + gvjs_B5 + (gvjs_7(gvjs__) + '" optionType="size" value="2">2px</li><li class="' + gvjs_7(gvjs__) + '" optionType="size" value="7">7px</li><li class="' + gvjs_7(gvjs__) + '" optionType="size" value="10">10px</li><li class="' + gvjs_7(gvjs__) + '" optionType="size" value="14">14px</li></ul>');
+  return gvjs_W(a)
+}
+function gvjs_mva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_bsa) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB("Axis");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_D4;
+  b = b + 'Left axis</li><li class="' + (gvjs_7(gvjs__) + gvjs_E4);
+  return gvjs_W(b + "Right axis</li></ul></div>")
+}
+function gvjs_ova(a) {
+  var b = '<div class="goog-inline-block"><input id="' + gvjs_7(gvjs_2ra) + gvjs_44 + gvjs_7(a) + '" type="text" class="google-visualization-charteditor-mid-input" data-tooltip-base=\'';
+  b += gvjs_GB("Size");
+  b += "'></div><div id=\"" + gvjs_7(gvjs_asa) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_q4;
+  b += gvjs_GB("Type");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_J4;
+  b = b + gvjs_B5 + (gvjs_7(gvjs__) + '" value="constant">');
+  b = b + 'Constant</li><li class="' + (gvjs_7(gvjs__) + gvjs_wqa);
+  return gvjs_W(b + "Percent</li></ul></div>")
+}
+function gvjs_kva(a) {
+  var b = a.Ud;
+  b = gvjs_h5 + gvjs_7(gvjs_9ra) + gvjs_44 + gvjs_7(b) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4;
+  b += gvjs_GB("Point shape");
+  b += "'>" + gvjs_xva(a.Ud) + gvjs_a;
+  return gvjs_W(b)
+}
+function gvjs_xva(a) {
+  a = gvjs_o5 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + '" optionType="shape" value=""></li>' : "") + gvjs_k5 + gvjs_7(gvjs__) + '" optionType="shape" value="circle"><svg class="google-visualization-charteditor-combobox-icon"><circle cx="6" cy="6" r="6" fill="black"/></svg>';
+  a = a + 'Circle</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="triangle"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 6,0 L 12,12 L 0,12" fill="black"/></svg>');
+  a = a + 'Triangle</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="square"><svg class="google-visualization-charteditor-combobox-icon"><rect x="0" y="0" width="12" height="12"/></svg>');
+  a = a + 'Square</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="diamond"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 6,0 L 12,6 L 6,12 L 0,6 z" fill="black"/></svg>');
+  a = a + 'Diamond</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="star"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 6,0 L 10,12 L 0,4.75 L 12,4.75 L 2,12 z" fill="black"/></svg>');
+  a = a + 'Star</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="xMark"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 0,0 L 6,5 L 12,0 L 7,6 L 12,12 L 6,7 L 0,12 L 5,6 z" fill="black"/></svg>');
+  a = a + 'X mark</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="pentagon"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 6,0 L 12,5 L 9,12 L 3,12 L 0,5 z" fill="black"/></svg>');
+  a = a + 'Pentagon</li><li class="' + (gvjs_7(gvjs__) + '" optionType="shape" value="hexagon"><svg class="google-visualization-charteditor-combobox-icon"><path d="M 6,0 L 12,3 L 12,9 L 6,12 L 0,9 L 0,3 z" fill="black"/></svg>');
+  return gvjs_W(a + "Hexagon</li></ul>")
+}
+function gvjs_lva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_csa) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB("Type");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + '" value="line">' + gvjs_FB(gvjs_47(gvjs_Va)) + gvjs_84 + gvjs_7(gvjs__) + '" value="bars">' + gvjs_Uta(gvjs_xa) + gvjs_84 + gvjs_7(gvjs__) + '" value="area">' + gvjs_FB(gvjs_47(gvjs_na)) + gvjs_84 + gvjs_7(gvjs__) + '" value="steppedArea">';
+  return gvjs_W(b + "Stepped area</li></ul></div>")
+}
+function gvjs_pva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_q6) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB("Trendline");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_J4;
+  b = b + gvjs_B5 + (gvjs_7(gvjs__) + gvjs_vqa);
+  b = b + 'Linear</li><li class="' + (gvjs_7(gvjs__) + gvjs_uqa);
+  b = b + 'Exponential</li><li class="' + (gvjs_7(gvjs__) + '" value="polynomial">');
+  return gvjs_W(b + "Polynomial</li></ul></div>")
+}
+function gvjs_n9(a, b) {
+  a = gvjs_h5 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_p4;
+  a += gvjs_GB(gvjs_Mqa);
+  a += gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_X + (b ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + '" value="sum">';
+  a = a + 'Sum</li><li class="' + (gvjs_7(gvjs__) + '" value="count">');
+  a = a + 'Count</li><li class="' + (gvjs_7(gvjs__) + '" value="min">');
+  a = a + 'Min</li><li class="' + (gvjs_7(gvjs__) + '" value="max">');
+  a = a + 'Max</li><li class="' + (gvjs_7(gvjs__) + '" value="average">');
+  a = a + 'Average</li><li class="' + (gvjs_7(gvjs__) + '" value="median">');
+  return gvjs_W(a + "Median</li></ul></div>")
+}
+function gvjs_qva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_Zra) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_q4;
+  b += gvjs_GB("Degree");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + '" value="2">2</li><li class="' + gvjs_7(gvjs__) + '" value="3">3</li><li class="' + gvjs_7(gvjs__) + '" value="4">4</li><li class="' + gvjs_7(gvjs__) + '" value="5">5</li><li class="' + gvjs_7(gvjs__) + '" value="6">6</li><li class="' + gvjs_7(gvjs__) + '" value="7">7</li><li class="' + gvjs_7(gvjs__) + '" value="8">8</li><li class="' + gvjs_7(gvjs__) + '" value="9">9</li><li class="' + gvjs_7(gvjs__) + '" value="10">10</li></ul></div>';
+  return gvjs_W(b)
+}
+function gvjs_rva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_p6) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB("Label");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_J4;
+  b = b + gvjs_B5 + (gvjs_7(gvjs__) + '" value="equation">');
+  b = b + 'Use equation</li><li class="' + (gvjs_7(gvjs__) + gvjs_I4);
+  return gvjs_W(b + "Custom</li></ul></div>")
+}
+function gvjs_sva(a) {
+  var b = gvjs_h5 + gvjs_7(gvjs_fsa) + gvjs_44 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4;
+  b += gvjs_GB(gvjs_y5);
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_X + (gvjs_8(a, gvjs_Lu) ? gvjs_k5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_65) + gvjs_C4 : "") + gvjs_k5 + gvjs_7(gvjs__) + gvjs_F4 + gvjs_7(gvjs__) + gvjs_G4 + gvjs_7(gvjs__) + gvjs_H4 + gvjs_7(gvjs__) + gvjs_rqa;
+  return gvjs_W(b)
+}
+;function gvjs_yva(a) {
+  a = a || {};
+  var b = a.attributes
+    , c = a.content
+    , d = a.disabled
+    , e = a.id
+    , f = a.Kxa
+    , g = a.title
+    , h = a.Sya
+    , k = a.value;
+  e = '<div role="button"' + (e ? gvjs_t4 + gvjs_7(e) + '"' : "") + gvjs_dr;
+  a = a || {};
+  var l = a.p8
+    , m = a.style
+    , n = "goog-inline-block jfk-button ";
+  switch (gvjs_r(m) ? m.toString() : m) {
+    case 0:
+      n += gvjs_Lsa;
+      break;
+    case 2:
+      n += "jfk-button-action";
+      break;
+    case 3:
+      n += "jfk-button-primary";
+      break;
+    case 1:
+      n += "jfk-button-default";
+      break;
+    case 4:
+      n += "jfk-button-flat";
+      break;
+    case 5:
+      n += "jfk-button-mini";
+      break;
+    case 6:
+      n += "jfk-button-contrast";
+      break;
+    default:
+      n += gvjs_Lsa
+  }
+  n += (gvjs_8(a.width, 1) ? " jfk-button-narrow" : "") + (a.checked ? " jfk-button-checked" : "") + (l ? " " + l : "") + (a.disabled ? " jfk-button-disabled" : "");
+  return gvjs_W(e + gvjs_7(n) + '"' + (d ? gvjs_$pa : ' tabindex="' + (f ? gvjs_7(f) : "0") + '"') + (g ? h ? ' data-tooltip="' + gvjs_7(g) + '"' : ' title="' + gvjs_7(g) + '"' : "") + (k ? ' value="' + gvjs_7(k) + '"' : "") + (b ? gvjs_o7(gvjs_q7(b)) : "") + ">" + gvjs_FB(null != c ? c : "") + gvjs_a)
+}
+;function gvjs_q9(a, b, c, d) {
+  gvjs_4D.call(this, a, gvjs_r9.Lc(), b);
+  this.md = c || 0;
+  this.ga = d || 0;
+  this.S5 = !1
+}
+gvjs_t(gvjs_q9, gvjs_4D);
+gvjs_ = gvjs_q9.prototype;
+gvjs_.getStyle = function() {
+  return this.md
+}
+;
+gvjs_.La = function() {
+  return this.ga
+}
+;
+gvjs_.setStyle = function(a) {
+  this.md != a && (this.md = a,
+    gvjs_s9(this))
+}
+;
+gvjs_.Ug = function(a) {
+  this.ga != a && (this.ga = a,
+    gvjs_s9(this))
+}
+;
+gvjs_.il = function(a) {
+  this.PE(a);
+  var b = this.j();
+  b && (this.S5 ? gvjs_v8(b, a, void 0) : a ? b.title = a : b.removeAttribute(gvjs_fx))
+}
+;
+gvjs_.Gb = function(a) {
+  this.isEnabled() != a && (gvjs_q9.G.Gb.call(this, a),
+    gvjs_s9(this))
+}
+;
+gvjs_.focus = function() {
+  var a = this.H;
+  try {
+    a.focus()
+  } catch (b) {}
+}
+;
+gvjs_.KE = function(a) {
+  gvjs_q9.G.KE.call(this, a);
+  this.ME(!1)
+}
+;
+gvjs_.Cf = function(a) {
+  gvjs_q9.G.Cf.call(this, a);
+  this.isEnabled() && this.ME(!0)
+}
+;
+gvjs_.Mo = function(a) {
+  gvjs_q9.G.Mo.call(this, a);
+  this.isEnabled() && this.ME(!0)
+}
+;
+gvjs_.ME = function(a) {
+  this.j() && gvjs_ZC(this.j(), "jfk-button-clear-outline", a)
+}
+;
+function gvjs_s9(a) {
+  a.j() && gvjs_zva(a.Oa(), a)
+}
+function gvjs_t9() {
+  var a = new gvjs_q9(null,void 0);
+  a.eg(16, !0);
+  return a
+}
+function gvjs_r9() {
+  this.bga = this.sa() + "-standard";
+  this.P6 = this.sa() + "-action";
+  this.xea = this.sa() + "-primary";
+  this.m9 = this.sa() + gvjs_Fr;
+  this.p$ = this.sa() + "-flat";
+  this.ida = this.sa() + "-narrow";
+  this.Wca = this.sa() + "-mini";
+  this.I8 = this.sa() + "-contrast"
+}
+gvjs_t(gvjs_r9, gvjs_2D);
+gvjs_le(gvjs_r9);
+gvjs_ = gvjs_r9.prototype;
+gvjs_.jx = function(a, b, c) {
+  a && c.setStyle(a);
+  b && c.Ug(b)
+}
+;
+gvjs_.sa = function() {
+  return "jfk-button"
+}
+;
+gvjs_.J = function(a) {
+  var b = a.wa()
+    , c = gvjs_LB(gvjs_yva, {
+    disabled: !a.isEnabled(),
+    checked: a.nn(),
+    style: a.getStyle(),
+    title: a.en(),
+    Sya: a.S5,
+    value: a.getValue(),
+    width: a.La()
+  }, void 0, b);
+  b.append(c, a.getContent());
+  this.fb(a, c);
+  return c
+}
+;
+gvjs_.fb = function(a, b) {
+  gvjs_r9.G.fb.call(this, a, b);
+  this.o8 || (this.o8 = gvjs_cta(this.bga, gvjs_re(this.jx, 0, null), this.P6, gvjs_re(this.jx, 2, null), this.xea, gvjs_re(this.jx, 3, null), this.m9, gvjs_re(this.jx, 1, null), this.p$, gvjs_re(this.jx, 4, null), this.Wca, gvjs_re(this.jx, 5, null), this.I8, gvjs_re(this.jx, 6, null), this.ida, gvjs_re(this.jx, null, 1)));
+  for (var c = gvjs_SC(b), d = 0; d < c.length; ++d) {
+    var e = this.o8[c[d]];
+    e && e(a)
+  }
+  if (c = b.getAttribute(gvjs_R5))
+    a.PE(c),
+      a.S5 = !0;
+  return b
+}
+;
+gvjs_.getValue = function(a) {
+  return a.getAttribute(gvjs_Vd) || ""
+}
+;
+gvjs_.Wa = function(a, b) {
+  a && a.setAttribute(gvjs_Vd, b)
+}
+;
+function gvjs_zva(a, b) {
+  function c(g, h) {
+    (g ? d : e).push(h)
+  }
+  var d = []
+    , e = []
+    , f = b.getStyle();
+  c(0 == f, a.bga);
+  c(2 == f, a.P6);
+  c(3 == f, a.xea);
+  c(4 == f, a.p$);
+  c(5 == f, a.Wca);
+  c(1 == f, a.m9);
+  c(6 == f, a.I8);
+  c(1 == b.La(), a.ida);
+  c(!b.isEnabled(), a.sa() + gvjs_Gr);
+  gvjs_YC(b.j(), e);
+  gvjs_WC(b.j(), d)
+}
+;function gvjs_Ava(a) {
+  a = a || {};
+  var b = a.attributes
+    , c = a.p8
+    , d = a.checked
+    , e = a.disabled
+    , f = a.id
+    , g = a.Kxa
+    , h = a.Gya
+    , k = a.yka
+    , l = a.nCa;
+  a = h ? " " + gvjs_7("jfk-checkbox-undetermined") : d ? " " + gvjs_7("jfk-checkbox-checked") : " " + gvjs_7("jfk-checkbox-unchecked");
+  d = h ? "mixed" : d ? gvjs_Rd : gvjs_Sb;
+  k = l ? ' aria-labelledby="' + gvjs_7(l) + '"' : k ? gvjs_o4 + gvjs_7(k) + '"' : "";
+  return gvjs_W('<span class="' + gvjs_7("jfk-checkbox") + " " + gvjs_7(gvjs_Y) + a + (e ? " " + gvjs_7("jfk-checkbox-disabled") : "") + (c ? " " + gvjs_7(c) : "") + '" role="checkbox" aria-checked="' + d + '"' + k + (f ? gvjs_t4 + gvjs_7(f) + '"' : "") + (e ? ' aria-disabled="true" tabindex="-1"' : ' tabindex="' + (g ? gvjs_7(g) : "0") + '"') + (b ? gvjs_o7(gvjs_q7(b)) : "") + ' dir="ltr"><div class="' + gvjs_7(gvjs_O6) + '" role="presentation"></div></span>')
+}
+;function gvjs_u9(a, b) {
+  gvjs_RE.call(this, a, b, gvjs_lQ("jfk-checkbox"));
+  this.eg(4, !0)
+}
+gvjs_o(gvjs_u9, gvjs_RE);
+gvjs_ = gvjs_u9.prototype;
+gvjs_.J = function() {
+  this.H = gvjs_LB(gvjs_Ava, {
+    checked: this.nn(),
+    disabled: !this.isEnabled(),
+    Gya: null == this.ns
+  }, void 0, this.wa())
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_RE.prototype.vf.call(this, a);
+  gvjs_VC(a, gvjs_Y);
+  this.j().dir = gvjs_Dv;
+  this.hd(gvjs_O6) || (a = this.wa().J(gvjs_b, gvjs_O6),
+    this.j().appendChild(a));
+  gvjs_VB(this.yP(gvjs_O6), "presentation")
+}
+;
+gvjs_.KE = function(a) {
+  gvjs_RE.prototype.KE.call(this, a);
+  this.ME(!1)
+}
+;
+gvjs_.Cf = function(a) {
+  gvjs_RE.prototype.Cf.call(this, a);
+  this.isEnabled() && this.ME(!0)
+}
+;
+gvjs_.ME = function(a) {
+  this.j() && gvjs_ZC(this.j(), "jfk-checkbox-clearOutline", a)
+}
+;
+function gvjs_v9() {
+  gvjs_H.call(this);
+  this.pd = new gvjs_KA(this);
+  gvjs_6x(this, this.pd);
+  this.J8 = []
+}
+gvjs_o(gvjs_v9, gvjs_H);
+function gvjs_w9(a, b) {
+  a.J8.push(b);
+  a.pd.o(b, gvjs_Ss, a.dua)
+}
+gvjs_v9.prototype.dua = function(a) {
+  a.target && (typeof a.target.Av === gvjs_d && this.tr(a.target.Av()),
+    this.dispatchEvent(gvjs_Ss))
+}
+;
+gvjs_v9.prototype.getValue = function() {
+  return this.$d
+}
+;
+gvjs_v9.prototype.tr = function(a) {
+  this.$d = a;
+  for (var b = 0, c; c = this.J8[b]; b++)
+    typeof c.tr == gvjs_d && c.tr(a)
+}
+;
+gvjs_v9.prototype.$d = null;
+function gvjs_x9() {}
+gvjs_o(gvjs_x9, gvjs_68);
+gvjs_x9.prototype.sa = function() {
+  return "jfk-palette"
+}
+;
+gvjs_le(gvjs_x9);
+function gvjs_y9() {}
+gvjs_t(gvjs_y9, gvjs_nE);
+gvjs_le(gvjs_y9);
+gvjs_y9.prototype.createCaption = function(a, b) {
+  return gvjs_y9.G.createCaption.call(this, gvjs_Bva(a, b), b)
+}
+;
+function gvjs_Bva(a, b) {
+  return b.J(gvjs_b, gvjs_0qa, a)
+}
+gvjs_y9.prototype.Wa = function(a, b) {
+  a && gvjs_Cva(this.ib(a), b)
+}
+;
+function gvjs_Cva(a, b) {
+  a && a.firstChild && (b = b && gvjs_0z(b) ? gvjs_qj(b).hex : null,
+    a.firstChild.style.borderBottomColor = b || gvjs_Qd)
+}
+gvjs_y9.prototype.ln = function(a) {
+  var b = a.j();
+  this.Wa(b, a.getValue());
+  gvjs_VC(b, gvjs__qa);
+  gvjs_y9.G.ln.call(this, a)
+}
+;
+function gvjs_z9(a, b, c, d) {
+  gvjs_xE.call(this, a, b, c || gvjs_y9.Lc(), d)
+}
+gvjs_t(gvjs_z9, gvjs_xE);
+var gvjs_Dva = {
+  kAa: [gvjs_kr, "#444", "#666", gvjs_sr, gvjs_yr, "#eee", "#f3f3f3", gvjs_Br],
+  Cja: "#f00 #f90 #ff0 #0f0 #0ff #00f #90f #f0f".split(" "),
+  ZAa: ["#f4cccc", "#fce5cd", "#fff2cc", "#d9ead3", "#d0e0e3", "#cfe2f3", "#d9d2e9", "#ead1dc", "#ea9999", "#f9cb9c", "#ffe599", "#b6d7a8", "#a2c4c9", "#9fc5e8", "#b4a7d6", "#d5a6bd", "#e06666", "#f6b26b", "#ffd966", "#93c47d", "#76a5af", "#6fa8dc", "#8e7cc3", "#c27ba0", "#cc0000", "#e69138", "#f1c232", "#6aa84f", "#45818e", gvjs_Y4, "#674ea7", "#a64d79", gvjs_iQ, "#b45f06", "#bf9000", "#38761d", "#134f5c", "#0b5394", "#351c75", "#741b47", "#660000", "#783f04", "#7f6000", "#274e13", "#0c343d", "#073763", "#20124d", "#4c1130"]
+};
+function gvjs_Eva(a) {
+  var b = new gvjs_kE(a);
+  gvjs_w(gvjs_Dva, function(c) {
+    c = new gvjs_c9(c,null,a);
+    c.wg(8);
+    b.addChild(c, !0)
+  });
+  return b
+}
+gvjs_ = gvjs_z9.prototype;
+gvjs_.Av = function() {
+  return this.getValue()
+}
+;
+gvjs_.tr = function(a) {
+  this.Wa(a)
+}
+;
+gvjs_.Wa = function(a) {
+  for (var b = 0, c; c = this.od(b); b++)
+    typeof c.tr == gvjs_d && c.tr(a);
+  gvjs_z9.G.Wa.call(this, a)
+}
+;
+gvjs_.az = function(a) {
+  typeof a.target.Av == gvjs_d ? this.Wa(a.target.Av()) : a.target.getValue() == gvjs_f && this.Wa(null);
+  gvjs_z9.G.az.call(this, a);
+  a.stopPropagation();
+  this.dispatchEvent(gvjs_Ss)
+}
+;
+gvjs_.Kd = function(a, b) {
+  a && 0 == this.bh() && (this.lp(gvjs_Eva(this.wa())),
+    this.Wa(this.getValue()));
+  gvjs_z9.G.Kd.call(this, a, b)
+}
+;
+gvjs_HD(gvjs__qa, function() {
+  return new gvjs_z9(null)
+});
+function gvjs_A9() {}
+gvjs_t(gvjs_A9, gvjs_nE);
+gvjs_le(gvjs_A9);
+gvjs_A9.prototype.sa = function() {
+  return gvjs_5qa
+}
+;
+function gvjs_B9(a, b, c, d) {
+  gvjs_DE.call(this, a, b, c || gvjs_A9.Lc(), d)
+}
+gvjs_t(gvjs_B9, gvjs_DE);
+gvjs_HD(gvjs_6qa, function() {
+  return new gvjs_B9(null)
+});
+function gvjs_C9(a) {
+  gvjs_KA.call(this);
+  this.Yta = a;
+  this.f2 = [];
+  this.Cz = null
+}
+gvjs_o(gvjs_C9, gvjs_KA);
+gvjs_ = gvjs_C9.prototype;
+gvjs_.clear = function() {
+  gvjs_u(this.f2, function(a) {
+    gvjs_E(a)
+  });
+  this.f2 = [];
+  gvjs_D9(this, null)
+}
+;
+function gvjs_D9(a, b) {
+  a.Cz && gvjs_FD(a.Cz, 64) && a.Cz.Kd(!1);
+  a.Cz = b
+}
+gvjs_.VW = function() {
+  this.Cz && this.Cz.Kd(!1);
+  this.Cz = null
+}
+;
+gvjs_.Ar = function(a) {
+  gvjs_u(arguments, function(b) {
+    this.f2.push(b)
+  }, this)
+}
+;
+function gvjs_Fva(a, b) {
+  var c = new gvjs_u9;
+  c.In(b.parentNode);
+  b.parentNode.className = gvjs_rra;
+  c.fb(b);
+  a.Ar(c);
+  return c
+}
+gvjs_.j9 = function(a) {
+  gvjs_E9(a);
+  var b = new gvjs_A8;
+  b.Xr("google-visualization-charteditor-combobox");
+  b.Qs(gvjs_45, !0);
+  b.fb(a);
+  this.Ar(b);
+  this.o(b, gvjs_Sw, function() {
+    gvjs_D9(this, b)
+  });
+  this.o(b, [gvjs_Sw, gvjs_1u], function() {
+    b.Qs(gvjs_45, !gvjs_FD(b, 64))
+  });
+  return b
+}
+;
+gvjs_.cC = function(a) {
+  gvjs_E9(a);
+  var b = new gvjs_DE(null);
+  b.AT((0,
+    gvjs_48.Lc)());
+  b.fb(a);
+  this.Ar(b);
+  this.o(b, gvjs_Sw, function() {
+    gvjs_D9(this, b)
+  });
+  return b
+}
+;
+gvjs_.k9 = function() {}
+;
+gvjs_.l9 = function(a) {
+  var b = gvjs_t9();
+  b.fb(a);
+  b.setStyle(0);
+  b.Ug(1);
+  gvjs_UC(a, gvjs_isa) && b.Lw(1);
+  gvjs_UC(a, gvjs_hsa) && b.Lw(2);
+  return b
+}
+;
+gvjs_.Jea = function(a) {
+  var b = gvjs_Gva(this, a);
+  gvjs_VC(a, gvjs_Y);
+  var c = new gvjs_z9(null,b,gvjs_zG(gvjs_58));
+  c.iD = !0;
+  c.R(a);
+  this.Ar(c);
+  this.o(c, gvjs_Sw, function() {
+    gvjs_D9(this, c)
+  });
+  this.o(c.j(), gvjs_Yo, function() {
+    c.isVisible() && c.Kd(!1)
+  });
+  b = null;
+  if (b = a.getAttribute(gvjs_S5))
+    c.j().setAttribute(gvjs_S5, b),
+      a.setAttribute(gvjs_S5, "");
+  return c
+}
+;
+function gvjs_Hva(a) {
+  var b = !1;
+  a = a.id || a.parentNode && a.parentNode.id;
+  if (gvjs_jf(gvjs_gg(a)))
+    return !1;
+  for (var c = 0; c < gvjs_Iva.length; c++)
+    if (gvjs_hf(a, gvjs_Iva[c])) {
+      b = !0;
+      break
+    }
+  return b
+}
+function gvjs_Jva(a) {
+  a = a.id || a.parentNode && a.parentNode.id;
+  return !gvjs_jf(gvjs_gg(a)) && (gvjs_hf(a, gvjs_0ra) || gvjs_hf(a, gvjs__ra))
+}
+function gvjs_Kva(a) {
+  a = a.id || a.parentNode && a.parentNode.id;
+  return !gvjs_jf(gvjs_gg(a)) && gvjs_hf(a, gvjs_ora)
+}
+function gvjs_E9(a) {
+  var b = gvjs_Oh();
+  a = b.hd(gvjs_Z, a);
+  null != a && b.Qo(a) && (gvjs_VC(a, gvjs_Jra),
+    gvjs_m8(a))
+}
+function gvjs_Gva(a, b) {
+  var c = new gvjs_v9
+    , d = gvjs_Hva(b)
+    , e = gvjs_Jva(b)
+    , f = gvjs_Kva(b)
+    , g = new gvjs_kE;
+  g.J();
+  a.Ar(c, g);
+  var h = g.j();
+  gvjs_WC(h, ["jfk-colormenu", "google-visualization-charteditor-colormenu"]);
+  gvjs_m8(h);
+  gvjs__ua(h);
+  var k = gvjs_x9.Lc(), l;
+  e ? l = gvjs_LB(gvjs_tva) : f && (l = gvjs_LB(gvjs_uva));
+  l && (e = new gvjs_e9(k,l),
+    g.addChild(e, !0),
+    gvjs_w9(c, e));
+  d && (d = new gvjs_f9("None".toString()),
+    g.addChild(d, !0),
+    gvjs_w9(c, d));
+  gvjs_u(gvjs_g9, function(m) {
+    for (var n = [], p = 0; p < m.length; p++) {
+      var q = n
+        , r = q.push;
+      var t = void 0;
+      try {
+        var u = gvjs_qj(m[p])
+          , v = gvjs_38[u.hex];
+        if (v)
+          var w = v;
+        else {
+          var x = gvjs_vj(u.hex)
+            , y = null
+            , z = 2147483647;
+          for (t in gvjs_38) {
+            var A = gvjs_38[t]
+              , B = gvjs_vj(t);
+            var D = Math.abs(B[0] - x[0]) + Math.abs(B[1] - x[1]) + Math.abs(B[2] - x[2]);
+            if (null == y || D < z)
+              y = A,
+                z = D
+          }
+          w = y ? u.hex + ", close to " + y : null
+        }
+      } catch (C) {
+        w = null
+      }
+      r.call(q, w)
+    }
+    p = new gvjs_c9(void 0,k);
+    p.ip(m, n);
+    p.wg(10);
+    g.addChild(p, !0);
+    gvjs_w9(c, p)
+  });
+  a = a.Yta;
+  if (0 < a) {
+    a = Math.min(20, a);
+    a = gvjs_Oe(gvjs_P7, 0, a);
+    if (gvjs_sf(b.id, "trendline-color"))
+      for (b = 0; b < a.length; b++)
+        a[b] = gvjs_5F(a[b]).jh;
+    b = new gvjs_c9(a,k);
+    b.wg(Math.min(10, a.length));
+    a = new gvjs_gE("Default".toString());
+    a.Xr("google-visualization-charteditor-theme-header");
+    g.addChild(a, !0);
+    g.addChild(b, !0);
+    gvjs_w9(c, b)
+  }
+  return g
+}
+var gvjs_Iva = [gvjs_i6, gvjs_r6, gvjs_vra, gvjs__5, gvjs_zra, gvjs_Ara, gvjs_yra];
+function gvjs_Lva(a, b) {
+  var c = a.axis
+    , d = a.type
+    , e = a.features
+    , f = a.lJ;
+  a = a.mJ;
+  var g = "";
+  gvjs_8(c, "x") ? (g += gvjs_F9(b, "google-visualization-charteditor-font-style-axisx-clickeditor"),
+  gvjs_9(e.Raa[d]) && gvjs_9(e.Xfa[d]) && (b = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_Q4 + gvjs_7(gvjs__) + gvjs_K4,
+    b = b + 'Auto</div><div class="' + (gvjs_7(gvjs__) + '" value="0"><span dir=\'ltr\'>0&deg;</span></div><div class="' + gvjs_7(gvjs__) + '" value="30"><span dir=\'ltr\'>30&deg;</span></div><div class="' + gvjs_7(gvjs__) + '" value="60"><span dir=\'ltr\'>60&deg;</span></div><div class="' + gvjs_7(gvjs__) + '" value="90"><span dir=\'ltr\'>90&deg;</span></div></div>'),
+    g += gvjs_B7({
+      icon: "docs-icon-img docs-icon-label-slant",
+      id: gvjs_pra,
+      $k: gvjs_sq(b)
+    }))) : gvjs_8(c, "y") ? g += gvjs_F9(b, "google-visualization-charteditor-font-style-axisy-clickeditor") : gvjs_8(c, gvjs_j) && (g += gvjs_F9(b, "google-visualization-charteditor-font-style-axis-right-clickeditor"));
+  if (gvjs_8(c, "x") && gvjs_9(f) || !gvjs_8(c, "x") && gvjs_9(a))
+    g += '<div class="google-visualization-clickeditor-separator"></div><div class="google-visualization-clickeditor-min-max-block ' + gvjs_7(gvjs_Y) + gvjs_X,
+      g += gvjs_Mva("google-visualization-charteditor-axis-input-min-explicit-clickeditor-" + c, "Min", c),
+      g += gvjs_Mva("google-visualization-charteditor-axis-input-max-explicit-clickeditor-" + c, "Max", c),
+      g += gvjs_a;
+  return gvjs_W(g)
+}
+function gvjs_Nva(a, b) {
+  a = a.axis;
+  b = gvjs_8(a, "x") ? gvjs_F9(b, "google-visualization-charteditor-font-style-titlex-clickeditor") + gvjs_G9(gvjs_Hra) : gvjs_8(a, "y") ? gvjs_F9(b, "google-visualization-charteditor-font-style-titley-clickeditor") + gvjs_G9(gvjs_Ira) : gvjs_8(a, gvjs_j) ? gvjs_F9(b, "google-visualization-charteditor-font-style-title-right-clickeditor") + gvjs_G9("google-visualization-charteditor-input-title-right-clickeditor") : "";
+  return gvjs_W(b)
+}
+function gvjs_Ova(a, b) {
+  return gvjs_W(gvjs_F9(b, gvjs_Cra) + gvjs_G9(gvjs_Fra))
+}
+function gvjs_Pva(a, b) {
+  return gvjs_W(gvjs_F9(b, "google-visualization-charteditor-font-style-legend-clickeditor") + gvjs_i9(gvjs_CB({
+    r0: "google-visualization-charteditor-select-legend-position-clickeditor"
+  }, a)))
+}
+function gvjs_Qva(a, b) {
+  a = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_Q4 + gvjs_7(gvjs__) + gvjs_J4;
+  a = a + gvjs_Tqa + (gvjs_7(gvjs__) + gvjs_vqa);
+  a = a + 'Linear</div><div class="' + (gvjs_7(gvjs__) + gvjs_uqa);
+  a = a + 'Exponential</div><div class="' + (gvjs_7(gvjs_Ps) + gvjs_X);
+  a = a + 'Polynomial<div class="' + (gvjs_7(gvjs_Z) + gvjs_Q4 + gvjs_7(gvjs__) + '" value="polynomial-2">');
+  a = a + '2nd order</div><div class="' + (gvjs_7(gvjs__) + '" value="polynomial-3">');
+  a = a + '3rd order</div><div class="' + (gvjs_7(gvjs__) + '" value="polynomial-4">');
+  a = a + '4th order</div><div class="' + (gvjs_7(gvjs__) + '" value="polynomial-5">');
+  a = a + '5th order</div><div class="' + (gvjs_7(gvjs__) + '" value="polynomial-6">');
+  b = "" + gvjs_B7({
+    icon: "docs-icon-img docs-icon-add-trendline",
+    id: "google-visualization-charteditor-series-menu-add-trendline-clickeditor-series-" + b,
+    $k: gvjs_sq(a + "6th order</div></div></div></div>")
+  });
+  return gvjs_W(b)
+}
+function gvjs_Rva(a, b) {
+  var c = a.Ud;
+  a = gvjs_h5 + gvjs_7(gvjs_o6) + gvjs_X + gvjs_Qva(b, a.Ud) + gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4 + gvjs_E7({
+    icon: gvjs_era,
+    id: "google-visualization-charteditor-series-trendline-color-clickeditor-series-" + c
+  }) + gvjs_l9("google-visualization-charteditor-series-trendline-opacity-clickeditor-series-" + c) + gvjs_G7({
+    $k: gvjs_sq(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_o9(gvjs_p7(1, 2, 4, 8), gvjs_T) + gvjs_a),
+    ri: gvjs_A6,
+    id: "google-visualization-charteditor-series-trendline-size-clickeditor-series-" + c,
+    QI: !0
+  });
+  a += gvjs_H9({
+    icon: "docs-icon-img docs-icon-r-squared",
+    ri: gvjs_B6,
+    id: "google-visualization-charteditor-series-menu-trendline-showr2-clickeditor-series-" + c,
+    title: gvjs_sq("Show R&sup2;")
+  });
+  return gvjs_W(a + gvjs_a)
+}
+function gvjs_Sva() {
+  var a = gvjs_sq("" + gvjs_eva());
+  a = gvjs_W(gvjs_F7({
+    hidden: gvjs_9(void 0) || gvjs_9(!0) ? gvjs_Rd : "",
+    id: void 0
+  }) + gvjs_C7({
+    id: gvjs_Pra,
+    PG: gvjs_sq(gvjs_Z4),
+    hidden: void 0,
+    $k: a,
+    ri: gvjs_6qa,
+    Bna: void 0
+  }) + gvjs_F7({
+    hidden: gvjs_9(void 0) || gvjs_9(!0) ? gvjs_Rd : "",
+    id: void 0
+  }));
+  return gvjs_W(a + gvjs_E7({
+    icon: gvjs_dra,
+    id: gvjs_tra
+  }) + gvjs_l9(gvjs_25))
+}
+function gvjs_Tva(a, b) {
+  var c = a.type
+    , d = a.features
+    , e = a.lra
+    , f = a.jra
+    , g = a.fxa
+    , h = a.lJ;
+  a = a.mJ;
+  b = "" + gvjs_E7({
+    icon: gvjs_dra,
+    id: gvjs_ura
+  }) + gvjs_l9(gvjs_35) + (gvjs_9(d.Ja[c]) && gvjs_9(a) ? (f ? gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4 + gvjs_I9(b, "y") : "") + (e ? gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4 + gvjs_I9(b, gvjs_j) : "") : "") + (gvjs_9(d.Ja[c]) && gvjs_9(h) ? d.Ja[c] ? gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4 + gvjs_I9(b, "x") : "" : "");
+  g && (b += '<div class="google-visualization-clickeditor-separator"></div>',
+    g = gvjs_sq("Move & Resize"),
+    c = gvjs_sq("Fit to area"),
+    b += gvjs_Kqa + gvjs_7(gvjs_Y) + ' google-visualization-clickeditor-resize" data-tooltip-contained="true"><div class="jfk-tooltip-data">' + gvjs_57(g) + gvjs_a + gvjs_D7("docs-icon-img docs-icon-drag-move") + '<div class="google-visualization-clickeditor-resize-text ' + gvjs_7(gvjs_Y) + gvjs_X + g + '</div></div><div class="jfk-button jfk-button-standard jfk-button-narrow ' + gvjs_7(gvjs_Y) + ' google-visualization-clickeditor-fit-area" data-tooltip-contained="true"><div class="jfk-tooltip-data">' + gvjs_57(c) + gvjs_a + gvjs_D7("docs-icon-img docs-icon-fit-area") + '<div class="google-visualization-clickeditor-fit-area-text ' + gvjs_7(gvjs_Y) + gvjs_X + c + gvjs_64);
+  return gvjs_W(b)
+}
+function gvjs_Uva(a, b) {
+  var c = a.Ud
+    , d = a.type
+    , e = a.features
+    , f = a.lsa
+    , g = a.vo
+    , h = a.kC
+    , k = gvjs_h5 + gvjs_7(gvjs_o6) + gvjs_X
+    , l = e.z3[d] ? "docs-icon-line-color" : "docs-icon-fill-color";
+  var m = e.z3[d] ? gvjs_G7({
+    $k: gvjs_sq(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_o9(gvjs_p7(1, 2, 4, 8), gvjs_T) + gvjs_a),
+    ri: gvjs_A6,
+    id: "google-visualization-charteditor-series-combo-line-size-clickeditor-series-" + c,
+    QI: !0
+  }) : "";
+  k += gvjs_E7({
+    icon: "docs-icon-img " + l,
+    id: "google-visualization-charteditor-series-color-clickeditor-series-" + c
+  }) + m;
+  e.kea[d] && (h ? (h = gvjs_b5 + gvjs_7(gvjs_Z) + ' google-visualization-charteditor-horizontal-menu">',
+    h += gvjs_zta({
+      textContent: "Size",
+      $k: gvjs_sq("" + gvjs_p9(a.Ud))
+    }),
+    h += gvjs_zta({
+      textContent: "Shape",
+      $k: gvjs_sq("" + gvjs_xva(a.Ud))
+    }),
+    k += gvjs_B7({
+      ri: "google-visualization-clickeditor-select google-visualization-clickeditor-no-initial-select",
+      id: "google-visualization-charteditor-series-multi-icon-select-point-style-clickeditor-series-" + c,
+      icon: gvjs_gra,
+      $k: gvjs_sq(h + gvjs_a)
+    })) : k += gvjs_G7({
+    $k: gvjs_sq("" + gvjs_p9(a.Ud)),
+    ri: gvjs_A6,
+    id: "google-visualization-charteditor-series-combo-point-size-clickeditor-series-" + c,
+    QI: !0
+  }));
+  h = e.sfa[d] ? gvjs_m9("google-visualization-charteditor-series-combo-opacity-area-clickeditor-series-" + c) : "";
+  k += h;
+  e.UH[d] && (k += "<div dir='ltr' class=\"" + gvjs_7(gvjs_Y) + gvjs_X,
+    k += gvjs_H9({
+      icon: "docs-icon-img docs-icon-left-axis",
+      ri: gvjs_B6,
+      id: "google-visualization-charteditor-series-toggle-axis-left-clickeditor-series-" + c,
+      title: gvjs_sq("Left axis")
+    }),
+    k += gvjs_H9({
+      icon: "docs-icon-img docs-icon-right-axis",
+      ri: gvjs_B6,
+      id: "google-visualization-charteditor-series-toggle-axis-right-clickeditor-series-" + c,
+      title: gvjs_sq("Right axis")
+    }),
+    k += gvjs_a);
+  c = k;
+  b = gvjs_9(e.GU[d]) && gvjs_9(f) ? gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4 + gvjs_Qva(b, a.Ud) : "";
+  gvjs_9(e.annotations[d]) && gvjs_9(g) ? (d = gvjs_b5 + gvjs_7(gvjs_G5) + " " + gvjs_7(gvjs_Y) + gvjs_M4,
+    e = a.Ud,
+    a = a.annotations,
+    g = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_Q4 + gvjs_7(gvjs__) + gvjs_J4,
+    g = g + gvjs_Tqa + (gvjs_7(gvjs__) + gvjs_L4),
+    g += "Value</div>",
+  a[e] && (g += gvjs_b5 + gvjs_7(gvjs__) + gvjs_I4,
+    g += "Custom</div>"),
+    a = "" + gvjs_B7({
+      icon: "docs-icon-img docs-icon-data-label",
+      id: "google-visualization-charteditor-series-icon-select-data-label-type-clickeditor-series-" + e,
+      $k: gvjs_sq(g + gvjs_a)
+    }),
+    a = gvjs_W(a),
+    a = d + a) : a = "";
+  return gvjs_W(c + (b + a + gvjs_a))
+}
+function gvjs_Vva(a) {
+  return gvjs_W('<div class="google-visualization-clickeditor-entity-cover">' + (a.Qba ? '<div class="google-visualization-clickeditor-entity-cover-stripes"></div>' : "") + (a.Lba ? '<div class="google-visualization-clickeditor-entity-cover-top"></div><div class="google-visualization-clickeditor-entity-cover-bottom"></div><div class="google-visualization-clickeditor-entity-cover-left"></div><div class="google-visualization-clickeditor-entity-cover-right"></div>' : "") + gvjs_a)
+}
+function gvjs_F9(a, b) {
+  return gvjs_W(gvjs_h5 + gvjs_7(b) + gvjs_u4 + gvjs_7(gvjs_Y) + gvjs_X + gvjs_H9({
+    icon: "docs-icon-img docs-icon-bold",
+    ri: "google-visualization-clickeditor-toggle google-visualization-clickeditor-toggle-bold",
+    title: gvjs_sq("" + gvjs_FB(gvjs_j9(gvjs_st)))
+  }) + gvjs_H9({
+    icon: "docs-icon-img docs-icon-italic",
+    ri: "google-visualization-clickeditor-toggle google-visualization-clickeditor-toggle-italic",
+    title: gvjs_sq("" + gvjs_FB(gvjs_j9(gvjs_Gp)))
+  }) + gvjs_G7({
+    $k: gvjs_sq("" + gvjs_vva(b)),
+    ri: gvjs_A6,
+    id: gvjs_usa,
+    QI: !0
+  }) + gvjs_E7({
+    icon: "docs-icon-img docs-icon-text-color",
+    id: gvjs_tsa
+  }) + gvjs_a)
+}
+function gvjs_G9(a) {
+  a = '<div class="google-visualization-clickeditor-separator"></div><div class="google-visualization-clickeditor-input-box"><input id="' + gvjs_7(a) + '" type="text" class="google-visualization-charteditor-input"/><div class="google-visualization-clickeditor-enter-msg">';
+  return gvjs_W(a + "Press Enter to apply</div></div>")
+}
+function gvjs_Mva(a, b, c) {
+  return gvjs_W(gvjs_i5 + gvjs_7(a) + '" type="text" class="google-visualization-charteditor-input google-visualization-charteditor-input-inline-' + gvjs_7(c) + '" placeholder="' + gvjs_7(b) + '"/>')
+}
+function gvjs_I9(a, b) {
+  return gvjs_W(gvjs_G7({
+    $k: gvjs_sq(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_wva() + gvjs_a),
+    ri: gvjs_A6,
+    id: "google-visualization-charteditor-axis-combo-gridline-count-" + b + gvjs_34,
+    QI: !0
+  }) + gvjs_E7({
+    icon: gvjs_era,
+    id: "google-visualization-charteditor-axis-color-grid-" + b + gvjs_34
+  }))
+}
+function gvjs_Wva(a) {
+  a = a.id;
+  if (gvjs_m7("" + a, gvjs_m6))
+    a = gvjs_J9(gvjs_gra);
+  else if (gvjs_m7("" + a, gvjs_k6))
+    a = gvjs_J9(gvjs_fra);
+  else if (gvjs_m7("" + a, gvjs_w6))
+    a = gvjs_J9(gvjs_fra);
+  else if (gvjs_8(a, "google-visualization-charteditor-axis-combo-gridline-count-x-clickeditor"))
+    a = gvjs_J9("docs-icon-img docs-icon-vertical-gridlines");
+  else if (gvjs_8(a, "google-visualization-charteditor-axis-combo-gridline-count-y-clickeditor"))
+    a = gvjs_J9("docs-icon-img docs-icon-left-axis-gridlines");
+  else if (gvjs_8(a, "google-visualization-charteditor-axis-combo-gridline-count-right-clickeditor"))
+    a = gvjs_J9("docs-icon-img docs-icon-right-axis-gridlines");
+  else if (gvjs_m7("" + a, gvjs_l6))
+    a = gvjs_J9(gvjs_V5);
+  else if (gvjs_8(a, gvjs_25))
+    a = gvjs_J9(gvjs_V5);
+  else {
+    var b = gvjs_8(a, gvjs_35);
+    b || (b = gvjs_m7("" + a, gvjs_t6));
+    a = b ? gvjs_J9(gvjs_V5) : ""
+  }
+  return gvjs_W(a)
+}
+function gvjs_Xva(a) {
+  a = a.id;
+  var b = "";
+  gvjs_m7("" + a, gvjs_m6) ? b += "Point size" : gvjs_m7("" + a, gvjs_8ra) ? b += "Point style" : gvjs_m7("" + a, gvjs_Vra) ? b += "Series color" : gvjs_m7("" + a, gvjs_k6) ? b += gvjs_y5 : gvjs_m7("" + a, gvjs_7ra) ? b += "Trendline" : gvjs_m7("" + a, gvjs_w6) ? b += "Trendline thickness" : gvjs_m7("" + a, gvjs_t6) ? b += "Trendline opacity" : gvjs_m7("" + a, gvjs_dsa) ? b += "Trendline color" : gvjs_m7("" + a, gvjs_1ra) ? b += "Data label" : gvjs_m7("" + a, "google-visualization-charteditor-axis-combo-gridline-count-x") ? b += "Horizontal axis gridlines" : gvjs_m7("" + a, "google-visualization-charteditor-axis-combo-gridline-count-y") ? b += "Left vertical axis gridlines" : gvjs_m7("" + a, "google-visualization-charteditor-axis-combo-gridline-count-right") ? b += "Right vertical axis gridlines" : gvjs_m7("" + a, gvjs_l6) ? b += gvjs_r5 : gvjs_m7("" + a, gvjs_pra) ? b += "Slant labels" : gvjs_m7("" + a, gvjs__5) ? b += "Gridlines color" : gvjs_8(a, gvjs_tsa) ? b += gvjs_j9(gvjs_Du) : gvjs_8(a, gvjs_usa) ? b += gvjs_j9(gvjs_zp) : gvjs_8(a, gvjs_25) ? b += "Background opacity" : gvjs_8(a, gvjs_35) ? b += "Axis area background opacity" : gvjs_8(a, gvjs_tra) ? b += gvjs_Oqa : gvjs_8(a, gvjs_ura) ? b += "Axis area background color" : gvjs_8(a, gvjs_Pra) ? b += "Font" : gvjs_8(a, gvjs_h6) && (b += "Legend position");
+  return b
+}
+function gvjs_J9(a) {
+  return gvjs_W('<div class="google-visualization-clickeditor-combobox-icon">' + gvjs_D7(a) + gvjs_a)
+}
+function gvjs_H9(a) {
+  a = gvjs_CB({
+    C8: gvjs_sq("" + gvjs_D7(a.icon))
+  }, a);
+  a = gvjs_W(gvjs_Bta(gvjs_CB({
+    yX: gvjs_3qa,
+    X1: "goog-toolbar-button-outer-box",
+    E_: "goog-toolbar-button-inner-box"
+  }, a)));
+  return gvjs_W(a)
+}
+;function gvjs_K9() {}
+gvjs_t(gvjs_K9, gvjs_A9);
+gvjs_le(gvjs_K9);
+gvjs_K9.prototype.createCaption = function(a, b) {
+  return gvjs_oE(gvjs_Bva(a, b), this.sa(), b)
+}
+;
+gvjs_K9.prototype.Wa = function(a, b) {
+  a && gvjs_Cva(this.ib(a), b)
+}
+;
+gvjs_K9.prototype.ln = function(a) {
+  this.Wa(a.j(), a.getValue());
+  gvjs_VC(a.j(), gvjs_F5);
+  gvjs_K9.G.ln.call(this, a)
+}
+;
+function gvjs_L9(a, b, c, d) {
+  gvjs_z9.call(this, a, b, c || gvjs_K9.Lc(), d)
+}
+gvjs_t(gvjs_L9, gvjs_z9);
+gvjs_HD(gvjs_F5, function() {
+  return new gvjs_L9(null)
+});
+function gvjs_M9(a, b, c) {
+  gvjs_4D.call(this, a, b || gvjs_lE.Lc(), c);
+  this.eg(16, !0)
+}
+gvjs_t(gvjs_M9, gvjs_4D);
+gvjs_HD("goog-toggle-button", function() {
+  return new gvjs_M9(null)
+});
+function gvjs_N9() {}
+gvjs_t(gvjs_N9, gvjs_lE);
+gvjs_le(gvjs_N9);
+gvjs_N9.prototype.sa = function() {
+  return gvjs_3qa
+}
+;
+function gvjs_O9(a, b, c) {
+  gvjs_M9.call(this, a, b || gvjs_N9.Lc(), c)
+}
+gvjs_t(gvjs_O9, gvjs_M9);
+gvjs_HD("goog-toolbar-toggle-button", function() {
+  return new gvjs_O9(null)
+});
+function gvjs_P9(a) {
+  gvjs_C9.call(this, a)
+}
+gvjs_o(gvjs_P9, gvjs_C9);
+gvjs_ = gvjs_P9.prototype;
+gvjs_.l9 = function(a) {
+  var b = new gvjs_O9(null);
+  gvjs_Eua(a);
+  b.fb(a);
+  return b
+}
+;
+gvjs_.Jea = function(a) {
+  var b = gvjs_Gva(this, a)
+    , c = new gvjs_L9(null);
+  c.iD = !0;
+  c.fb(a);
+  c.lp(b);
+  this.Ar(c);
+  gvjs_Q9(a);
+  gvjs_R9(a);
+  return c
+}
+;
+gvjs_.j9 = function(a) {
+  gvjs_E9(a);
+  var b = new gvjs_A8;
+  b.Xr("google-visualization-clickeditor-combobox");
+  b.fb(a);
+  this.Ar(b);
+  gvjs_Q9(a);
+  gvjs_R9(a);
+  return b
+}
+;
+gvjs_.cC = function(a) {
+  gvjs_E9(a);
+  var b = new gvjs_B9(null);
+  b.fb(a);
+  this.Ar(b);
+  gvjs_Q9(a);
+  gvjs_R9(a);
+  return b
+}
+;
+gvjs_.k9 = function(a) {
+  var b = new gvjs_B9(null,void 0,gvjs_zG(gvjs_S9));
+  this.Ar(b);
+  b.fb(a);
+  gvjs_R9(a);
+  return b
+}
+;
+function gvjs_Q9(a) {
+  if (a.id) {
+    var b = gvjs_LB(gvjs_Wva, {
+      id: a.id
+    });
+    b.innerHTML && a.appendChild(b)
+  }
+}
+function gvjs_R9(a) {
+  if (a.id) {
+    var b = gvjs_LB(gvjs_Xva, {
+      id: a.id
+    });
+    b.innerHTML && gvjs_Eua(a, b.innerHTML)
+  }
+}
+function gvjs_S9() {}
+gvjs_o(gvjs_S9, gvjs_A9);
+gvjs_S9.prototype.setContent = function() {}
+;
+function gvjs_Yva(a, b, c, d, e, f) {
+  if (e) {
+    e = gvjs_Oh();
+    var g = {};
+    g.jW = e.hd("google-visualization-clickeditor-toggle-bold", b);
+    g.$_ = e.hd("google-visualization-clickeditor-toggle-italic", b);
+    g.ZW = e.hd(gvjs_F5, b);
+    g.PY = e.hd(gvjs_A6, b);
+    b = g
+  } else
+    e = gvjs_Oh(),
+      g = {},
+      g.jW = e.hd(gvjs_hsa, b),
+      g.$_ = e.hd(gvjs_isa, b),
+      g.ZW = e.hd("google-visualization-charteditor-color", b),
+      g.PY = e.hd(gvjs_Os, b),
+      b = g;
+  e = gvjs_re(gvjs_Zva, c);
+  c = gvjs_re(gvjs__va, c, d);
+  b.jW && a(b.jW, gvjs_36, e(gvjs_st), c(gvjs_st), f);
+  b.$_ && a(b.$_, gvjs_36, e(gvjs_Gp), c(gvjs_Gp), f);
+  b.ZW && a(b.ZW, gvjs_1, e(gvjs_1), c(gvjs_1), f);
+  b.PY && a(b.PY, gvjs_O5, e(gvjs_zp), c(gvjs_zp), f)
+}
+function gvjs_Zva(a, b) {
+  return function() {
+    return a()[b]
+  }
+}
+function gvjs__va(a, b, c) {
+  return function(d) {
+    var e = a();
+    e[c] = d;
+    b(e)
+  }
+}
+;function gvjs_0va(a) {
+  a = a || {};
+  var b = a.attributes
+    , c = a.checked
+    , d = a.p8
+    , e = a.disabled
+    , f = a.id
+    , g = a.label
+    , h = a.name;
+  a = a.value;
+  return gvjs_W(gvjs_b5 + gvjs_7(gvjs_P6) + (c ? " " + gvjs_7("jfk-radiobutton-checked") : "") + (e ? " " + gvjs_7("jfk-radiobutton-disabled") : "") + (d ? " " + gvjs_7(d) : "") + '"' + (h ? ' data-name="' + gvjs_7(h) + '"' : "") + (a ? ' data-value="' + gvjs_7(a) + '"' : "") + (f ? gvjs_t4 + gvjs_7(f) + '"' : "") + (b ? gvjs_o7(gvjs_q7(b)) : "") + ' role="radio"><span class="' + gvjs_7("jfk-radiobutton-radio") + '"></span><span class="' + gvjs_7("jfk-radiobutton-label") + gvjs_X + (g ? gvjs_FB(g) : "") + gvjs_$4)
+}
+;function gvjs_T9(a, b, c, d) {
+  gvjs_LD.call(this, null, gvjs_U9.Lc(), a);
+  this.$d = c || "";
+  this.Ei = d || "";
+  this.eg(16, !0);
+  this.cs &= -17;
+  b && this.In(b)
+}
+gvjs_o(gvjs_T9, gvjs_LD);
+gvjs_ = gvjs_T9.prototype;
+gvjs_.$h = function(a) {
+  this.bi(!0);
+  return gvjs_LD.prototype.$h.call(this, a)
+}
+;
+gvjs_.Wj = function(a) {
+  switch (a.keyCode) {
+    case 38:
+    case 37:
+      return this.dispatchEvent(a.ctrlKey ? "j" : "l"),
+        !0;
+    case 40:
+    case 39:
+      return this.dispatchEvent(a.ctrlKey ? "i" : "k"),
+        !0;
+    case 32:
+      return this.$h(a);
+    case 9:
+      return this.dispatchEvent(a.shiftKey ? "o" : "n"),
+        !1
+  }
+  return gvjs_LD.prototype.Wj.call(this, a)
+}
+;
+gvjs_.Wa = function(a) {
+  this.$d = a;
+  var b = this.j();
+  b && this.Oa().Wa(b, a)
+}
+;
+gvjs_.getValue = function() {
+  return this.$d
+}
+;
+gvjs_.rr = function(a) {
+  this.Ei = a;
+  var b = this.j();
+  b && this.Oa().rr(b, a)
+}
+;
+gvjs_.getName = function() {
+  return this.Ei
+}
+;
+gvjs_.bi = function(a) {
+  gvjs_LD.prototype.bi.call(this, a)
+}
+;
+gvjs_.Gb = function(a) {
+  gvjs_LD.prototype.Gb.call(this, a);
+  this.dispatchEvent("m")
+}
+;
+gvjs_.In = function(a) {
+  this.Qb = a;
+  (a = this.j()) && this.Oa().In(a, this.Qb)
+}
+;
+gvjs_.Dd = function() {
+  return this.Qb
+}
+;
+function gvjs_U9() {}
+gvjs_o(gvjs_U9, gvjs_zD);
+gvjs_ = gvjs_U9.prototype;
+gvjs_.J = function(a) {
+  var b = gvjs_LB(gvjs_0va, {
+    checked: a.nn(),
+    disabled: !a.isEnabled(),
+    name: a.getName(),
+    value: a.getValue()
+  }, void 0, a.wa());
+  (a = a.Dd()) && this.In(b, a);
+  return b
+}
+;
+gvjs_.fb = function(a, b) {
+  gvjs_zD.prototype.fb.call(this, a, b);
+  var c = b.getAttribute(gvjs_bu);
+  c && a.Wa(c);
+  (c = b.getAttribute(gvjs_Q5)) && a.rr(c);
+  c = this.ib(b);
+  c.firstChild ? a.In(c.firstChild.nextSibling ? gvjs_Le(c.childNodes) : c.firstChild) : a.In(null);
+  return b
+}
+;
+gvjs_.Qk = function() {
+  return gvjs_Z6
+}
+;
+gvjs_.In = function(a, b) {
+  a = this.ib(a);
+  gvjs_hh(a);
+  gvjs_gh(a, b)
+}
+;
+gvjs_.Wa = function(a, b) {
+  a.setAttribute(gvjs_bu, b)
+}
+;
+gvjs_.rr = function(a, b) {
+  a.setAttribute(gvjs_Q5, b)
+}
+;
+gvjs_.ib = function(a) {
+  return gvjs_f7(this.sa() + "-label", a)
+}
+;
+gvjs_.sa = function() {
+  return gvjs_P6
+}
+;
+gvjs_le(gvjs_U9);
+function gvjs_V9(a, b) {
+  gvjs_H.call(this);
+  this.Ei = b || "";
+  this.Ca = new gvjs_BE;
+  gvjs_6x(this, this.Ca);
+  this.ea = new gvjs_KA(this);
+  gvjs_6x(this, this.ea);
+  this.Ca.bT = gvjs_1va;
+  this.ea.o(this.Ca, gvjs_k, gvjs_re(this.dispatchEvent, gvjs_Kt));
+  this.ea.o(this, "i", this.Kpa);
+  this.ea.o(this, "j", this.Lpa);
+  this.ea.o(this, "k", this.Vpa);
+  this.ea.o(this, "l", this.dra);
+  this.ea.o(this, "m", this.SP);
+  this.ea.o(this, "n", gvjs_re(this.KP, !1));
+  this.ea.o(this, "o", gvjs_re(this.KP, !0));
+  a && gvjs_u(a, this.Pi, this)
+}
+gvjs_o(gvjs_V9, gvjs_H);
+function gvjs_2va(a, b) {
+  var c = gvjs_Px(gvjs_P6, b)
+    , d = new gvjs_V9(null,a);
+  b = gvjs_3g(b);
+  for (var e = 0; e < c.length; e++)
+    if (c[e].getAttribute(gvjs_Q5) == a) {
+      var f = new gvjs_T9(b);
+      f.fb(c[e]);
+      d.Pi(f)
+    }
+  return d
+}
+gvjs_ = gvjs_V9.prototype;
+gvjs_.Pi = function(a) {
+  this.ea.o(a, gvjs_Ss, this.ipa);
+  a.uA(this);
+  a.rr(this.Ei);
+  var b = a.nn();
+  this.Ca.Bj(a);
+  b && gvjs_W9(this, a);
+  a.j() && this.SP()
+}
+;
+function gvjs_W9(a, b) {
+  a.Ca.gl(b);
+  a.SP()
+}
+gvjs_.getName = function() {
+  return this.Ei
+}
+;
+function gvjs_3va(a, b, c) {
+  var d = a.Ca.od(b);
+  c && gvjs_W9(a, d);
+  gvjs_u(a.Ca.Qy(), function(e) {
+    e.j() && gvjs_jz(e.j(), d == e)
+  });
+  try {
+    d.j().focus()
+  } catch (e) {}
+}
+function gvjs_X9(a, b, c, d) {
+  c = gvjs_Y9(a, b, c);
+  -1 != c && a.Ca.od(c) && (gvjs_jz(b.j(), !1),
+    gvjs_3va(a, c, d))
+}
+function gvjs_Y9(a, b, c) {
+  var d = a.Ca.bh();
+  b = b ? a.Ca.Iq.indexOf(b) : -1;
+  for (var e = 1; e <= d; e++) {
+    var f = gvjs_3y(b + c * e, d);
+    if (a.Ca.od(f).isEnabled())
+      return f
+  }
+  return -1
+}
+gvjs_.dra = function(a) {
+  gvjs_X9(this, a.target, -1, !0)
+}
+;
+gvjs_.Vpa = function(a) {
+  gvjs_X9(this, a.target, 1, !0)
+}
+;
+gvjs_.Lpa = function(a) {
+  gvjs_X9(this, a.target, -1, !1)
+}
+;
+gvjs_.Kpa = function(a) {
+  gvjs_X9(this, a.target, 1, !1)
+}
+;
+gvjs_.KP = function(a, b) {
+  b = this.SP(b);
+  try {
+    var c = b[a ? 0 : 1];
+    c && c.j().focus()
+  } catch (d) {}
+}
+;
+gvjs_.SP = function() {
+  var a = this.Ca.Be()
+    , b = this.Ca.od(0)
+    , c = a && a.isEnabled()
+    , d = c ? a : b;
+  d.isEnabled() || (a = gvjs_Y9(this, d, 1),
+    d = -1 != a ? this.Ca.od(a) : null);
+  var e = d;
+  d && !c && (a = gvjs_Y9(this, d, -1),
+    e = -1 != a ? this.Ca.od(a) : null);
+  gvjs_u(this.Ca.Qy(), function(f) {
+    f.j() && gvjs_jz(f.j(), d == f || e == f)
+  });
+  return [d, e]
+}
+;
+gvjs_.ipa = function(a) {
+  a = a.target;
+  gvjs_W9(this, a);
+  try {
+    a.j().focus()
+  } catch (b) {}
+}
+;
+gvjs_.M = function() {
+  gvjs_u(this.Ca.Qy(), function(a) {
+    gvjs_E(a)
+  });
+  gvjs_H.prototype.M.call(this)
+}
+;
+function gvjs_1va(a, b) {
+  a.bi(b);
+  a.j() && gvjs_jz(a.j(), b)
+}
+;var gvjs_Z9, gvjs_4va, gvjs_5va = !1;
+function gvjs_6va() {
+  gvjs_5va || (gvjs_5va = !0,
+    gvjs_Z9 = function() {}
+    ,
+    gvjs_4va = function() {}
+    ,
+    gvjs_Oh().j("charteditor-log"))
+}
+;function gvjs__9(a) {
+  gvjs_MC.call(this, a)
+}
+gvjs_t(gvjs__9, gvjs_MC);
+gvjs_ = gvjs__9.prototype;
+gvjs_.uc = null;
+gvjs_.vf = function(a) {
+  gvjs__9.G.vf.call(this, a);
+  this.Yj()
+}
+;
+gvjs_.J = function() {
+  this.H = this.wa().J(gvjs_Na, {
+    type: gvjs_m
+  });
+  this.Yj()
+}
+;
+gvjs_.Yj = function() {
+  this.G3();
+  this.uc = new gvjs_0O(this.j());
+  gvjs_G(this.uc, gvjs_fv, this.G3, !1, this)
+}
+;
+gvjs_.G3 = function() {
+  var a = this.j();
+  if (a) {
+    var b = this.getValue();
+    switch (gvjs_mq(b)) {
+      case 1:
+        a.dir !== gvjs_Dv && (a.dir = gvjs_Dv);
+        break;
+      case -1:
+        a.dir !== gvjs_Up && (a.dir = gvjs_Up);
+        break;
+      default:
+        a.removeAttribute("dir")
+    }
+  }
+}
+;
+gvjs_.getDirection = function() {
+  var a = this.j().dir;
+  "" == a && (a = null);
+  return a
+}
+;
+gvjs_.Wa = function(a) {
+  var b = this.j();
+  null != b.value ? b.value = a : gvjs_th(b, a);
+  this.G3()
+}
+;
+gvjs_.getValue = function() {
+  var a = this.j();
+  return null != a.value ? a.value : gvjs_kz(a)
+}
+;
+gvjs_.M = function() {
+  this.uc && (gvjs_li(this.uc),
+    this.uc.pa(),
+    this.uc = null);
+  gvjs__9.G.M.call(this)
+}
+;
+function gvjs_09(a, b, c, d, e, f, g) {
+  gvjs_KA.call(this);
+  this.aa = a;
+  this.Z = b;
+  this.nc = c;
+  this.Wv = [];
+  this.Y_ = e;
+  this.t_ = f;
+  this.OY = g;
+  this.Eq = e ? new gvjs_P9(d) : new gvjs_C9(d);
+  this.D = gvjs_Oh()
+}
+gvjs_o(gvjs_09, gvjs_KA);
+gvjs_ = gvjs_09.prototype;
+gvjs_.clear = function() {
+  this.Eq.clear();
+  gvjs_Fy(this.Wv);
+  this.removeAll()
+}
+;
+gvjs_.TC = function(a, b, c, d, e) {
+  var f = this
+    , g = this.D.j(a);
+  a = e || {};
+  var h = a.MI;
+  d = gvjs_7va(d, a);
+  c = gvjs_8va(c, b, a);
+  if (this.D.Qo(g)) {
+    switch (b) {
+      case gvjs_m:
+        var k = gvjs_Yo;
+        h && gvjs_zua(g, gvjs_y8(h));
+        h = new gvjs__9;
+        h.fb(g);
+        this.LA(h);
+        break;
+      case gvjs_36:
+        g = this.Eq.l9(g);
+        k = gvjs_Ss;
+        break;
+      case gvjs_Z6:
+        k = gvjs_2va(g.id, g);
+        this.LA(k);
+        for (h = 0; h < k.Ca.bh(); h++) {
+          var l = k.Ca.od(h);
+          this.LA(l);
+          gvjs_VC(l.j(), gvjs_Y);
+          l.uA(k)
+        }
+        g = k;
+        k = gvjs_Ss;
+        break;
+      case gvjs_Ut:
+        g = gvjs_Fva(this.Eq, g);
+        k = gvjs_Kt;
+        break;
+      case gvjs_1:
+        g = this.Eq.Jea(g);
+        k = gvjs_Ss;
+        break;
+      case gvjs_k:
+        g = this.Eq.cC(g);
+        k = gvjs_Ss;
+        break;
+      case gvjs_L6:
+      case gvjs_W6:
+        g = this.Eq.k9(g);
+        k = gvjs_Ss;
+        break;
+      case gvjs_O5:
+        k = e.Ve || {};
+        g = this.Eq.j9(g);
+        gvjs_Kua(g, k);
+        k = gvjs_Ss;
+        break;
+      case gvjs_Z5:
+        gvjs_Yva(this.TC.bind(this), g, c, d, this.Y_, e);
+        return;
+      default:
+        throw Error(gvjs_66 + b);
+    }
+    (h = g.j && g.j()) && g.rk && gvjs_UC(h, "google-visualization-clickeditor-no-initial-select") && g.rk(-1);
+    g.Gb && g.Gb(!0);
+    this.Wv.push(this.Lya.bind(this, g, b, c));
+    (c = a.ub) && this.Wv.push(this.Cna.bind(this, g, b, c, e));
+    var m = a.nl;
+    m && this.Wv.push(function() {
+      var p = g
+        , q = m(f.aa, f.Z);
+      gvjs_19(p);
+      var r;
+      switch (b) {
+        case gvjs_Ut:
+          p = p.j();
+          (r = f.D.tP(p)) && gvjs_UC(r, gvjs_rra) && (p = r);
+          break;
+        case gvjs_O5:
+        case gvjs_36:
+        case gvjs_Z6:
+        case gvjs_1:
+        case gvjs_k:
+        case gvjs_L6:
+        case gvjs_W6:
+          p = p.H;
+          r = f.D.tP(p);
+          p && r && gvjs_UC(r, "google-visualization-charteditor-label") && (p = r);
+          break;
+        case gvjs_m:
+          r = f.D.tP(p);
+          p && r && gvjs_UC(r, gvjs_Gra) && (p = r);
+          break;
+        default:
+          throw Error(gvjs_66 + b);
+      }
+      if (p) {
+        r = p;
+        for (var t = void 0 !== r.previousElementSibling ? r.previousElementSibling : gvjs_nh(r.previousSibling, !1); t && t.style.display == gvjs_f; )
+          t = void 0 !== t.previousElementSibling ? t.previousElementSibling : gvjs_nh(t.previousSibling, !1);
+        if (gvjs_9va(t))
+          r = t;
+        else {
+          for (r = f.D.P$(r); r && r.style.display == gvjs_f; )
+            r = f.D.P$(r);
+          r = gvjs_9va(r) ? r : null
+        }
+        gvjs_ZC(p, gvjs_65, !q);
+        r && p.style.display != gvjs_f && gvjs_ZC(r, gvjs_65, !q)
+      }
+      gvjs_Z9()
+    });
+    this.Wv.push(this.Mya.bind(this, g));
+    var n = this.Jya.bind(this, g, b, d);
+    this.o(g, k, n);
+    b == gvjs_m && (this.o(g, gvjs_xu, function() {
+      var p = g
+        , q = gvjs_SC(p);
+      gvjs_He(q, gvjs_75) && (p.value = "",
+        gvjs_ZC(p, gvjs_75, !1))
+    }),
+      this.o(g, gvjs_lv, function(p) {
+        13 == p.keyCode && n()
+      }))
+  }
+}
+;
+gvjs_.cC = function(a) {
+  return this.Eq.cC(a)
+}
+;
+gvjs_.VW = function() {
+  this.Eq.VW()
+}
+;
+function gvjs_$va(a, b) {
+  var c = new gvjs_4D("",(0,
+    gvjs_dP.Lc)());
+  c.fb(b);
+  a.LA(c)
+}
+gvjs_.LA = function(a) {
+  this.Eq.Ar(a)
+}
+;
+gvjs_.update = function() {
+  gvjs_u(this.Wv, function(a) {
+    a.apply()
+  })
+}
+;
+function gvjs_8va(a, b, c) {
+  return function() {
+    var d = a();
+    gvjs_jf(gvjs_gg(d)) && b == gvjs_m && c.MI && (d = {
+      MI: c.MI
+    });
+    return d
+  }
+}
+function gvjs_7va(a, b) {
+  return function(c, d) {
+    b.isNumeric ? gvjs_jf(gvjs_gg(c)) ? a(null, null) : (c = gvjs_jg(c),
+    null != b.min && c < b.min && (c = null),
+    null != b.max && c > b.max && (c = null),
+    null !== c && isFinite(c) && a(c, d)) : a(c, d)
+  }
+}
+gvjs_.Jya = function(a, b, c) {
+  switch (b) {
+    case gvjs_Ut:
+      b = a.nn();
+      break;
+    case gvjs_m:
+      b = a.value;
+      break;
+    case gvjs_36:
+      b = a.nn();
+      break;
+    case gvjs_Z6:
+      b = a.Ca.Be().getValue();
+      break;
+    case gvjs_1:
+      b = a.Av();
+      break;
+    case gvjs_O5:
+      b = a.Be() ? gvjs_29(a.Be()) : a.getValue();
+      break;
+    case gvjs_k:
+    case gvjs_L6:
+      b = gvjs_29(a.Be());
+      break;
+    case gvjs_W6:
+      var d = a.Be();
+      b = gvjs_29(d);
+      if (d) {
+        var e = (e = d.j()) && e.getAttribute("optionType");
+        e = e == gvjs_rd ? null : e
+      }
+      d = typeof e === gvjs_l ? e : null;
+      break;
+    default:
+      throw Error(gvjs_66 + b);
+  }
+  gvjs_Z9("specification is updated from " + gvjs_19(a) + " value is " + b);
+  c(b, d);
+  gvjs_Z9();
+  this.nc.dispatchEvent(gvjs_N6)
+}
+;
+gvjs_.Lya = function(a, b, c) {
+  c = c();
+  switch (b) {
+    case gvjs_Ut:
+      a.bi(null);
+      a.bi(c ? !0 : !1);
+      break;
+    case gvjs_m:
+      gvjs_r(c) ? (c = c.MI,
+        gvjs_ZC(a, gvjs_75, !0)) : gvjs_ZC(a, gvjs_75, !1);
+      a.value = null != c ? c : "";
+      break;
+    case gvjs_36:
+      a.bi(!!c);
+      break;
+    case gvjs_Z6:
+      b = a.Ca.bh();
+      for (var d = 0; d < b; d++) {
+        var e = a.Ca.od(d).getValue();
+        if (c === String(e) || null === c && null === e) {
+          gvjs_W9(a, a.Ca.od(d));
+          return
+        }
+      }
+      break;
+    case gvjs_1:
+      a.tr(c);
+      break;
+    case gvjs_O5:
+      b = !1;
+      for (d = 0; d < a.bh(); d++)
+        if (e = gvjs_29(a.od(d)),
+        e === String(c) || null === e && null === c) {
+          a.rk(d);
+          b = !0;
+          break
+        }
+      b || a.Wa(c);
+      break;
+    case gvjs_k:
+    case gvjs_L6:
+    case gvjs_W6:
+      e = a.getId();
+      d = a.bh();
+      b = 74;
+      gvjs_hf(a.getId(), gvjs_Ora) && this.OY(a);
+      gvjs_hf(e, gvjs_q6) || gvjs_hf(e, gvjs_p6) ? b = 104 : gvjs_hf(e, "google-visualization-charteditor-select-font-size") && e != gvjs_Qra && (b = 40);
+      for (e = 0; e < d; e++) {
+        var f = gvjs_29(a.od(e));
+        if (f === String(c) || null === f && null === c) {
+          a.rk(e);
+          d = a.od(e).getValue();
+          e = a;
+          f = e.setContent;
+          var g = d
+            , h = Math.floor(b / 7.5);
+          d.length > h && (g = gvjs_0y(d, h));
+          b = gvjs_4(gvjs_6a, {
+            style: "width: " + b + "px; overflow: hidden; display: inline-block;"
+          }, g);
+          f.call(e, b);
+          gvjs_Fua(a.j(), gvjs_dg(d));
+          break
+        }
+      }
+      break;
+    default:
+      throw Error(gvjs_66 + b);
+  }
+  gvjs_Z9(gvjs_19(a) + " is updated with " + c)
+}
+;
+gvjs_.Mya = function(a) {
+  var b = null;
+  this.D.Qo(a) ? b = a : typeof a.j === gvjs_d && (b = a.j());
+  if (b) {
+    a = b;
+    b = a.getAttribute(gvjs_cra);
+    var c = a.getAttribute(gvjs_S5), d = a.getAttribute(gvjs_bra), e, f = gvjs_i7();
+    d ? d = e = "_disabled_" != d ? d : "" : c ? (d = e = c,
+    b && (d = gvjs_Gua(b, !1),
+      e = gvjs_Gua(c, f) + " : " + d,
+      d = c + " " + b)) : d = e = b;
+    e ? (b = gvjs_y8(e),
+      gvjs_v8(a, b, d)) : gvjs_v8(a, "", d)
+  }
+}
+;
+function gvjs_29(a) {
+  var b = a && a.j()
+    , c = null
+    , d = !1;
+  b && (b = b.getAttribute(gvjs_Vd),
+  null !== b && (d = !0,
+    b = b == gvjs_rd ? null : b),
+    c = d ? b : a && a.getValue());
+  return typeof c === gvjs_l ? c : null
+}
+function gvjs_9va(a) {
+  return !!a && (gvjs_UC(a, "google-visualization-charteditor-title-gap") || gvjs_UC(a, "google-visualization-charteditor-item-gap"))
+}
+gvjs_.Cna = function(a, b, c, d) {
+  var e = c(this.aa, this.Z);
+  c = gvjs_19(a);
+  switch (b) {
+    case gvjs_Ut:
+      a.Gb(e);
+      gvjs_ZC(a.j().parentNode, "google-visualization-charteditor-checkbox-disabled", !e);
+      break;
+    case gvjs_m:
+      a.disabled = !e;
+      gvjs_ZC(a, "google-visualization-charteditor-input-disabled", !e);
+      (b = a.parentNode) && gvjs_UC(b, gvjs_Gra) && gvjs_ZC(b, "google-visualization-charteditor-input-label-disabled", !e);
+      break;
+    case gvjs_36:
+      a.Gb(e);
+      gvjs_ZC(a.j(), "google-visualization-charteditor-toggle-disabled", !e);
+      break;
+    case gvjs_Z6:
+      b = a.Ca.bh();
+      for (var f = 0; f < b; f++)
+        a.Ca.od(f).Gb(e);
+      break;
+    case gvjs_1:
+      a.Gb(e);
+      break;
+    case gvjs_O5:
+      a.Gb(e);
+      gvjs_ZC(a.j(), gvjs_45, e);
+      gvjs_ZC(a.j(), "google-visualization-charteditor-combobox-disabled", !e);
+      break;
+    case gvjs_k:
+    case gvjs_L6:
+    case gvjs_W6:
+      b = [];
+      f = !1;
+      typeof e === gvjs_zb ? (a.Gb(e),
+        f = e) : (a.Gb(!0),
+        b = e);
+      for (var g = d && d.u9, h = a.bh(), k = 0; k < h; k++) {
+        var l = a.od(k)
+          , m = gvjs_29(l)
+          , n = f || gvjs_He(b, m);
+        l.Gb(n);
+        if (m = g && g[m])
+          n = n ? "" : gvjs_Xta({
+            key: m
+          }),
+            n = n.toString() ? gvjs_y8(n) : gvjs_9f,
+            l = l.j(),
+            gvjs_v8(l, n, void 0)
+      }
+      break;
+    default:
+      throw Error(gvjs_66 + b);
+  }
+  b = "";
+  e || (b = (d = d && d.Lk) ? gvjs_Xta({
+    key: d
+  }) : "",
+  b.toString() || (b = "_disabled_"));
+  (a = a.j ? a.j() : this.D.j(c)) && a.setAttribute(gvjs_bra, (void 0 === b ? "" : b).toString());
+  gvjs_Z9()
+}
+;
+function gvjs_19(a) {
+  a = a.j ? a.j() : a;
+  var b = a.id;
+  a.constructor == gvjs_V9 ? b = "jfk-radio-button" : a.constructor == gvjs_v9 && (b = "color-model");
+  if (null == b)
+    throw Error("error: no id for input");
+  return b
+}
+;function gvjs_awa() {
+  var a = '<div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Range</div><table><tbody><tr><td>Min<br><input id="' + (gvjs_7(gvjs_$5) + gvjs_B4 + gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + gvjs_z5 + (gvjs_7(gvjs_95) + '" type="text" class="google-visualization-charteditor-small-input"></div></td></tr><tr><td colspan=\'2\'><span><span id="' + gvjs_7("google-visualization-charteditor-checkbox-scale-type") + gvjs_P4);
+  a = a + 'Fixed (show zero)</span></td></tr><tr></tbody></table></div><div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Appearance</div><table><tbody><tr style="height: 5px"></tr><tr><td>Fill (1-100)<br><input id="' + (gvjs_7("google-visualization-charteditor-input-fill") + gvjs_B4 + gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + 'Thickness<br><div id="' + (gvjs_7("google-visualization-charteditor-combo-thickness") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_F4 + gvjs_7(gvjs__) + gvjs_G4 + gvjs_7(gvjs__) + gvjs_H4 + gvjs_7(gvjs__) + '" value="8">8px</li></ul></div></div></td></tr><tr style="height: 5px"></tr><tr><td>');
+  a = a + 'Values suffix<br><input id="' + (gvjs_7("google-visualization-charteditor-input-values-suffix") + gvjs_B4 + gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + 'Date format<br><div id="' + (gvjs_7("google-visualization-charteditor-input-date-format") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4);
+  a = a + gvjs_u5 + (gvjs_7(gvjs__) + '" value="MM/dd/yyyy">12/31/1990</li><li class="' + gvjs_7(gvjs__) + '" value="dd/MM/yyyy">31/12/1990</li><li class="' + gvjs_7(gvjs__) + '" value="dd.MM.yyyy">31.12.1990</li></ul></div></div></td></tr></tbody></table></div>');
+  return gvjs_W(a)
+}
+;function gvjs_39(a) {
+  var b = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-gridlines-' + gvjs_7(a) + '"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-gridlines-' + gvjs_7(a) + gvjs_X;
+  b = b + 'Gridlines</div><div role="group" aria-labelledby="google-visualization-charteditor-gridlines-major-' + (gvjs_7(a) + gvjs_T4 + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-gridlines-major-' + gvjs_7(a) + gvjs_X);
+  b = b + 'Major</div><div class="google-visualization-charteditor-float-end ' + (gvjs_7(gvjs_Y) + gvjs_U4 + gvjs_7("google-visualization-charteditor-axis-combo-gridline-count") + "-" + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4);
+  b += gvjs_GB("Count");
+  b += gvjs_Bqa + gvjs_7(gvjs_Z) + gvjs_X + gvjs_wva() + gvjs_Fqa + gvjs_7(gvjs__5) + "-" + gvjs_7(a) + gvjs_w4;
+  b += gvjs_GB(gvjs_7r);
+  b += '\'></div></div></div><div style="height: 6px"></div><div role="group" aria-labelledby="google-visualization-charteditor-gridlines-minor-' + gvjs_7(a) + gvjs_T4 + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-gridlines-minor-' + gvjs_7(a) + gvjs_X;
+  b = b + 'Minor</div><div class="google-visualization-charteditor-float-end ' + (gvjs_7(gvjs_Y) + gvjs_U4 + gvjs_7("google-visualization-charteditor-axis-combo-minor-gridline-count") + "-" + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_y4);
+  b += gvjs_GB("Count");
+  b += gvjs_Bqa + gvjs_7(gvjs_Z) + gvjs_X + gvjs_o9(gvjs_p7(0, 1, 2, 3, 4, 5, 10)) + gvjs_Fqa + gvjs_7(gvjs_ora) + "-" + gvjs_7(a) + gvjs_w4;
+  b += gvjs_GB(gvjs_7r);
+  return gvjs_W(b + gvjs_Aqa)
+}
+function gvjs_49(a, b, c) {
+  var d = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-axis-' + gvjs_7(c) + gvjs_T4 + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-axis-' + gvjs_7(c) + gvjs_X;
+  d = d + 'Number format</div><div id="' + (gvjs_7("google-visualization-charteditor-axis-select-format-options-source") + "-" + gvjs_7(c) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_q4);
+  d += gvjs_GB("Source");
+  d += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="data">';
+  d = d + 'From data</li><li class="' + (gvjs_7(gvjs__) + gvjs_J4);
+  d = d + gvjs_B5 + (gvjs_7(gvjs__) + '" value="inline">');
+  d = d + 'Custom</li></ul></div><div class="google-visualization-charteditor-item-gap"></div><div class="' + (gvjs_7(gvjs_Y) + ' google-visualization-charteditor-input-label">');
+  d = d + gvjs_Wqa + (gvjs_7("google-visualization-charteditor-axis-input-format-options-prefix") + "-" + gvjs_7(c) + gvjs_A4);
+  d += gvjs_GB("Prefix");
+  d += "'></div><div class=\"" + gvjs_7(gvjs_Y) + ' google-visualization-charteditor-float-end google-visualization-charteditor-align-start google-visualization-charteditor-input-label">';
+  d = d + gvjs_Yqa + (gvjs_7("google-visualization-charteditor-axis-input-format-options-suffix") + "-" + gvjs_7(c) + gvjs_A4);
+  d += gvjs_GB("Suffix");
+  var e = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-scale-' + gvjs_7(c) + '"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-scale-' + gvjs_7(c) + gvjs_X;
+  e += "Scale</div>";
+  if (b.scaleFactor[a]) {
+    var f = gvjs_h5 + gvjs_7("google-visualization-charteditor-axis-select-scale") + "-" + gvjs_7(c) + '" class="google-visualization-charteditor-axis-select-scale ' + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="0.01">0.01</li><li class="' + gvjs_7(gvjs__) + '" value="0.1">0.1</li><li class="' + gvjs_7(gvjs__) + gvjs_K4;
+    f = f + gvjs_u5 + (gvjs_7(gvjs__) + '" value="100">100</li><li class="' + gvjs_7(gvjs__) + '" value="1000">1,000</li><li class="' + gvjs_7(gvjs__) + '" value="1000000">1,000,000</li><li class="' + gvjs_7(gvjs__) + '" value="1000000000">1,000,000,000</li><li class="' + gvjs_7(gvjs__) + '" value="1000000000000">1,000,000,000,000</li></ul></div>');
+    f = gvjs_W(f)
+  } else
+    f = "";
+  e += f;
+  b.Mq[a] && (e += gvjs_m5 + gvjs_7("google-visualization-charteditor-axis-checkbox-log-scale") + "-" + gvjs_7(c) + gvjs_P4,
+    e += "Log scale</span>");
+  a = gvjs_W(e + gvjs_a);
+  return gvjs_W(d + (gvjs__4 + a))
+}
+function gvjs_59(a, b, c) {
+  var d = gvjs_b5 + gvjs_7(gvjs_Y) + gvjs_X;
+  d = d + gvjs_Sqa + (gvjs_7("google-visualization-charteditor-axis-input-min") + "-" + gvjs_7(c) + gvjs_gqa);
+  d += gvjs_GB("Minimum value");
+  d += gvjs_O4 + gvjs_7(gvjs_Y) + ' google-visualization-charteditor-float-end google-visualization-charteditor-align-start">';
+  d = d + gvjs_z5 + (gvjs_7("google-visualization-charteditor-axis-input-max") + "-" + gvjs_7(c) + gvjs_gqa);
+  d += gvjs_GB("Maximum value");
+  b.aoa[a] ? (a = '<div><span style="width:auto"><span id="' + gvjs_7("google-visualization-charteditor-axis-checkbox-explicit-view-window") + "-" + gvjs_7(c) + gvjs_P4,
+    b = gvjs_W("Allow bounds to hide data"),
+    a = a + b + gvjs_$4) : a = "";
+  return gvjs_W(d + (gvjs_N4 + a))
+}
+function gvjs_bwa(a) {
+  var b = a.type
+    , c = a.features
+    , d = a.NO
+    , e = a.lJ
+    , f = a.mJ;
+  a = '<div class="google-visualization-charteditor-multi-section-gap"> </div><div role="group" aria-labelledby="google-visualization-charteditor-axis">' + gvjs_gva("Axis", gvjs_sq(gvjs_h5 + gvjs_7(gvjs_lra) + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_W4 + gvjs_7(gvjs_Z) + '"></ul></div>'), "google-visualization-charteditor-axis");
+  a += gvjs_h5 + gvjs_7(gvjs_nra) + gvjs_S4;
+  c.cW[b] && (a += '<div role="group" aria-labelledby="google-visualization-charteditor-y-title">' + gvjs_69(gvjs_fx, "google-visualization-charteditor-y-title") + gvjs_h9("google-visualization-charteditor-font-style-titley") + gvjs_g5 + gvjs_7("google-visualization-charteditor-input-titley") + '" type="text" class="google-visualization-charteditor-input" data-tooltip-base="',
+    a += gvjs_GB(gvjs_x5),
+    a += gvjs_N4);
+  var g = c.aW[b] ? '<div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualization-charteditor-y-axis">' + gvjs_69(gvjs_Q6, "google-visualization-charteditor-y-axis") + gvjs_h9(gvjs_Ara) + gvjs_a : "";
+  a += gvjs_c5 + g;
+  gvjs_9(c.mya[b]) && gvjs_9(d) && (a += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X,
+    a = a + gvjs_Zqa + (gvjs_7(gvjs_qra) + gvjs_Cqa));
+  a += (f ? gvjs_c5 + gvjs_59(b, c, "y") : "") + gvjs_a + (f ? (c.Ja[b] ? gvjs_39("y") : "") + gvjs_49(b, c, "y") : "") + gvjs_a;
+  c.Raa[b] && (a += gvjs_h5 + gvjs_7(gvjs_mra) + gvjs_S4,
+  c.cW[b] && (a += '<div role="group" aria-labelledby="google-visualization-charteditor-x-title">' + gvjs_69(gvjs_fx, "google-visualization-charteditor-x-title") + gvjs_h9("google-visualization-charteditor-font-style-titlex") + gvjs_g5 + gvjs_7("google-visualization-charteditor-input-titlex") + gvjs_fqa,
+    a += gvjs_GB(gvjs_v5),
+    a += "'></div>"),
+    f = c.aW[b] ? '<div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualization-charteditor-x-axis">' + gvjs_69(gvjs_Q6, "google-visualization-charteditor-x-axis") + gvjs_h9(gvjs_zra) + gvjs_a : "",
+    a += gvjs_c5 + f,
+  c.Xfa[b] && (a += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X,
+    a = a + 'Slant labels</div><div class="google-visualization-charteditor-float-end"><div id="' + (gvjs_7("google-visualization-charteditor-select-slant") + gvjs_u4 + gvjs_7(gvjs_Os) + " " + gvjs_7(gvjs_Y) + gvjs_q4),
+    a += gvjs_GB("Slant"),
+    a += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4,
+    a = a + gvjs_Nqa + (gvjs_7(gvjs__) + '" value="0"><span dir=\'ltr\'>0&deg;</span></li><li class="' + gvjs_7(gvjs__) + '" value="30"><span dir=\'ltr\'>30&deg;</span></li><li class="' + gvjs_7(gvjs__) + '" value="60"><span dir=\'ltr\'>60&deg;</span></li><li class="' + gvjs_7(gvjs__) + '" value="90"><span dir=\'ltr\'>90&deg;</span></li></ul></div></div>')),
+  gvjs_9(c.lya[b]) && gvjs_9(d) && (a += gvjs_d5 + gvjs_7(gvjs_Y) + gvjs_X,
+    a = a + gvjs_Zqa + (gvjs_7(gvjs_qra) + gvjs_Cqa)),
+    a += (e ? gvjs_c5 + gvjs_59(b, c, "x") : "") + gvjs_a + (e ? (c.Ja[b] ? gvjs_39("x") : "") + gvjs_49(b, c, "x") + gvjs_a : "") + gvjs_a);
+  c.UH[b] && (a += gvjs_h5 + gvjs_7(gvjs_kra) + gvjs_S4,
+  c.cW[b] && (a += '<div role="group" aria-labelledby="google-visualization-charteditor-title-right">' + gvjs_69(gvjs_fx, "google-visualization-charteditor-title-right") + gvjs_h9("google-visualization-charteditor-font-style-title-right") + gvjs_g5 + gvjs_7("google-visualization-charteditor-input-title-right") + gvjs_fqa,
+    a += gvjs_GB(gvjs_C5),
+    a += "'></div>"),
+    d = c.aW[b] ? '<div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualizaton-charteditor-right-axis">' + gvjs_69(gvjs_Q6, "google-visualizaton-charteditor-right-axis") + gvjs_h9(gvjs_yra) + gvjs_a : "",
+    a += gvjs_c5 + gvjs_59(b, c, gvjs_j) + d + gvjs_a + (c.Saa[b] ? (c.Ja[b] ? gvjs_39(gvjs_j) : "") + gvjs_49(b, c, gvjs_j) : "") + gvjs_a);
+  return gvjs_W(a + gvjs_a)
+}
+function gvjs_69(a, b) {
+  var c = "";
+  gvjs_8(a, gvjs_fx) && (c += gvjs_f5 + gvjs_7(gvjs_Y) + '"' + (b ? gvjs_t4 + gvjs_7(b) + '"' : "") + ">",
+    c += "Title</div>");
+  if (gvjs_8(a, gvjs_Q6)) {
+    a = gvjs_sq("Axis labels");
+    var d = "" + gvjs_57(a);
+    gvjs_sq(d);
+    c += gvjs_b5 + gvjs_7("google-visualization-charteditor-section-title goog-inline-block google-visualization-charteditor-short-title") + '"' + (b ? gvjs_t4 + gvjs_7(b) + '"' : "") + ">" + a + gvjs_a
+  }
+  return gvjs_W(c)
+}
+;function gvjs_cwa() {
+  var a = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-guagechart-title"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-guagechart-title">Gauge range</div><table><tbody><tr><td><div id="google-visualization-charteditor-guagechart-min-label">Min</div><input id="' + (gvjs_7(gvjs_$5) + '" type="text" class="google-visualization-charteditor-small-input" aria-labelledby="google-visualization-charteditor-guagechart-min-label"></td><td><div class="' + gvjs_7(gvjs_Y) + '"><div id="google-visualization-charteditor-guagechart-max-label">');
+  a = a + 'Max</div><input id="' + (gvjs_7(gvjs_95) + '" type="text" class="google-visualization-charteditor-small-input" aria-labelledby="google-visualization-charteditor-guagechart-max-label"></div></td></tr></tbody></table></div><div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-guagechart-colored-ranges"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-guagechart-colored-ranges">');
+  a = a + 'Colored ranges</div><table><tbody><tr style="color: #109618"><td>Min<input id="' + (gvjs_7("google-visualization-charteditor-input-green-from") + gvjs_A4);
+  a += gvjs_GB("Minimum green value");
+  a += gvjs_04 + gvjs_7(gvjs_Y) + gvjs_X;
+  a = a + gvjs_A5 + (gvjs_7("google-visualization-charteditor-input-green-to") + gvjs_A4);
+  a += gvjs_GB("Maximum green value");
+  a = a + '\'></div></td></tr><tr style="height: 4px"></tr><tr style="color: #FF9900"><td>Min<input id="' + (gvjs_7("google-visualization-charteditor-input-yellow-from") + gvjs_A4);
+  a += gvjs_GB("Minimum yellow value");
+  a += gvjs_04 + gvjs_7(gvjs_Y) + gvjs_X;
+  a = a + gvjs_A5 + (gvjs_7("google-visualization-charteditor-input-yellow-to") + gvjs_A4);
+  a += gvjs_GB("Maximum yellow value");
+  a = a + '\'></div></td></tr><tr style="height: 4px"></tr><tr style="color: #DC3912"><td>Min<input id="' + (gvjs_7("google-visualization-charteditor-input-red-from") + gvjs_A4);
+  a += gvjs_GB("Minimum red value");
+  a += gvjs_04 + gvjs_7(gvjs_Y) + gvjs_X;
+  a = a + gvjs_A5 + (gvjs_7("google-visualization-charteditor-input-red-to") + gvjs_A4);
+  a += gvjs_GB("Maximum red value");
+  return gvjs_W(a + "'></div></td></tr></tbody></table></div>")
+}
+;function gvjs_dwa(a) {
+  var b = gvjs_e5 + gvjs_7(gvjs_Y) + gvjs_X + gvjs_FB("Region") + gvjs_Hqa + gvjs_7("google-visualization-charteditor-select-region") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_p4 + gvjs_7("Region") + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="002">';
+  b = b + 'Africa</li><li class="' + (gvjs_7(gvjs__) + '" value="142">');
+  b = b + 'Asia</li><li class="' + (gvjs_7(gvjs__) + '" value="150">');
+  b = b + 'Europe</li><li class="' + (gvjs_7(gvjs__) + '" value="021">');
+  b = b + 'North America</li><li class="' + (gvjs_7(gvjs__) + '" value="005">');
+  b = b + 'South America</li><li class="' + (gvjs_7(gvjs__) + '" value="009">');
+  b = b + 'Oceania</li><li class="' + (gvjs_7(gvjs__) + '" value="US">');
+  b = b + 'United States</li><li class="' + (gvjs_7(gvjs__) + '" value="world">');
+  b = b + 'World</li></ul></div></div><div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-geochart-color"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-geochart-color">Colors</div>' + (gvjs_cva(a.features, a.type) + gvjs_c5);
+  b = b + 'No value: <div id="' + (gvjs_7("google-visualization-charteditor-color-no-value") + gvjs_v4);
+  b += gvjs_GB("No value color");
+  return gvjs_W(b + gvjs__4)
+}
+;function gvjs_ewa() {
+  var a = gvjs_h5 + gvjs_7(gvjs_n6) + '" class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Buckets</div><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '"><span id="' + gvjs_7("google-visualization-charteditor-checkbox-item-divisions") + gvjs_zqa;
+  a = a + 'Omit item dividers</span></div><br><div class="google-visualization-charteditor-section-title ' + (gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + 'Bucket size</div><div class="google-visualization-charteditor-float-end"><input id="google-visualization-charteditor-input-bucket-size" type="text" class="google-visualization-charteditor-small-input google-visualization-charteditor-input"></div><br><div class="google-visualization-charteditor-section-title ' + (gvjs_7(gvjs_Y) + gvjs_X);
+  return gvjs_W(a + 'Outlier percentile</div><div class="google-visualization-charteditor-float-end"><input id="google-visualization-charteditor-input-bucket-outlier-percentile" type="text" class="google-visualization-charteditor-small-input google-visualization-charteditor-input"></div></div>')
+}
+;function gvjs_fwa() {
+  var a = '<div class="google-visualization-charteditor-multi-section-gap"> </div><div class="google-visualization-charteditor-multi-section-title">Axis</div><div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Range</div><div class="' + (gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + gvjs_Sqa + (gvjs_7(gvjs_$5) + '" type="text" class="google-visualization-charteditor-small-input"></div><div class="' + gvjs_7(gvjs_Y) + gvjs_r4);
+  a = a + gvjs_z5 + (gvjs_7(gvjs_95) + '" type="text" class="google-visualization-charteditor-small-input"></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title">');
+  a = a + 'Labels</div><div class="' + (gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + gvjs_Wqa + (gvjs_7("google-visualization-charteditor-input-prefix") + gvjs_hqa + gvjs_7(gvjs_sra) + gvjs_P4);
+  a = a + 'Show labels</span></div></div><div class="' + (gvjs_7(gvjs_Y) + gvjs_r4);
+  a = a + gvjs_Yqa + (gvjs_7("google-visualization-charteditor-input-suffix") + gvjs_hqa + gvjs_7("google-visualization-charteditor-checkbox-show-separator") + gvjs_P4);
+  return gvjs_W(a + "Show separator</span></div></div></div>")
+}
+;function gvjs_gwa() {
+  var a = '<div class="google-visualization-charteditor-multi-section-gap"> </div><div class="google-visualization-charteditor-multi-section-title">Appearance</div><div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Type</div><div class="google-visualization-charteditor-panel-item"><div id="' + (gvjs_7(gvjs_f6) + '"><div class="jfk-radiobutton" style="width: 100px" data-name="' + gvjs_7(gvjs_f6) + '" data-value=\'hybrid\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Hybrid</span></div><div class="jfk-radiobutton" style="width: 100px" data-name="' + (gvjs_7(gvjs_f6) + '" data-value=\'normal\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Normal</span></div><br><div class="jfk-radiobutton" style="width: 100px" data-name="' + (gvjs_7(gvjs_f6) + '" data-value=\'satellite\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Satellite</span></div><div class="jfk-radiobutton" style="width: 100px" data-name="' + (gvjs_7(gvjs_f6) + '" data-value=\'terrain\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Terrain</span></div></div></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title ' + (gvjs_7(gvjs_Y) + gvjs_X);
+  a = a + 'Zoom</div><div class="google-visualization-charteditor-float-end"><div id="' + (gvjs_7("google-visualization-charteditor-select-zoom") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4);
+  a = a + gvjs_Nqa + (gvjs_7(gvjs__) + gvjs_E4);
+  a = a + 'World</li><li class="' + (gvjs_7(gvjs__) + '" value="3">');
+  a = a + 'Continent</li><li class="' + (gvjs_7(gvjs__) + '" value="5">');
+  a = a + 'Country</li><li class="' + (gvjs_7(gvjs__) + '" value="7">');
+  a = a + 'Region</li></ul></div></div><div class="google-visualization-charteditor-item-gap"></div><div class="google-visualization-charteditor-section-title">Polyline</div><div class="' + (gvjs_7(gvjs_Y) + '" style="width: 110px; overflow: hidden;"><span><span id="' + gvjs_7("google-visualization-charteditor-checkbox-show-line") + gvjs_P4);
+  a = a + 'Show </span></div><div class="google-visualization-charteditor-float-end"><div id="' + (gvjs_7("google-visualization-charteditor-combo-line-weight") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_F4 + gvjs_7(gvjs__) + '" value="5">5px</li><li class="' + gvjs_7(gvjs__) + '" value="10">10px</li><li class="' + gvjs_7(gvjs__) + '" value="15">15px</li><li class="' + gvjs_7(gvjs__) + '" value="20">20px</li></ul></div><div id="' + gvjs_7("google-visualization-charteditor-color-line") + '" class="google-visualization-charteditor-color"></div></div></div>');
+  return gvjs_W(a)
+}
+;function gvjs_hwa() {
+  var a = '<div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-orgchart-size">Size</div><div id="' + (gvjs_7(gvjs_g6) + '" role="radiogroup" aria-labelledby="google-visualization-charteditor-orgchart-size"><div class="jfk-radiobutton" data-name="' + gvjs_7(gvjs_g6) + '" data-value=\'small\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Small</span></div><br><div class="jfk-radiobutton" data-name="' + (gvjs_7(gvjs_g6) + '" data-value=\'medium\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Medium</span></div><br><div class="jfk-radiobutton" data-name="' + (gvjs_7(gvjs_g6) + '" data-value=\'large\'><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Large</span></div></div></div><div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Colors</div>Node<div id="' + (gvjs_7("google-visualization-charteditor-color-node") + gvjs_v4);
+  a += gvjs_GB("Node color");
+  a = a + '\'></div><div class="google-visualization-charteditor-item-gap"></div>Selected node<div id="' + (gvjs_7("google-visualization-charteditor-color-selected-node") + gvjs_v4);
+  a += gvjs_GB("Selected node color");
+  return gvjs_W(a + gvjs__4)
+}
+;function gvjs_iwa() {
+  var a = '<div class="google-visualization-charteditor-section"><div class="google-visualization-charteditor-section-title">Label</div><div id="' + (gvjs_7(gvjs_e6) + '"><div class="jfk-radiobutton" style=\'width: 28%\' data-name="' + gvjs_7(gvjs_e6) + '" data-value="right"><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Right</span></div><div class="jfk-radiobutton" style=\'width: 28%\' data-name="' + (gvjs_7(gvjs_e6) + '" data-value="left"><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'Left</span></div><div class="jfk-radiobutton" style=\'width: 28%\' data-name="' + (gvjs_7(gvjs_e6) + '" data-value="none"><span class="jfk-radiobutton-radio"></span><span class="jfk-radiobutton-label">');
+  a = a + 'None</span></div></div><p></p><span><span id="' + (gvjs_7(gvjs_sra) + gvjs_P4);
+  return gvjs_W(a + "Show values</span></div>")
+}
+;function gvjs_jwa() {
+  return gvjs_W('<div class="google-visualization-charteditor-panel"></div>')
+}
+function gvjs_kwa(a) {
+  a = a.charts;
+  var b = '<div class="google-visualization-charteditor-section" role="radiogroup" aria-labelledby="google-visualization-charteditor-recommendedcharts"><span class="google-visualization-charteditor-section-title" style="font-weight: 800;" id="google-visualization-charteditor-recommendedcharts">Recommended charts <span style="font-weight: normal;">-</span></span> <div id="' + (gvjs_7(gvjs_gsa) + gvjs_u4 + gvjs_7(gvjs_Y) + ' google-visualization-charteditor-link" aria-label="');
+  b += gvjs_GB("Go to charts tab");
+  b = b + '">More &raquo;</div><div id="' + (gvjs_7("google-visualization-charteditor-start-thumbnails-wrapper") + gvjs_X);
+  if (0 < a.length) {
+    b += "<table><tbody>";
+    for (var c = Math.max(0, Math.ceil((a.length - 0) / 2)), d = 0; d < c; d++) {
+      var e = 2 * d;
+      b += "<tr><td>" + gvjs_37(a[e]) + "</td>" + (e + 1 < a.length ? "<td>" + gvjs_37(a[e + 1]) + "</td>" : "") + "</tr>"
+    }
+    b += "</tbody></table>"
+  }
+  return gvjs_W(b + gvjs_64)
+}
+function gvjs_lwa(a) {
+  var b = a.tsa
+    , c = a.row
+    , d = a.features
+    , e = a.type
+    , f = a.asa
+    , g = a.sY
+    , h = a.rY
+    , k = '<div class="google-visualization-charteditor-section"><div id="' + gvjs_7(gvjs_wra) + '"><span class="google-visualization-charteditor-section-title" style="font-weight: 800;">';
+  k = k + 'Data</span><span id="' + (gvjs_7(gvjs_55) + '"></span><div><input type="text" maxlength="' + gvjs_7(2048) + gvjs_ir + gvjs_7(gvjs_85) + '" class="google-visualization-charteditor-input"/></div></div><span id="' + gvjs_7(gvjs_55) + '"></span><div>');
+  if (b) {
+    h && (k += gvjs_m5 + gvjs_7("google-visualization-charteditor-checkbox-hidden-dimension") + gvjs_P4,
+      k += "Include hidden / filtered data</span>");
+    k += gvjs_m5 + gvjs_7("google-visualization-charteditor-checkbox-transpose") + gvjs_P4;
+    k += 'Switch rows / columns</span><br><span style="width:auto"><span id="';
+    b = gvjs_7("google-visualization-charteditor-checkbox-headers") + gvjs_P4;
+    if (c) {
+      var l = a.row;
+      h = "";
+      a.transpose ? (l = "Use column " + gvjs_FB(a.$G) + " as headers",
+        h += l) : (l = "Use row " + gvjs_FB(l) + " as headers",
+        h += l);
+      h = gvjs_W(h)
+    } else
+      h = gvjs_W(a.transpose ? "Use 1st column as headers" : "Use 1st row as headers");
+    k += b + h + "</span><br>"
+  }
+  d.YO[e] ? (d = gvjs_m5 + gvjs_7("google-visualization-charteditor-checkox-labels-column") + gvjs_P4,
+    c ? (e = a.$G,
+      c = "",
+      a.transpose ? (a = "Use row " + gvjs_FB(a.row) + " as labels",
+        c += a) : (a = "Use column " + gvjs_FB(e) + " as labels",
+        c += a),
+      a = gvjs_W(c)) : a = gvjs_W(a.transpose ? "Use 1st row as labels" : "Use 1st column as labels"),
+    a = d + a + gvjs_94) : a = "";
+  f = gvjs_9(g) && gvjs_9(f) ? gvjs_m5 + gvjs_7("google-visualization-charteditor-checkbox-quantum-lite-theme") + '"></span>Use Material Theme</span>' : "";
+  return gvjs_W(k + (a + f + gvjs_64))
+}
+;function gvjs_mwa(a) {
+  a = a.labels;
+  var b = '<div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-tablechart-sortcolumn"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-tablechart-sortcolumn">Sort by column</div><div class="' + (gvjs_7(gvjs_Y) + '" style="width:120px"><div id="' + gvjs_7("google-visualization-charteditor-select-sort-column") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4);
+  b += gvjs_GB("Column");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_K4;
+  b += "none</li>";
+  for (var c = a.length, d = 0; d < c; d++) {
+    var e = a[d];
+    b += gvjs_k5 + gvjs_7(gvjs__) + gvjs_jr + gvjs_7(d) + '" title="' + gvjs_7(e) + gvjs_X + gvjs_FB(e) + gvjs_Yr
+  }
+  b += '</ul></div></div><div class="' + gvjs_7(gvjs_Y) + '"><span><span id="' + gvjs_7("google-visualization-charteditor-checkbox-ascending") + gvjs_zqa;
+  b = b + 'Ascending</span></span></div></div><div class="google-visualization-charteditor-section" role="group" aria-labellelby="google-visualization-charteditor-tablechart-paging"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-tablechart-paging">Paging</div><span><span id="' + (gvjs_7("google-visualization-charteditor-checkbox-page") + gvjs_P4);
+  b = b + 'Paging</span><div id="' + (gvjs_7("google-visualization-charteditor-select-page-size") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_q4);
+  b += gvjs_GB("Page size");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '">5</li><li class="' + gvjs_7(gvjs__) + '">10</li><li class="' + gvjs_7(gvjs__) + '">20</li><li class="' + gvjs_7(gvjs__) + '">50</li><li class="' + gvjs_7(gvjs__) + '">100</li></ul></div></div>';
+  return gvjs_W(b)
+}
+;function gvjs_nwa(a) {
+  var b = gvjs_e5 + gvjs_7(gvjs_Y) + gvjs_X;
+  b = b + 'Levels</div><div id="' + (gvjs_7("google-visualization-charteditor-select-levels") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_q4);
+  b += gvjs_GB("Level count");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_E4;
+  b = b + '1 level</li><li class="' + (gvjs_7(gvjs__) + '" value="2">');
+  b = b + '2 levels</li><li class="' + (gvjs_7(gvjs__) + '" value="3">');
+  b = b + '3 levels</li></ul></div><div class="google-visualization-charteditor-item-gap"></div><div role="group" aria-labelledby="google-visualization-charteditor-treemap-header"><div class="google-visualization-charteditor-section-title ' + (gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-treemap-header">');
+  b = b + 'Header</div><div class="google-visualization-charteditor-float-end"><div id="' + (gvjs_7("google-visualization-charteditor-select-header-height") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4);
+  b += gvjs_GB("Size");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + gvjs_D4;
+  b = b + gvjs_B5 + (gvjs_7(gvjs__) + '" value="15">');
+  b = b + gvjs_u5 + (gvjs_7(gvjs__) + '" value="40">');
+  b = b + 'Big</li></ul></div><div id="' + (gvjs_7("google-visualization-charteditor-color-tree-header") + gvjs_w4);
+  b += gvjs_GB(gvjs_7r);
+  b = b + '\'></div></div></div></div><div class="google-visualization-charteditor-section" role="group" aria-labelledby="google-visualization-charteditor-treemap-scale"><div class="google-visualization-charteditor-section-title" id="google-visualization-charteditor-treemap-scale">Scale</div>' + (gvjs_cva(a.features, a.type) + '</div><div class="google-visualization-charteditor-section"><div role="group" aria-labelledby="google-visualization-charteditor-treemap-font"><div class="google-visualization-charteditor-section-title ' + gvjs_7(gvjs_Y) + '" id="google-visualization-charteditor-treemap-font">');
+  b = b + 'Font</div><div class="' + (gvjs_7(gvjs_Y) + gvjs_aqa + gvjs_7(gvjs_Qra) + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_y4);
+  b += gvjs_GB("Size");
+  b += gvjs_14 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="10">';
+  b = b + 'Small</li><li class="' + (gvjs_7(gvjs__) + '" value="14">');
+  b = b + 'Default size</li><li class="' + (gvjs_7(gvjs__) + '" value="18">');
+  b = b + 'Large</li><li class="' + (gvjs_7(gvjs__) + '" value="24">');
+  b = b + 'Very large</li></ul></div><div id="' + (gvjs_7("google-visualization-charteditor-color-font-tree") + gvjs_w4);
+  b += gvjs_GB(gvjs_7r);
+  return gvjs_W(b + gvjs_Aqa)
+}
+;function gvjs_79(a) {
+  gvjs_KA.call(this);
+  this.Nka = new gvjs_l7;
+  this.M_ = !!a;
+  this.D = gvjs_Oh()
+}
+gvjs_t(gvjs_79, gvjs_KA);
+gvjs_ = gvjs_79.prototype;
+gvjs_.vH = null;
+gvjs_.nc = null;
+gvjs_.aa = null;
+gvjs_.zj = null;
+gvjs_.oa = null;
+gvjs_.sg = null;
+gvjs_.Yt = null;
+gvjs_.Gx = null;
+gvjs_.Yq = null;
+gvjs_.uc = null;
+gvjs_.qn = null;
+gvjs_.kF = null;
+function gvjs_89(a, b) {
+  a.kF = [];
+  var c = a.aa;
+  gvjs_99(a, b, c);
+  gvjs_owa(a, b);
+  var d = a.M_ ? gvjs_Pta : gvjs_Ota
+    , e = gvjs_$9(a);
+  if (gvjs_a$(d.tV, b))
+    for (var f in d) {
+      var g = d[f];
+      null != gvjs_b$(a, g) && gvjs_pwa(a, e, g)
+    }
+  if (d = gvjs_a$(d.C6, b))
+    gvjs_E(a.Yt),
+      a.Yt = a.uc.cC(d),
+      gvjs_qwa(a, e),
+      e = gvjs_s(a.eha, a),
+      a.uc.Wv.push(e);
+  gvjs_rwa(a, b);
+  (b = a.D.j(gvjs_Era)) && gvjs_99(a, b, c)
+}
+function gvjs_99(a, b, c) {
+  if (a.D.Qo(b)) {
+    var d = a.D.getChildren(b);
+    d && gvjs_u(d, function(e) {
+      gvjs_99(this, e, c)
+    }, a);
+    gvjs_swa(a, b, c);
+    (d = gvjs_twa(a, b)) && a.kF.push(d);
+    gvjs_UC(b, "google-visualization-charteditor-link") && gvjs_$va(a.uc, b)
+  }
+}
+function gvjs_b$(a, b) {
+  if (!b)
+    return null;
+  a = a.M_ ? b.replace(gvjs_34, "") : b;
+  a = gvjs_i8[a];
+  return gvjs_r(a) ? a : null
+}
+function gvjs_twa(a, b) {
+  var c = (b = b && b.id) && b.replace("google-visualization-charteditor-thumbnail-", "");
+  a = gvjs_Nta(a.oa.yl);
+  a = c && a.charts[c];
+  return gvjs_r(a) ? (a.id = b,
+    a.OW = c,
+    a) : null
+}
+function gvjs_swa(a, b, c) {
+  var d = gvjs_b$(a, b && b.id);
+  if (d) {
+    var e = d.type
+      , f = d.gEa
+      , g = d.handler;
+    if (g) {
+      var h = g.get ? gvjs_re(g.get, c) : gvjs_s(a.getOption, a, d);
+      c = g.set ? gvjs_re(g.set, c) : gvjs_s(a.ba, a, d);
+      a.uc.TC(b, e, h, c, f)
+    } else
+      gvjs_uwa(a, b, e, d, f)
+  }
+}
+function gvjs_c$(a, b) {
+  a && typeof b === gvjs_g && (a.rk(b),
+    a.dispatchEvent(gvjs_Ss))
+}
+gvjs_.wQ = function() {
+  return this.nt(gvjs_Lb) || this.nt(gvjs_Mb) || this.nt(gvjs_Od)
+}
+;
+gvjs_.Hq = function() {
+  return gvjs_$.ska[gvjs_d$(this)] || this.nt(gvjs_g)
+}
+;
+gvjs_.nt = function(a) {
+  var b = gvjs_d$(this)
+    , c = this.vH;
+  if (!gvjs_$.YN[b] || !c || 0 == c.$())
+    return !1;
+  if (gvjs_$.lfa[b])
+    return c.W(1) === a;
+  if (c.W(0) != a)
+    return !1;
+  a = gvjs_c8(b, c);
+  return null === a ? (a = !!this.getOption({
+    name: gvjs_76,
+    defaultValue: gvjs_$.EH[b]
+  }),
+  !this.getOption({
+    name: gvjs_46
+  }) && a) : a
+}
+;
+function gvjs_$9(a) {
+  return a.zj ? gvjs_a8(a.zj) : 0
+}
+gvjs_.wZ = function(a) {
+  gvjs_d$(this);
+  var b = ""
+    , c = this.zj;
+  null != c && (b = c.wZ(a));
+  gvjs_jf(gvjs_gg(b)) && (b = gvjs_47(gvjs_d$(this)) + " " + (a + 1));
+  return b
+}
+;
+function gvjs_qwa(a, b) {
+  function c() {
+    var l = a.Yt
+      , m = l.Vl();
+    gvjs_e$(a, l.ib());
+    var n = k.j(d.tV)
+      , p = k.j(d.yia);
+    if (f && 0 == m)
+      gvjs_6(p, !0),
+        gvjs_6(n, !1);
+    else {
+      f && (gvjs_6(p, !1),
+        m--);
+      gvjs_6(n, !0);
+      p = d.A6;
+      var q = k.hd(gvjs_j6);
+      h.oq() && g && 1 < b && (0 === m ? (m = gvjs_Lu,
+        gvjs_6(q, !1)) : (m--,
+        gvjs_6(q, !0)));
+      gvjs_vwa(n, p + ".*-series-[0-9]*", p + ".*-series-" + m + "(\\.lbl)?$")
+    }
+    n = a.aa.getOption(gvjs_56);
+    m = (l = h.oq() && g && 1 < b && 0 === l.Vl()) ? n && gvjs_Ye(n).length == b : n && n[m];
+    (n = k.hd(gvjs_u6)) && gvjs_6(n, m);
+    (m = k.hd(gvjs_x6)) && gvjs_6(m, !l);
+    a.uc.update()
+  }
+  var d = a.M_ ? gvjs_Pta : gvjs_Ota
+    , e = a.Yt
+    , f = gvjs_$.II[gvjs_d$(a)]
+    , g = gvjs_$.Lg[gvjs_d$(a)];
+  null !== b && a.eha(b);
+  var h = a.oa
+    , k = a.D;
+  a.o(e, gvjs_Ss, c);
+  null !== b && (e.rk(0),
+    c())
+}
+gvjs_.eha = function(a) {
+  var b = this.Yt
+    , c = gvjs_$.II[gvjs_d$(this)] || this.oa.oq() && gvjs_$.Lg[gvjs_d$(this)] && 1 < a;
+  null == a && (a = b.bh(),
+    a = (c = gvjs_$.II[gvjs_d$(this)] || this.oa.oq() && gvjs_$.Lg[gvjs_d$(this)] && 1 < a) ? a - 1 : a);
+  for (var d = gvjs_wwa(this, a), e = 0; e < a; e++) {
+    var f = d[e];
+    f && b.od(c ? e + 1 : e).setContent(f)
+  }
+}
+;
+function gvjs_wwa(a, b) {
+  var c = [];
+  b = typeof b === gvjs_g ? b : gvjs_$9(a);
+  for (var d = 0; d < b; d++) {
+    var e = a.wZ(d);
+    if (e) {
+      e = a.D.J(gvjs_6a, {}, e);
+      gvjs_e$(a, e);
+      var f = gvjs_V7(a.aa, d);
+      f && (e = a.D.J(gvjs_b, gvjs_Y, a.D.J(gvjs_b, {
+        "class": gvjs_Rra,
+        style: gvjs_vb + f
+      }), e))
+    }
+    c[d] = e
+  }
+  return c
+}
+function gvjs_vwa(a, b, c) {
+  a = gvjs_6sa(a, function(g) {
+    return g && g.id && g.id.match(b)
+  });
+  for (var d = 0; d < a.length; d++) {
+    var e = a[d]
+      , f = c && e.id.match(c) ? "" : gvjs_f;
+    gvjs_C(e, gvjs_ku, f)
+  }
+}
+function gvjs_f$(a, b, c) {
+  var d = a.D.j(gvjs_b6);
+  a.D.appendChild(d, gvjs_r7(b, c))
+}
+gvjs_.getOption = function(a) {
+  var b = a.defaultValue;
+  if (gvjs_r(b)) {
+    var c = gvjs_R7(this.aa, a.name, {});
+    gvjs_w(b, function(d, e) {
+      gvjs_f8(c, e, d)
+    });
+    return c
+  }
+  return gvjs_R7(this.aa, a.name, b)
+}
+;
+gvjs_.ba = function(a, b) {
+  gvjs_Gta(this.aa, a.name, b)
+}
+;
+function gvjs_uwa(a, b, c, d, e) {
+  e = void 0 === e ? {} : e;
+  a.uc.TC(b, c, function() {
+    return a.getOption(d)
+  }, function(f) {
+    a.ba(d, f)
+  }, e)
+}
+function gvjs_d$(a) {
+  a = a.aa.Va();
+  a == gvjs_w5 && (a = gvjs_Oa);
+  return a
+}
+function gvjs_xwa(a) {
+  var b = gvjs_d$(a)
+    , c = a.aa.cf
+    , d = gvjs_jf(gvjs_gg(c)) ? !1 : -1 != c.indexOf("transpose=1")
+    , e = gvjs_g$(a, c, !1);
+  c = (e = e && e.replace(/:.*/, "")) && e.match(/\d+/);
+  e = e && e.match(/[A-Z]+/);
+  a.D.appendChild(a.sg.firstChild, gvjs_r7(gvjs_lwa, {
+    transpose: d,
+    tsa: a.oa.V_,
+    row: c,
+    $G: e,
+    features: gvjs_$,
+    type: b,
+    asa: !1,
+    sY: a.oa.sY(),
+    rY: a.oa.rY()
+  }))
+}
+function gvjs_pwa(a, b, c) {
+  for (var d = gvjs_b$(a, c), e = d.handler && d.handler.get || function(n, p) {
+    n = a.getOption(n);
+    d.type == gvjs_1 && (p %= n.length);
+    return n[p]
+  }
+         , f = d.handler && d.handler.set || function(n, p, q, r) {
+      q = a.getOption(n);
+      d.type == gvjs_1 && (p %= q.length);
+      q[p] = r;
+      a.ba(n, q)
+    }
+         , g = 0; g < b; g++) {
+    var h = gvjs_re(e, d, g, a.aa)
+      , k = gvjs_re(f, d, g, a.aa)
+      , l = gvjs_r(d.L) ? gvjs_x(d.L) : {};
+    l.ub = l.ub ? gvjs_re(l.ub, g) : null;
+    l.nl = l.nl ? gvjs_re(l.nl, g) : null;
+    var m = c + gvjs_44 + g;
+    a.D.j(m) && a.uc.TC(m, d.type, h, k, l)
+  }
+  a.oa.oq() && gvjs_$.Lg[gvjs_d$(a)] && 1 < b && (m = function(n, p, q, r) {
+    for (var t = 0; t < p; t++)
+      if (!n.call(this, t, q, r))
+        return !1;
+    return !0
+  }
+    ,
+    l = function(n, p, q, r) {
+      for (var t = 0; t < p; t++)
+        if (!n.call(this, t, q, r))
+          return !1;
+      return !0
+    }
+    ,
+    g = gvjs_r(d.L) ? gvjs_x(d.L) : {},
+    h = gvjs_re(function(n, p, q, r) {
+      var t = n.call(this, d, 0, q);
+      for (p = 1; p < r; p++)
+        if (gvjs_r(t)) {
+          var u = n.call(this, d, p, q)
+            , v = gvjs_Ye(t).concat(gvjs_Ye(u));
+          gvjs_Pe(v);
+          gvjs_w(v, function(w) {
+            t[w] != u[w] && (t[w] = "")
+          })
+        } else if (t !== n.call(this, d, p, q))
+          return "";
+      return t
+    }, e, d, a.aa, b),
+    k = gvjs_re(function(n, p, q, r, t) {
+      for (p = 0; p < r; p++)
+        n.call(this, d, p, q, t)
+    }, f, d, a.aa, b),
+    g.ub = g.ub ? gvjs_re(m, g.ub, b) : null,
+    g.nl = g.nl ? gvjs_re(l, g.nl, b) : null,
+    m = c + "-series-global",
+  a.D.j(m) && a.uc.TC(m, d.type, h, k, g))
+}
+function gvjs_rwa(a, b) {
+  b = gvjs_a$(gvjs_lra, b);
+  if (a.D.O_(b)) {
+    gvjs_E(a.Gx);
+    var c = a.Gx = a.uc.cC(b)
+      , d = {
+      x: a.D.j(gvjs_mra),
+      y: a.D.j(gvjs_nra),
+      right: a.D.j(gvjs_kra)
+    };
+    gvjs_w(d, function(e, f) {
+      if (e) {
+        if (e = "",
+        gvjs_8(f, "y") && (e += "Left vertical"),
+        gvjs_8(f, "x") && (e += "Horizontal"),
+        gvjs_8(f, gvjs_j) && (e += "Right vertical"),
+          e = new gvjs_ZD(e,f),
+          c.Bj(e),
+        f == gvjs_j || "y" == f)
+          f = gvjs_s(a.kya, a, e, "y" == f ? 0 : 1),
+            a.uc.Wv.push(f)
+      } else
+        delete d[f]
+    });
+    b = function() {
+      var e = c.Be();
+      gvjs_e$(a, c.ib());
+      gvjs_w(d, function(f, g) {
+        gvjs_6(f, g == e.Zh)
+      })
+    }
+    ;
+    a.o(c, gvjs_Ss, b);
+    c.rk(0);
+    b()
+  }
+}
+gvjs_.kya = function(a, b) {
+  var c = this.aa
+    , d = gvjs_$9(this);
+  b = 0 == b ? gvjs_e8(c, 0, d) : gvjs_e8(c, 1, d);
+  a.Gb(b);
+  b = this.Gx;
+  a.isEnabled() || a != b.Be() || gvjs_c$(b, 0)
+}
+;
+function gvjs_owa(a, b) {
+  if (gvjs_a$(gvjs_85, b)) {
+    var c = a.aa;
+    b = gvjs_s(a.Hoa, a, c);
+    c = gvjs_s(a.Awa, a, c);
+    a.uc.TC(gvjs_85, gvjs_m, b, c);
+    b = a.oa;
+    b.KO() && (c = a.D.j(gvjs_55)) && (gvjs_C(c, gvjs_ku, "inline-block"),
+      a.o(c, gvjs_Wt, gvjs_s(a.Zma, a)));
+    c = a.D.j(gvjs_wra);
+    var d = b.wma;
+    a.D.Qo(d) && (a.D.qc(c),
+      a.D.appendChild(c, d));
+    b.kx() && (gvjs_ZC(c, "google-visualization-charteditor-glasspane", !0),
+      a = gvjs_zh(a.D, gvjs_Na, null, c),
+      gvjs_u(a, function(e) {
+        e.disabled = !0
+      }))
+  }
+}
+gvjs_.Awa = function(a, b) {
+  var c = a.cf
+    , d = gvjs_g$(this, c, !1)
+    , e = gvjs_g$(this, b, !0);
+  d && e ? a.yh(c.replace(d, e)) : a.yh(b)
+}
+;
+gvjs_.Hoa = function(a) {
+  a = a.cf;
+  if (gvjs_jf(gvjs_gg(a)))
+    return "";
+  var b = gvjs_g$(this, a, !1);
+  return null === b ? a : b.toString()
+}
+;
+function gvjs_g$(a, b, c) {
+  a = a.oa.tma;
+  c && (a = "^" + a + "$");
+  b = (b || "").match(a);
+  if (null === b || 0 == b.length)
+    return null;
+  if (1 == b.length)
+    return b[0];
+  gvjs_Z9();
+  return null
+}
+gvjs_.Zma = function() {
+  gvjs_Z9();
+  this.nc.dispatchEvent(gvjs_3sa)
+}
+;
+function gvjs_h$(a) {
+  a.removeAll();
+  gvjs_E(a.Gx);
+  gvjs_E(a.Yt);
+  gvjs_E(a.qn);
+  a.uc && a.uc.clear()
+}
+gvjs_.init = function(a, b, c, d, e, f) {
+  a && this.D.qc(a);
+  this.sg = a;
+  this.aa = b;
+  this.nc = c;
+  this.oa = d;
+  this.vH = e;
+  this.zj = f;
+  this.uc = new gvjs_09(b,e,c,gvjs_$9(this),this.oa.Y_,this.oa.t_,this.oa.OY)
+}
+;
+gvjs_.LA = function(a) {
+  this.uc.LA(a)
+}
+;
+function gvjs_e$(a, b) {
+  var c = a.D.Voa(b) || ""
+    , d = a.Nka;
+  c = d.Una(c, void 0);
+  a.D.sr(b, {
+    dir: -1 == (0 == c ? d.D8 : c) ? gvjs_Up : gvjs_Dv
+  })
+}
+gvjs_.zqa = function(a, b) {
+  this.D.G$(b.target, function(c) {
+    return c == a
+  }, !0) && (a.scrollTop += 30 * gvjs_$y(b.deltaY),
+    b.preventDefault(),
+    this.uc.VW())
+}
+;
+function gvjs_a$(a, b) {
+  var c = gvjs_Oh();
+  return (a = c.j(a)) && b ? c.G$(a, function(d) {
+    return d == b
+  }) ? a : null : a
+}
+;function gvjs_ywa(a) {
+  this.t_ = a
+}
+;function gvjs_i$(a) {
+  a = a || {};
+  this.Zka = a.buttonKeys || {};
+  this.yl = a.chartTypes || [gvjs_q5, gvjs_ma, gvjs_na, gvjs_oa, gvjs_qa, gvjs_ra, gvjs_ua, gvjs_xa, gvjs_ya, gvjs_Ga, gvjs_Ha, gvjs_La, gvjs_Oa, gvjs_Pa, gvjs_Va, gvjs_3a, gvjs_Za, gvjs_2a, gvjs_9a, gvjs_ab, gvjs_db, gvjs_fb, gvjs_hb];
+  a.enableTimeline || gvjs_Ie(this.yl, gvjs_fb);
+  this.bv = gvjs_r(a.containers) ? a.containers : null;
+  this.tma = a.dataMask || ".*";
+  this.wma = a.dataSourceInput || a.dataInput || gvjs_4(gvjs_b);
+  this.vna = a.enableAutomaticDataSampling || !1;
+  this.xna = !!a.enableChartMarkerShapes;
+  this.Ana = !!a.enableDataPreview;
+  this.Hna = !!a.enableTextHistograms;
+  this.Jna = !!a.enableTryLiveExample;
+  this.Ina = !!a.enableToggledDiscreteAxis;
+  this.Gna = !!a.enableQuantumLiteCharts;
+  this.JO = !!a.enableDataLabel;
+  this.una = !!a.enableAllSeries;
+  this.yna = !!a.enableChartsHiddenDimensionStrategy;
+  this.vba = typeof a.installTooltipManager === gvjs_zb ? a.installTooltipManager : !0;
+  this.nra = a.helpUrl || "";
+  this.gsa = !!a.isIFrame;
+  this.Iba = !!a.isModal;
+  this.V_ = !!a.isSpreadsheetUrls;
+  this.Y_ = !!a.isToolbar;
+  this.Pta = a.noDataElement || null;
+  this.Oua = a.panelIndex || 0;
+  this.$wa = typeof a.showChartNameInput === gvjs_zb ? a.showChartNameInput : !0;
+  this.e4 = typeof a.showPanelNavigation === gvjs_zb ? a.showPanelNavigation : !0;
+  this.$ea = !!a.sampleData;
+  this.Oxa = a.templateUrl || "";
+  this.t_ = new gvjs_ywa(a.impressionFramework || null);
+  this.Jba = typeof a.isNewChart === gvjs_zb ? a.isNewChart : !0;
+  this.sna = !!a.enable100PercentStacked;
+  this.O9 = !!a.enableNewTabNames;
+  this.As = a.customStartPanel || null;
+  this.$B = a.customChartPanel || null;
+  this.OY = a.fontNameSelectProcessor || function() {}
+  ;
+  this.tna = !!a.enableAllDomainTrendlines
+}
+gvjs_ = gvjs_i$.prototype;
+gvjs_.kC = function() {
+  return this.xna
+}
+;
+gvjs_.KO = function() {
+  return this.Ana
+}
+;
+gvjs_.MO = function() {
+  return this.Hna
+}
+;
+gvjs_.NO = function() {
+  return this.Ina
+}
+;
+gvjs_.sY = function() {
+  return this.Gna
+}
+;
+gvjs_.vo = function() {
+  return this.JO
+}
+;
+gvjs_.rY = function() {
+  return this.yna
+}
+;
+gvjs_.oq = function() {
+  return this.una
+}
+;
+gvjs_.K$ = function() {
+  return this.yl
+}
+;
+gvjs_.kx = function() {
+  return this.$ea
+}
+;
+gvjs_.Fna = function() {
+  return this.O9
+}
+;
+gvjs_.qY = function() {
+  return this.tna
+}
+;
+var gvjs_j$ = [gvjs_q5, gvjs_ma, gvjs_na, gvjs_oa, gvjs_qa, gvjs_ra, gvjs_ua, gvjs_xa, gvjs_ya, gvjs_Ga, gvjs_Ha, gvjs_La, gvjs_Va, gvjs_3a, gvjs_9a, gvjs_Wa, gvjs_Za, gvjs_2a, gvjs_ab, gvjs_db, gvjs_fb, gvjs_hb, gvjs_mb, gvjs_Oa, gvjs_Pa]
+  , gvjs_zwa = [gvjs_na, gvjs_qa, gvjs_ra, gvjs_ua, gvjs_xa, gvjs_ya, gvjs_La, gvjs_Va, gvjs_3a, gvjs_9a, gvjs_ab];
+function gvjs_k$(a) {
+  gvjs_KA.call(this);
+  this.ma = a.j(gvjs_xra);
+  this.D = a;
+  this.Db = !1;
+  gvjs_C(this.ma, gvjs_Xd, "880px");
+  gvjs_l$(this)
+}
+gvjs_t(gvjs_k$, gvjs_KA);
+gvjs_ = gvjs_k$.prototype;
+gvjs_.M7 = "";
+gvjs_.Z = null;
+gvjs_.Ua = "";
+gvjs_.Tga = null;
+gvjs_.close = function() {
+  var a = this.ma
+    , b = new gvjs_mO(a,300,0,500);
+  this.vD(b, gvjs_R, function() {
+    gvjs_6(a, !1)
+  });
+  b.play();
+  this.Db = !1;
+  gvjs_l$(this)
+}
+;
+gvjs_.M = function() {
+  this.Db = !1;
+  this.Z = this.ma = null;
+  gvjs_k$.G.M.call(this)
+}
+;
+function gvjs_m$(a) {
+  return a.mb() ? "dataEntry" : "" != gvjs_n$(a) ? gvjs_Jw : "noData"
+}
+function gvjs_n$(a) {
+  var b = new gvjs_Xm(a.M7 + "/tq");
+  b.Ld(gvjs_kv, a.Tga);
+  gvjs_jf(gvjs_gg(a.Ua)) || b.Ld(gvjs_sw, a.Ua);
+  return b = b.toString()
+}
+gvjs_.mb = function() {
+  return this.Z
+}
+;
+gvjs_.isVisible = function() {
+  return this.Db
+}
+;
+gvjs_.open = function() {
+  if ("noData" != gvjs_m$(this)) {
+    var a = this.ma;
+    gvjs_C(a, gvjs_ku, gvjs_xb);
+    (new gvjs_mO(a,0,300,500)).play();
+    this.Db = !0;
+    this.Mj();
+    gvjs_l$(this)
+  }
+}
+;
+function gvjs_Awa(a, b) {
+  function c(f) {
+    return typeof f === gvjs_l ? f : ""
+  }
+  b = gvjs_LU(b);
+  var d = b.getPath();
+  d = d.substring(0, d.lastIndexOf("/"));
+  var e = new gvjs_Xm;
+  gvjs_Ym(e, b.gp);
+  gvjs__m(e, b.jv);
+  e.setPath(d);
+  a.M7 = e.toString();
+  a.Tga = c(b.cg.get(gvjs_kv));
+  a.Ua = c(b.cg.get(gvjs_sw))
+}
+gvjs_.toggle = function() {
+  this.Db ? this.close() : this.open()
+}
+;
+function gvjs_Bwa(a, b) {
+  var c = b.mb();
+  if (c) {
+    if (a.Z && a.Z.toJSON() == c.toJSON())
+      return;
+    a.Z = c
+  } else {
+    b = b.cf;
+    if (b == gvjs_n$(a))
+      return;
+    gvjs_Awa(a, gvjs_gg(b))
+  }
+  a.Db && a.Mj()
+}
+gvjs_.Mj = function() {
+  var a = new gvjs_Q;
+  a.cc(gvjs_db);
+  a.yh(gvjs_n$(this));
+  a.zh(this.mb());
+  a.draw(this.ma)
+}
+;
+function gvjs_l$(a) {
+  var b = a.D.j(gvjs_55);
+  b && (b.style.backgroundPosition = a.Db ? "-406px" : "-422px")
+}
+;function gvjs_Cwa(a) {
+  var b = gvjs_re(gvjs_Dwa, a, "ok");
+  a.Bb ? b() : gvjs_y ? gvjs_ei(a, gvjs_Sw, b) : gvjs_ei(a, gvjs_pt, b);
+  var c = null;
+  gvjs_G(a, gvjs_Sw, function() {
+    a.getDraggable() && (c = new gvjs_o$(a))
+  });
+  gvjs_G(a, gvjs_1u, function() {
+    gvjs_E(c)
+  })
+}
+function gvjs_Dwa(a, b) {
+  gvjs_lD(a, .75);
+  var c = a.ki;
+  c && b && (b = gvjs_qD(c, b)) && gvjs_VC(b, "goog-buttonset-action");
+  b = gvjs_vM(a.j(), .13);
+  c = gvjs_wM(a.j(), .13);
+  var d = gvjs_uM(a.AC(), .13, "ease-out", 0, .75)
+    , e = gvjs_uM(a.AC(), .13, "ease-in", .75, 0);
+  a.QE(b, c, d, e)
+}
+function gvjs_o$(a) {
+  gvjs__C.call(this, a.j());
+  this.Xf = a;
+  gvjs_G(this, gvjs_2, this.Swa, !1, this)
+}
+gvjs_o(gvjs_o$, gvjs__C);
+gvjs_o$.prototype.Swa = function(a) {
+  a = a.Wka;
+  if (this.Xf.getDraggable() && gvjs_UC(a.target, this.Xf.sa())) {
+    var b = gvjs_Dz(this.Xf.j());
+    b = new gvjs_B(0,b.width,b.height,0);
+    var c = gvjs_Ih(this.Xf.j());
+    b.expand(-1 * c.top, -1 * c.right, -1 * c.bottom, -1 * c.left);
+    if (!b.contains(new gvjs_z(a.offsetX,a.offsetY)))
+      return this.I3(),
+        !0
+  }
+  return !1
+}
+;
+gvjs_o$.prototype.I3 = function() {
+  var a = this.Xf.wa().kc()
+    , b = gvjs_0x(gvjs_3x(a) || window)
+    , c = gvjs_Dz(this.Xf.j());
+  if (gvjs_Eh(this.Xf.j()) == gvjs_wu)
+    a = b.width - c.width,
+      b = b.height - c.height;
+  else {
+    var d = Math.max(a.body.scrollHeight, b.height);
+    a = Math.max(a.body.scrollWidth, b.width) - c.width;
+    b = d - c.height
+  }
+  gvjs_0C(this, new gvjs_5(0,0,Math.max(0, a),Math.max(0, b)))
+}
+;
+function gvjs_p$(a, b, c) {
+  gvjs_KA.call(this);
+  this.oa = a;
+  this.nc = b;
+  this.D = c;
+  this.SJ = this.XY = this.Xf = this.uW = null
+}
+gvjs_o(gvjs_p$, gvjs_KA);
+gvjs_ = gvjs_p$.prototype;
+gvjs_.show = function() {
+  this.Xf.setVisible(!0)
+}
+;
+gvjs_.clear = function() {
+  this.removeAll();
+  gvjs_E(this.Xf);
+  this.uW = this.SJ = this.XY = this.Xf = null
+}
+;
+gvjs_.f1 = function() {
+  if (null === this.SJ) {
+    var a = this.Xf
+      , b = a.ib().parentNode
+      , c = this.XY = gvjs_Gh(b)
+      , d = this.SJ = gvjs_Ewa;
+    0 != a.WJ && gvjs_mD(a, !1);
+    a = new gvjs_s7(b,[c.width, c.height],[d.width, d.height],125);
+    this.vD(a, gvjs_R, function() {
+      gvjs_6(b, !1)
+    });
+    a.play()
+  }
+}
+;
+gvjs_.LJ = function(a) {
+  var b = this.SJ;
+  if (b) {
+    var c = this.Xf
+      , d = c.ib().parentNode
+      , e = this.XY;
+    b = new gvjs_s7(d,[b.width, b.height],[e.width, e.height],125);
+    (e = this.oa.Iba) && e != c.WJ && gvjs_mD(c, e);
+    this.vD(b, gvjs_R, function() {
+      gvjs_C(d, gvjs_4c, gvjs_ub);
+      gvjs_6(d, !0);
+      a && a()
+    });
+    b.play();
+    this.SJ = null
+  }
+}
+;
+gvjs_.oZ = function() {
+  var a = this.Xf && gvjs_8sa(this.Xf);
+  return a ? gvjs_bO(a) : null
+}
+;
+gvjs_.naa = function(a) {
+  a = a.key;
+  if ("ok" == a)
+    this.nc.dispatchEvent(gvjs_N5),
+      gvjs_Z9();
+  else if (a == gvjs_Ab)
+    this.nc.dispatchEvent(gvjs_M5),
+      gvjs_Z9();
+  else
+    throw Error("invalid dialog select key - " + a);
+}
+;
+gvjs_.j = function() {
+  return this.Xf.j()
+}
+;
+var gvjs_Ewa = new gvjs_A(0,0);
+function gvjs_Fwa() {
+  this.Oda = {}
+}
+var gvjs_Gwa = [gvjs_J5, "annotations", gvjs_ht, gvjs_Mt, gvjs_yp, gvjs_yu, gvjs_Xu, gvjs_R6, gvjs_S6, gvjs_rv, gvjs_yv, gvjs_Gv, gvjs_Ov, gvjs_Mw, gvjs_16, gvjs_fx, gvjs_ix, gvjs_Pd, gvjs_76, gvjs_Hx]
+  , gvjs_Hwa = {
+  "BarChart.hAxis": !0,
+  "BarChart.vAxes": !0,
+  "CandlestickChart.legend": !0,
+  "ComboChart.isStacked": !0,
+  "ComboChart.series": !0,
+  "ComboChart.type": !0,
+  "ImageRadarChart.legend": !0,
+  "ImageRadarChart.theme": !0,
+  "ImageSparkLine.max": !0,
+  "ImageSparkLine.min": !0,
+  "LineChart.isStacked": !0,
+  "PieChart.legend": !0,
+  "ScatterChart.lineWidth": !0,
+  "ScatterChart.pointSize": !0,
+  "ScatterChart.useFirstColumnAsDomain": !0,
+  "Table.height": !0,
+  "Histogram.focusTarget": !0,
+  "Histogram.vAxes": !0
+}
+  , gvjs_Iwa = [/^LineChart\.series\.\d+\.lineWidth$/, /^BarChart\.series\.\d+\.targetAxisIndex$/];
+function gvjs_Jwa(a, b, c, d) {
+  a.Oda[b] = c;
+  for (var e = a.Oda[d] || {}, f = gvjs_Gwa.length, g = 0; g < f; g++) {
+    var h = gvjs_Gwa[g]
+      , k = gvjs_Kwa(a, h, b, d, gvjs_je(h, c || {}), gvjs_je(h, e || {}))
+      , l = e;
+    h = h.split(".");
+    for (var m = h.shift(); 0 < h.length; )
+      null == l[m] && (l[m] = l[m] || {}),
+        l = l[m],
+        m = h.shift();
+    null === k ? delete l[m] : l[m] = k
+  }
+  return e
+}
+function gvjs_Lwa(a) {
+  return gvjs_Hwa[a] ? !0 : gvjs_Fe(gvjs_Iwa, function(b) {
+    return b.test(a)
+  })
+}
+function gvjs_Kwa(a, b, c, d, e, f) {
+  var g = d + "." + b;
+  if (gvjs_Lwa(c + "." + b) || gvjs_Lwa(g))
+    return f;
+  if (Array.isArray(e) || !gvjs_r(e))
+    return e;
+  g = {};
+  for (var h in e) {
+    var k = gvjs_Kwa(a, b + "." + h, c, d, e[h], gvjs_je(b, f));
+    k && (g[h] = k)
+  }
+  return g
+}
+;var gvjs_Mwa = {
+  AnnotationChart: gvjs_Isa,
+  AnnotatedTimeLine: gvjs_Isa,
+  AreaChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:A5,D1:D5,B1:C5&gid=4&headers=1",
+  BarChart: gvjs_K6,
+  BubbleChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:E5&gid=12&headers=1",
+  CandlestickChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A2:E6&gid=10&headers=0",
+  ColumnChart: gvjs_Hsa,
+  ComboChart: gvjs_K6,
+  Gauge: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A2:B3&gid=2&headers=0",
+  GeoChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A:B&gid=5&headers=0",
+  LineChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=B:B,A:A,E:E,C:D&gid=12&headers=1",
+  PieChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A2:B9&gid=2&headers=0",
+  ScatterChart: gvjs_Hsa,
+  SteppedAreaChart: gvjs_K6,
+  Map: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:C9&gid=0&headers=1",
+  MotionChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:F21&gid=6&headers=1",
+  OrgChart: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:B15&gid=7&headers=1",
+  Table: gvjs_K6,
+  TreeMap: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:D15&gid=7&headers=1",
+  WordTree: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=A1:B7&gid=11&headers=0",
+  ImageRadarChart: gvjs_K6,
+  ImageSparkLine: "https://spreadsheets.google.com/pub?key=tTXfOkiU1PfRGUMenCEhxZA&range=B1:E9&gid=2&headers=1"
+}
+  , gvjs_Nwa = {
+    AnnotationChart: gvjs_Dsa,
+    AnnotatedTimeLine: gvjs_Dsa,
+    AreaChart: gvjs_Esa,
+    BarChart: gvjs_Fsa,
+    BubbleChart: "",
+    CandlestickChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=11",
+    ColumnChart: gvjs_Fsa,
+    ComboChart: "",
+    Gauge: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=8",
+    GeoChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=9",
+    LineChart: gvjs_Esa,
+    PieChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=4",
+    ScatterChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=6",
+    SteppedAreaChart: "",
+    Map: "",
+    MotionChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=2",
+    OrgChart: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=0",
+    Table: "",
+    TreeMap: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=10",
+    WordTree: "",
+    ImageRadarChart: "",
+    ImageSparkLine: "https://drive.google.com/previewtemplate?id=0AoFkkLP2MB8kdHVSUFI1NEwtNHFWNzRCVlVnUUE0a1E&mode=public&gid=7"
+  }
+  , gvjs_Owa = {
+    AnnotationChart: [gvjs_Gsa],
+    AnnotatedTimeLine: [gvjs_Gsa],
+    BubbleChart: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A56:E58&gid=0"],
+    CandlestickChart: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A51:E53&gid=0"],
+    Gauge: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A2:B4&gid=0"],
+    GeoChart: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A11:B13&gid=0"],
+    Map: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A21:B23&gid=0&headers=1", "https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A26:B28&gid=0&headers=1"],
+    MotionChart: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A38:D42&gid=0"],
+    OrgChart: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A31:C34&gid=0&headers=1"],
+    TreeMap: ["https://spreadsheets.google.com/pub?key=0AiYEkZd0eh-MdDAzZE91YzJyMGdSRVBnQVh5b0licnc&range=A45:D47&gid=0&headers=1"]
+  };
+function gvjs_q$(a, b, c) {
+  this.D = b;
+  this.oa = a;
+  this.ma = c;
+  gvjs_Cz(this.ma.parentNode, gvjs_r$.width, gvjs_r$.height)
+}
+var gvjs_r$ = new gvjs_A(600,371);
+gvjs_q$.prototype.B4 = null;
+gvjs_q$.prototype.pa = function() {
+  gvjs_s$(this);
+  this.ma && (this.D.qc(this.ma),
+    this.ma = null)
+}
+;
+function gvjs_s$(a) {
+  a.D.removeNode(a.B4)
+}
+gvjs_q$.prototype.draw = function(a, b) {
+  gvjs_Z9("drawing with specification: " + a.toJSON());
+  a.ba(gvjs_Xd, gvjs_r$.width);
+  var c = gvjs_r$.height;
+  a.ba(gvjs_4c, b ? null : c);
+  gvjs_Cz(this.ma, gvjs_r$);
+  gvjs_oi(a, gvjs_Rb, gvjs_s(this.oaa, this, a, !1));
+  gvjs_oi(a, gvjs_i, gvjs_s(this.oaa, this, a, !0));
+  b = {
+    wrapper: a,
+    container: this.ma
+  };
+  gvjs_I(this, gvjs_K5, b);
+  b.preventDefaulted || a.draw(this.ma)
+}
+;
+gvjs_q$.prototype.oaa = function(a, b, c) {
+  gvjs_Z9();
+  gvjs_s$(this);
+  gvjs_vi(a);
+  a = c || {};
+  b ? gvjs_I(this, gvjs_i, a) : gvjs_I(this, gvjs_Rb, a)
+}
+;
+function gvjs_Pwa(a) {
+  var b = a.$a;
+  a = b.names;
+  for (var c = gvjs_h5 + gvjs_7(gvjs_05) + gvjs_u4 + gvjs_7(gvjs_E5) + " " + gvjs_7("goog-tab-bar-vertical") + '" tabIndex="0">', d = Math.max(0, Math.ceil(a.length - 0)), e = 0; e < d; e++) {
+    var f = 1 * e
+      , g = '<div class="google-visualization-charteditor-category ' + gvjs_7(gvjs_D5) + '"><span class="' + gvjs_7(gvjs_a6) + " " + gvjs_7(gvjs_a6) + "-" + gvjs_7(a[f]) + " " + gvjs_7(gvjs_Y) + '"></span><span class="google-visualization-charteditor-category-label">';
+    f = a[f];
+    var h = "";
+    gvjs_8(f, gvjs_e) ? h += "Line" : gvjs_8(f, gvjs_at) ? h += "Area" : gvjs_8(f, gvjs_Fb) ? h += "Column" : gvjs_8(f, gvjs_wb) ? h += "Bar" : gvjs_8(f, gvjs_Dd) ? h += "Scatter" : gvjs_8(f, gvjs_fw) ? h += "Pie" : gvjs_8(f, "map") ? h += gvjs_Wa : gvjs_8(f, "trend") ? h += "Trend" : gvjs_8(f, "network") ? h += "Network" : gvjs_8(f, "more") && (h += "More");
+    f = gvjs_W(h);
+    c += g + f + gvjs_$4
+  }
+  a = '<div class="google-visualization-charteditor-panel" style="position: relative;"><p></p>' + gvjs_W(c + gvjs_a);
+  d = b.names;
+  e = b.groups;
+  b = new Map;
+  for (var k in e)
+    e.hasOwnProperty(k) && b.set(k, e[k]);
+  k = gvjs_h5 + gvjs_7(gvjs_15) + '" role="radiogroup">';
+  e = Math.max(0, Math.ceil(d.length - 0));
+  for (c = 0; c < e; c++) {
+    g = 1 * c;
+    k += gvjs_h5 + gvjs_7(gvjs_15) + "-" + gvjs_7(d[g]) + '" class="google-visualization-charteditor-chart-type-subtypes">';
+    f = b.get(d[g]).length;
+    f = Math.max(0, Math.ceil(f - 0));
+    for (h = 0; h < f; h++) {
+      var l = 1 * h;
+      k += gvjs_37(b.get(d[g])[l])
+    }
+    k += gvjs_a
+  }
+  k = gvjs_W(k + gvjs_a);
+  return gvjs_W(a + k + gvjs_a)
+}
+;function gvjs_t$(a) {
+  gvjs_H.call(this);
+  this.H = a;
+  gvjs_G(a, gvjs_lv, this.gn, !1, this);
+  gvjs_G(a, gvjs_Wt, this.et, !1, this)
+}
+gvjs_t(gvjs_t$, gvjs_H);
+gvjs_t$.prototype.gn = function(a) {
+  (13 == a.keyCode || gvjs_tg && 3 == a.keyCode) && gvjs_Qwa(this, a)
+}
+;
+gvjs_t$.prototype.et = function(a) {
+  gvjs_Qwa(this, a)
+}
+;
+function gvjs_Qwa(a, b) {
+  var c = new gvjs_Rwa(b);
+  if (a.dispatchEvent(c)) {
+    c = new gvjs_Swa(b);
+    try {
+      a.dispatchEvent(c)
+    } finally {
+      b.stopPropagation()
+    }
+  }
+}
+gvjs_t$.prototype.M = function() {
+  gvjs_t$.G.M.call(this);
+  gvjs_ji(this.H, gvjs_lv, this.gn, !1, this);
+  gvjs_ji(this.H, gvjs_Wt, this.et, !1, this);
+  delete this.H
+}
+;
+function gvjs_Swa(a) {
+  gvjs_5h.call(this, a.$i);
+  this.type = gvjs_Ss
+}
+gvjs_t(gvjs_Swa, gvjs_5h);
+function gvjs_Rwa(a) {
+  gvjs_5h.call(this, a.$i);
+  this.type = "beforeaction"
+}
+gvjs_t(gvjs_Rwa, gvjs_5h);
+function gvjs_Twa(a) {
+  var b = gvjs_JD(a);
+  b && b.fb(a);
+  return b
+}
+;function gvjs_u$() {}
+gvjs_t(gvjs_u$, gvjs_zD);
+gvjs_le(gvjs_u$);
+gvjs_ = gvjs_u$.prototype;
+gvjs_.sa = function() {
+  return gvjs_D5
+}
+;
+gvjs_.Qk = function() {
+  return "tab"
+}
+;
+gvjs_.J = function(a) {
+  var b = gvjs_u$.G.J.call(this, a);
+  (a = a.en()) && this.il(b, a);
+  return b
+}
+;
+gvjs_.fb = function(a, b) {
+  b = gvjs_u$.G.fb.call(this, a, b);
+  var c = this.en(b);
+  c && a.PE(c);
+  a.CQ() && (c = a.getParent()) && typeof c.Qw === gvjs_d && (a.setState(8, !1),
+    c.Qw(a));
+  return b
+}
+;
+gvjs_.en = function(a) {
+  return a.title || ""
+}
+;
+gvjs_.il = function(a, b) {
+  a && (a.title = b || "")
+}
+;
+function gvjs_v$(a, b, c) {
+  gvjs_LD.call(this, a, b || gvjs_u$.Lc(), c);
+  this.eg(8, !0);
+  this.ju |= 9
+}
+gvjs_t(gvjs_v$, gvjs_LD);
+gvjs_v$.prototype.en = function() {
+  return this.xa
+}
+;
+gvjs_v$.prototype.il = function(a) {
+  this.Oa().il(this.j(), a);
+  this.PE(a)
+}
+;
+gvjs_v$.prototype.PE = function(a) {
+  this.xa = a
+}
+;
+gvjs_HD(gvjs_D5, function() {
+  return new gvjs_v$(null)
+});
+function gvjs_w$() {
+  this.dN = "tablist"
+}
+gvjs_t(gvjs_w$, gvjs_5D);
+gvjs_le(gvjs_w$);
+gvjs_w$.prototype.sa = function() {
+  return gvjs_E5
+}
+;
+gvjs_w$.prototype.T3 = function(a, b, c) {
+  this.nca || (this.GN || gvjs_Uwa(this),
+    this.nca = gvjs_Uy(this.GN));
+  var d = this.nca[b];
+  d ? a.LE(d) : gvjs_w$.G.T3.call(this, a, b, c)
+}
+;
+gvjs_w$.prototype.Rl = function(a) {
+  var b = gvjs_w$.G.Rl.call(this, a);
+  this.GN || gvjs_Uwa(this);
+  b.push(this.GN[a.lc]);
+  return b
+}
+;
+function gvjs_Uwa(a) {
+  var b = a.sa();
+  a.GN = {
+    top: b + "-top",
+    bottom: b + "-bottom",
+    start: b + "-start",
+    end: b + "-end"
+  }
+}
+;function gvjs_x$(a, b, c) {
+  this.LE(a || gvjs_vx);
+  gvjs_8D.call(this, this.vi(), b || gvjs_w$.Lc(), c);
+  gvjs_Vwa(this)
+}
+gvjs_t(gvjs_x$, gvjs_8D);
+gvjs_ = gvjs_x$.prototype;
+gvjs_.A7 = !0;
+gvjs_.mm = null;
+gvjs_.Nb = function() {
+  gvjs_x$.G.Nb.call(this);
+  gvjs_Vwa(this)
+}
+;
+gvjs_.M = function() {
+  gvjs_x$.G.M.call(this);
+  this.mm = null
+}
+;
+gvjs_.removeChild = function(a, b) {
+  gvjs_y$(this, a);
+  return gvjs_x$.G.removeChild.call(this, a, b)
+}
+;
+gvjs_.LE = function(a) {
+  this.setOrientation(a == gvjs_2 || a == gvjs_R ? gvjs_U : gvjs_S);
+  this.lc = a
+}
+;
+gvjs_.N3 = function(a) {
+  gvjs_x$.G.N3.call(this, a);
+  this.A7 && this.Qw(this.Ye(a))
+}
+;
+gvjs_.Qw = function(a) {
+  a ? a.qp(!0) : this.mm && this.mm.qp(!1)
+}
+;
+function gvjs_y$(a, b) {
+  if (b && b == a.mm) {
+    for (var c = gvjs_QC(a, b), d = c - 1; b = a.Ye(d); d--) {
+      var e = b;
+      if (e.isVisible() && e.isEnabled()) {
+        a.Qw(b);
+        return
+      }
+    }
+    for (c += 1; b = a.Ye(c); c++)
+      if (d = b,
+      d.isVisible() && d.isEnabled()) {
+        a.Qw(b);
+        return
+      }
+    a.Qw(null)
+  }
+}
+gvjs_.$qa = function(a) {
+  this.mm && this.mm != a.target && this.mm.qp(!1);
+  this.mm = a.target
+}
+;
+gvjs_.ara = function(a) {
+  a.target == this.mm && (this.mm = null)
+}
+;
+gvjs_.Yqa = function(a) {
+  gvjs_y$(this, a.target)
+}
+;
+gvjs_.Zqa = function(a) {
+  gvjs_y$(this, a.target)
+}
+;
+gvjs_.Iv = function() {
+  gvjs_aE(this) || this.ci(this.mm || this.Ye(0))
+}
+;
+function gvjs_Vwa(a) {
+  a.hc().o(a, gvjs_k, a.$qa).o(a, "unselect", a.ara).o(a, gvjs_ju, a.Yqa).o(a, gvjs_1u, a.Zqa)
+}
+gvjs_HD(gvjs_E5, function() {
+  return new gvjs_x$
+});
+function gvjs_z$() {
+  gvjs_KA.call(this);
+  this.D = gvjs_Oh();
+  this.bE = new gvjs_KA;
+  this.Ge = new gvjs_79;
+  this.EK = [];
+  this.Pm = null;
+  this.uS = [];
+  this.DE = null;
+  this.Rga = !1;
+  this.tda = 0;
+  gvjs_6va();
+  this.UG = this.rw = this.hq = this.sg = this.MA = this.yl = this.oa = this.nc = this.Yba = this.ck = this.ut = this.zj = this.aa = null;
+  this.sz = this.hJ = !1;
+  this.QU = "";
+  this.ni = this.Om = this.qh = this.YD = null
+}
+gvjs_o(gvjs_z$, gvjs_KA);
+gvjs_ = gvjs_z$.prototype;
+gvjs_.openDialog = function(a, b) {
+  gvjs_Z9();
+  try {
+    if (this.hJ)
+      throw Error(gvjs_8r);
+    b = void 0 === b ? {} : b;
+    var c = this.oa = new gvjs_i$(b)
+      , d = new Set(gvjs_Le(gvjs_j$))
+      , e = gvjs_oj(d, new Set(c.yl));
+    this.yl = gvjs_nj(e);
+    this.MA = [];
+    this.nc = new gvjs_H;
+    this.YD = new gvjs_Fwa;
+    var f = a.getOption(gvjs_R6);
+    this.oa.NO() && typeof f !== gvjs_zb && a.ba(gvjs_R6, this.oa.Jba);
+    this.oa.vba && gvjs_t8(this.D);
+    var g = this.oa;
+    if (null !== (g.bv && g.bv.panels || g.bv && g.bv.preview || null)) {
+      var h = this.oa
+        , k = this.D
+        , l = k.j(h.bv && h.bv.preview || null);
+      gvjs_ph(l) && gvjs_VC(l, gvjs_Mra);
+      var m = k.j(h.bv && h.bv.panels || null);
+      c = null;
+      gvjs_ph(m) && (gvjs_VC(m, "google-visualization-charteditor-custom-panel"),
+        c = k.J(gvjs_b),
+      h.e4 && gvjs_KB(m, gvjs_Qta),
+        k.appendChild(m, c),
+        gvjs_m8(c));
+      gvjs_Wwa(this, c, l)
+    } else {
+      var n = this.ni = new gvjs_p$(this.oa,this.nc,this.D)
+        , p = n.oa
+        , q = p.gsa;
+      gvjs_E(n.Xf);
+      var r = n.Xf = new gvjs_fD("modal-dialog",q);
+      r.JI = !0;
+      r.vj && gvjs_6(r.vj, r.JI);
+      r.vA(!1);
+      var t = n.oa.Zka
+        , u = t.ok;
+      null == u && (u = gvjs_eg("\u00a0", 4) + "OK".toString() + gvjs_eg("\u00a0", 4));
+      var v = t.cancel || "Cancel".toString();
+      n.uW = (new gvjs_gD).set("ok", u, !1).set(gvjs_Ab, v, !1, !0);
+      r.ki = n.uW;
+      if (r.Dh) {
+        if (r.ki) {
+          var w = r.ki;
+          w.H = r.Dh;
+          w.R()
+        } else
+          gvjs_cg(r.Dh, gvjs_9f);
+        gvjs_6(r.Dh, !!r.ki)
+      }
+      r.setTitle(gvjs_Wta({
+        Zea: p.kx()
+      }).toString());
+      var x = p.e4
+        , y = p.$wa
+        , z = p.O9
+        , A = '<div><table id="' + gvjs_7("google-visualization-charteditor-layout-table") + '"><tbody><tr><td class="google-visualization-charteditor-settings-td">' + (x ? gvjs_Rta(z) : "") + gvjs_h5 + gvjs_7(gvjs_Kra) + '"></div></td><td class="google-visualization-charteditor-preview-td">'
+        , B = '<div class="google-visualization-charteditor-panel"><div class="google-visualization-charteditor-panel-title" style="height: 24px;">' + (y ? gvjs_j5 + gvjs_7(gvjs_Era) + '" class="google-visualization-charteditor-name-input"/>' : "") + gvjs_h5 + gvjs_7("google-visualization-charteditor-chart-name") + gvjs_u4 + gvjs_7(gvjs_Y) + '"></div><div id="' + gvjs_7(gvjs_Dra) + gvjs_u4 + gvjs_7(gvjs_Y) + '"><a target="_blank">';
+      B = B + 'Help</a></div></div><div id="' + (gvjs_7(gvjs_Mra) + gvjs_U4 + gvjs_7(gvjs_Lra) + gvjs_yqa);
+      var D = gvjs_W(B);
+      var C = gvjs_W(A + D + '</td></tr></tbody></table></div><div id="' + gvjs_7(gvjs_xra) + gvjs_N4);
+      gvjs_jD(r, gvjs_wy(C));
+      r.qT(!0);
+      var G = p.Iba;
+      G != r.WJ && gvjs_mD(r, G);
+      r.R();
+      var J = n.Xf;
+      gvjs_Cwa(J);
+      var I = gvjs_8sa(J);
+      gvjs_ZC(I, "google-visualization-charteditor-dialog", !0);
+      gvjs_C(I, gvjs_vd, gvjs_c);
+      var M = gvjs_i7() ? gvjs_Up : gvjs_Dv;
+      n.D.sr(I, {
+        dir: M
+      });
+      var H = n.D.j(gvjs_Dra)
+        , Q = n.oa.nra;
+      H && Q ? gvjs_eta(H.firstChild, Q) : H && gvjs_C(H, gvjs_ku, gvjs_f);
+      gvjs_Wwa(this, this.D.j(gvjs_Kra), this.D.j(gvjs_Lra));
+      this.ni.show();
+      var R = this.ni;
+      R.o(R.Xf, gvjs_fu, R.naa);
+      this.o(this.nc, gvjs_N5, this.Zpa);
+      this.oa.KO() && (this.KO(a),
+        this.o(this.nc, gvjs_3sa, gvjs_ata(this.jya.bind(this))))
+    }
+    gvjs_Xwa(this);
+    this.hJ = !0;
+    this.wfa(a);
+    this.oa.kx() && this.kx(!0)
+  } catch (T) {
+    gvjs_4va()
+  }
+}
+;
+gvjs_.draw = function(a, b) {
+  a = gvjs_vo(a);
+  this.openDialog(a, b)
+}
+;
+gvjs_.K$ = function() {
+  return this.yl
+}
+;
+function gvjs_A$(a, b) {
+  a = b || a.aa;
+  b = a.Va();
+  switch (b) {
+    case gvjs_w5:
+      return gvjs_Oa;
+    case gvjs_oa:
+      return a.cc(gvjs_na),
+        a.ba(gvjs_jv, !0),
+        b;
+    default:
+      return b
+  }
+}
+gvjs_.xoa = function() {
+  return gvjs_Le(gvjs_j$)
+}
+;
+gvjs_.My = function() {
+  return this.aa ? this.aa.clone() : null
+}
+;
+gvjs_.zoa = function() {
+  return this.My().toJSON()
+}
+;
+gvjs_.wfa = function(a, b) {
+  if (this.sz)
+    gvjs_Z9();
+  else {
+    if (null === a)
+      throw Error("error: chart wrapper is null");
+    a = a.clone();
+    gvjs_B$(this, a, void 0, b)
+  }
+}
+;
+gvjs_.kx = function(a) {
+  if (this.hJ) {
+    a ? this.QU = gvjs_gg(this.aa.cf) : gvjs_jf(gvjs_gg(this.QU)) || (this.aa.yh(this.QU),
+      this.QU = "");
+    if (this.ni) {
+      var b = this.ni;
+      b.Xf.setTitle(gvjs_Wta({
+        Zea: a
+      }).toString());
+      gvjs_qD(b.Xf.ki, "ok").disabled = a
+    }
+    this.oa.$ea = a;
+    gvjs_C$(this)
+  }
+}
+;
+gvjs_.Zpa = function() {
+  if (!this.oa.As) {
+    var a = !1;
+    if (this.oa.Jba)
+      if (null === this.DE || this.DE) {
+        var b = 1902;
+        a = !0
+      } else
+        b = 1903;
+    else
+      null === this.DE ? b = null : this.DE ? (b = 1904,
+        a = !0) : b = 1905;
+    if (null !== b) {
+      var c = gvjs_Ywa(this.aa.Va())
+        , d = gvjs_v(this.uS, gvjs_Ywa);
+      b = d.indexOf(c);
+      var e = new gvjs_sta;
+      c = gvjs_g7(e, 1, c);
+      d = gvjs_g7(c, 2, gvjs_Rg(d || []));
+      a = gvjs_g7(d, 3, a);
+      a = gvjs_g7(a, 4, -1 != b);
+      -1 != b && gvjs_g7(a, 5, b);
+      gvjs_g7(a, 6, this.Rga);
+      gvjs_g7(a, 7, this.tda);
+      b = new gvjs_x7;
+      this.ck && (d = this.ck.ca(),
+        gvjs_g7(b, 1, d),
+        d = this.ck.$(),
+        gvjs_g7(b, 2, d));
+      d = new gvjs_rta;
+      a = gvjs_h7(d, 1, a);
+      b = gvjs_h7(a, 2, b);
+      a = new gvjs_y7;
+      b = gvjs_h7(a, 39, b);
+      gvjs_yta(1).A3(b).cd()
+    }
+  }
+}
+;
+function gvjs_B$(a, b, c, d) {
+  d && b.Dfa(!1);
+  d = gvjs_A$(a, b);
+  a.oa.kx() && b.yh(gvjs_Mwa[d]);
+  d = a.ck;
+  gvjs_5ta(b, d, a.oa.vo());
+  null != d && (null === a.zj ? a.zj = new gvjs_$7(d,b,a.oa.vo()) : gvjs_0ta(a.zj, d, b));
+  a.aa = b;
+  d = !a.aa.mb() && !gvjs_Zwa(a);
+  var e = !!a.aa.mb() && !a.UP(a.ck, b.mb());
+  if (d || e) {
+    d = a.ck;
+    var f = (e = gvjs_D$(d) ? [gvjs_db] : (new gvjs_6l(a.yl)).BW(a.zj ? gvjs_Rk(d, a.zj.bC || {}).Gr() : d)) && e[0];
+    b && null === b.Va() && typeof f === gvjs_l && (gvjs_Z9(),
+      b.cc(f));
+    a.MA = e;
+    a.oa.As && a.oa.As.Oya(e || []);
+    a.oa.$B && a.oa.$B.Oya(e || []);
+    gvjs_Z9("suggested charts:" + e + " " + (d && d.toJSON()))
+  }
+  if (a.hJ)
+    if (a.sz)
+      gvjs_Z9();
+    else if (b = a.aa.mb(),
+    a.aa.mb() && a.UP(a.ck, b))
+      gvjs_E$(a, b);
+    else if (!a.aa.mb() && gvjs_Zwa(a)) {
+      c = a.Kqa.bind(a);
+      a.qh && (b = a.qh,
+        d = b.ma,
+        d.style.cssText = "",
+        e = b.D,
+        e.qc(d),
+        b.B4 = e.J(gvjs_b, "google-visualization-charteditor-dialog-spinner-div", e.J(gvjs_b, "google-visualization-charteditor-dialog-spinner goog-inline-block", "\u00a0")),
+        e.appendChild(d, b.B4));
+      b = gvjs_gg(a.aa.cf);
+      d = a.ut;
+      if (gvjs_jf(gvjs_gg(b)))
+        a.ut = null,
+          gvjs_E$(a, null);
+      else {
+        if (a.oa.V_ && !a.oa.kx() && !a.oa.As) {
+          if (f = null == d)
+            if (e = gvjs_Wm(b, gvjs_J6),
+            null == e || "-1" == e)
+              b = gvjs_k7(b, gvjs_J6, "-2");
+          f || gvjs_j7(d || "", gvjs_J6) == gvjs_j7(b, gvjs_J6) || (e = gvjs_Wm(d || "", gvjs_J6),
+            b = gvjs_k7(b, gvjs_J6, e || ""))
+        }
+        a.aa.yh(b);
+        if (a.oa.vna && (d = a.aa,
+          e = gvjs_gg(d.cf),
+        gvjs_Bn(e) && null == gvjs_Wm(e, "tq") && (f = d.getQuery() || "",
+        null == d.getQuery() || /^skipping\s+\d+$/i.test(f)))) {
+          var g = gvjs_Wm(e, gvjs_sw);
+          if (null != g) {
+            f = null != d.Zc().width ? d.Zc().width : gvjs_r$.width;
+            var h = null != d.Zc().height ? d.Zc().height : gvjs_r$.height;
+            e = d.Va();
+            if (gvjs_Kca.test(g)) {
+              g = g.toUpperCase();
+              var k = g.split(":");
+              g = k[1];
+              k = gvjs_hta(k[0]);
+              g = gvjs_hta(g);
+              g = new gvjs_A(Math.abs(g.x - k.x) + 1,Math.abs(g.y - k.y) + 1)
+            } else
+              g = null;
+            f = Math.min(f, h);
+            switch (e) {
+              case gvjs_qa:
+              case gvjs_xa:
+              case gvjs_na:
+              case gvjs_Va:
+              case gvjs_9a:
+                e = Math.ceil(g.height / Math.floor(Math.floor(Math.floor(f / 1.618)) / Math.ceil(1.618 * (2 * g.width - 1))));
+                break;
+              default:
+                e = -1
+            }
+            e = 1 < e ? e : -1;
+            -1 != e ? d.Jn("skipping " + e) : d.Jn("")
+          }
+        }
+        a.ut = b;
+        d = a.aa.yH;
+        b = null != d ? new gvjs_to(d,b) : new gvjs_En(b);
+        null != a.aa.getQuery() && b.Jn(gvjs_gg(a.aa.getQuery()));
+        a.sz = !0;
+        gvjs_Z9();
+        b.send(c)
+      }
+      null === a.hq && null != a.aa.getType() && (c = a.aa.getOption(gvjs_3c),
+        gvjs_C$(a),
+        a.aa.ba(gvjs_3c, c))
+    } else if (0 == a.MA.length)
+      gvjs_E$(a, null);
+    else {
+      b = !!a.aa.getOption(gvjs_46);
+      d = a.Yba !== b;
+      if (a.qh) {
+        if (gvjs_D$(a.ck))
+          e = a.qh,
+            gvjs_s$(e),
+            f = e.ma,
+            e.D.qc(f),
+            gvjs_C(f, gvjs_4c, gvjs_So),
+            h = e.oa.Pta,
+            e.D.Qo(h) ? e.D.appendChild(f, h) : gvjs_KB(f, gvjs_Sta),
+            gvjs_I(e, gvjs_Rb, {
+              message: "no data"
+            });
+        else if (e = gvjs_A$(a, a.aa),
+          gvjs_He(a.MA, e))
+          e = a.aa.clone(),
+            e.zh(a.ck),
+            f = e.Va() === gvjs_db,
+            a.qh.draw(e, f);
+        else {
+          f = a.qh;
+          gvjs_Z9();
+          gvjs_s$(f);
+          f.D.qc(f.ma);
+          gvjs_KB(f.ma, gvjs_Tta, {
+            type: e
+          });
+          h = gvjs_Owa[e];
+          if (Array.isArray(h))
+            for (g = 0; g < h.length; g++)
+              gvjs_wo({
+                chartType: gvjs_db,
+                dataSourceUrl: h[g],
+                containerId: "google-visualization-charteditor-preview-div-sample-" + g
+              });
+          if (h = f.D.j(gvjs_Nra))
+            g = f.oa.Oxa,
+            f.oa.Jna && (g = gvjs_Nwa[e]),
+            gvjs_jf(gvjs_gg(g)) || (gvjs_C(h, gvjs_ku, gvjs_xb),
+              gvjs_eta(h.firstChild, g));
+          gvjs_I(f, gvjs_Rb, {
+            message: "data mismatch"
+          })
+        }
+        a.Yba = b
+      }
+      a.Om && gvjs_Bwa(a.Om, a.aa);
+      c != gvjs_Rsa || d ? gvjs_C$(a) : a.Ge.uc.update();
+      gvjs_Z9("update edtitor: " + a.aa.toJSON())
+    }
+}
+function gvjs_Wwa(a, b, c) {
+  gvjs_ph(b) && (a.sg = b,
+  a.oa.e4 && gvjs__wa(a));
+  gvjs_ph(c) && (gvjs_E(a.qh),
+    a.qh = new gvjs_q$(a.oa,a.D,c))
+}
+gvjs_.oZ = function() {
+  return this.ni ? this.ni.oZ() : null
+}
+;
+gvjs_.LJ = function(a) {
+  this.ni && this.ni.LJ(a)
+}
+;
+gvjs_.f1 = function() {
+  this.ni && this.ni.f1()
+}
+;
+gvjs_.bJ = function() {
+  var a = this.Ge;
+  a.init(this.sg, this.aa, this.nc, this.oa, this.ck, this.zj);
+  return a
+}
+;
+function gvjs__wa(a) {
+  var b = a.D.j(gvjs_c6);
+  gvjs_E(a.rw);
+  var c = a.rw = gvjs_Twa(b);
+  a.o(c, gvjs_k, function() {
+    var d = gvjs_QC(c, c.mm);
+    a.xaa(d)
+  })
+}
+gvjs_.xaa = function(a) {
+  this.sz ? gvjs_Z9() : (gvjs_Z9(),
+  this.hq != a && (gvjs_F$(this, a),
+    this.rw.j().focus()))
+}
+;
+function gvjs_F$(a, b) {
+  gvjs_Z9();
+  var c = a.D.Ly() ? a.D.Ly().id : "";
+  a.Ge.Yq = null;
+  var d = a.hq === b;
+  a.hq = b;
+  switch (b) {
+    case 0:
+      gvjs_G$(a);
+      gvjs_0wa(a);
+      break;
+    case 1:
+      gvjs_G$(a);
+      d = a.bJ();
+      var e = a.oa.$B;
+      e ? (gvjs_hh(a.sg),
+        a.sg.appendChild(e.H),
+        e.setActive(!0)) : (e = gvjs_Nta(a.yl),
+        gvjs_KB(a.sg, gvjs_Pwa, {
+          $a: e
+        }),
+        gvjs_1wa(a, e.names, e.groups),
+        gvjs_89(d, a.sg),
+        gvjs_2wa(a, d.kF, e.groups),
+        gvjs_Fy(d.kF));
+      break;
+    case 2:
+      d && (d = a.Ge,
+        e = d.D.j(gvjs_b6)) && (d.Yq = {},
+        d.Yq.offset = e.scrollTop,
+        d.Yq.Cka = d.Gx && d.Gx.Vl(),
+        d.Yq.hT = d.Yt && d.Yt.Vl());
+      gvjs_G$(a);
+      d = a.bJ();
+      var f = d.vH;
+      gvjs_KB(d.sg, gvjs_bva, {});
+      e = d.D.hd("jfk-scrollbar", d.sg);
+      d.D.O_(e) && (gvjs_E(d.qn),
+        d.qn = new gvjs_TE(d.D.Toa(e)),
+        d.o(d.qn, gvjs_Wv, gvjs_s(d.zqa, d, e)));
+      e = gvjs_d$(d);
+      var g = d.zj && d.zj.VP(), h;
+      a: {
+        for (var k = (h = d.vH) && h.$(), l = 0; l < k; l++)
+          if (h.W(l) == gvjs_zb) {
+            h = !0;
+            break a
+          }
+        h = !1
+      }
+      gvjs_f$(d, gvjs_dva, {
+        type: e,
+        features: gvjs_$,
+        Ywa: h,
+        exa: e != gvjs_ra || null == f || 3 < f.$() && f.W(3) == gvjs_l,
+        VP: g
+      });
+      f = gvjs_d$(d);
+      k = d.oa.sna;
+      g = d.oa.MO();
+      h = "";
+      gvjs_$.fill[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-fill") + gvjs_P4,
+        h += "Fill</span>");
+      gvjs_$.Wwa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-show-axis-lines") + gvjs_P4,
+        h += "Show axis lines</span>");
+      gvjs_$.Sxa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-3d") + gvjs_P4,
+        h += "3D</span>");
+      gvjs_9(gvjs_$.aga[f]) && !k && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-stack") + gvjs_P4,
+        h += "Stack</span>");
+      gvjs_$.smooth[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-smooth") + gvjs_P4,
+        h += "Smooth</span>");
+      gvjs_$.Mva[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-reverse-axis") + gvjs_P4,
+        h += "Reverse</span>");
+      gvjs_$.Dta[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-scroll") + gvjs_P4,
+        h += "Scroll</span>");
+      gvjs_$.rL[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-show-scale") + gvjs_P4,
+        h += "Show scale</span>");
+      gvjs_$.ixa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-show-tip") + gvjs_P4,
+        h += "Show tooltip</span>");
+      gvjs_$.qka[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-alter-row") + gvjs_P4,
+        h += "Alternate rows</span>");
+      gvjs_$.gxa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-row-number") + gvjs_P4,
+        h += "Row number</span>");
+      gvjs_$.qza[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-zoom-button") + gvjs_P4,
+        h += "Zoom button</span>");
+      gvjs_$.sva[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-range-selector") + gvjs_P4,
+        h += "Range selector</span>");
+      gvjs_$.Fsa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-show-large-control") + gvjs_P4,
+        h += "Large control</span>");
+      gvjs_$.zya[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-show-type-control") + gvjs_P4,
+        h += "Type control</span>");
+      gvjs_$.Zwa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-chart-buttons") + gvjs_P4,
+        h += "Show buttons </span>");
+      gvjs_$.hxa[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-side-panel") + gvjs_P4,
+        h += "Side panel </span>");
+      gvjs_$.Zj[f] && (h += gvjs_n5 + gvjs_7("google-visualization-charteditor-checkbox-plot-nulls") + gvjs_P4,
+        h += "Plot null values </span>");
+      gvjs_$.LJ[f] && (h += gvjs_Lqa + gvjs_7("google-visualization-charteditor-checkbox-maximize") + gvjs_P4,
+        h += "Maximize</span></td>");
+      gvjs_$.Pla[f] && (h += gvjs_Lqa + gvjs_7("google-visualization-charteditor-comparison-mode") + gvjs_P4,
+        h += "Compare mode</span></td>");
+      gvjs_9(gvjs_$.aga[f]) && gvjs_9(k) ? (k = '<div class="google-visualization-charteditor-section-title google-visualization-charteditor-float-start">' + gvjs_FB("Stacking") + gvjs_Hqa + gvjs_7("google-visualization-charteditor-select-stacked") + gvjs_u4 + gvjs_7(gvjs_Os) + gvjs_p4 + gvjs_7("Stacking") + gvjs_W4 + gvjs_7(gvjs_Z) + gvjs_V4 + gvjs_7(gvjs__) + '" value="false">',
+        k = k + gvjs_B5 + (gvjs_7(gvjs__) + '" value="true">'),
+        k = k + 'Standard</li><li class="' + (gvjs_7(gvjs__) + gvjs_wqa),
+        k = "<div>" + gvjs_W(k + '100%</li></ul></div><div class="google-visualization-charteditor-float-clear"></div>') + gvjs_a) : k = "";
+      h += k;
+      gvjs_9(gvjs_$.V6[f]) && gvjs_9(g) && (h += gvjs_b5 + gvjs_7(gvjs_y6) + gvjs_R4 + gvjs_7(gvjs_Y) + gvjs_X,
+        h = h + 'Aggregate Type</div><div class="google-visualization-charteditor-float-end">' + (gvjs_n9("google-visualization-charteditor-select-aggregate-type", !1) + gvjs_64));
+      f = gvjs_W(h);
+      "" != f && gvjs_f$(d, gvjs_fva, {
+        options: f
+      });
+      g = gvjs_d$(d);
+      f = d.vH;
+      switch (g) {
+        case gvjs_q5:
+          gvjs_f$(d, gvjs_awa, {});
+          break;
+        case gvjs_ma:
+          gvjs_f$(d, gvjs_awa, {});
+          break;
+        case gvjs_Ga:
+          gvjs_f$(d, gvjs_cwa, {});
+          break;
+        case gvjs_Ha:
+          gvjs_f$(d, gvjs_dwa, {
+            features: gvjs_$,
+            type: g
+          });
+          break;
+        case gvjs_La:
+          gvjs_f$(d, gvjs_ewa, {});
+          break;
+        case gvjs_Pa:
+          gvjs_f$(d, gvjs_iwa, {});
+          break;
+        case gvjs_Wa:
+          gvjs_f$(d, gvjs_gwa, {});
+          break;
+        case gvjs_2a:
+          gvjs_f$(d, gvjs_hwa, {});
+          break;
+        case gvjs_db:
+          if (null === f)
+            gvjs_Z9();
+          else {
+            g = [];
+            for (h = 0; h < f.$(); h++)
+              k = f.Ga(h),
+              gvjs_jf(gvjs_gg(k)) && (k = gvjs_wa + gvjs_FB(h),
+                k = gvjs_W(k)),
+                g.push(k);
+            gvjs_f$(d, gvjs_mwa, {
+              labels: g
+            })
+          }
+          break;
+        case gvjs_hb:
+          gvjs_f$(d, gvjs_nwa, {
+            features: gvjs_$,
+            type: g
+          })
+      }
+      gvjs_$.Naa[e] && (f = gvjs_d$(d),
+        gvjs_f$(d, f == gvjs_Oa ? gvjs_fwa : gvjs_bwa, {
+          type: f,
+          features: gvjs_$,
+          NO: d.oa.NO(),
+          lJ: gvjs_77(f, d.Hq()),
+          mJ: gvjs_87(f, d.Hq())
+        }));
+      if (gvjs_$.ez[e]) {
+        f = gvjs_$9(d);
+        g = gvjs_d$(d);
+        h = d.zj && gvjs_b8(d.zj);
+        k = {};
+        if (h) {
+          l = gvjs_2ta(d.zj);
+          for (var m = !0, n = 0; n < f; n++)
+            k[n] = !!l[n],
+            k[n] || (m = !1);
+          d.oa.oq() && (k.global = m)
+        }
+        gvjs_f$(d, gvjs_hva, {
+          type: g,
+          features: gvjs_$,
+          hra: h,
+          annotations: k,
+          vo: d.oa.vo(),
+          MO: d.oa.MO(),
+          J1: f,
+          kC: d.oa.kC(),
+          ksa: d.Hq(),
+          $ra: d.wQ(),
+          oq: d.oa.oq(),
+          qY: d.oa.qY()
+        })
+      }
+      f = d.D.hd("google-visualization-charteditor-section");
+      !gvjs_$.U1[e] && f && gvjs_C(f, "margin-top", "0");
+      gvjs_89(d, d.sg);
+      (e = d.D.j(gvjs_b6)) && d.Yq && (e.scrollTop = d.Yq.offset,
+        gvjs_c$(d.Gx, d.Yq.Cka),
+        gvjs_c$(d.Yt, d.Yq.hT),
+        d.Yq = null);
+      break;
+    default:
+      throw Error("invalid panel index");
+  }
+  a.rw && (d = a.rw,
+    d.Qw(d.Ye(b)));
+  a.Ge.uc.update();
+  (b = a.D.hd("jfk-tooltip")) && a.D.appendChild(a.D.kc().body, b);
+  gvjs_jf(c) && a.ni.j().focus();
+  (b = a.D.Ly()) && b.id == c || (a.D.j(c) || a.ni.j()).focus()
+}
+function gvjs_C$(a) {
+  var b = null == a.hq
+    , c = b ? a.oa.Oua : a.hq;
+  null === c && (c = 0);
+  var d = 0 === c && a.oa.As || 1 === c && a.oa.$B || null;
+  b ? (gvjs_F$(a, c),
+  d && d.qEa() && gvjs_F$(a, 1)) : d ? d.setActive(!0) : gvjs_F$(a, c)
+}
+function gvjs_0wa(a) {
+  var b = a.bJ();
+  gvjs_hh(a.sg);
+  var c = a.oa.As;
+  if (c)
+    gvjs_hh(a.sg),
+      a.sg.appendChild(c.H),
+      c.setActive(!0);
+  else {
+    c = a.D;
+    gvjs_KB(a.sg, gvjs_jwa);
+    gvjs_xwa(b);
+    var d = [];
+    a.uS = [];
+    for (var e = 0; 4 > e; e++) {
+      var f = a.MA[e];
+      gvjs_jf(gvjs_gg(f)) || (d.push(f),
+        a.uS.push(f))
+    }
+    c.appendChild(a.sg.firstChild, gvjs_r7(gvjs_kwa, {
+      charts: gvjs_v(a.uS, function(g) {
+        return g.toLowerCase()
+      })
+    }));
+    if (c = a.D.j(gvjs_gsa))
+      c = new gvjs_t$(c),
+        a.bE.o(c, gvjs_Ss, a.xaa.bind(a, 1)),
+        b.LA(c);
+    gvjs_89(b, a.sg);
+    gvjs_2wa(a, b.kF);
+    gvjs_Fy(b.kF)
+  }
+}
+function gvjs_G$(a) {
+  gvjs_h$(a.Ge);
+  a.bE.removeAll()
+}
+function gvjs_2wa(a, b, c) {
+  a.EK = [];
+  c ? (b = gvjs_bta(b, function(d) {
+    var e = null;
+    gvjs_Ue(c, function(f, g) {
+      return gvjs_He(f, d.OW) ? (e = g,
+        !0) : !1
+    });
+    return e
+  }),
+    gvjs_w(b, function(d) {
+      this.EK.push(gvjs_3wa(this, d))
+    }, a)) : a.EK.push(gvjs_3wa(a, b))
+}
+function gvjs_3wa(a, b) {
+  var c = [];
+  gvjs_u(b, function(e) {
+    c.push(gvjs_4wa(this, e))
+  }, a);
+  var d = new gvjs_V9(c);
+  a.bE.o(d, gvjs_Kt, function() {
+    d.Ca.Be() && d.Ca.Be().dispatchEvent(gvjs_$qa)
+  });
+  return d
+}
+function gvjs_1wa(a, b, c) {
+  var d = a.D
+    , e = b.length
+    , f = d.j(gvjs_05);
+  gvjs_E(a.UG);
+  var g = a.UG = gvjs_Twa(f);
+  g.A7 = !1;
+  a.bE.o(g, gvjs_Ss, function() {
+    var p = gvjs_QC(g, g.mm);
+    gvjs_5wa(a, p)
+  });
+  var h = d.j(gvjs_15);
+  if (d.Qo(f) && d.Qo(h)) {
+    d = f.childNodes;
+    f = gvjs_A$(a);
+    for (var k = h = 0; k < e; k++) {
+      var l = b[k]
+        , m = d[k].childNodes[1]
+        , n = gvjs_wh(m);
+      10 < n.length && (gvjs_th(m, gvjs_0y(n, 10)),
+        m.title = n);
+      -1 != gvjs_Be(c[l], f.toLowerCase()) && (h = k)
+    }
+    g.Qw(g.Ye(h));
+    gvjs_5wa(a, h)
+  }
+}
+function gvjs_5wa(a, b) {
+  var c = a.D;
+  a = c.j(gvjs_05);
+  var d = c.j(gvjs_15);
+  a = c.getChildren(a);
+  c = c.getChildren(d);
+  d = a.length;
+  for (var e = 0; e < d; e++)
+    gvjs_C(c[e], gvjs_ku, e == b ? gvjs_xb : gvjs_f),
+      gvjs_ZC(a[e], "visualization-charteditor-category-selected", e == b)
+}
+function gvjs_4wa(a, b) {
+  function c() {
+    var m = a.My()
+      , n = gvjs_A$(a)
+      , p = a.YD
+      , q = m.Zc();
+    n = gvjs_Jwa(p, n, q, e);
+    m.setOptions(n);
+    for (var r in f)
+      m.ba(r, f[r]);
+    for (r = 0; r < a.EK.length; r++)
+      n = a.EK[r],
+      n.Ca.Be() && n.Ca.Be() != k && gvjs_W9(n, null);
+    m.cc(e);
+    gvjs_B$(a, m, void 0, !0);
+    0 == a.hq ? (a.DE = !0,
+      a.Rga = !0) : 1 == a.hq && (a.DE = !1);
+    a.tda++;
+    a.Pm = null
+  }
+  var d = a.D
+    , e = b.type
+    , f = b.options || {}
+    , g = "google-visualization-charteditor-thumbs-" + b.OW;
+  -1 == gvjs_Be(a.MA, e) && (g += gvjs_Gr);
+  var h = d.j(b.id);
+  d.Qo(h) && (gvjs_ZC(h.firstChild.firstChild, g, !0),
+    b = gvjs_Vta({
+      Gxa: b.OW
+    }),
+    gvjs_zua(h, gvjs_y8(b)),
+    gvjs_0B(h, b));
+  var k = new gvjs_T9;
+  h && (k.fb(h),
+    h.removeAttribute("aria-labelledby"));
+  h = a.My();
+  b = !1;
+  if (e == gvjs_A$(a)) {
+    b = !0;
+    if (1 == a.hq)
+      for (var l in f)
+        d = h.getOption(l),
+          g = f[l],
+          b = b && g == d;
+    b && k.bi(!0)
+  }
+  a.bE.o(k, gvjs_$qa, function() {
+    null !== a.Pm && gvjs_ql(a.Pm);
+    a.Pm = gvjs_pl(c, 500)
+  });
+  return k
+}
+function gvjs_Xwa(a) {
+  a.o(a.nc, gvjs_N6, function() {
+    gvjs_B$(a, a.aa, gvjs_Rsa)
+  });
+  a.o(a.nc, [gvjs_N5, gvjs_M5], a.Jpa);
+  a.qh && (gvjs_oi(a.qh, gvjs_i, function(b) {
+    gvjs_I(a, gvjs_i, b)
+  }),
+    gvjs_oi(a.qh, gvjs_Rb, function(b) {
+      gvjs_I(a, gvjs_Rb, b)
+    }),
+    gvjs_oi(a.qh, gvjs_K5, function(b) {
+      gvjs_I(a, gvjs_K5, b)
+    }))
+}
+function gvjs_Zwa(a) {
+  var b = a.aa.cf;
+  a = a.ut;
+  gvjs_Z9();
+  return !(gvjs_jf(gvjs_gg(a)) && gvjs_jf(gvjs_gg(b)) || a == b)
+}
+function gvjs_E$(a, b) {
+  a.ck = b;
+  a.nc.dispatchEvent("dataChanged");
+  var c = a.My();
+  if (!gvjs_D$(b) && !a.aa.mb() && a.ut && a.oa.V_ && !a.oa.As) {
+    b = a.ut;
+    var d = a.ck;
+    if ("-2" == gvjs_Wm(b, gvjs_J6)) {
+      for (var e = !1, f = d && d.$(), g = 0; g < f; g++) {
+        var h = d.Ga(g);
+        h = null === h || "" == h;
+        e = e || !h
+      }
+      b = gvjs_k7(b, gvjs_J6, e ? "1" : "0")
+    }
+    a.ut = b;
+    c.yh(a.ut)
+  }
+  gvjs_B$(a, c);
+  a.oa.As && a.oa.As.Dwa(a.ck);
+  a.oa.$B && a.oa.$B.Dwa(a.ck)
+}
+gvjs_.Kqa = function(a) {
+  if (this.sz)
+    if (this.sz = !1,
+      a.Xk()) {
+      if (gvjs_E$(this, null),
+        this.qh) {
+        var b = this.qh
+          , c = b.ma;
+        b.D.qc(c);
+        gvjs_Xk(c, a);
+        gvjs_I(b, gvjs_Rb, {
+          message: a.sP()
+        })
+      }
+    } else
+      gvjs_E$(this, a.mb())
+}
+;
+gvjs_.UP = function(a, b) {
+  var c = gvjs_D$(a)
+    , d = gvjs_D$(b);
+  return c && d ? !1 : c || d ? !0 : a.toJSON() != b.toJSON()
+}
+;
+gvjs_.Jpa = function(a) {
+  a.type == gvjs_N5 ? gvjs_I(this, "ok", null) : a.type == gvjs_M5 && gvjs_I(this, gvjs_Ab, null);
+  this.UW()
+}
+;
+gvjs_.UW = function() {
+  if (null !== this.aa) {
+    this.ni && (this.ni.clear(),
+      this.ni = null);
+    null !== this.Pm && gvjs_ql(this.Pm);
+    gvjs_G$(this);
+    this.removeAll();
+    gvjs_E(this.bE);
+    var a = this.D;
+    this.nc = null;
+    gvjs_E(this.qh);
+    this.qh = null;
+    this.sg && (a.removeNode(this.sg),
+      this.sg = null);
+    this.rw && (a.removeNode(a.j(gvjs_c6)),
+      gvjs_E(this.rw),
+      this.rw = null);
+    this.UG && (a.removeNode(a.j(gvjs_05)),
+      gvjs_E(this.UG),
+      this.UG = null);
+    this.oa = this.aa = null;
+    this.hJ = !1;
+    this.ck = this.hq = this.ut = this.MA = this.yl = null;
+    this.sz = !1;
+    this.YD = null;
+    this.removeAll();
+    this.qh && gvjs_vi(this.qh);
+    this.qh = null;
+    this.Om && gvjs_vi(this.Om);
+    gvjs_E(this.Om);
+    this.Om = null
+  }
+}
+;
+gvjs_.Ela = function() {
+  this.UW()
+}
+;
+function gvjs_D$(a) {
+  return null === a || 0 == a.$()
+}
+gvjs_.KO = function(a) {
+  if (!this.Om) {
+    var b = this.Mpa.bind(this);
+    this.Om = new gvjs_k$(this.D);
+    gvjs_Bwa(this.Om, a);
+    gvjs_oi(this.Om, "viewerUpdated", b)
+  }
+}
+;
+gvjs_.jya = function() {
+  this.Om.toggle()
+}
+;
+gvjs_.Mpa = function() {
+  var a = this.Om
+    , b = this.aa;
+  "dataEntry" == gvjs_m$(a) ? b.zh(a.Z) : gvjs_m$(a) == gvjs_Jw && b.yh(gvjs_n$(a));
+  gvjs_B$(this, this.aa)
+}
+;
+function gvjs_Ywa(a) {
+  switch (a) {
+    case gvjs_ma:
+      return 1;
+    case gvjs_na:
+      return 2;
+    case gvjs_qa:
+      return 3;
+    case gvjs_ra:
+      return 4;
+    case gvjs_ua:
+      return 5;
+    case gvjs_xa:
+      return 6;
+    case gvjs_ya:
+      return 7;
+    case gvjs_Ga:
+      return 8;
+    case gvjs_Ha:
+      return 9;
+    case gvjs_La:
+      return 10;
+    case gvjs_Oa:
+      return 11;
+    case gvjs_Pa:
+      return 12;
+    case gvjs_Za:
+      return 13;
+    case gvjs_Va:
+      return 14;
+    case gvjs_3a:
+      return 15;
+    case gvjs_Wa:
+      return 16;
+    case gvjs_2a:
+      return 17;
+    case gvjs_9a:
+      return 18;
+    case gvjs_oa:
+      return 19;
+    case gvjs_ab:
+      return 20;
+    case gvjs_db:
+      return 21;
+    case gvjs_fb:
+      return 22;
+    case gvjs_hb:
+      return 23;
+    case gvjs_mb:
+      return 24;
+    default:
+      return 0
+  }
+}
+;function gvjs_H$(a) {
+  a = a || {};
+  a.isToolbar = !0;
+  gvjs_i$.call(this, a);
+  this.mra = a.headerBarElement ? gvjs_Oh().j(a.headerBarElement) : null;
+  this.wna = null != a.enableChartAreaInPercent ? !!a.enableChartAreaInPercent : !0;
+  this.wsa = a.keyboardShortcutEventTarget ? a.keyboardShortcutEventTarget : new gvjs_H;
+  this.aza = typeof a.viewEditIsSideBar === gvjs_zb ? a.viewEditIsSideBar : !1
+}
+gvjs_o(gvjs_H$, gvjs_i$);
+function gvjs_6wa(a) {
+  return gvjs_I$(a.Rs)
+}
+function gvjs_I$(a) {
+  var b = "";
+  gvjs_8(a, gvjs_Bb) ? b += "Chart area" : gvjs_8(a, gvjs_Tt) ? b += "Axis area" : gvjs_8(a, "axis") ? b += "Axis" : gvjs_8(a, gvjs_Mw) ? b += "Series" : gvjs_8(a, "series.edit") ? b += "Edit series" : gvjs_8(a, gvjs_fx) ? b += "Title" : gvjs_8(a, gvjs_26) ? b += "Edit title" : gvjs_8(a, "title.clear") ? b += "Clear title" : gvjs_8(a, gvjs_Xu) ? b += "Horizontal axis labels" : gvjs_8(a, gvjs_86) ? b += "Left vertical axis labels" : gvjs_8(a, gvjs_b7) ? b += "Right vertical axis labels" : gvjs_8(a, "hAxis.edit") ? b += "Edit horizontal axis labels" : gvjs_8(a, "vAxes.0.edit") ? b += "Edit left vertical axis labels" : gvjs_8(a, "vAxes.1.edit") ? b += "Edit right vertical axis labels" : gvjs_8(a, gvjs_H6) ? b += gvjs_v5 : gvjs_8(a, gvjs_a7) ? b += gvjs_x5 : gvjs_8(a, gvjs_d7) ? b += gvjs_C5 : gvjs_8(a, "hAxis.title.edit") ? b += "Edit horizontal axis title" : gvjs_8(a, "vAxes.0.title.edit") ? b += "Edit left vertical axis title" : gvjs_8(a, "vAxes.1.title.edit") ? b += "Edit right vertical axis title" : gvjs_8(a, "hAxis.title.clear") ? b += "Clear horizontal axis title" : gvjs_8(a, "vAxes.0.title.clear") ? b += "Clear left vertical axis title" : gvjs_8(a, "vAxes.1.title.clear") ? b += "Clear right vertical axis title" : gvjs_8(a, gvjs_rv) ? b += "Legend" : gvjs_8(a, gvjs_T6) ? b += "Edit legend" : gvjs_8(a, "legend.clear") && (b += "Clear legend");
+  return gvjs_W(b)
+}
+;function gvjs_7wa(a) {
+  var b = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_ir + gvjs_7(gvjs_z6) + gvjs_dqa + gvjs_7(gvjs_Ks) + gvjs_X;
+  b += "Edit:</div>";
+  var c = a.type;
+  var d = a.features
+    , e = a.C1
+    , f = a.$ta;
+  var g = d.PW[c] ? gvjs_J$(gvjs_osa, gvjs_fx) : "";
+  var h = d.qg[c] ? gvjs_J$(gvjs_msa, gvjs_rv) : "";
+  if (d.Naa[c]) {
+    var k = d.UH[c] ? gvjs_b5 + gvjs_7(gvjs_Ls) + gvjs_N4 + gvjs_J$(gvjs_psa, gvjs_d7) + gvjs_J$(gvjs_jsa, gvjs_b7) : "";
+    k = gvjs_b5 + gvjs_7(gvjs_Ps) + gvjs_X + gvjs_I$("axis") + gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_J$("google-visualization-clickeditor-edit-chart-area", gvjs_Tt) + gvjs_b5 + gvjs_7(gvjs_Ls) + gvjs_N4 + gvjs_J$(gvjs_qsa, gvjs_H6) + gvjs_J$(gvjs_ksa, gvjs_Xu) + gvjs_b5 + gvjs_7(gvjs_Ls) + gvjs_N4 + gvjs_J$(gvjs_rsa, gvjs_a7) + gvjs_J$(gvjs_lsa, gvjs_86) + k + gvjs_64
+  } else
+    k = "";
+  e = "" + gvjs_J$("google-visualization-clickeditor-edit-chart", gvjs_Bb) + g + h + k + (gvjs_9(d.ez[c]) && 0 < e ? gvjs_b5 + gvjs_7(gvjs_Ps) + gvjs_X + gvjs_I$(gvjs_Mw) + gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_8wa(e) + gvjs_64 : "");
+  if (gvjs_9(d.GU[c]) && 0 < f) {
+    e += gvjs_b5 + gvjs_7(gvjs_Ps) + gvjs_X;
+    e = e + 'Trendlines<div class="' + (gvjs_7(gvjs_Z) + gvjs_X);
+    c = Math.max(0, Math.ceil(f - 0));
+    for (d = 0; d < c; d++)
+      f = 1 * d,
+        e += gvjs_b5 + gvjs_7(gvjs__) + gvjs_ir + gvjs_7("google-visualization-clickeditor-edit-trendline") + "-" + gvjs_7(f) + gvjs_X + gvjs_17(f) + gvjs_a;
+    e += gvjs_64
+  }
+  c = gvjs_W(e);
+  b += c + gvjs_b5 + gvjs_7(gvjs_Ls) + gvjs_O4 + gvjs_7(gvjs_Ps) + gvjs_X;
+  b += 'Change chart<div class="';
+  c = gvjs_7(gvjs_Z) + gvjs_X;
+  a = a.zla;
+  e = "";
+  d = Math.max(0, Math.ceil(a.length - 0));
+  for (f = 0; f < d; f++)
+    g = a[1 * f],
+      h = "" + gvjs_27(g),
+      h = gvjs_sq(h),
+      h = gvjs_b5 + gvjs_7(gvjs__) + " " + gvjs_7(gvjs_Ms) + " " + gvjs_7(gvjs_wsa) + gvjs_jr + gvjs_7(g) + gvjs_X + h,
+      g = gvjs_8(g, gvjs_na) ? gvjs_at : gvjs_8(g, gvjs_qa) ? gvjs_wb : gvjs_8(g, gvjs_ra) ? gvjs_Dd : gvjs_8(g, gvjs_ua) ? "candle" : gvjs_8(g, gvjs_xa) ? gvjs_Fb : gvjs_8(g, gvjs_ya) ? "combo" : gvjs_8(g, gvjs_La) ? gvjs_4u : gvjs_8(g, gvjs_Va) ? gvjs_e : gvjs_8(g, gvjs_3a) ? gvjs_fw : gvjs_8(g, gvjs_9a) ? gvjs_Dd : gvjs_8(g, gvjs_ab) ? "step" : "",
+      g = gvjs_b5 + gvjs_7("google-visualization-clickeditor-context-icon") + " " + gvjs_7(gvjs_a6) + "-" + gvjs_7(g) + gvjs_N4,
+      g = gvjs_W(g),
+      e += h + g + gvjs_a;
+  a = gvjs_W(e);
+  b += c + a + '</div></div><div class="' + gvjs_7(gvjs_Ls) + gvjs_O4 + gvjs_7(gvjs__) + gvjs_ir + gvjs_7(gvjs_vsa) + gvjs_X;
+  return gvjs_W(b + "Advanced edit...</div></div>")
+}
+function gvjs_9wa() {
+  return gvjs_W(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_ir + gvjs_7(gvjs_z6) + gvjs_z4 + gvjs_J$(gvjs_osa, gvjs_26) + gvjs_J$("google-visualization-clickeditor-clear-title", "title.clear") + gvjs_a)
+}
+function gvjs_$wa(a) {
+  var b = a.type
+    , c = a.features;
+  a = a.C1;
+  return gvjs_W(gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_ir + gvjs_7(gvjs_z6) + gvjs_z4 + gvjs_J$(gvjs_msa, gvjs_T6) + gvjs_J$("google-visualization-clickeditor-clear-legend", "legend.clear") + (gvjs_9(c.ez[b]) && 0 < a ? gvjs_b5 + gvjs_7(gvjs_Ps) + gvjs_X + gvjs_I$(gvjs_Mw) + gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_X + gvjs_8wa(a) + gvjs_64 : "") + gvjs_a)
+}
+function gvjs_axa(a) {
+  a = a.C7;
+  var b = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_ir + gvjs_7(gvjs_z6) + gvjs_z4;
+  b += gvjs_J$(gvjs_8(a, gvjs_Xu) ? gvjs_ksa : gvjs_8(a, gvjs_86) ? gvjs_lsa : gvjs_8(a, gvjs_b7) ? gvjs_jsa : "", a + ".edit") + gvjs_a;
+  return gvjs_W(b)
+}
+function gvjs_bxa(a) {
+  a = a.C7;
+  var b = gvjs_b5 + gvjs_7(gvjs_Z) + gvjs_ir + gvjs_7(gvjs_z6) + gvjs_z4
+    , c = gvjs_8(a, gvjs_Xu) ? "google-visualization-clickeditor-clear-title-x" : gvjs_8(a, gvjs_86) ? "google-visualization-clickeditor-clear-title-y" : gvjs_8(a, gvjs_b7) ? "google-visualization-clickeditor-clear-title-right" : "";
+  b += gvjs_J$(gvjs_8(a, gvjs_Xu) ? gvjs_qsa : gvjs_8(a, gvjs_86) ? gvjs_rsa : gvjs_8(a, gvjs_b7) ? gvjs_psa : "", a + ".title.edit") + gvjs_J$(c, a + ".title.clear") + gvjs_a;
+  return gvjs_W(b)
+}
+function gvjs_cxa() {
+  var a = '<div class="google-visualization-clickeditor-header">'
+    , b = gvjs_sq("View mode")
+    , c = gvjs_sq("Quick edit mode");
+  a += gvjs_Kqa + gvjs_7(gvjs_Y) + ' google-visualization-clickeditor-header-view" data-tooltip-contained="true"><div class="jfk-tooltip-data" aria-hidden="false">' + gvjs_57(b) + gvjs_a + gvjs_D7("docs-icon-img docs-icon-mode-view") + '</div><div class="jfk-button jfk-button-standard jfk-button-narrow ' + gvjs_7(gvjs_Y) + ' google-visualization-clickeditor-header-edit" data-tooltip-contained="true"><div class="jfk-tooltip-data" aria-hidden="false">' + gvjs_57(c) + gvjs_a + gvjs_D7("docs-icon-img docs-icon-mode-edit") + '</div><div class="google-visualization-clickeditor-header-text ' + gvjs_7(gvjs_Y) + gvjs_xqa;
+  return gvjs_W(a)
+}
+function gvjs_8wa(a) {
+  var b = "";
+  a = Math.max(0, Math.ceil(a - 0));
+  for (var c = 0; c < a; c++) {
+    var d = 1 * c;
+    b += gvjs_b5 + gvjs_7(gvjs__) + gvjs_ir + gvjs_7("google-visualization-clickeditor-edit-series") + "-" + gvjs_7(d) + gvjs_X + gvjs_17(d) + gvjs_a
+  }
+  return gvjs_W(b)
+}
+function gvjs_J$(a, b) {
+  a = gvjs_h5 + gvjs_7(a) + gvjs_u4 + gvjs_7(gvjs__) + " " + gvjs_7("") + gvjs_jr + gvjs_7(b) + gvjs_X + gvjs_I$(b) + gvjs_a;
+  return gvjs_W(a)
+}
+function gvjs_dxa(a) {
+  a = a.key;
+  var b = "";
+  gvjs_8(a, gvjs_fx) ? b += gvjs_s5 : gvjs_8(a, gvjs_H6) ? b += gvjs_v5 : gvjs_8(a, gvjs_a7) ? b += gvjs_x5 : gvjs_8(a, gvjs_d7) && (b += gvjs_C5);
+  return gvjs_W(b)
+}
+;function gvjs_K$(a, b, c) {
+  this.da = a;
+  this.Ei = b.targetID;
+  this.h2 = this.Ei.split("#");
+  this.pf = this.h2[0];
+  a = b.x;
+  b = b.y;
+  this.lc = typeof a === gvjs_g && typeof b === gvjs_g ? new gvjs_z(a,b) : null;
+  this.oa = c || new gvjs_H$({})
+}
+function gvjs_exa(a, b) {
+  return {
+    type: gvjs_Aw,
+    targetID: a.getName(),
+    x: b.x,
+    y: b.y
+  }
+}
+gvjs_ = gvjs_K$.prototype;
+gvjs_.equals = function(a) {
+  return this.getName() == (a && a.getName()) && this.zf() == (a && a.zf())
+}
+;
+gvjs_.zf = function() {
+  return this.da
+}
+;
+gvjs_.getName = function() {
+  return this.Ei
+}
+;
+gvjs_.getType = function() {
+  return this.pf
+}
+;
+function gvjs_L$(a, b) {
+  var c = a.da;
+  if (typeof c.Ql !== gvjs_d)
+    return null;
+  var d = c.Ql().getBoundingBox
+    , e = a.getName()
+    , f = null;
+  c = gvjs_fxa(a);
+  switch (a.getType()) {
+    case gvjs_wb:
+    case gvjs_5w:
+    case gvjs_yt:
+    case gvjs_Fb:
+    case gvjs_Np:
+      f = d(e);
+      break;
+    case gvjs_at:
+    case gvjs_Zp:
+      f = b ? null : gvjs_M$(a);
+      break;
+    case gvjs_e:
+      f = gvjs_M$(a);
+      break;
+    case gvjs_Wsa:
+      b = a.da;
+      typeof b.Ql === gvjs_d ? (b = b.Ql().getBoundingBox,
+        d = gvjs_Bb,
+        b(gvjs_Tt) ? d = gvjs_Tt : b(gvjs_zv) ? d = gvjs_zv : b(gvjs_fx) && (d = gvjs_fx),
+        b = b(d),
+        b = new gvjs_z(b.left + Math.abs(b.width / 2),b.top)) : b = null;
+      a.lc = b;
+      f = gvjs_M$(a);
+      break;
+    case gvjs_Xu:
+    case gvjs_Ud:
+      /(hAxis||vAxis)#\d+#label/.test(a.getName()) ? (f = d(gvjs_gxa(a)),
+        gvjs_N$(f)) : gvjs_O$(a) && (f = d(e),
+        gvjs_hxa(f, c, a.getType() != gvjs_Xu));
+      break;
+    case gvjs_fx:
+      f = d(e);
+      gvjs_hxa(f, c, !1);
+      break;
+    case gvjs_zv:
+      f = d(gvjs_gxa(a));
+      null === f && (f = d(a.getName()));
+      gvjs_N$(f);
+      break;
+    case gvjs_Bb:
+      b || (f = d(e));
+      break;
+    case gvjs_Tt:
+      b || (f = c)
+  }
+  if (f)
+    if (gvjs_He(gvjs_ixa, a.getType()) && c)
+      a: {
+        a = gvjs_P$(f);
+        e = gvjs_P$(c);
+        c = Math.max(a.left, e.left);
+        b = Math.min(a.left + a.width, e.left + e.width);
+        if (c <= b && (d = Math.max(a.top, e.top),
+          a = Math.min(a.top + a.height, e.top + e.height),
+        d <= a)) {
+          a = new gvjs_5(c,d,b - c,a - d);
+          break a
+        }
+        a = null
+      }
+    else
+      a = gvjs_P$(f);
+  else
+    a = null;
+  return a
+}
+function gvjs_jxa(a, b) {
+  var c = b.Va()
+    , d = null
+    , e = null
+    , f = a.da;
+  if (typeof f.Ql !== gvjs_d)
+    return null;
+  f = f.Ql ? f.Ql().getBoundingBox : null;
+  switch (a.getType()) {
+    case gvjs_Xu:
+    case gvjs_Ud:
+      e = {
+        axis: gvjs_kxa(a),
+        type: c,
+        features: gvjs_$,
+        lJ: gvjs_77(c, a.Hq(b)),
+        mJ: gvjs_87(c, a.Hq(b))
+      };
+      d = gvjs_O$(a) ? gvjs_Nva : gvjs_Lva;
+      break;
+    case gvjs_zv:
+      d = gvjs_Pva;
+      e = {
+        type: c,
+        features: gvjs_$
+      };
+      break;
+    case gvjs_at:
+    case gvjs_wb:
+    case gvjs_yt:
+    case gvjs_e:
+    case gvjs_Wsa:
+    case gvjs_Zp:
+    case gvjs_5w:
+    case gvjs_Np:
+    case gvjs_Pd:
+      f = a.getType() == gvjs_yt ? 2 : 1;
+      var g = parseInt(a.h2[f], 10);
+      gvjs_Yy(g) && (e = gvjs_Xx(a.da.ti().C, function(h) {
+        return h.XL == g
+      }),
+        -1 < e ? (d = gvjs_Rva,
+          e = {
+            Ud: e
+          }) : (d = gvjs_Uva,
+          e = [],
+          f = b.mb(),
+        null != f && (f = new gvjs_$7(f,b,a.oa.vo()),
+        gvjs_b8(f) && (e = gvjs_2ta(f))),
+          e = {
+            Ud: g,
+            type: c,
+            lsa: a.Hq(b) || a.wQ(b),
+            features: gvjs_$,
+            annotations: e,
+            vo: a.oa.vo(),
+            kC: a.oa.kC()
+          }));
+      break;
+    case gvjs_fx:
+      d = gvjs_Ova;
+      break;
+    case gvjs_Tt:
+      d = gvjs_Tva;
+      e = {
+        type: c,
+        features: gvjs_$,
+        jra: !(!f || !f("vAxis#0#label")),
+        lra: !(!f || !f("vAxis#1#label")),
+        fxa: b.getOption(gvjs_16) != gvjs_Lv,
+        lJ: gvjs_77(c, a.Hq(b)),
+        mJ: gvjs_87(c, a.Hq(b))
+      };
+      break;
+    default:
+      d = gvjs_Sva,
+        e = {
+          type: c,
+          features: gvjs_$
+        }
+  }
+  return d ? gvjs_LB(d, e) : null
+}
+gvjs_.xI = function() {
+  var a = null;
+  switch (this.getType()) {
+    case gvjs_Xu:
+    case gvjs_Ud:
+      a = gvjs_lxa(this) + ".edit";
+      break;
+    case gvjs_wb:
+    case gvjs_yt:
+    case gvjs_Fb:
+    case gvjs_Np:
+    case gvjs_e:
+    case gvjs_5w:
+      a = "series.edit";
+      break;
+    case gvjs_zv:
+      a = gvjs_T6;
+      break;
+    case gvjs_fx:
+      a = gvjs_26
+  }
+  return a ? (a = gvjs_LB(gvjs_6wa, {
+    Rs: a
+  }),
+    gvjs_wh(a)) : ""
+}
+;
+function gvjs_fxa(a) {
+  a = a.da;
+  if (!a || typeof a.Ql !== gvjs_d)
+    return null;
+  a = a.Ql().getBoundingBox;
+  var b = [];
+  b.push(a("hAxis#0#baseline"));
+  b.push(a("vAxis#0#baseline"));
+  b.push(a("vAxis#1#baseline"));
+  b.push(a("hAxis#0#gridline"));
+  b.push(a("vAxis#0#gridline"));
+  b.push(a("vAxis#1#gridline"));
+  var c = null;
+  gvjs_u(b, function(d) {
+    if (d) {
+      d = new gvjs_5(d.left,d.top,d.width,d.height);
+      if (c)
+        if (c && d) {
+          var e = new gvjs_5(c.left,c.top,c.width,c.height)
+            , f = Math.max(e.left + e.width, d.left + d.width)
+            , g = Math.max(e.top + e.height, d.top + d.height);
+          e.left = Math.min(e.left, d.left);
+          e.top = Math.min(e.top, d.top);
+          e.width = f - e.left;
+          e.height = g - e.top;
+          d = e
+        } else
+          d = null;
+      c = d
+    }
+  });
+  return c ? {
+    left: c.left,
+    top: c.top,
+    width: c.width,
+    height: c.height
+  } : null
+}
+function gvjs_mxa(a) {
+  var b = !1;
+  switch (a.getType()) {
+    case gvjs_Xu:
+    case gvjs_Ud:
+    case gvjs_fx:
+    case gvjs_zv:
+      b = !0
+  }
+  return b
+}
+function gvjs_O$(a) {
+  return /(hAxis||vAxis)#\d+#title/.test(a.getName())
+}
+function gvjs_N$(a) {
+  a && (a.left -= 5,
+    a.top -= 5,
+    a.width += 10,
+    a.height += 10)
+}
+function gvjs_M$(a) {
+  return {
+    left: a.lc.x - 2,
+    top: a.lc.y - 2,
+    width: 1,
+    height: 1
+  }
+}
+function gvjs_hxa(a, b, c) {
+  a && (b ? c ? (a.height = b.height,
+    a.top = b.top,
+    a.width += 16,
+    a.left -= 8) : (a.width = b.width,
+    a.left = b.left,
+    a.height += 16,
+    a.top -= 8) : gvjs_N$(a))
+}
+function gvjs_gxa(a) {
+  a = a.getName();
+  return a.substring(0, a.lastIndexOf("#"))
+}
+function gvjs_kxa(a) {
+  var b = "";
+  a.getType() == gvjs_Xu && (b = "x");
+  a.getType() == gvjs_Ud && (b = 0 == a.h2[1] ? "y" : gvjs_j);
+  return b
+}
+function gvjs_lxa(a) {
+  return {
+    x: gvjs_Xu,
+    y: gvjs_86,
+    right: gvjs_b7
+  }[gvjs_kxa(a)]
+}
+gvjs_.Hq = function(a) {
+  return this.nt(gvjs_g, a)
+}
+;
+gvjs_.wQ = function(a) {
+  return this.nt(gvjs_Lb, a) || this.nt(gvjs_Mb, a) || this.nt(gvjs_Od, a)
+}
+;
+gvjs_.nt = function(a, b) {
+  var c = b.Va()
+    , d = b.mb();
+  if (!gvjs_$.YN[c] || !d || 0 == d.$())
+    return !1;
+  if (gvjs_$.lfa[c])
+    return d.W(1) === a;
+  if (d.W(0) != a)
+    return !1;
+  a = gvjs_c8(c, d);
+  return null === a ? (a = !!b.getOption(gvjs_76, gvjs_$.EH[c]),
+  !b.getOption(gvjs_46) && a) : a
+}
+;
+function gvjs_P$(a) {
+  return new gvjs_5(a.left,a.top,a.width,a.height)
+}
+var gvjs_ixa = [gvjs_at, gvjs_wb, gvjs_yt, gvjs_Fb, gvjs_e, gvjs_Np, gvjs_Zp, gvjs_5w];
+function gvjs_nxa(a, b) {
+  var c = gvjs_LB(gvjs_dxa, {
+    key: b + gvjs_fx
+  }).innerHTML;
+  a.ba(b + gvjs_fx, c);
+  a.ba(b + gvjs_ix, null)
+}
+function gvjs_oxa(a, b) {
+  b = b || {};
+  a.ba(gvjs_3o, b.width);
+  a.ba(gvjs__o, b.height);
+  a.ba(gvjs_2o, b.top);
+  a.ba(gvjs_0o, b.left)
+}
+function gvjs_pxa(a) {
+  a = a && a.Yx;
+  var b = gvjs_Oh();
+  return a ? b.j(a) : null
+}
+function gvjs_qxa(a, b) {
+  var c = b && b.width;
+  b = b && b.height;
+  typeof c === gvjs_g && 0 < c && typeof b === gvjs_g && 0 < b && gvjs_r(a) && (a.width = gvjs_Q$(a.width, c),
+    a.height = gvjs_Q$(a.height, b),
+    a.top = gvjs_Q$(a.top, b),
+    a.left = gvjs_Q$(a.left, c))
+}
+function gvjs_Q$(a, b) {
+  var c = a || "";
+  gvjs_jf(gvjs_gg(a)) || -1 != String(a).indexOf("%") || (c = Math.round(Number(a) / b * 1E5) / 1E3,
+    c += "%");
+  return c
+}
+;function gvjs_R$(a) {
+  return {
+    has: function(b) {
+      return !gvjs_jf(gvjs_gg(b.getOption(a + gvjs_fx)))
+    },
+    show: function(b) {
+      gvjs_nxa(b, a)
+    },
+    Vaa: function(b) {
+      b.ba(a + gvjs_fx, null)
+    }
+  }
+}
+function gvjs_rxa() {
+  return {
+    has: function(a) {
+      return a.getOption(gvjs_rv) != gvjs_f
+    },
+    show: function(a) {
+      a.ba(gvjs_rv, null)
+    },
+    Vaa: function(a) {
+      a.ba(gvjs_rv, gvjs_f)
+    }
+  }
+}
+var gvjs_sxa = {
+  "google-visualization-clickeditor-edit-chart": {
+    name: gvjs_Bb
+  },
+  "google-visualization-clickeditor-edit-chart-area": {
+    name: gvjs_Tt
+  },
+  "google-visualization-clickeditor-edit-title": {
+    name: gvjs_fx,
+    uy: gvjs_R$("")
+  },
+  "google-visualization-clickeditor-edit-legend": {
+    name: "legendentry#",
+    uy: gvjs_rxa()
+  },
+  "google-visualization-clickeditor-edit-axis-x": {
+    name: "hAxis#0#label#"
+  },
+  "google-visualization-clickeditor-edit-axis-y": {
+    name: "vAxis#0#label#"
+  },
+  "google-visualization-clickeditor-edit-axis-right": {
+    name: "vAxis#1#label#"
+  },
+  "google-visualization-clickeditor-edit-title-x": {
+    name: "hAxis#0#title",
+    uy: gvjs_R$(gvjs_E6)
+  },
+  "google-visualization-clickeditor-edit-title-y": {
+    name: "vAxis#0#title",
+    uy: gvjs_R$(gvjs_96)
+  },
+  "google-visualization-clickeditor-edit-title-right": {
+    name: "vAxis#1#title",
+    uy: gvjs_R$(gvjs_c7)
+  }
+}
+  , gvjs_txa = {
+  "google-visualization-clickeditor-clear-title": {
+    name: gvjs_fx,
+    OI: gvjs_R$("")
+  },
+  "google-visualization-clickeditor-clear-legend": {
+    name: "legendentry#",
+    OI: gvjs_rxa()
+  },
+  "google-visualization-clickeditor-clear-title-x": {
+    name: "hAxis#0#title",
+    OI: gvjs_R$(gvjs_E6)
+  },
+  "google-visualization-clickeditor-clear-title-y": {
+    name: "vAxis#0#title",
+    OI: gvjs_R$(gvjs_96)
+  },
+  "google-visualization-clickeditor-clear-title-right": {
+    name: "vAxis#1#title",
+    OI: gvjs_R$(gvjs_c7)
+  }
+}
+  , gvjs_uxa = {
+  "google-visualization-clickeditor-edit-axis-y": {
+    VH: function(a, b) {
+      return gvjs_e8(a, 0, b)
+    }
+  },
+  "google-visualization-clickeditor-edit-title-y": {
+    VH: function(a, b) {
+      return gvjs_e8(a, 0, b)
+    }
+  },
+  "google-visualization-clickeditor-edit-axis-right": {
+    VH: function(a, b) {
+      return gvjs_e8(a, 1, b)
+    }
+  },
+  "google-visualization-clickeditor-edit-title-right": {
+    VH: function(a, b) {
+      return gvjs_e8(a, 1, b)
+    }
+  }
+};
+function gvjs_S$(a, b, c) {
+  gvjs_KA.call(this);
+  this.aa = a;
+  this.nc = b;
+  this.oa = c;
+  this.YP = c.mra;
+  this.YD = new gvjs_Fwa;
+  this.Aq = [];
+  this.ql = !1;
+  this.D = gvjs_Oh();
+  this.Nv = this.Mv = this.ft = this.YL = this.pr = this.Z = this.la = null
+}
+gvjs_o(gvjs_S$, gvjs_KA);
+gvjs_ = gvjs_S$.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.ft);
+  gvjs_E(this.Mv);
+  this.Nv = null;
+  this.YP && gvjs_hh(this.YP);
+  this.Aq && (gvjs_u(this.Aq, function(a) {
+    gvjs_ui(a)
+  }),
+    this.Aq = null);
+  gvjs_vxa(this);
+  this.pr = this.Z = this.YD = null;
+  gvjs_KA.prototype.M.call(this)
+}
+;
+function gvjs_wxa(a, b) {
+  var c = a.YP;
+  if (c && !a.ft) {
+    gvjs_m8(c);
+    gvjs_KB(c, gvjs_cxa);
+    var d = a.D.hd("google-visualization-clickeditor-header-view", c)
+      , e = gvjs_t9();
+    a.ft = e;
+    e.Lw(2);
+    e.fb(d);
+    a.o(e, gvjs_Ss, function() {
+      gvjs_xxa(a, !1)
+    });
+    d = a.D.hd("google-visualization-clickeditor-header-edit", c);
+    e = gvjs_t9();
+    a.Mv = e;
+    e.Lw(1);
+    e.fb(d);
+    a.o(e, gvjs_Ss, function() {
+      gvjs_xxa(a, !0)
+    });
+    a.Nv = a.D.hd("google-visualization-clickeditor-header-text", c);
+    a.ql = b;
+    gvjs_T$(a, !b);
+    a.o(c, gvjs_3t, function(f) {
+      f.preventDefault()
+    })
+  }
+}
+function gvjs_xxa(a, b) {
+  a.aa.ba("mode", b ? "edit" : "view");
+  gvjs_T$(a, b);
+  b == a.ql && (a.ql = !b,
+    a.nc.dispatchEvent(b ? "editmode" : "viewmode"))
+}
+function gvjs_T$(a, b) {
+  a.ft && a.ft.bi(!b);
+  a.Mv && a.Mv.bi(b);
+  gvjs_U$(a, b ? "Click the area of the chart you want to edit" : "")
+}
+function gvjs_U$(a, b) {
+  a.Nv && (gvjs_th(a.Nv, b),
+    gvjs_yxa(a))
+}
+function gvjs_yxa(a) {
+  if (a.Nv) {
+    var b = a.Nv;
+    if (a.Nv) {
+      var c = gvjs_zxa(a) || 0;
+      c = gvjs_Ez(a.Nv).width < c - 150
+    } else
+      c = !1;
+    gvjs_6(b, c)
+  }
+  b = gvjs_zxa(a);
+  b = a.oa.aza ? !0 : 150 < b;
+  a.Mv && a.Mv.setVisible(b);
+  a.ft && a.ft.setVisible(b)
+}
+gvjs_.zh = function(a, b, c) {
+  this.Z = a;
+  this.pr = b;
+  this.YL = c
+}
+;
+gvjs_.Ov = function() {
+  this.la && this.la.setVisible(!1)
+}
+;
+gvjs_.c4 = function(a, b) {
+  var c = null;
+  if (b) {
+    c = this.pr && this.pr.length || 0;
+    var d = this.aa.Va()
+      , e = null
+      , f = null;
+    switch (b.getType()) {
+      case gvjs_fx:
+        e = gvjs_9wa;
+        break;
+      case gvjs_zv:
+        e = gvjs_$wa;
+        f = {
+          type: d,
+          features: gvjs_$,
+          C1: c
+        };
+        break;
+      case gvjs_Xu:
+      case gvjs_Ud:
+        f = {
+          C7: gvjs_lxa(b)
+        },
+          e = gvjs_O$(b) ? gvjs_bxa : gvjs_axa
+    }
+    c = e ? gvjs_LB(e, f) : null
+  }
+  c || (c = this.pr && this.pr.length || 0,
+    b = this.YL && this.YL.length || 0,
+    d = this.aa.Va(),
+    e = this.oa,
+    f = new Set(gvjs_Le(gvjs_zwa)),
+    e = gvjs_oj(f, new Set(e.yl)),
+    e = gvjs_nj(e),
+    e = new gvjs_6l(e),
+    f = [this.aa.Va()],
+  this.Z && (f = e.BW(this.Z)),
+    c = gvjs_LB(gvjs_7wa, {
+      features: gvjs_$,
+      type: d,
+      zla: f,
+      C1: c,
+      tEa: !0,
+      rEa: !1,
+      $ta: b
+    }));
+  b = c;
+  gvjs_vxa(this);
+  d = gvjs_Le(this.D.wq(gvjs_Z, b));
+  d.push(b);
+  gvjs_u(d, this.Bwa.bind(this));
+  this.D.kc().body.appendChild(b);
+  d = this.la = new gvjs_kE;
+  d.fb(b);
+  gvjs_Axa(this, b);
+  this.Ov();
+  this.o(d, gvjs_Ss, this.tqa);
+  b = gvjs_Bxa(this);
+  for (d = 0; d < b.length; d++)
+    if (e = b[d],
+      f = gvjs_Cxa(e))
+      e.bi(f == this.aa.Va());
+    else if (typeof (f = gvjs_Dxa(e)) === gvjs_g)
+      this.pr[f] && e.setContent(this.pr[f]);
+    else if (typeof (f = gvjs_Exa(e)) === gvjs_g)
+      this.YL[f] && e.setContent(this.YL[f]);
+    else if (f = gvjs_uxa[e.getId()]) {
+      var g = void 0
+        , h = this.aa;
+      f.Iua ? g = h.getOption(f.Iua) != f.value : f.VH && (g = f.VH(h, this.pr ? this.pr.length : 0));
+      typeof g === gvjs_zb && e.Gb(g)
+    }
+  this.nc.dispatchEvent("showmenu");
+  b = gvjs_tz(c);
+  b = gvjs_wz(b);
+  gvjs_6A(a, c, 8, void 0, b, 5);
+  this.la.setVisible(!0)
+}
+;
+gvjs_.Ax = function(a, b, c) {
+  a = gvjs_oi(a, b, c);
+  this.Aq.push(a);
+  return a
+}
+;
+function gvjs_vxa(a) {
+  a.la && (a.Ov(),
+    gvjs_li(a.la),
+    gvjs_E(a.la),
+    delete a.la)
+}
+gvjs_.Xma = function(a, b) {
+  var c = this
+    , d = this.Ax(a, gvjs_i, function() {
+    gvjs_ui(d);
+    a.ba(gvjs_Ws, null);
+    c.xO(b)
+  });
+  this.fC()
+}
+;
+gvjs_.xO = function(a) {
+  this.nc.dispatchEvent({
+    type: "editentity",
+    targetID: a,
+    x: -1,
+    y: -1
+  })
+}
+;
+gvjs_.fC = function() {
+  this.nc.dispatchEvent(gvjs_N6)
+}
+;
+gvjs_.Yma = function() {
+  this.nc.dispatchEvent(gvjs_Y6)
+}
+;
+function gvjs_Fxa(a, b) {
+  var c = a.aa
+    , d = c.Va();
+  return b && b != d ? (a = gvjs_Jwa(a.YD, d, c.Zc(), b),
+    c.setOptions(a),
+    c.cc(b),
+    !0) : !1
+}
+gvjs_.tqa = function(a) {
+  var b = this
+    , c = a.target;
+  a = this.aa;
+  if (c) {
+    var d = null;
+    var e = null;
+    (e = gvjs_Cxa(c)) ? gvjs_Fxa(this, e) && (d = this.fC.bind(this)) : (e = gvjs_sxa[c.getId()]) ? e.uy && !e.uy.has(a) ? (e.uy.show(a),
+      a.ba(gvjs_Ws, 0),
+      d = this.Xma.bind(this, a, e.name)) : d = this.xO.bind(this, e.name) : (e = gvjs_txa[c.getId()]) ? (e.OI.Vaa(a),
+      d = this.fC.bind(this)) : c.getId() == gvjs_vsa ? d = this.Yma.bind(this) : typeof (e = gvjs_Dxa(c)) === gvjs_g ? d = this.xO.bind(this, gvjs_Xsa + e) : typeof (c = gvjs_Exa(c)) === gvjs_g && (a = a.zf().ti().C,
+      e = gvjs_De(a, function(f) {
+        return null != f.XL
+      })[c].XL,
+      d = this.xO.bind(this, gvjs_Xsa + e));
+    d && gvjs_pl(d, 0)
+  }
+  gvjs_pl(function() {
+    b.Ov()
+  }, 0)
+}
+;
+function gvjs_Axa(a, b) {
+  var c = gvjs_i7()
+    , d = c ? "\u25c4" : "\u25ba";
+  a = a.D.wq(gvjs_Qs, b);
+  gvjs_u(a, function(e) {
+    gvjs_ZC(e, gvjs_Rs, c);
+    gvjs_th(e, d)
+  })
+}
+function gvjs_Bxa(a) {
+  function b(f) {
+    c.push(f)
+  }
+  var c = [];
+  if (a = a.la) {
+    gvjs_PC(a, b);
+    for (var d = 0; d < a.ze(); d++) {
+      var e = a.Ye(d);
+      typeof e.LT === gvjs_d && gvjs_PC(e.Td(), b)
+    }
+  }
+  return c
+}
+function gvjs_Cxa(a) {
+  a = a.j();
+  return gvjs_UC(a, gvjs_wsa) ? a.getAttribute && a.getAttribute(gvjs_Vd) : null
+}
+function gvjs_zxa(a) {
+  return (a = gvjs_pxa(a.aa)) && gvjs_Ez(a).width
+}
+function gvjs_Dxa(a) {
+  a = a.getId();
+  return gvjs_hf(a, gvjs_nsa) ? Number(a.replace(gvjs_nsa, "")) : null
+}
+function gvjs_Exa(a) {
+  a = a.getId();
+  return gvjs_hf(a, gvjs_ssa) ? Number(a.replace(gvjs_ssa, "")) : null
+}
+gvjs_.Bwa = function(a) {
+  gvjs_VC(a, gvjs_Jra);
+  gvjs_m8(a)
+}
+;
+function gvjs_Gxa() {
+  return gvjs_W(gvjs_V$(gvjs_xsa) + gvjs_V$(gvjs_zsa) + gvjs_V$(gvjs_Asa) + gvjs_V$(gvjs_Bsa) + gvjs_V$(gvjs_ysa))
+}
+function gvjs_V$(a) {
+  return gvjs_W('<div class="google-visualization-resizer-bar ' + gvjs_7(a) + gvjs_N4)
+}
+;function gvjs_W$(a) {
+  gvjs_H.call(this);
+  var b = gvjs_Oh();
+  this.ma = a = b.j(a);
+  this.nh = b.J(gvjs_b);
+  this.z9 = [];
+  this.ea = new gvjs_KA;
+  gvjs_Hxa(this);
+  gvjs_Ixa(this)
+}
+gvjs_o(gvjs_W$, gvjs_H);
+gvjs_ = gvjs_W$.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.ea);
+  this.nh && (gvjs_li(this.nh),
+    gvjs_kh(this.nh));
+  gvjs_H.prototype.M.call(this)
+}
+;
+function gvjs_Jxa(a) {
+  if (a.nh) {
+    var b = gvjs_Ez(a.nh);
+    a = gvjs_vz(a.ma);
+    return {
+      left: b.left - a.x,
+      top: b.top - a.y,
+      width: b.width,
+      height: b.height
+    }
+  }
+  return null
+}
+function gvjs_Kxa(a, b) {
+  if (a.nh) {
+    var c = gvjs_ez(new gvjs_z(b.left,b.top), gvjs_vz(a.ma));
+    gvjs_sz(a.nh, c);
+    gvjs_Cz(a.nh, b.width, b.height);
+    gvjs_X$(a)
+  }
+}
+gvjs_.Wma = function() {
+  this.dispatchEvent(gvjs_vw)
+}
+;
+gvjs_.Wpa = function() {
+  this.I4 = this.E4 = 0;
+  gvjs_X$(this);
+  this.dispatchEvent(gvjs_R)
+}
+;
+gvjs_.Xpa = function() {
+  var a = gvjs_Jxa(this);
+  this.E4 = a.height;
+  this.I4 = a.width;
+  this.dispatchEvent(gvjs_2)
+}
+;
+function gvjs_Ixa(a) {
+  var b = a.nh
+    , c = gvjs_Oh()
+    , d = gvjs_s(c.hd, c)
+    , e = d(gvjs_zsa, b)
+    , f = d(gvjs_Asa, b)
+    , g = d(gvjs_Bsa, b);
+  c = d(gvjs_ysa, b);
+  d = d(gvjs_xsa, b);
+  e = new gvjs__C(b,e);
+  f = new gvjs__C(b,f);
+  g = new gvjs__C(b,g);
+  c = new gvjs__C(b,c);
+  d = new gvjs__C(b,d);
+  e.ky = function(h, k) {
+    h = gvjs_Ez(b);
+    var l = k - h.top;
+    gvjs_C(a.nh, gvjs_vx, k + gvjs_T);
+    gvjs_C(a.nh, gvjs_4c, h.height - l + gvjs_T)
+  }
+  ;
+  f.ky = function(h, k) {
+    h = gvjs_Ez(b);
+    gvjs_C(a.nh, gvjs_4c, a.E4 + (k - h.top) + gvjs_T)
+  }
+  ;
+  g.ky = function(h) {
+    var k = gvjs_Ez(b)
+      , l = h - k.left;
+    gvjs_C(a.nh, gvjs_$c, h + gvjs_T);
+    gvjs_C(a.nh, gvjs_Xd, k.width - l + gvjs_T)
+  }
+  ;
+  c.ky = function(h) {
+    var k = gvjs_Ez(b);
+    gvjs_C(a.nh, gvjs_Xd, a.I4 + (h - k.left) + gvjs_T)
+  }
+  ;
+  gvjs_Y$(a, e);
+  gvjs_Y$(a, f);
+  gvjs_Y$(a, g);
+  gvjs_Y$(a, c);
+  gvjs_Y$(a, d);
+  gvjs_X$(a)
+}
+function gvjs_Hxa(a) {
+  a = a.nh;
+  gvjs_VC(a, "google-visualization-resizer-overlay");
+  gvjs_Ph().body.appendChild(a);
+  gvjs_G(a, gvjs_3t, function(b) {
+    b.preventDefault()
+  });
+  gvjs_KB(a, gvjs_Gxa)
+}
+function gvjs_Y$(a, b) {
+  a.z9.push(b);
+  gvjs_6x(a, b);
+  a.ea.o(b, gvjs_nu, gvjs_s(a.Wma, a));
+  a.ea.o(b, gvjs_2, gvjs_s(a.Xpa, a));
+  a.ea.o(b, gvjs_R, gvjs_s(a.Wpa, a))
+}
+function gvjs_X$(a) {
+  var b = gvjs_Ez(a.ma)
+    , c = gvjs_Ez(a.nh);
+  b.width -= c.width;
+  b.height -= c.height;
+  gvjs_u(a.z9, function(d) {
+    gvjs_0C(d, b)
+  })
+}
+gvjs_.E4 = 0;
+gvjs_.I4 = 0;
+function gvjs_Lxa(a) {
+  var b = a.axa;
+  a = a.uid;
+  a = gvjs_b5 + gvjs_7("jfk-bubble") + '" role="alertdialog"' + (a ? ' aria-describedby="' + gvjs_7(a) + '"' : "") + gvjs_p5 + gvjs_7("jfk-bubble-content-id") + '"' + (a ? gvjs_t4 + gvjs_7(a) + '"' : "") + "></div>";
+  b && (a += gvjs_b5 + gvjs_7("jfk-bubble-closebtn-id") + " " + gvjs_7("jfk-bubble-closebtn") + '" aria-label="',
+    a += gvjs_GB("Close"),
+    a += '" role="button" tabindex=0></div>');
+  a += gvjs_b5 + gvjs_7("jfk-bubble-arrow-id") + " " + gvjs_7("jfk-bubble-arrow") + gvjs_Q4 + gvjs_7("jfk-bubble-arrowimplbefore") + gvjs_O4 + gvjs_7("jfk-bubble-arrowimplafter") + gvjs_yqa;
+  return gvjs_W(a)
+}
+;function gvjs_Z$() {}
+var gvjs_Mxa = new gvjs_Z$
+  , gvjs__$ = [gvjs_Wt, gvjs_lv, gvjs_mv];
+gvjs_Z$.prototype.o = function(a, b, c, d, e) {
+  function f(g) {
+    var h = gvjs_fi(b)
+      , k = gvjs_ph(g.target) ? g.target.getAttribute(gvjs_Bd) || null : null;
+    g.type == gvjs_Wt && gvjs_7x(g) ? h.call(d, g) : 13 != g.keyCode && 3 != g.keyCode || g.type == gvjs_mv ? 32 != g.keyCode || g.type != gvjs_mv || k != gvjs_Bt && "tab" != k && k != gvjs_Z6 || (h.call(d, g),
+      g.preventDefault()) : (g.type = gvjs_7c,
+      h.call(d, g))
+  }
+  f.Bt = b;
+  f.dwa = d;
+  e ? e.o(a, gvjs__$, f, c) : gvjs_G(a, gvjs__$, f, c)
+}
+;
+gvjs_Z$.prototype.Ab = function(a, b, c, d, e) {
+  for (var f, g = 0; f = gvjs__$[g]; g++) {
+    var h = a;
+    var k = f;
+    var l = !!c;
+    k = gvjs_7h(h) ? h.EC(k, l) : h ? (h = gvjs_hi(h)) ? h.EC(k, l) : [] : [];
+    for (h = 0; l = k[h]; h++) {
+      var m = l.listener;
+      if (m.Bt == b && m.dwa == d) {
+        e ? e.Ab(a, f, l.listener, c, d) : gvjs_ji(a, f, l.listener, c, d);
+        break
+      }
+    }
+  }
+}
+;
+function gvjs_0$(a) {
+  gvjs_MC.call(this, a);
+  this.Fx = new gvjs_n8(this.ps,!0);
+  this.$q = new gvjs_fB;
+  this.$aa = 0;
+  this.f$ = []
+}
+gvjs_t(gvjs_0$, gvjs_MC);
+gvjs_ = gvjs_0$.prototype;
+gvjs_.ps = "jfk-bubble";
+gvjs_.b4 = !0;
+gvjs_.JH = !1;
+gvjs_.hL = function(a) {
+  this.Fx.hL(a);
+  this.Mf()
+}
+;
+gvjs_.setPosition = function(a, b, c, d, e) {
+  this.Fx.XM = !!e;
+  this.Fx.setPosition(a, b, c, d)
+}
+;
+gvjs_.Xr = function(a) {
+  this.f$.push(a)
+}
+;
+gvjs_.setContent = function(a) {
+  this.Wi = a;
+  gvjs_Nxa(this, a)
+}
+;
+function gvjs_Nxa(a, b) {
+  a = a.ib();
+  b && a && (typeof b === gvjs_l ? gvjs_th(a, b) : b instanceof gvjs_rq ? (b = gvjs_wy(b),
+    gvjs_cg(a, b)) : b instanceof gvjs_Zf ? gvjs_cg(a, b) : (gvjs_cg(a, gvjs_9f),
+    a.appendChild(b)))
+}
+gvjs_.iT = function(a) {
+  this.$q.iT(a)
+}
+;
+gvjs_.iL = function(a) {
+  this.Fx.iL(a)
+}
+;
+gvjs_.qT = function(a) {
+  this.JH = a
+}
+;
+gvjs_.ib = function() {
+  return this.hd(this.ps + "-content-id")
+}
+;
+gvjs_.J = function() {
+  this.H = gvjs_LB(gvjs_Lxa, {
+    axa: this.b4,
+    uid: "bubble-" + gvjs_pe(this)
+  }, void 0, this.wa());
+  gvjs_Nxa(this, this.Wi);
+  gvjs_6(this.j(), !1);
+  this.$q.sA(this.j());
+  gvjs_Daa || this.$q.QE(gvjs_vM(this.j(), .218), gvjs_wM(this.j(), .218));
+  gvjs_WC(this.j(), this.f$)
+}
+;
+gvjs_.FT = function(a) {
+  this.Fx.FT(a)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_0$.G.Nb.call(this);
+  this.hc().o(this.$q, [gvjs_pt, gvjs_Sw, gvjs_ot, gvjs_1u], this.Jqa);
+  if (this.b4) {
+    var a = this.hc()
+      , b = this.hd(this.ps + "-closebtn-id")
+      , c = gvjs_re(this.setVisible, !1);
+    gvjs_Mxa.o(b, c, void 0, a.pd || a, a)
+  }
+  a = this.j();
+  b = this.hd(this.ps + "-arrow-id");
+  c = this.Fx;
+  c.Em = a;
+  c.XV = b;
+  this.$q.setPosition(this.Fx)
+}
+;
+gvjs_.setVisible = function(a) {
+  this.$q.setVisible(a)
+}
+;
+gvjs_.isVisible = function() {
+  return this.$q.isVisible()
+}
+;
+gvjs_.Mf = function() {
+  this.isVisible() && this.$q.Mf()
+}
+;
+gvjs_.M = function() {
+  this.$q.pa();
+  delete this.$q;
+  gvjs_0$.G.M.call(this)
+}
+;
+gvjs_.GI = function() {
+  var a = gvjs_zz(this.j());
+  this.$aa && a.y < this.$aa && this.setVisible(!1);
+  return !1
+}
+;
+gvjs_.Jqa = function(a) {
+  if (a.type == gvjs_Sw || a.type == gvjs_1u) {
+    var b = this.hc()
+      , c = this.wa();
+    c = gvjs_y ? c.Vj() : c.kc();
+    a.type == gvjs_Sw ? b.o(c, gvjs_Gw, this.GI) : b.Ab(c, gvjs_Gw, this.GI)
+  }
+  b = this.dispatchEvent(a.type);
+  this.JH && a.type == gvjs_1u && this.pa();
+  return b
+}
+;
+function gvjs_1$(a, b, c, d, e) {
+  d = d || (b ? gvjs_3g(gvjs_6g(document, b)) : gvjs_3g());
+  this.F = a;
+  a = d.kc().body;
+  var f = this.F.j();
+  a.appendChild(f);
+  gvjs_6(this.F.j(), !1);
+  this.className = gvjs_r8();
+  gvjs_jB.call(this, b, c, d);
+  gvjs_6x(this, this.F);
+  this.sA(this.F.j());
+  b = gvjs_vM(this.F.j(), .13);
+  c = gvjs_wM(this.F.j(), .13);
+  this.QE(b, c);
+  this.rG = new gvjs_n8(gvjs_r8(),!0);
+  this.rG.setPosition(null != e ? e : 1, void 0, void 0, -1);
+  e = this.rG;
+  b = this.F.j();
+  c = this.F.WV;
+  e.Em = b;
+  e.XV = c;
+  this.rG.iL(!0);
+  this.JT = 300
+}
+gvjs_t(gvjs_1$, gvjs_jB);
+gvjs_ = gvjs_1$.prototype;
+gvjs_.uP = function() {
+  this.rG.hL(this.Ly());
+  return this.rG
+}
+;
+gvjs_.ib = function() {
+  return this.F.ib()
+}
+;
+gvjs_.du = function(a) {
+  gvjs_th(this.ib(), a)
+}
+;
+gvjs_.BT = function(a) {
+  var b = this.ib();
+  gvjs_cg(b, a)
+}
+;
+gvjs_.dn = function() {
+  return gvjs_wh(this.ib())
+}
+;
+gvjs_.qP = function() {
+  return this.ib().innerHTML
+}
+;
+function gvjs_Oxa(a, b, c, d) {
+  c = c || (a ? gvjs_3g(gvjs_6g(document, a)) : gvjs_3g());
+  var e = new gvjs_q8(c);
+  gvjs_1$.call(this, e, a, b, c, d)
+}
+gvjs_o(gvjs_Oxa, gvjs_1$);
+function gvjs_2$(a) {
+  gvjs_F.call(this);
+  this.nc = a;
+  this.xa = new gvjs_Oxa(null,null,null,2);
+  this.UK = this.iz = this.Fm = this.Ge = this.Fe = null;
+  this.zQ = !1;
+  this.CU = this.GS = null
+}
+gvjs_o(gvjs_2$, gvjs_F);
+function gvjs_3$(a) {
+  a.Fm && (gvjs_li(a.Fm),
+    gvjs_kh(a.Fm),
+    a.Fm = null,
+    a.TW = null,
+  a.Ge && gvjs_h$(a.Ge),
+  a.Fe && (gvjs_kh(a.Fe.j()),
+    a.Fe = null),
+  a.UK && (gvjs_E(a.UK),
+    gvjs_li(a.UK),
+    a.zQ = !1),
+  a.GS && gvjs_u(a.GS, function(b) {
+    b && (gvjs_li(b),
+      gvjs_E(b))
+  }),
+    a.GS = null,
+    a.YC())
+}
+function gvjs_4$(a) {
+  a.iz && (gvjs_li(a.iz),
+    gvjs_kh(a.iz));
+  a.iz = null;
+  a.YC()
+}
+gvjs_ = gvjs_2$.prototype;
+gvjs_.M = function() {
+  gvjs_3$(this);
+  gvjs_4$(this);
+  gvjs_E(this.xa);
+  gvjs_E(this.Fe);
+  this.Ge = null;
+  gvjs_F.prototype.M.call(this)
+}
+;
+function gvjs_Pxa(a, b, c, d) {
+  var e = a.Fm;
+  e && (e.parentElement || d.appendChild(e),
+    d = gvjs_L$(b, !1),
+    c = c.getOption(gvjs_Ws) || 0,
+    gvjs_5$(a, e, d),
+    gvjs_pl(function() {
+      if (a.Fm) {
+        var f = gvjs_L$(b, !1);
+        gvjs_5$(a, e, f);
+        a.Fe && a.Fe.Mf()
+      }
+    }, c))
+}
+gvjs_.fC = function() {
+  this.nc.dispatchEvent(gvjs_N6)
+}
+;
+function gvjs_Qxa(a, b, c, d) {
+  var e = a.Fe.j()
+    , f = gvjs_Oh()
+    , g = f.hd("google-visualization-clickeditor-resize", e);
+  e = f.hd("google-visualization-clickeditor-fit-area", e);
+  if (g && e) {
+    f = new gvjs_q9(null,void 0,1);
+    var h = new gvjs_q9(null,void 0,1);
+    f.fb(g);
+    h.fb(e);
+    a.GS = [f, h];
+    gvjs_G(f, gvjs_Ss, a.Pqa.bind(a, b, c, d));
+    gvjs_G(h, gvjs_Ss, function() {
+      gvjs_oxa(c, null);
+      a.fC()
+    })
+  }
+}
+gvjs_.Pqa = function(a, b, c) {
+  var d = this;
+  this.Fe && this.Fe.setVisible(!1);
+  a = gvjs_fxa(a);
+  if (!(!a || 2 > a.width || 2 > a.height)) {
+    gvjs_E(this.UK);
+    var e = this.UK = new gvjs_W$(c);
+    gvjs_Kxa(e, gvjs_P$(a));
+    var f = this.Fm;
+    gvjs_G(e, gvjs_2, function() {
+      d.zQ = !0;
+      gvjs_4$(d)
+    });
+    gvjs_G(e, gvjs_vw, function() {
+      var g = gvjs_Jxa(e);
+      gvjs_oxa(b, g);
+      b.ba(gvjs_Ws, 0);
+      b.draw();
+      f && g && gvjs_5$(d, f, gvjs_P$(g))
+    });
+    gvjs_G(e, gvjs_R, function() {
+      b.ba(gvjs_Ws, null);
+      d.zQ = !1;
+      d.fC()
+    })
+  }
+}
+;
+gvjs_.Ln = function(a, b) {
+  var c = this
+    , d = a.xI();
+  d && this.TW && !this.TW.equals(a) && (this.xa.du(d),
+    gvjs_ZC(this.xa.j(), "google-visualization-clickeditor-tooltip", !0),
+    gvjs_7sa(this.xa, b),
+    this.CU = gvjs_pl(function() {
+      c.YC()
+    }, 3E3))
+}
+;
+function gvjs_Rxa(a, b) {
+  gvjs_G(a.iz, gvjs_Wt, function(c) {
+    var d = {
+      type: gvjs_Wt,
+      targetID: b.getName(),
+      x: 0,
+      y: 0
+    };
+    a.nc.dispatchEvent(d);
+    c.stopPropagation();
+    c.preventDefault()
+  });
+  gvjs_G(a.iz, gvjs_3t, function(c) {
+    var d = gvjs_Az(c, c.target.parentNode.parentNode);
+    d = gvjs_exa(b, d);
+    a.nc.dispatchEvent(d);
+    c.stopPropagation();
+    c.preventDefault()
+  })
+}
+function gvjs_Sxa(a, b) {
+  gvjs_G(a.Fm, gvjs_3t, function(c) {
+    var d = gvjs_Az(c, c.target.parentNode.parentNode);
+    d = gvjs_exa(b, d);
+    a.nc.dispatchEvent(d);
+    c.stopPropagation();
+    c.preventDefault()
+  })
+}
+gvjs_.YC = function() {
+  this.CU && gvjs_ql(this.CU);
+  this.CU = null;
+  this.xa.setVisible(!1)
+}
+;
+function gvjs_5$(a, b, c) {
+  b && c ? gvjs_6$(b, c) : gvjs_3$(a)
+}
+function gvjs_6$(a, b) {
+  gvjs_Bz(a, b.width);
+  a.style.height = gvjs_rz(b.height, !0);
+  gvjs_sz(a, b.left, b.top)
+}
+;function gvjs_7$() {
+  gvjs_KA.call(this);
+  gvjs_6va();
+  this.AX = this.zs = this.oa = this.Sx = this.aa = this.da = null;
+  this.a4 = !1;
+  this.UI = this.Hk = this.Ge = this.Aq = this.nc = this.oi = this.LQ = null;
+  this.ql = !1;
+  this.b6 = this.a6 = null
+}
+gvjs_o(gvjs_7$, gvjs_KA);
+gvjs_ = gvjs_7$.prototype;
+gvjs_.Dla = function() {
+  this.Aq && (gvjs_u(this.Aq, function(b) {
+    gvjs_ui(b)
+  }),
+    gvjs_Fy(this.Aq));
+  gvjs_E(this.Hk);
+  gvjs_E(this.oi);
+  var a = gvjs_8$(this);
+  a && gvjs_hh(a);
+  this.b6 = this.a6 = this.Ge = this.aa = null;
+  this.removeAll();
+  this.ql = !1;
+  gvjs_0ua()
+}
+;
+gvjs_.aQ = function() {
+  this.oi && (gvjs_3$(this.oi),
+    this.Sx = null,
+    gvjs_4$(this.oi),
+    this.UI = null);
+  this.Hk && this.Hk.Ov()
+}
+;
+gvjs_.draw = function(a, b) {
+  var c = this.aa && this.aa.toJSON() || "{}"
+    , d = a && a.toJSON() || "{}"
+    , e = gvjs_8$(this, a)
+    , f = this.AX
+    , g = e ? gvjs_Dz(e) : null;
+  e = f && g && f.width == g.width && f.height == g.height;
+  c = gvjs_Li(c);
+  d = gvjs_Li(d);
+  gvjs_Txa(c, f);
+  gvjs_Txa(d, g);
+  f = gvjs_Uz(c, d);
+  e && f ? gvjs_I(this, gvjs_i, null) : (this.aa ? (b = a.zf(),
+    this.aa.setOptions(a.Zc()),
+    this.aa.cc(a.Va()),
+    this.aa.yh(a.cf),
+    this.aa.zh(a.mb()),
+    this.aa.C3(a.iZ()),
+  b && this.aa.jT(b),
+    gvjs_Uxa(this)) : (this.aa = a.clone(),
+    this.ql = "view" == this.aa.getOption("mode"),
+    gvjs_Uxa(this),
+    this.LQ = null,
+    this.oa = new gvjs_H$(b || {}),
+    gvjs_yta(23).cd(),
+    this.nc = new gvjs_H,
+    a = this.oa.wsa,
+    gvjs_0ua(),
+    gvjs_Zua = a,
+    this.Aq = [],
+    gvjs_E(this.Hk),
+    this.Hk = new gvjs_S$(this.aa,this.nc,this.oa),
+    gvjs_wxa(this.Hk, this.ql),
+    gvjs_E(this.oi),
+    this.oi = new gvjs_2$(this.nc),
+    this.Ge = null,
+  this.oa.vba && gvjs_t8(),
+    gvjs_Vxa(this),
+    a = this.nc,
+    this.o(a, gvjs_N6, this.GO),
+    this.o(a, "showmenu", this.aQ),
+    this.o(a, "editentity", this.Ypa),
+    this.o(a, "viewmode", this.Efa.bind(this, !1)),
+    this.o(a, "editmode", this.Efa.bind(this, !0)),
+    this.o(a, "undo", gvjs_re(gvjs_I, this, "undo", null)),
+    this.o(a, gvjs_Y6, gvjs_re(gvjs_I, this, gvjs_Y6, null)),
+    this.o(a, gvjs_Wt, this.WZ),
+    this.o(a, gvjs_Aw, this.paa)),
+    this.GO())
+}
+;
+gvjs_.zf = function() {
+  return this.aa ? this.aa.zf() : null
+}
+;
+gvjs_.My = function() {
+  if (this.aa) {
+    var a = this.aa.clone();
+    gvjs_9$(this, a, !1);
+    this.oa.wna && gvjs_qxa(a.getOption(gvjs_Mt), this.AX);
+    return a
+  }
+  return null
+}
+;
+function gvjs_9$(a, b, c) {
+  c ? (b.ba(gvjs_yu, gvjs_Mw),
+    b.ba(gvjs_qx, gvjs_f)) : (b.ba(gvjs_yu, a.a6),
+    b.ba(gvjs_qx, a.b6))
+}
+gvjs_.Efa = function(a) {
+  if (this.ql = !a)
+    this.aQ(),
+      this.aa.jT(null),
+    this.da && gvjs_vi(this.da);
+  gvjs_9$(this, this.aa, !this.ql);
+  this.da = null;
+  gvjs_T$(this.Hk, !this.ql);
+  this.GO()
+}
+;
+function gvjs_Vxa(a) {
+  var b = a.aa;
+  b && (a.Ax(b, gvjs_i, function() {
+    gvjs_$$(a, gvjs_i)
+  }),
+    a.Ax(b, gvjs_Rb, function() {
+      gvjs_$$(a, gvjs_Rb)
+    }))
+}
+function gvjs_$$(a, b) {
+  try {
+    var c = a.aa;
+    if (c.getOption(gvjs_I5)) {
+      c.ba(gvjs_I5, null);
+      var d = !1
+    } else
+      b == gvjs_Rb && c.getOption("animation") && typeof c.zf === gvjs_d && c.zf() ? (c.zf().Jb(),
+        c.ba(gvjs_I5, !0),
+        a.GO(),
+        d = !0) : d = !1;
+    if (!(d || a.oi && a.oi.zQ)) {
+      gvjs_I(a, b, null);
+      a.a4 && gvjs_I(a, gvjs_Kt, null);
+      a.a4 = !0;
+      var e = a.aa.zf()
+        , f = a.zs;
+      if (b == gvjs_Rb || null === e || null === f || null === a.aa) {
+        a.aQ();
+        a.aa && a.aa.jT(null);
+        a.da && gvjs_vi(a.da);
+        a.da = null;
+        var g = !0
+      } else
+        g = !1;
+      if (!g && !a.ql) {
+        var h = a.UP();
+        var k = a.aa.zf();
+        if (a.da != k) {
+          a.da && gvjs_vi(a.da);
+          a.da = k;
+          gvjs_Wxa(a);
+          var l = !0
+        } else
+          l = !1;
+        var m = a.bJ(l, h)
+          , n = gvjs_8$(a);
+        a.AX = n ? gvjs_Dz(n) : null;
+        a.Hk.Ov();
+        gvjs_4$(a.oi);
+        a.UI = null;
+        var p = a.Sx;
+        if (!m && p) {
+          var q = a.oi;
+          q.Ge && q.Fm && q.Ge.uc.update();
+          gvjs_Pxa(a.oi, p, a.aa, gvjs_8$(a))
+        } else
+          gvjs_3$(a.oi),
+            a.Sx = null
+      }
+    }
+  } catch (r) {
+    d = gvjs_8$(a),
+      b = r && r.message || gvjs_Rb,
+      d = (0,
+        gvjs_D.Sc)(d, b),
+      gvjs_I(a, gvjs_Rb, {
+        id: d,
+        message: b
+      })
+  }
+}
+function gvjs_Wxa(a) {
+  var b = a.da
+    , c = a.aa.Va();
+  gvjs_$.bU[c] && null != b && (c = gvjs_8$(a),
+    a.Ax(b, gvjs_Wt, a.WZ.bind(a)),
+    a.Ax(b, gvjs_5v, a.$pa.bind(a)),
+    a.Ax(b, gvjs_Aw, a.paa.bind(a)),
+    a.o(c, gvjs_3t, function(d) {
+      d.preventDefault()
+    }))
+}
+gvjs_.Ax = function(a, b, c) {
+  a = gvjs_oi(a, b, c);
+  this.Aq.push(a)
+}
+;
+function gvjs_8$(a, b) {
+  b = void 0 !== b ? b : a.aa;
+  return gvjs_pxa(b)
+}
+gvjs_.Ypa = function(a) {
+  this.WZ(a)
+}
+;
+gvjs_.WZ = function(a) {
+  gvjs_I(this, gvjs_Wt, a);
+  this.Hk.Ov();
+  a = new gvjs_K$(this.da,a,this.oa);
+  if (!a.equals(this.Sx))
+    if (this.Sx = a,
+      gvjs_L$(a, !1)) {
+      gvjs_U$(this.Hk, "");
+      var b = this.oi;
+      a = this.Sx;
+      var c = this.aa
+        , d = gvjs_8$(this);
+      gvjs_3$(b);
+      gvjs_4$(b);
+      b.TW = a;
+      var e = b.Fm = gvjs_LB(gvjs_Vva, {
+        Qba: gvjs_mxa(a),
+        Lba: !0
+      });
+      gvjs_Sxa(b, a);
+      d.appendChild(e);
+      var f = gvjs_L$(a, !1);
+      if (f) {
+        gvjs_6$(e, f);
+        if (e = gvjs_jxa(a, c, gvjs_$9(b.Ge))) {
+          if (!b.Fe) {
+            f = new gvjs_0$;
+            f.qT(!1);
+            f.iT(!1);
+            f.b4 = !1;
+            f.setPosition(2, 2);
+            f.iL(!0);
+            f.R();
+            var g = f.j();
+            gvjs_VC(g, "google-visualization-clickeditor-bubble");
+            var h = gvjs_i7() ? gvjs_Up : gvjs_Dv;
+            gvjs_8g(g, {
+              dir: h
+            });
+            b.Fe = f;
+            f = f.ib();
+            gvjs__ua(f)
+          }
+          f = b.Fe;
+          f.hL(b.Fm);
+          f.setContent(e);
+          f.setVisible(!0);
+          gvjs_89(b.Ge, b.Fe.j());
+          gvjs_Qxa(b, a, c, d)
+        }
+        b.Ge && b.Fm && b.Ge.uc.update();
+        b.Fe && b.Fe.Mf();
+        b = null;
+        switch (a.getType()) {
+          case gvjs_Xu:
+            b = gvjs_O$(a) ? gvjs_Hra : null;
+            break;
+          case gvjs_Ud:
+            b = gvjs_O$(a) ? gvjs_Ira : null;
+            break;
+          case gvjs_fx:
+            b = gvjs_Fra
+        }
+        a = b;
+        (a = gvjs_Oh().j(a)) && a.tagName == gvjs_Na && (a.focus(),
+          a.select())
+      }
+    } else
+      gvjs_3$(this.oi),
+        this.Sx = null
+}
+;
+gvjs_.paa = function(a) {
+  a = new gvjs_K$(this.da,a,this.oa);
+  var b = gvjs_ez(a.lc, gvjs_vz(gvjs_8$(this)));
+  this.Hk.c4(b, a)
+}
+;
+gvjs_.$pa = function(a) {
+  gvjs_I(this, gvjs_5v, a);
+  a = new gvjs_K$(this.da,a,this.oa);
+  if (!a.equals(this.UI))
+    if (this.UI = a,
+      gvjs_L$(a, !0)) {
+      var b = this.oi
+        , c = gvjs_8$(this);
+      gvjs_4$(b);
+      var d = gvjs_mxa(a);
+      d = b.iz = gvjs_LB(gvjs_Vva, {
+        Qba: d,
+        Lba: !d
+      });
+      gvjs_Rxa(b, a);
+      c.appendChild(d);
+      if (c = gvjs_L$(a, !0))
+        gvjs_6$(d, c),
+          b.Ln(a, d)
+    } else
+      gvjs_4$(this.oi),
+        this.UI = null
+}
+;
+gvjs_.UP = function() {
+  var a = this.zs;
+  if (a)
+    for (var b = a.$(), c = 0; c < b; c++) {
+      var d = a.Rj(c);
+      d && gvjs_Py(d) && a.lT && a.lT(c, void 0)
+    }
+  a = a && a.toJSON() || "";
+  b = this.LQ ? this.LQ != a : !0;
+  this.LQ = a;
+  return b
+}
+;
+gvjs_.GO = function() {
+  var a = this;
+  gvjs_Xxa(this);
+  var b = this.aa
+    , c = b.mb();
+  null != c ? gvjs_Yxa(this, c) : b.nr(function(d) {
+    a.aa && (d.Xk() ? gvjs_$$(a, gvjs_Rb) : (d = d.mb(),
+    null != d && gvjs_Yxa(a, d)))
+  })
+}
+;
+function gvjs_Yxa(a, b) {
+  a.zs = b;
+  var c = a.aa;
+  a.A1(c, b);
+  var d = a.aa.Va();
+  b = a.Hk;
+  d = !!gvjs_$.bU[d];
+  b.YP && (b.Mv && b.Mv.Gb(d),
+  b.ft && b.ft.Gb(d),
+    d ? gvjs_T$(b, !b.ql) : gvjs_U$(b, "Quick edit unavailable for this chart type"));
+  gvjs_yxa(a.Hk);
+  c.draw()
+}
+function gvjs_Uxa(a) {
+  a.a6 = a.aa.getOption(gvjs_yu);
+  a.b6 = a.aa.getOption(gvjs_qx);
+  gvjs_9$(a, a.aa, !a.ql && gvjs_$.bU[a.aa.Va()]);
+  gvjs_Xxa(a);
+  a.a4 = !1
+}
+gvjs_.bJ = function(a, b) {
+  var c = this.aa
+    , d = this.zs
+    , e = null === this.Ge;
+  e && (this.Ge = new gvjs_79(!0));
+  var f = !1;
+  if (e || a || b)
+    f = !0,
+      a = this.Ge,
+      gvjs_h$(a),
+      b = new gvjs_$7(d,c,this.oa.vo()),
+      a.init(null, c, this.nc, this.oa, d, b),
+      this.oi.Ge = this.Ge;
+  c = this.Hk;
+  a = c.zh;
+  b = gvjs_wwa(this.Ge);
+  e = this.Ge;
+  var g = [], h;
+  gvjs_$.GU[gvjs_d$(e)] && (e.Hq() || e.wQ()) && (h = e.aa.getOption(gvjs_56));
+  for (var k = gvjs_$9(e), l = 0, m = 0; m < k; m++)
+    if (h && h[m]) {
+      var n = h[m].mD || "Trendline " + m;
+      if (n) {
+        n = e.D.J(gvjs_6a, {}, n);
+        gvjs_e$(e, n);
+        var p = h[m].color
+          , q = gvjs_V7(e.aa, m);
+        (p = p || gvjs_5F(q).jh) && (n = e.D.J(gvjs_b, gvjs_Y, e.D.J(gvjs_b, {
+          "class": gvjs_Rra,
+          style: gvjs_vb + p
+        }), n));
+        g[l] = n;
+        l += 1
+      }
+    }
+  a.call(c, d, b, g);
+  return f
+}
+;
+function gvjs_Txa(a, b) {
+  a.options = a.options || {};
+  gvjs_u([gvjs_Ws, gvjs_yu, gvjs_qx], function(c) {
+    c = "options." + c;
+    gvjs_q(c, {}, a);
+    gvjs_q(c, null, a)
+  });
+  gvjs_qxa(a.options.chartArea, b)
+}
+gvjs_.A1 = function(a, b) {
+  gvjs_5ta(a, b, this.oa.vo())
+}
+;
+function gvjs_Xxa(a) {
+  if (null == a.aa)
+    throw Error("ChartWrapper must be passed");
+  if (!gvjs_8$(a))
+    throw Error("ChartWrapper must have a valid container id");
+}
+;gvjs_q("google.visualization.ChartEditor", gvjs_z$, void 0);
+gvjs_q("google.visualization.ChartEditor.getSupportedChartTypes", function() {
+  return gvjs_Le(gvjs_j$)
+}, void 0);
+gvjs_z$.prototype.openDialog = gvjs_z$.prototype.openDialog;
+gvjs_z$.prototype.getChartWrapper = gvjs_z$.prototype.My;
+gvjs_z$.prototype.setChartWrapper = gvjs_z$.prototype.wfa;
+gvjs_z$.prototype.closeDialog = gvjs_z$.prototype.UW;
+gvjs_z$.prototype.minimize = gvjs_z$.prototype.f1;
+gvjs_z$.prototype.maximize = gvjs_z$.prototype.LJ;
+gvjs_z$.prototype.getDialogPosition = gvjs_z$.prototype.oZ;
+gvjs_z$.prototype.useSampleData = gvjs_z$.prototype.kx;
+gvjs_q("google.visualization.ClickEditor", gvjs_7$, void 0);
+gvjs_7$.prototype.clearEditor = gvjs_7$.prototype.Dla;
+gvjs_7$.prototype.hideEditor = gvjs_7$.prototype.aQ;
+gvjs_7$.prototype.draw = gvjs_7$.prototype.draw;
+gvjs_7$.prototype.getChart = gvjs_7$.prototype.zf;
+gvjs_7$.prototype.getChartWrapper = gvjs_7$.prototype.My;
+gvjs_q("google.visualization.ClickEditor.fillEmptyTitles", function(a) {
+  gvjs_u(["", gvjs_E6, gvjs_96], function(b) {
+    gvjs_jf(gvjs_gg(a.getOption(b + gvjs_fx))) && gvjs_nxa(a, b)
+  });
+  a.ba(gvjs_ix, {
+    fontSize: 16
+  })
+}, void 0);
+gvjs_z$.prototype.draw = gvjs_z$.prototype.draw;
+gvjs_z$.prototype.getAllChartTypes = gvjs_z$.prototype.xoa;
+gvjs_z$.prototype.getChartTypes = gvjs_z$.prototype.K$;
+gvjs_z$.prototype.clearEditorState = gvjs_z$.prototype.Ela;
+gvjs_z$.prototype.getChartSpecification = gvjs_z$.prototype.zoa;

--- a/cypress/fixtures/charts/jsapi_compiled_controls_module
+++ b/cypress/fixtures/charts/jsapi_compiled_controls_module
@@ -1,0 +1,4615 @@
+var gvjs_YN = "Invalid state: should be an array of values."
+  , gvjs_ZN = "No valid DataTable received from draw()"
+  , gvjs__N = "Start and end points must be 2D"
+  , gvjs_0N = "goog-combobox-active"
+  , gvjs_1N = "goog-flat-button"
+  , gvjs_2N = "goog-link-button"
+  , gvjs_3N = "aside"
+  , gvjs_4N = "belowStacked"
+  , gvjs_5N = "blockIncrement"
+  , gvjs_6N = "google-visualization-controls-rangefilter"
+  , gvjs_7N = "placeholder"
+  , gvjs_8N = "rangechange"
+  , gvjs_9N = "uichange"
+  , gvjs_$N = "useFormattedValue"
+  , gvjs_aO = "yy/MM/dd hh:mma";
+gvjs_iL.prototype.pZ = gvjs_V(71, function() {
+  return this.ab
+});
+gvjs__C.prototype.pq = gvjs_V(58, function(a) {
+  this.bB = a
+});
+gvjs_1E.prototype.pq = gvjs_V(57, function(a) {
+  this.bB = a
+});
+gvjs_rB.prototype.xA = gvjs_V(53, function() {});
+gvjs_PB.prototype.xA = gvjs_V(52, function(a, b) {
+  a.setAttribute("y", b)
+});
+gvjs_TB.prototype.xA = gvjs_V(51, function(a, b) {
+  a.style.top = this.Ub(b)
+});
+gvjs_rB.prototype.tA = gvjs_V(50, function() {});
+gvjs_PB.prototype.tA = gvjs_V(49, function(a, b) {
+  a.setAttribute("x", b)
+});
+gvjs_TB.prototype.tA = gvjs_V(48, function(a, b) {
+  a.style.left = this.Ub(b)
+});
+gvjs_F.prototype.fh = gvjs_V(11, function() {
+  return this.xf
+});
+function gvjs_bO(a) {
+  return new gvjs_z(a.offsetLeft,a.offsetTop)
+}
+function gvjs_cO(a) {
+  for (var b = 0, c = arguments.length; b < c; ++b) {
+    var d = arguments[b];
+    gvjs_ne(d) ? gvjs_cO.apply(null, d) : gvjs_E(d)
+  }
+}
+function gvjs_dO(a) {
+  gvjs_F.call(this);
+  this.ma = a;
+  this.ea = new gvjs_KA(this)
+}
+gvjs_t(gvjs_dO, gvjs_F);
+gvjs_ = gvjs_dO.prototype;
+gvjs_.M = function() {
+  this.clear();
+  gvjs_dO.G.M.call(this)
+}
+;
+gvjs_.clear = function() {
+  this.ea.removeAll();
+  gvjs_E(this.ea);
+  gvjs_hh(this.ma)
+}
+;
+gvjs_.getContainer = function() {
+  return this.ma
+}
+;
+gvjs_.addEventListener = function(a, b, c, d, e) {
+  e ? gvjs_LA(this.ea, a, b, c, d, e) : this.ea.o(a, b, c, d)
+}
+;
+gvjs_.draw = function() {}
+;
+gvjs_.getState = function() {
+  return {}
+}
+;
+function gvjs_eO(a) {
+  gvjs_Qn.call(this, a);
+  this.q9 = [];
+  this.Tv = this.K = this.R5 = this.$L = this.Rc = this.m = this.su = this.ra = null
+}
+gvjs_o(gvjs_eO, gvjs_Qn);
+gvjs_ = gvjs_eO.prototype;
+gvjs_.M = function() {
+  this.clear();
+  gvjs_Qn.prototype.M.call(this)
+}
+;
+gvjs_.clear = function() {
+  this.He()
+}
+;
+gvjs_.He = function() {
+  this.$L && (gvjs_ui(this.$L),
+    gvjs_E(this.$L),
+    this.$L = null);
+  gvjs_E(this.Rc);
+  this.Rc = null;
+  gvjs_hh(this.container)
+}
+;
+gvjs_.mb = function() {
+  return this.ra
+}
+;
+gvjs_.Zc = function() {
+  return this.m
+}
+;
+gvjs_.og = function() {
+  return {}
+}
+;
+gvjs_.Xl = function(a, b) {
+  return gvjs_my(b, "ui", {})
+}
+;
+gvjs_.vv = function() {
+  return ""
+}
+;
+gvjs_.zfa = function(a) {
+  this.q9 = a
+}
+;
+gvjs_.nP = function() {
+  return this.q9
+}
+;
+gvjs_.Mt = function() {}
+;
+gvjs_.getState = function() {
+  return this.K ? gvjs_Li(gvjs_Ii(this.K)) : null
+}
+;
+gvjs_.draw = function(a, b, c) {
+  gvjs_Kk(a);
+  this.ra = a;
+  this.su = b || {};
+  this.R5 = c || {};
+  gvjs_Zg(this.Hg, this.D9, this)
+}
+;
+gvjs_.Rd = function() {}
+;
+gvjs_.D9 = function() {
+  if (this.ra) {
+    this.K = this.R5 || {};
+    if (!gvjs_r(this.K))
+      throw Error("Control state must be an object.");
+    this.Tv = this.Tv || this.K;
+    this.m = new gvjs_Aj([this.su, this.og() || {}]);
+    this.Mt(this.ra, this.m, this.K);
+    if (!this.Rc) {
+      var a = this.m.fa("ui.type", this.vv());
+      a = typeof a === gvjs_d ? new a(this.container) : (a = gvjs_Gm(a)) ? new a(this.container) : null;
+      this.Rc = a;
+      if (!this.Rc)
+        throw Error("Invalid UI instance.");
+      this.$L = gvjs_oi(this.Rc, gvjs_9N, this.Bya.bind(this))
+    }
+    this.Rc.draw(this.K, this.Xl(this.ra, this.m));
+    this.K = this.Rc.getState();
+    gvjs_I(this, gvjs_i, null)
+  }
+}
+;
+gvjs_.Bya = function(a) {
+  this.K = this.Rc.getState();
+  gvjs_I(this, gvjs_Hd, a)
+}
+;
+gvjs_.Gw = function() {
+  gvjs_Zg(this.Hg, this.Gva, this)
+}
+;
+gvjs_.Gva = function() {
+  this.Tv && (this.R5 = this.Tv,
+    this.D9())
+}
+;
+function gvjs_bia(a) {
+  if (a.altKey && !a.ctrlKey || a.metaKey || 112 <= a.keyCode && 123 >= a.keyCode)
+    return !1;
+  if (gvjs_$A(a.keyCode))
+    return !0;
+  switch (a.keyCode) {
+    case 18:
+    case 20:
+    case 93:
+    case 17:
+    case 40:
+    case 35:
+    case 27:
+    case 36:
+    case 45:
+    case 37:
+    case 224:
+    case 91:
+    case 144:
+    case 12:
+    case 34:
+    case 33:
+    case 19:
+    case 255:
+    case 44:
+    case 39:
+    case 145:
+    case 16:
+    case 38:
+    case 252:
+    case 224:
+    case 92:
+      return !1;
+    case 0:
+      return !gvjs_sg;
+    default:
+      return 166 > a.keyCode || 183 < a.keyCode
+  }
+}
+function gvjs_fO(a, b) {
+  var c = gvjs_Iy(a, b);
+  if (0 <= c)
+    return b;
+  c = -(c + 1);
+  if (0 == c)
+    return a[0];
+  if (c == a.length)
+    return gvjs_Ae(a);
+  var d = a[c - 1];
+  a = a[c];
+  return Math.abs(b - d) <= Math.abs(b - a) ? d : a
+}
+var gvjs_gO = {};
+function gvjs_hO() {
+  gvjs_0E.call(this);
+  this.cr = []
+}
+gvjs_t(gvjs_hO, gvjs_0E);
+gvjs_hO.prototype.add = function(a) {
+  gvjs_He(this.cr, a) || (this.cr.push(a),
+    gvjs_G(a, gvjs_vu, this.yda, !1, this))
+}
+;
+gvjs_hO.prototype.remove = function(a) {
+  gvjs_Ie(this.cr, a) && gvjs_ji(a, gvjs_vu, this.yda, !1, this)
+}
+;
+gvjs_hO.prototype.M = function() {
+  this.cr.forEach(function(a) {
+    a.pa()
+  });
+  this.cr.length = 0;
+  gvjs_hO.G.M.call(this)
+}
+;
+function gvjs_iO() {
+  gvjs_hO.call(this);
+  this.IY = 0
+}
+gvjs_t(gvjs_iO, gvjs_hO);
+gvjs_iO.prototype.play = function(a) {
+  if (0 == this.cr.length)
+    return !1;
+  if (a || this.Ef())
+    this.IY = 0,
+      this.jK();
+  else if (this.So())
+    return !1;
+  this.Jh("play");
+  -1 == this.K && this.Jh("resume");
+  var b = -1 == this.K && !a;
+  this.startTime = gvjs_se();
+  this.endTime = null;
+  this.K = 1;
+  this.cr.forEach(function(c) {
+    b && -1 != c.K || c.play(a)
+  });
+  return !0
+}
+;
+gvjs_iO.prototype.pause = function() {
+  this.So() && (this.cr.forEach(function(a) {
+    a.So() && a.pause()
+  }),
+    this.K = -1,
+    this.Jh("pause"))
+}
+;
+gvjs_iO.prototype.stop = function(a) {
+  this.cr.forEach(function(b) {
+    b.Ef() || b.stop(a)
+  });
+  this.K = 0;
+  this.endTime = gvjs_se();
+  this.Jh(gvjs__p);
+  this.Xz()
+}
+;
+gvjs_iO.prototype.yda = function() {
+  this.IY++;
+  this.IY == this.cr.length && (this.endTime = gvjs_se(),
+    this.K = 0,
+    this.Jh(gvjs_vu),
+    this.Xz())
+}
+;
+function gvjs_jO(a, b, c, d, e) {
+  gvjs_1E.call(this, b, c, d, e);
+  this.element = a
+}
+gvjs_t(gvjs_jO, gvjs_1E);
+gvjs_ = gvjs_jO.prototype;
+gvjs_.aB = gvjs_ke;
+gvjs_.gh = function() {
+  void 0 === this.gr && (this.gr = gvjs_Gz(this.element));
+  return this.gr
+}
+;
+gvjs_.M1 = function() {
+  this.aB();
+  gvjs_jO.G.M1.call(this)
+}
+;
+gvjs_.Xz = function() {
+  this.aB();
+  gvjs_jO.G.Xz.call(this)
+}
+;
+gvjs_.jK = function() {
+  this.aB();
+  gvjs_jO.G.jK.call(this)
+}
+;
+function gvjs_kO(a, b, c, d, e) {
+  if (2 != b.length || 2 != c.length)
+    throw Error(gvjs__N);
+  gvjs_jO.call(this, a, b, c, d, e)
+}
+gvjs_t(gvjs_kO, gvjs_jO);
+gvjs_kO.prototype.aB = function() {
+  var a = this.bB && this.gh() ? gvjs_j : gvjs_$c;
+  this.element.style[a] = Math.round(this.coords[0]) + gvjs_T;
+  this.element.style.top = Math.round(this.coords[1]) + gvjs_T
+}
+;
+function gvjs_lO(a, b, c, d, e) {
+  gvjs_jO.call(this, a, [b], [c], d, e)
+}
+gvjs_t(gvjs_lO, gvjs_jO);
+gvjs_lO.prototype.aB = function() {
+  this.element.style.width = Math.round(this.coords[0]) + gvjs_T
+}
+;
+function gvjs_mO(a, b, c, d, e) {
+  gvjs_jO.call(this, a, [b], [c], d, e)
+}
+gvjs_t(gvjs_mO, gvjs_jO);
+gvjs_mO.prototype.aB = function() {
+  this.element.style.height = Math.round(this.coords[0]) + gvjs_T
+}
+;
+function gvjs_nO() {
+  gvjs_H.call(this)
+}
+gvjs_t(gvjs_nO, gvjs_H);
+gvjs_ = gvjs_nO.prototype;
+gvjs_.$d = 0;
+gvjs_.$o = 0;
+gvjs_.pn = 100;
+gvjs_.Ll = 0;
+gvjs_.sj = 1;
+gvjs_.Wk = !1;
+gvjs_.Nz = !1;
+gvjs_.Wa = function(a) {
+  a = gvjs_oO(this, a);
+  this.$d != a && (this.$d = a + this.Ll > this.pn ? this.pn - this.Ll : a < this.$o ? this.$o : a,
+  this.Wk || this.Nz || this.dispatchEvent(gvjs_Kt))
+}
+;
+gvjs_.getValue = function() {
+  return gvjs_oO(this, this.$d)
+}
+;
+gvjs_.rT = function(a) {
+  a = gvjs_oO(this, a);
+  this.Ll != a && (this.Ll = 0 > a ? 0 : this.$d + a > this.pn ? this.pn - this.$d : a,
+  this.Wk || this.Nz || this.dispatchEvent(gvjs_Kt))
+}
+;
+gvjs_.Tl = function() {
+  var a = this.Ll;
+  return null == this.sj ? a : Math.round(a / this.sj) * this.sj
+}
+;
+gvjs_.Ow = function(a) {
+  if (this.$o != a) {
+    var b = this.Wk;
+    this.Wk = !0;
+    this.$o = a;
+    a + this.Ll > this.pn && (this.Ll = this.pn - this.$o);
+    a > this.$d && this.Wa(a);
+    a > this.pn && (this.Ll = 0,
+      this.bu(a),
+      this.Wa(a));
+    (this.Wk = b) || this.Nz || this.dispatchEvent(gvjs_Kt)
+  }
+}
+;
+gvjs_.lf = function() {
+  return gvjs_oO(this, this.$o)
+}
+;
+gvjs_.bu = function(a) {
+  a = gvjs_oO(this, a);
+  if (this.pn != a) {
+    var b = this.Wk;
+    this.Wk = !0;
+    this.pn = a;
+    a < this.$d + this.Ll && this.Wa(a - this.Ll);
+    a < this.$o && (this.Ll = 0,
+      this.Ow(a),
+      this.Wa(this.pn));
+    a < this.$o + this.Ll && (this.Ll = this.pn - this.$o);
+    (this.Wk = b) || this.Nz || this.dispatchEvent(gvjs_Kt)
+  }
+}
+;
+gvjs_.kf = function() {
+  return gvjs_oO(this, this.pn)
+}
+;
+gvjs_.vI = function() {
+  return this.sj
+}
+;
+gvjs_.ET = function(a) {
+  this.sj != a && (this.sj = a,
+    a = this.Wk,
+    this.Wk = !0,
+    this.bu(this.kf()),
+    this.rT(this.Tl()),
+    this.Wa(this.getValue()),
+  (this.Wk = a) || this.Nz || this.dispatchEvent(gvjs_Kt))
+}
+;
+function gvjs_oO(a, b) {
+  return null == a.sj ? b : a.$o + Math.round((b - a.$o) / a.sj) * a.sj
+}
+function gvjs_pO(a, b) {
+  gvjs_MC.call(this, a);
+  this.T6 = null;
+  this.Qe = new gvjs_nO;
+  this.Bsa = b || gvjs_ye;
+  this.ioa = !0;
+  gvjs_G(this.Qe, gvjs_Kt, this.zaa, !1, this)
+}
+gvjs_t(gvjs_pO, gvjs_MC);
+gvjs_ = gvjs_pO.prototype;
+gvjs_.tb = gvjs_S;
+gvjs_.uQ = !1;
+gvjs_.j1 = !1;
+gvjs_.Dm = 10;
+gvjs_.vR = 0;
+gvjs_.Gba = !0;
+gvjs_.bda = 0;
+gvjs_.aja = 1E3;
+gvjs_.kg = !0;
+gvjs_.Ml = !1;
+gvjs_.J = function() {
+  gvjs_pO.G.J.call(this);
+  var a = this.wa().J(gvjs_b, this.sa(this.tb));
+  this.vf(a)
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_pO.G.vf.call(this, a);
+  gvjs_VC(a, this.sa(this.tb));
+  a = this.j();
+  var b = this.wa().J(gvjs_b, "google-visualization-controls-slider-handle");
+  gvjs_VB(b, gvjs_Bt);
+  this.mC = b;
+  a.appendChild(this.mC);
+  this.Nd = gvjs_qO(this);
+  a.appendChild(this.Nd);
+  this.aj = gvjs_qO(this);
+  a.appendChild(this.aj);
+  a = this.j();
+  gvjs_VB(a, "slider");
+  gvjs_rO(this)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_pO.G.Nb.call(this);
+  this.xm = new gvjs__C(this.Nd);
+  this.qq = new gvjs__C(this.aj);
+  this.xm.pq(this.Ml);
+  this.qq.pq(this.Ml);
+  this.xm.ky = this.qq.ky = gvjs_ke;
+  this.Gf = new gvjs_uD(this.j());
+  gvjs_sO(this, !0);
+  this.j().tabIndex = 0;
+  gvjs_tO(this)
+}
+;
+function gvjs_sO(a, b) {
+  b ? (a.hc().o(a.xm, gvjs_nt, a.JP).o(a.qq, gvjs_nt, a.JP).o(a.xm, [gvjs_2, gvjs_R], a.Jv).o(a.qq, [gvjs_2, gvjs_R], a.Jv).o(a.Gf, gvjs_kv, a.gn).o(a.j(), gvjs_Wt, a.NP).o(a.j(), gvjs_gd, a.NP),
+  a.Gba && gvjs_uO(a, !0)) : (a.hc().Ab(a.xm, gvjs_nt, a.JP).Ab(a.qq, gvjs_nt, a.JP).Ab(a.xm, [gvjs_2, gvjs_R], a.Jv).Ab(a.qq, [gvjs_2, gvjs_R], a.Jv).Ab(a.Gf, gvjs_kv, a.gn).Ab(a.j(), gvjs_Wt, a.NP).Ab(a.j(), gvjs_gd, a.NP),
+  a.Gba && gvjs_uO(a, !1))
+}
+gvjs_.Le = function() {
+  gvjs_pO.G.Le.call(this);
+  gvjs_cO(this.xm, this.qq, this.Gf, this.qn)
+}
+;
+gvjs_.JP = function(a) {
+  var b = a.eY == this.xm ? this.Nd : this.aj;
+  if (this.tb == gvjs_U) {
+    var c = this.j().clientHeight - b.offsetHeight;
+    c = (c - a.top) / c * (this.kf() - this.lf()) + this.lf()
+  } else
+    c = this.j().clientWidth - b.offsetWidth,
+      c = a.left / c * (this.kf() - this.lf()) + this.lf();
+  c = a.eY == this.xm ? Math.min(Math.max(c, this.lf()), this.getValue() + this.Tl()) : Math.min(Math.max(c, this.getValue()), this.kf());
+  gvjs_vO(this, b, c)
+}
+;
+gvjs_.Jv = function(a) {
+  var b = a.type == gvjs_2;
+  gvjs_ZC(this.j(), "goog-slider-dragging", b);
+  gvjs_ZC(a.target.SC, "goog-slider-thumb-dragging", b);
+  a = a.eY == this.xm;
+  b ? (this.dispatchEvent("e"),
+    this.dispatchEvent(a ? "a" : "c")) : (this.dispatchEvent("f"),
+    this.dispatchEvent(a ? "b" : "d"))
+}
+;
+gvjs_.gn = function(a) {
+  var b = !0;
+  switch (a.keyCode) {
+    case 36:
+      gvjs_wO(this, this.lf());
+      break;
+    case 35:
+      gvjs_wO(this, this.kf());
+      break;
+    case 33:
+      gvjs_xO(this, this.Dm);
+      break;
+    case 34:
+      gvjs_xO(this, -this.Dm);
+      break;
+    case 37:
+      var c = this.Ml && this.gh() ? 1 : -1;
+      gvjs_xO(this, a.shiftKey ? c * this.Dm : c * this.ZA);
+      break;
+    case 40:
+      gvjs_xO(this, a.shiftKey ? -this.Dm : -this.ZA);
+      break;
+    case 39:
+      c = this.Ml && this.gh() ? -1 : 1;
+      gvjs_xO(this, a.shiftKey ? c * this.Dm : c * this.ZA);
+      break;
+    case 38:
+      gvjs_xO(this, a.shiftKey ? this.Dm : this.ZA);
+      break;
+    default:
+      b = !1
+  }
+  b && a.preventDefault()
+}
+;
+gvjs_.NP = function(a) {
+  this.ioa && this.j().focus && this.j().focus();
+  var b = a.target;
+  gvjs_rh(this.Nd, b) || gvjs_rh(this.aj, b) || (b = a.type == gvjs_Wt,
+  b && Date.now() < this.bda + this.aja || (b || (this.bda = Date.now()),
+    this.j1 ? gvjs_wO(this, gvjs_yO(this, a)) : (this.O4(a),
+      this.On = gvjs_zO(this, gvjs_yO(this, a)),
+      this.lba = this.tb == gvjs_U ? this.Bz < this.On.offsetTop : this.Bz > gvjs_AO(this, this.On) + this.On.offsetWidth,
+      a = gvjs_5g(this.j()),
+      this.hc().o(a, gvjs_md, this.M4, !0).o(this.j(), gvjs_jd, this.O4),
+    this.Sv || (this.Sv = new gvjs_IA(200),
+      this.hc().o(this.Sv, gvjs_dx, this.Faa)),
+      this.Faa(),
+      this.Sv.start())))
+}
+;
+gvjs_.vaa = function(a) {
+  gvjs_xO(this, (0 < a.detail ? -1 : 1) * this.ZA);
+  a.preventDefault()
+}
+;
+gvjs_.Faa = function() {
+  var a;
+  if (this.tb == gvjs_U) {
+    var b = this.Bz
+      , c = this.On.offsetTop;
+    this.lba ? b < c && (a = gvjs_BO(this, this.On) + this.Dm) : b > c + this.On.offsetHeight && (a = gvjs_BO(this, this.On) - this.Dm)
+  } else
+    b = this.Bz,
+      c = gvjs_AO(this, this.On),
+      this.lba ? b > c + this.On.offsetWidth && (a = gvjs_BO(this, this.On) + this.Dm) : b < c && (a = gvjs_BO(this, this.On) - this.Dm);
+  void 0 !== a && gvjs_vO(this, this.On, a)
+}
+;
+gvjs_.M4 = function() {
+  this.Sv && this.Sv.stop();
+  var a = gvjs_5g(this.j());
+  this.hc().Ab(a, gvjs_md, this.M4, !0).Ab(this.j(), gvjs_jd, this.O4)
+}
+;
+function gvjs_CO(a, b) {
+  b = gvjs_Az(b, a.j());
+  return a.tb == gvjs_U ? b.y : a.Ml && a.gh() ? a.j().clientWidth - b.x : b.x
+}
+gvjs_.O4 = function(a) {
+  this.Bz = gvjs_CO(this, a)
+}
+;
+function gvjs_yO(a, b) {
+  var c = a.lf()
+    , d = a.kf();
+  if (a.tb == gvjs_U) {
+    var e = a.Nd.offsetHeight
+      , f = a.j().clientHeight - e;
+    a = gvjs_CO(a, b) - e / 2;
+    return (d - c) * (f - a) / f + c
+  }
+  e = a.Nd.offsetWidth;
+  f = a.j().clientWidth - e;
+  a = gvjs_CO(a, b) - e / 2;
+  return (d - c) * a / f + c
+}
+function gvjs_BO(a, b) {
+  if (b == a.Nd)
+    return a.Qe.getValue();
+  if (b == a.aj)
+    return a.Qe.getValue() + a.Qe.Tl();
+  throw Error("Illegal thumb element. Neither minThumb nor maxThumb");
+}
+function gvjs_xO(a, b) {
+  Math.abs(b) < a.vI() && (b = gvjs_$y(b) * a.vI());
+  var c = gvjs_BO(a, a.Nd) + b;
+  b = gvjs_BO(a, a.aj) + b;
+  c = gvjs_0g(c, a.lf(), a.kf() - a.vR);
+  b = gvjs_0g(b, a.lf() + a.vR, a.kf());
+  gvjs_DO(a, c, b - c)
+}
+function gvjs_vO(a, b, c) {
+  var d = gvjs_oO(a.Qe, c);
+  c = b == a.Nd ? d : a.Qe.getValue();
+  b = b == a.aj ? d : a.Qe.getValue() + a.Qe.Tl();
+  c >= a.lf() && b >= c + a.vR && a.kf() >= b && gvjs_DO(a, c, b - c)
+}
+function gvjs_DO(a, b, c) {
+  a.lf() <= b && b <= a.kf() - c && a.vR <= c && c <= a.kf() - b && (b != a.getValue() || c != a.Tl()) && (a.Qe.Nz = !0,
+    a.Qe.rT(0),
+    a.Qe.Wa(b),
+    a.Qe.rT(c),
+    a.Qe.Nz = !1,
+    a.zaa(null))
+}
+gvjs_.lf = function() {
+  return this.Qe.lf()
+}
+;
+gvjs_.Ow = function(a) {
+  this.Qe.Ow(a)
+}
+;
+gvjs_.kf = function() {
+  return this.Qe.kf()
+}
+;
+gvjs_.bu = function(a) {
+  this.Qe.bu(a)
+}
+;
+function gvjs_zO(a, b) {
+  return b <= a.Qe.getValue() + a.Qe.Tl() / 2 ? a.Nd : a.aj
+}
+gvjs_.zaa = function() {
+  gvjs_tO(this);
+  gvjs_rO(this);
+  this.dispatchEvent(gvjs_Kt)
+}
+;
+function gvjs_tO(a) {
+  if (a.Nd && !a.uQ) {
+    var b = gvjs_EO(a, gvjs_BO(a, a.Nd))
+      , c = gvjs_EO(a, gvjs_BO(a, a.aj));
+    if (a.tb == gvjs_U)
+      a.Nd.style.top = b.y + gvjs_T,
+        a.aj.style.top = c.y + gvjs_T,
+      a.tg && (b = gvjs_FO(c.y, b.y, a.Nd.offsetHeight),
+        a.tg.style.top = b.offset + gvjs_T,
+        a.tg.style.height = b.size + gvjs_T);
+    else {
+      var d = a.Ml && a.gh() ? gvjs_j : gvjs_$c;
+      a.Nd.style[d] = b.x + gvjs_T;
+      a.aj.style[d] = c.x + gvjs_T;
+      a.tg && (b = gvjs_FO(b.x, c.x, a.Nd.offsetWidth),
+        a.tg.style[d] = b.offset + gvjs_T,
+        a.tg.style.width = b.size + gvjs_T)
+    }
+  }
+}
+function gvjs_FO(a, b, c) {
+  var d = Math.ceil(c / 2);
+  return {
+    offset: a + d,
+    size: Math.max(b - a + c - 2 * d, 0)
+  }
+}
+function gvjs_EO(a, b) {
+  var c = new gvjs_z;
+  if (a.Nd) {
+    var d = a.lf()
+      , e = a.kf();
+    b = b == d && d == e ? 0 : (b - d) / (e - d);
+    a.tb == gvjs_U ? (d = a.Nd.offsetHeight,
+      d = a.j().clientHeight - d,
+      b = Math.round(b * d),
+      c.x = a.j1 ? 0 : gvjs_AO(a, a.Nd),
+      c.y = d - b) : (d = a.j().clientWidth - a.Nd.offsetWidth,
+      c.x = Math.round(b * d),
+      c.y = a.j1 ? 0 : a.Nd.offsetTop)
+  }
+  return c
+}
+function gvjs_wO(a, b) {
+  b = gvjs_0g(b, a.lf(), a.kf());
+  a.uQ && (a.tH.stop(!0),
+    a.tH.pa());
+  var c = new gvjs_iO
+    , d = gvjs_zO(a, b)
+    , e = a.getValue()
+    , f = a.Tl()
+    , g = gvjs_BO(a, d)
+    , h = gvjs_EO(a, g);
+  var k = a.vI();
+  Math.abs(b - g) < k && (b = gvjs_0g(g + (b > g ? k : -k), a.lf(), a.kf()));
+  gvjs_vO(a, d, b);
+  g = gvjs_EO(a, gvjs_BO(a, d));
+  k = a.tb == gvjs_U ? [gvjs_AO(a, d), g.y] : [g.x, d.offsetTop];
+  h = new gvjs_kO(d,[h.x, h.y],k,100);
+  h.pq(a.Ml);
+  c.add(h);
+  a.tg && gvjs_cia(a, d, e, f, g, c);
+  a.T6 && a.T6.yCa(e, b, 100).forEach(function(l) {
+    c.add(l)
+  });
+  a.tH = c;
+  a.hc().o(c, gvjs_R, a.Lna);
+  a.uQ = !0;
+  c.play(!1)
+}
+function gvjs_cia(a, b, c, d, e, f) {
+  var g = gvjs_EO(a, c)
+    , h = gvjs_EO(a, c + d);
+  c = g;
+  d = h;
+  b == a.Nd ? c = e : d = e;
+  a.tb == gvjs_U ? (b = gvjs_FO(h.y, g.y, a.Nd.offsetHeight),
+    g = gvjs_FO(d.y, c.y, a.Nd.offsetHeight),
+    e = new gvjs_kO(a.tg,[gvjs_AO(a, a.tg), b.offset],[gvjs_AO(a, a.tg), g.offset],100),
+    b = new gvjs_mO(a.tg,b.size,g.size,100),
+    e.pq(a.Ml),
+    b.pq(a.Ml),
+    f.add(e),
+    f.add(b)) : (b = gvjs_FO(g.x, h.x, a.Nd.offsetWidth),
+    g = gvjs_FO(c.x, d.x, a.Nd.offsetWidth),
+    e = new gvjs_kO(a.tg,[b.offset, a.tg.offsetTop],[g.offset, a.tg.offsetTop],100),
+    b = new gvjs_lO(a.tg,b.size,g.size,100),
+    e.pq(a.Ml),
+    b.pq(a.Ml),
+    f.add(e),
+    f.add(b))
+}
+gvjs_.Lna = function() {
+  this.uQ = !1;
+  this.dispatchEvent("g")
+}
+;
+gvjs_.setOrientation = function(a) {
+  if (this.tb != a) {
+    var b = this.sa(this.tb)
+      , c = this.sa(a);
+    this.tb = a;
+    this.j() && (a = this.j(),
+    gvjs_UC(a, b) && (gvjs_XC(a, b),
+      gvjs_VC(a, c)),
+      b = this.Ml && this.gh() ? gvjs_j : gvjs_$c,
+      this.Nd.style[b] = this.Nd.style.top = "",
+      this.aj.style[b] = this.aj.style.top = "",
+    this.tg && (this.tg.style[b] = this.tg.style.top = "",
+      this.tg.style.width = this.tg.style.height = ""),
+      gvjs_tO(this))
+  }
+}
+;
+gvjs_.vi = function() {
+  return this.tb
+}
+;
+gvjs_.M = function() {
+  gvjs_pO.G.M.call(this);
+  this.Sv && this.Sv.pa();
+  delete this.Sv;
+  this.tH && this.tH.pa();
+  delete this.tH;
+  delete this.Nd;
+  delete this.aj;
+  this.tg && delete this.tg;
+  this.Qe.pa();
+  delete this.Qe;
+  this.Gf && (this.Gf.pa(),
+    delete this.Gf);
+  this.qn && (this.qn.pa(),
+    delete this.qn);
+  this.xm && (this.xm.pa(),
+    delete this.xm);
+  this.qq && (this.qq.pa(),
+    delete this.qq)
+}
+;
+gvjs_.ZA = 1;
+gvjs_.vI = function() {
+  return this.Qe.vI()
+}
+;
+gvjs_.ET = function(a) {
+  this.Qe.ET(a)
+}
+;
+gvjs_.getValue = function() {
+  return this.Qe.getValue()
+}
+;
+gvjs_.Wa = function(a) {
+  gvjs_vO(this, this.Nd, a)
+}
+;
+gvjs_.Tl = function() {
+  return this.Qe.Tl()
+}
+;
+gvjs_.rT = function(a) {
+  gvjs_vO(this, this.aj, this.Qe.getValue() + a)
+}
+;
+gvjs_.setVisible = function(a) {
+  gvjs_6(this.j(), a);
+  a && gvjs_tO(this)
+}
+;
+function gvjs_rO(a) {
+  var b = a.j();
+  b && (gvjs_WB(b, "valuemin", a.lf()),
+    gvjs_WB(b, "valuemax", a.kf()),
+    gvjs_WB(b, "valuenow", a.getValue()),
+    gvjs_WB(b, "valuetext", a.Bsa(a.getValue()) || ""))
+}
+function gvjs_uO(a, b) {
+  b ? (a.qn || (a.qn = new gvjs_TE(a.j())),
+    a.hc().o(a.qn, gvjs_Wv, a.vaa, {
+      passive: !1
+    })) : a.hc().Ab(a.qn, gvjs_Wv, a.vaa, {
+    passive: !1
+  })
+}
+gvjs_.Gb = function(a) {
+  this.kg != a && this.dispatchEvent(a ? gvjs_qu : gvjs_ju) && (this.kg = a,
+    gvjs_sO(this, a),
+  a || this.M4(),
+    gvjs_ZC(this.j(), "goog-slider-disabled", !a))
+}
+;
+gvjs_.isEnabled = function() {
+  return this.kg
+}
+;
+function gvjs_AO(a, b) {
+  return a.Ml ? gvjs_3A(b) : b.offsetLeft
+}
+var gvjs_dia = {
+  MM: gvjs_U,
+  IM: gvjs_S
+};
+function gvjs_GO(a) {
+  gvjs_eO.call(this, a);
+  this.GT = []
+}
+gvjs_o(gvjs_GO, gvjs_eO);
+gvjs_GO.prototype.Mt = function() {
+  this.clear();
+  this.GT = this.Zc().fa("setters") || []
+}
+;
+gvjs_GO.prototype.apply = function() {
+  return this.UV(this.mb(), this.Zc(), this.getState())
+}
+;
+gvjs_GO.prototype.UV = function(a, b, c) {
+  gvjs_u(this.nP(), function(d) {
+    gvjs_u(this.GT, function(e) {
+      d.setProperty(e.output, c[e.input])
+    }, this)
+  }, this);
+  return a
+}
+;
+function gvjs_HO(a) {
+  gvjs_GO.call(this, a);
+  this.Cb = this.Xa = null
+}
+gvjs_o(gvjs_HO, gvjs_GO);
+gvjs_HO.prototype.Xl = function(a, b) {
+  a = gvjs_GO.prototype.Xl.call(this, a, b);
+  a.minValue = this.Xa;
+  a.maxValue = this.Cb;
+  null == a.label && (a.label = "");
+  return a
+}
+;
+gvjs_HO.prototype.Mt = function(a, b, c) {
+  this.Xa = gvjs_L(b, gvjs_ed);
+  this.Cb = gvjs_L(b, gvjs_cd);
+  this.GT = [{
+    input: "lowValue",
+    bg: gvjs_J(b, "lowKey")
+  }, {
+    input: "highValue",
+    bg: gvjs_J(b, "highKey")
+  }];
+  this.mM(c)
+}
+;
+gvjs_HO.prototype.mM = function(a) {
+  if (a.lowThumbAtMinimum)
+    a.lowValue = this.Xa;
+  else {
+    var b = gvjs_jg(String(a.lowValue));
+    isNaN(b) && (b = Number.NEGATIVE_INFINITY);
+    a.lowValue = gvjs_0g(b, this.Xa, this.Cb)
+  }
+  a.highThumbAtMaximum ? a.highValue = this.Cb : (b = gvjs_jg(String(a.highValue)),
+  isNaN(b) && (b = Number.POSITIVE_INFINITY),
+    a.highValue = gvjs_0g(b, this.Xa, this.Cb))
+}
+;
+function gvjs_IO(a) {
+  gvjs_eO.call(this, a)
+}
+gvjs_o(gvjs_IO, gvjs_eO);
+gvjs_IO.prototype.xB = function() {
+  return this.apply()
+}
+;
+gvjs_IO.prototype.apply = function() {
+  if (!this.mb())
+    throw Error(gvjs_ZN);
+  return this.pG(this.mb(), this.Zc(), this.getState())
+}
+;
+gvjs_IO.prototype.pG = function(a) {
+  return new gvjs_N(a)
+}
+;
+function gvjs_JO(a) {
+  gvjs_eO.call(this, a);
+  this.ye = -1;
+  this.Cb = this.Xa = this.sq = null
+}
+gvjs_o(gvjs_JO, gvjs_IO);
+gvjs_JO.prototype.yT = function(a) {
+  this.Xa = a
+}
+;
+gvjs_JO.prototype.xT = function(a) {
+  this.Cb = a
+}
+;
+function gvjs_KO(a, b) {
+  if (b.lowThumbAtMinimum)
+    b.lowValue = a.Xa;
+  else {
+    var c = a.U5(b.lowValue);
+    isNaN(c) && (c = Number.NEGATIVE_INFINITY);
+    b.lowValue = gvjs_0g(c, a.Xa, a.Cb)
+  }
+  b.highThumbAtMaximum ? b.highValue = a.Cb : (c = a.U5(b.highValue),
+  isNaN(c) && (c = Number.POSITIVE_INFINITY),
+    b.highValue = gvjs_0g(c, a.Xa, a.Cb))
+}
+gvjs_JO.prototype.pG = function(a, b, c) {
+  a = new gvjs_N(a);
+  b = {
+    column: this.ye,
+    test: this.rZ(b, c.lowValue.valueOf(), c.highValue.valueOf())
+  };
+  a.pp(a.at([b]));
+  return a
+}
+;
+gvjs_JO.prototype.rZ = function(a, b, c) {
+  return function(d) {
+    return b <= d && c >= d
+  }
+}
+;
+function gvjs_LO(a) {
+  gvjs_pO.call(this, a)
+}
+gvjs_o(gvjs_LO, gvjs_pO);
+gvjs_LO.prototype.sa = function(a) {
+  return a == gvjs_U ? "google-visualization-controls-slider-vertical" : "google-visualization-controls-slider-horizontal"
+}
+;
+gvjs_LO.prototype.Nb = function() {
+  gvjs_pO.prototype.Nb.call(this);
+  this.hc().o(this, gvjs_Kt, gvjs_s(this.dha, this));
+  this.dha()
+}
+;
+gvjs_LO.prototype.dha = function() {
+  var a = gvjs_bO(this.Nd)
+    , b = gvjs_bO(this.aj);
+  this.vi() == gvjs_U ? (this.mC.style.height = gvjs_rz(Math.abs(b.y - a.y), !0),
+    this.mC.style.top = Math.min(b.y, a.y) + gvjs_T) : (gvjs_Bz(this.mC, Math.abs(b.x - a.x)),
+    this.mC.style.left = Math.min(b.x, a.x) + gvjs_T)
+}
+;
+function gvjs_qO(a) {
+  a = a.wa().J(gvjs_b, "google-visualization-controls-slider-thumb");
+  gvjs_VB(a, gvjs_Bt);
+  return a
+}
+gvjs_LO.prototype.mC = null;
+function gvjs_MO(a) {
+  gvjs_dO.call(this, a);
+  this.Op = this.tm = 0
+}
+gvjs_o(gvjs_MO, gvjs_dO);
+gvjs_ = gvjs_MO.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.tm);
+  gvjs_E(this.Fc);
+  gvjs_dO.prototype.M.call(this)
+}
+;
+gvjs_.getState = function() {
+  if (!this.Fc)
+    return {
+      lowValue: null,
+      highValue: null,
+      lowThumbAtMinimum: null,
+      highThumbAtMaxium: null
+    };
+  var a = this.Fc.getValue()
+    , b = this.Fc.Tl();
+  return {
+    lowValue: a + this.Op,
+    highValue: a + b + this.Op,
+    lowThumbAtMinimum: a === this.Fc.lf(),
+    highThumbAtMaximum: a + b === this.Fc.kf()
+  }
+}
+;
+function gvjs_NO() {
+  return gvjs_4(gvjs_6a, {
+    "class": "google-visualization-controls-rangefilter-thumblabel"
+  }, "-")
+}
+gvjs_.uxa = function() {
+  this.K5();
+  this.tm && gvjs_ql(this.tm);
+  this.tm = gvjs_pl(function() {
+    this.tm = 0;
+    gvjs_I(this, gvjs_9N, null)
+  }, 200, this)
+}
+;
+function gvjs_OO(a, b, c, d, e) {
+  var f = gvjs_K(d, "showRangeValues");
+  e = gvjs_J(d, gvjs_9v, e.orientation, gvjs_dia);
+  var g = new gvjs_MC;
+  b.addChild(g, !0);
+  gvjs_VC(g.j(), gvjs_Y);
+  f && (e === gvjs_S ? (a.hw = gvjs_NO(),
+    g.ib().appendChild(a.hw)) : (a.Pv = gvjs_NO(),
+    g.ib().appendChild(a.Pv)));
+  b = new gvjs_LO;
+  gvjs_E(a.Fc);
+  a.Fc = b;
+  a.Ifa(d);
+  b = a.xZ(d, gvjs_ed);
+  var h = a.xZ(d, gvjs_cd);
+  if (null == b || null == h)
+    throw Error("minValue and maxValue must be specified");
+  c = a.pea(b, h, c);
+  b = c.minValue;
+  h = c.maxValue;
+  c = c.state;
+  a.Op = b;
+  h -= a.Op;
+  c.lowValue -= a.Op;
+  c.highValue -= a.Op;
+  a.Fc.Ow(0);
+  a.Fc.bu(h);
+  a.Fc.setOrientation(e);
+  b = c.lowThumbAtMinimum ? a.Fc.lf() : c.lowValue;
+  gvjs_DO(a.Fc, b, c.highThumbAtMaximum ? a.Fc.kf() : c.highValue - b);
+  g.addChild(a.Fc, !0);
+  f && (e == gvjs_S ? (a.Pv = gvjs_NO(),
+    g.ib().appendChild(a.Pv)) : (a.hw = gvjs_NO(),
+    g.ib().appendChild(a.hw)),
+  a.v2 && a.v2(d),
+    a.K5());
+  a.addEventListener(a.Fc, gvjs_Kt, a.uxa, !1, a)
+}
+gvjs_.hw = null;
+gvjs_.Pv = null;
+gvjs_.Fc = null;
+function gvjs_PO(a, b) {
+  var c = b.fa("filterColumnIndex");
+  if (null != c)
+    return b = parseInt(c, 10),
+      a.Ne(b),
+      b;
+  if (b = gvjs_J(b, "filterColumnLabel")) {
+    a: {
+      c = a.$();
+      for (var d = 0; d < c; d++)
+        if (a.Ga(d) == b)
+          break a;
+      throw Error("Invalid column label:" + b);
+    }
+    return d
+  }
+  throw Error("Either filterColumnIndex or filterColumnLabel must be specified.");
+}
+;function gvjs_QO(a) {
+  gvjs_eO.call(this, a);
+  this.ye = -1
+}
+gvjs_o(gvjs_QO, gvjs_IO);
+gvjs_ = gvjs_QO.prototype;
+gvjs_.og = function() {
+  return {
+    useFormattedValue: !1,
+    values: null
+  }
+}
+;
+gvjs_.Xl = function(a, b) {
+  a = gvjs_IO.prototype.Xl.call(this, a, b);
+  null == a.label && (a.label = this.sq);
+  a.values = this.mc;
+  return a
+}
+;
+gvjs_.Mt = function(a, b, c) {
+  this.clear();
+  this.ye = gvjs_PO(a, b);
+  this.sq = a.Ga(this.ye);
+  var d = b.fa("values");
+  if (Array.isArray(d) && d.length)
+    this.mc = d;
+  else {
+    b = gvjs_K(b, gvjs_$N);
+    d = new Set;
+    for (var e = [], f = 0; f < a.ca(); f++) {
+      var g = b ? a.Ha(f, this.ye) : a.getValue(f, this.ye);
+      null == g || d.has(g) || (d.add(g),
+        e.push(g))
+    }
+    this.mc = e
+  }
+  this.mM(c)
+}
+;
+gvjs_.mM = function(a) {
+  var b = a.selectedValues;
+  if (b) {
+    if (!Array.isArray(b))
+      throw Error(gvjs_YN);
+    var c = new Set;
+    gvjs_u(this.mc, function(d) {
+      null != d && c.add(String(d))
+    });
+    a.selectedValues = gvjs_De(b, function(d) {
+      return c.has(String(d))
+    })
+  }
+}
+;
+gvjs_.pG = function(a, b, c) {
+  var d = new Set;
+  c = c.selectedValues;
+  if (Array.isArray(c))
+    for (var e = 0; e < c.length; e++)
+      null != c[e] && d.add(String(c[e]));
+  if (0 == d.size)
+    return new gvjs_N(a);
+  c = gvjs_K(b, gvjs_$N);
+  b = [];
+  for (e = 0; e < a.ca(); e++) {
+    if (c)
+      var f = a.Ha(e, this.ye);
+    else
+      f = a.getValue(e, this.ye),
+      null != f && (f = String(f));
+    d.has(f) && b.push(e)
+  }
+  a = new gvjs_N(a);
+  a.pp(b);
+  return a
+}
+;
+gvjs_.sq = null;
+gvjs_.mc = null;
+function gvjs_RO(a, b, c, d) {
+  gvjs_MC.call(this, d);
+  this.Qb = a;
+  this.qsa = b == gvjs_U;
+  this.mwa = c || ""
+}
+gvjs_t(gvjs_RO, gvjs_MC);
+gvjs_ = gvjs_RO.prototype;
+gvjs_.Tba = null;
+gvjs_.iH = null;
+function gvjs_SO(a) {
+  if (!a.label)
+    return null;
+  var b = a.labelStacking == gvjs_U ? gvjs_U : gvjs_S, c;
+  a.labelSeparator && (c = String(a.labelSeparator));
+  return new gvjs_RO(String(a.label),b,c)
+}
+gvjs_.J = function() {
+  var a = this.D.J(gvjs_b);
+  this.H = a;
+  this.Tba = gvjs_4("LABEL", "google-visualization-controls-label", this.Qb + this.mwa);
+  a.appendChild(this.Tba);
+  this.iH = gvjs_4(gvjs_b);
+  this.qsa || gvjs_VC(this.iH, gvjs_Y);
+  a.appendChild(this.iH)
+}
+;
+gvjs_.Fh = function() {
+  return !1
+}
+;
+gvjs_.ib = function() {
+  return this.iH
+}
+;
+gvjs_.addElement = function(a) {
+  this.iH.appendChild(a)
+}
+;
+function gvjs_TO(a, b) {
+  this.$d = a;
+  this.Pca = b
+}
+gvjs_TO.prototype.Dd = function() {
+  return this.Pca.Dd(this)
+}
+;
+gvjs_TO.prototype.getId = function() {
+  return this.Pca.getId(this)
+}
+;
+gvjs_TO.prototype.get = function() {
+  return this.$d
+}
+;
+function gvjs_eia(a, b) {
+  return a.Dd().localeCompare(b.Dd())
+}
+function gvjs_UO() {}
+gvjs_UO.prototype.Dd = function(a) {
+  return String(a.get())
+}
+;
+gvjs_UO.prototype.getId = function(a) {
+  return String(a.get())
+}
+;
+/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+function gvjs_VO() {
+  this.Dca = null;
+  this.Eh = !1;
+  this.Z9 = void 0;
+  this.qa = new gvjs_aj;
+  this.pc = new gvjs_WO("",void 0);
+  this.pc.next = this.pc.Ji = this.pc
+}
+function gvjs_XO(a, b) {
+  (b = a.qa.get(b)) && a.Eh && (b.remove(),
+    gvjs_YO(a, b));
+  return b
+}
+gvjs_ = gvjs_VO.prototype;
+gvjs_.get = function(a, b) {
+  return (a = gvjs_XO(this, a)) ? a.value : b
+}
+;
+gvjs_.set = function(a, b) {
+  var c = gvjs_XO(this, a);
+  c ? c.value = b : (c = new gvjs_WO(a,b),
+    this.qa.set(a, c),
+    gvjs_YO(this, c))
+}
+;
+gvjs_.peek = function() {
+  return this.pc.next.value
+}
+;
+gvjs_.shift = function() {
+  return gvjs_ZO(this, this.pc.next)
+}
+;
+gvjs_.pop = function() {
+  return gvjs_ZO(this, this.pc.Ji)
+}
+;
+gvjs_.remove = function(a) {
+  return (a = this.qa.get(a)) ? (this.removeNode(a),
+    !0) : !1
+}
+;
+gvjs_.removeNode = function(a) {
+  a.remove();
+  this.qa.remove(a.key)
+}
+;
+gvjs_.Cd = function() {
+  return this.qa.Cd()
+}
+;
+gvjs_.isEmpty = function() {
+  return this.qa.isEmpty()
+}
+;
+gvjs_.cj = function() {
+  return this.map(function(a, b) {
+    return b
+  })
+}
+;
+gvjs_.ob = function() {
+  return this.map(function(a) {
+    return a
+  })
+}
+;
+gvjs_.contains = function(a) {
+  return this.some(function(b) {
+    return b == a
+  })
+}
+;
+gvjs_.tf = function(a) {
+  return this.qa.tf(a)
+}
+;
+gvjs_.clear = function() {
+  gvjs__O(this, 0)
+}
+;
+gvjs_.forEach = function(a, b) {
+  for (var c = this.pc.next; c != this.pc; c = c.next)
+    a.call(b, c.value, c.key, this)
+}
+;
+gvjs_.map = function(a, b) {
+  for (var c = [], d = this.pc.next; d != this.pc; d = d.next)
+    c.push(a.call(b, d.value, d.key, this));
+  return c
+}
+;
+gvjs_.some = function(a, b) {
+  for (var c = this.pc.next; c != this.pc; c = c.next)
+    if (a.call(b, c.value, c.key, this))
+      return !0;
+  return !1
+}
+;
+gvjs_.every = function(a, b) {
+  for (var c = this.pc.next; c != this.pc; c = c.next)
+    if (!a.call(b, c.value, c.key, this))
+      return !1;
+  return !0
+}
+;
+function gvjs_YO(a, b) {
+  a.Eh ? (b.next = a.pc.next,
+    b.Ji = a.pc,
+    a.pc.next = b,
+    b.next.Ji = b) : (b.Ji = a.pc.Ji,
+    b.next = a.pc,
+    a.pc.Ji = b,
+    b.Ji.next = b);
+  null != a.Dca && gvjs__O(a, a.Dca)
+}
+function gvjs__O(a, b) {
+  for (; a.Cd() > b; ) {
+    var c = a.Eh ? a.pc.Ji : a.pc.next;
+    a.removeNode(c);
+    a.Z9 && a.Z9(c.key, c.value)
+  }
+}
+function gvjs_ZO(a, b) {
+  a.pc != b && a.removeNode(b);
+  return b.value
+}
+function gvjs_WO(a, b) {
+  this.key = a;
+  this.value = b
+}
+gvjs_WO.prototype.remove = function() {
+  this.Ji.next = this.next;
+  this.next.Ji = this.Ji;
+  delete this.Ji;
+  delete this.next
+}
+;
+function gvjs_0O(a) {
+  gvjs_H.call(this);
+  this.Hc = null;
+  this.H = a;
+  a = gvjs_y || gvjs_rg || gvjs_tg && !gvjs_Eg("531") && a.tagName == gvjs_Vo;
+  this.ea = new gvjs_KA(this);
+  this.ea.o(this.H, a ? [gvjs_lv, "paste", "cut", "drop", gvjs_fv] : gvjs_fv, this)
+}
+gvjs_t(gvjs_0O, gvjs_H);
+gvjs_0O.prototype.handleEvent = function(a) {
+  if (a.type == gvjs_fv)
+    gvjs_y && gvjs_Eg(10) && 0 == a.keyCode && 0 == a.charCode || (gvjs_1O(this),
+      this.dispatchEvent(gvjs_2O(a)));
+  else if (a.type != gvjs_lv || gvjs_bia(a)) {
+    var b = a.type == gvjs_lv ? this.H.value : null;
+    gvjs_y && 229 == a.keyCode && (b = null);
+    var c = gvjs_2O(a);
+    gvjs_1O(this);
+    this.Hc = gvjs_pl(function() {
+      this.Hc = null;
+      this.H.value != b && this.dispatchEvent(c)
+    }, 0, this)
+  }
+}
+;
+function gvjs_1O(a) {
+  null != a.Hc && (gvjs_ql(a.Hc),
+    a.Hc = null)
+}
+function gvjs_2O(a) {
+  a = new gvjs_5h(a.$i);
+  a.type = gvjs_fv;
+  return a
+}
+gvjs_0O.prototype.M = function() {
+  gvjs_0O.G.M.call(this);
+  this.ea.pa();
+  gvjs_1O(this);
+  delete this.H
+}
+;
+function gvjs_3O(a, b, c) {
+  gvjs_1h.call(this, a, b);
+  this.item = c
+}
+gvjs_t(gvjs_3O, gvjs_1h);
+function gvjs_4O(a, b) {
+  gvjs_MC.call(this, b);
+  this.Qb = a || ""
+}
+var gvjs_5O;
+gvjs_t(gvjs_4O, gvjs_MC);
+gvjs_ = gvjs_4O.prototype;
+gvjs_.rq = null;
+gvjs_.Dsa = 10;
+function gvjs_6O() {
+  null == gvjs_5O && (gvjs_5O = gvjs_7N in gvjs_dh(gvjs_Na));
+  return gvjs_5O
+}
+gvjs_.WC = !1;
+gvjs_.J = function() {
+  this.H = this.wa().J(gvjs_Na, {
+    type: gvjs_m
+  })
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_4O.G.vf.call(this, a);
+  this.Qb || (this.Qb = a.getAttribute(gvjs_8c) || "");
+  gvjs_Tx(gvjs_5g(a)) == a && (this.WC = !0,
+    a = this.j(),
+    gvjs_XC(a, this.uJ));
+  gvjs_6O() && (this.j().placeholder = this.Qb);
+  a = this.j();
+  gvjs_WB(a, gvjs_8c, this.Qb)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_4O.G.Nb.call(this);
+  var a = new gvjs_KA(this);
+  a.o(this.j(), gvjs_xu, this.qaa);
+  a.o(this.j(), gvjs_Yo, this.KP);
+  if (gvjs_6O())
+    this.ea = a;
+  else {
+    gvjs_sg && a.o(this.j(), [gvjs_7c, gvjs_lv, gvjs_mv], this.aqa);
+    var b = gvjs_5g(this.j());
+    a.o(gvjs_3x(b), "load", this.gra);
+    this.ea = a;
+    gvjs_7O(this)
+  }
+  this.Wp();
+  this.j().lj = this
+}
+;
+gvjs_.Le = function() {
+  gvjs_4O.G.Le.call(this);
+  this.ea && (this.ea.pa(),
+    this.ea = null);
+  this.j().lj = null
+}
+;
+function gvjs_7O(a) {
+  !a.ooa && a.ea && a.j().form && (a.ea.o(a.j().form, "submit", a.bqa),
+    a.ooa = !0)
+}
+gvjs_.M = function() {
+  gvjs_4O.G.M.call(this);
+  this.ea && (this.ea.pa(),
+    this.ea = null)
+}
+;
+gvjs_.uJ = "label-input-label";
+gvjs_.qaa = function() {
+  this.WC = !0;
+  var a = this.j();
+  gvjs_XC(a, this.uJ);
+  if (!gvjs_6O() && !gvjs_8O(this) && !this.Fra) {
+    var b = this;
+    a = function() {
+      b.j() && (b.j().value = "")
+    }
+    ;
+    gvjs_y ? gvjs_pl(a, 10) : a()
+  }
+}
+;
+gvjs_.KP = function() {
+  gvjs_6O() || (this.ea.Ab(this.j(), gvjs_Wt, this.qaa),
+    this.rq = null);
+  this.WC = !1;
+  this.Wp()
+}
+;
+gvjs_.aqa = function(a) {
+  27 == a.keyCode && (a.type == gvjs_lv ? this.rq = this.j().value : a.type == gvjs_7c ? this.j().value = this.rq : a.type == gvjs_mv && (this.rq = null),
+    a.preventDefault())
+}
+;
+gvjs_.bqa = function() {
+  gvjs_8O(this) || (this.j().value = "",
+    gvjs_pl(this.mpa, 10, this))
+}
+;
+gvjs_.mpa = function() {
+  gvjs_8O(this) || (this.j().value = this.Qb)
+}
+;
+gvjs_.gra = function() {
+  this.Wp()
+}
+;
+gvjs_.hasFocus = function() {
+  return this.WC
+}
+;
+function gvjs_8O(a) {
+  return !!a.j() && "" != a.j().value && a.j().value != a.Qb
+}
+gvjs_.clear = function() {
+  this.j().value = "";
+  null != this.rq && (this.rq = "")
+}
+;
+gvjs_.reset = function() {
+  gvjs_8O(this) && (this.clear(),
+    this.Wp())
+}
+;
+gvjs_.Wa = function(a) {
+  null != this.rq && (this.rq = a);
+  this.j().value = a;
+  this.Wp()
+}
+;
+gvjs_.getValue = function() {
+  return null != this.rq ? this.rq : gvjs_8O(this) ? this.j().value : ""
+}
+;
+gvjs_.In = function(a) {
+  var b = this.j();
+  gvjs_6O() ? (b && (b.placeholder = a),
+    this.Qb = a) : gvjs_8O(this) || (b && (b.value = ""),
+    this.Qb = a,
+    this.Tea());
+  b && gvjs_WB(b, gvjs_8c, this.Qb)
+}
+;
+gvjs_.Dd = function() {
+  return this.Qb
+}
+;
+gvjs_.Wp = function() {
+  var a = this.j();
+  gvjs_6O() ? this.j().placeholder != this.Qb && (this.j().placeholder = this.Qb) : gvjs_7O(this);
+  gvjs_WB(a, gvjs_8c, this.Qb);
+  gvjs_8O(this) ? (a = this.j(),
+    gvjs_XC(a, this.uJ)) : (this.Fra || this.WC || (a = this.j(),
+    gvjs_VC(a, this.uJ)),
+  gvjs_6O() || gvjs_pl(this.Tea, this.Dsa, this))
+}
+;
+gvjs_.Gb = function(a) {
+  this.j().disabled = !a;
+  var b = this.j();
+  gvjs_ZC(b, this.uJ + gvjs_Gr, !a)
+}
+;
+gvjs_.isEnabled = function() {
+  return !this.j().disabled
+}
+;
+gvjs_.Tea = function() {
+  !this.j() || gvjs_8O(this) || this.WC || (this.j().value = this.Qb)
+}
+;
+function gvjs_9O(a, b, c) {
+  gvjs_MC.call(this, a);
+  this.lj = c || new gvjs_4O;
+  this.kg = !0;
+  a = this.la = b || new gvjs_kE(this.wa());
+  a.setVisible(!1);
+  a.kG = !1;
+  a.Z6 = !0
+}
+gvjs_t(gvjs_9O, gvjs_MC);
+gvjs_ = gvjs_9O.prototype;
+gvjs_.uc = null;
+gvjs_.rD = null;
+gvjs_.lj = null;
+gvjs_.la = null;
+gvjs_.gB = -1;
+gvjs_.zi = null;
+gvjs_.I0 = gvjs_hf;
+gvjs_.LB = null;
+gvjs_.RX = "";
+gvjs_.doa = "";
+gvjs_.kq = null;
+gvjs_.iha = !1;
+gvjs_.J = function() {
+  this.zi = this.wa().J(gvjs_Na, {
+    name: this.doa,
+    type: gvjs_m,
+    autocomplete: "off"
+  });
+  this.LB = this.wa().J(gvjs_6a, "goog-combobox-button");
+  this.H = this.wa().J(gvjs_6a, "goog-combobox", this.zi, this.LB);
+  this.iha && (gvjs_th(this.LB, "\u25bc"),
+    gvjs_Hz(this.LB, !0));
+  this.zi.setAttribute(gvjs_8c, this.RX);
+  this.lj.fb(this.zi);
+  this.la.jp(!1);
+  this.la.Bb || this.addChild(this.la, !0)
+}
+;
+gvjs_.Gb = function(a) {
+  this.kg = a;
+  this.lj.Gb(a);
+  gvjs_ZC(this.j(), "goog-combobox-disabled", !a)
+}
+;
+gvjs_.isEnabled = function() {
+  return this.kg
+}
+;
+gvjs_.Nb = function() {
+  gvjs_9O.G.Nb.call(this);
+  var a = this.hc();
+  a.o(this.j(), gvjs_gd, this.lua);
+  a.o(this.wa().kc(), gvjs_gd, this.mua);
+  a.o(this.zi, gvjs_Yo, this.tua);
+  this.Gf = new gvjs_uD(this.zi);
+  a.o(this.Gf, gvjs_kv, this.gj);
+  this.uc = new gvjs_0O(this.zi);
+  a.o(this.uc, gvjs_fv, this.uua);
+  a.o(this.la, gvjs_Ss, this.wua)
+}
+;
+gvjs_.Le = function() {
+  this.Gf.pa();
+  delete this.Gf;
+  this.uc.pa();
+  this.uc = null;
+  gvjs_9O.G.Le.call(this)
+}
+;
+gvjs_.Fh = function() {
+  return !1
+}
+;
+gvjs_.M = function() {
+  gvjs_9O.G.M.call(this);
+  this.JN();
+  this.lj.pa();
+  this.la.pa();
+  this.LB = this.zi = this.la = this.lj = null
+}
+;
+gvjs_.eC = function() {
+  this.JN();
+  gvjs_$O(this);
+  this.la.Tg(-1)
+}
+;
+gvjs_.Bj = function(a) {
+  this.la.addChild(a, !0);
+  this.gB = -1
+}
+;
+gvjs_.Bu = function(a, b) {
+  this.la.zx(a, b, !0);
+  this.gB = -1
+}
+;
+gvjs_.removeItem = function(a) {
+  if (a = this.la.removeChild(a, !0))
+    a.pa(),
+      this.gB = -1
+}
+;
+gvjs_.od = function(a) {
+  return this.la.Ye(a)
+}
+;
+gvjs_.bh = function() {
+  return this.la.ze()
+}
+;
+gvjs_.Td = function() {
+  return this.la
+}
+;
+gvjs_.Wa = function(a) {
+  this.lj.getValue() != a && (this.lj.Wa(a),
+    this.MP())
+}
+;
+gvjs_.getValue = function() {
+  return this.lj.getValue()
+}
+;
+function gvjs_aP(a, b) {
+  var c = a.la.isVisible(), d;
+  if (-1 == a.gB) {
+    for (var e = d = 0, f = a.la.ze(); e < f; e++)
+      a.la.Ye(e).isVisible() && d++;
+    a.gB = d
+  }
+  d = a.gB;
+  c && 0 == d ? gvjs_$O(a) : !c && 0 < d && (b && (a.mL(""),
+    a.vT(gvjs_kf(a.lj.getValue().toLowerCase()))),
+    gvjs_pl(a.JN, 1, a),
+    a.la.setVisible(!0),
+    gvjs_VC(a.j(), gvjs_0N));
+  a.mS()
+}
+gvjs_.mS = function() {
+  this.la && this.la.isVisible() && (new gvjs_1D(this.j(),9,!0)).Mf(this.la.j(), 8)
+}
+;
+function gvjs_$O(a) {
+  a.la.setVisible(!1);
+  gvjs_XC(a.j(), gvjs_0N)
+}
+gvjs_.JN = function() {
+  this.kq && (gvjs_ql(this.kq),
+    this.kq = null)
+}
+;
+gvjs_.lua = function(a) {
+  this.kg && (a.target == this.j() || a.target == this.zi || gvjs_rh(this.LB, a.target)) && (this.la.isVisible() ? this.eC() : (gvjs_aP(this, !0),
+  gvjs_qg && this.zi.focus(),
+    this.zi.select(),
+    this.la.Uq = !0,
+    a.preventDefault()));
+  a.stopPropagation()
+}
+;
+gvjs_.mua = function(a) {
+  gvjs_rh(this.la.j(), a.target) || this.eC()
+}
+;
+gvjs_.wua = function(a) {
+  var b = a.target;
+  this.dispatchEvent(new gvjs_3O(gvjs_Ss,this,b)) && (b = b.bj(),
+  this.lj.getValue() != b && (this.lj.Wa(b),
+    this.dispatchEvent(gvjs_Kt)),
+    this.eC());
+  a.stopPropagation()
+}
+;
+gvjs_.tua = function() {
+  this.JN();
+  this.kq = gvjs_pl(this.eC, 250, this)
+}
+;
+gvjs_.gj = function(a) {
+  var b = this.la.isVisible();
+  if (b && this.la.gj(a))
+    return !0;
+  var c = !1;
+  switch (a.keyCode) {
+    case 27:
+      b && (this.eC(),
+        c = !0);
+      break;
+    case 9:
+      b && (b = gvjs_aE(this.la)) && (b.$h(a),
+        c = !0);
+      break;
+    case 38:
+    case 40:
+      b || (gvjs_aP(this, !0),
+        c = !0)
+  }
+  c && a.preventDefault();
+  return c
+}
+;
+gvjs_.uua = function() {
+  this.MP()
+}
+;
+gvjs_.MP = function() {
+  var a = gvjs_kf(this.lj.getValue().toLowerCase());
+  this.mL(a);
+  gvjs_Tx(this.wa().kc()) == this.zi && gvjs_aP(this, !1);
+  var b = gvjs_aE(this.la);
+  "" != a && b && b.isVisible() || this.vT(a);
+  this.rD = a;
+  this.dispatchEvent(gvjs_Kt)
+}
+;
+gvjs_.mL = function(a) {
+  for (var b = !1, c = 0, d = !this.I0(a, this.rD), e = 0, f = this.la.ze(); e < f; e++) {
+    var g = this.la.Ye(e);
+    if (g instanceof gvjs_ZD) {
+      if (!g.isVisible() && !d)
+        continue;
+      var h = g.bj();
+      h = typeof g.rsa == gvjs_d && g.Pba || h && this.I0(h.toLowerCase(), a);
+      typeof g.sT == gvjs_d && g.sT(a);
+      g.setVisible(!!h);
+      b = h || b
+    } else
+      b = g.isVisible() || b;
+    g.isVisible() && c++
+  }
+  this.gB = c
+}
+;
+gvjs_.vT = function(a) {
+  if ("" != a)
+    for (var b = 0, c = this.la.ze(); b < c; b++) {
+      var d = this.la.Ye(b)
+        , e = d.bj();
+      if (e && this.I0(e.toLowerCase(), a)) {
+        this.la.Tg(b);
+        d.sT && d.sT(a);
+        return
+      }
+    }
+  this.la.Tg(-1)
+}
+;
+function gvjs_bP(a, b, c, d) {
+  gvjs_ZD.call(this, a, b, c, d)
+}
+gvjs_t(gvjs_bP, gvjs_ZD);
+gvjs_HD("goog-combobox-item", function() {
+  return new gvjs_bP(null)
+});
+gvjs_bP.prototype.Pba = !1;
+gvjs_bP.prototype.rsa = function() {
+  return this.Pba
+}
+;
+gvjs_bP.prototype.sT = function(a) {
+  if (this.isEnabled()) {
+    var b = this.bj()
+      , c = b.toLowerCase().indexOf(a);
+    if (0 <= c) {
+      var d = this.wa();
+      this.setContent([d.createTextNode(b.substr(0, c)), d.J("B", null, b.substr(c, a.length)), d.createTextNode(b.substr(c + a.length))])
+    }
+  }
+}
+;
+function gvjs_cP() {}
+gvjs_t(gvjs_cP, gvjs_2D);
+gvjs_le(gvjs_cP);
+gvjs_ = gvjs_cP.prototype;
+gvjs_.J = function(a) {
+  var b = this.Rl(a);
+  b = a.wa().J(gvjs_b, gvjs_Is + b.join(" "), a.getContent());
+  this.il(b, a.en());
+  return b
+}
+;
+gvjs_.Qk = function() {
+  return gvjs_Bt
+}
+;
+gvjs_.Fh = function(a) {
+  return a.tagName == gvjs_b
+}
+;
+gvjs_.fb = function(a, b) {
+  gvjs_VC(b, gvjs_Y);
+  return gvjs_cP.G.fb.call(this, a, b)
+}
+;
+gvjs_.getValue = function() {
+  return ""
+}
+;
+gvjs_.sa = function() {
+  return gvjs_1N
+}
+;
+gvjs_HD(gvjs_1N, function() {
+  return new gvjs_4D(null,gvjs_cP.Lc())
+});
+function gvjs_dP() {}
+gvjs_t(gvjs_dP, gvjs_cP);
+gvjs_le(gvjs_dP);
+gvjs_dP.prototype.sa = function() {
+  return gvjs_2N
+}
+;
+gvjs_HD(gvjs_2N, function() {
+  return new gvjs_4D(null,gvjs_dP.Lc())
+});
+function gvjs_eP(a, b, c) {
+  gvjs_ZD.call(this, a, b, c);
+  this.S3(!0)
+}
+gvjs_t(gvjs_eP, gvjs_ZD);
+gvjs_eP.prototype.$h = function() {
+  return this.dispatchEvent(gvjs_Ss)
+}
+;
+gvjs_HD(gvjs_Ms, function() {
+  return new gvjs_eP(null)
+});
+function gvjs_fP(a) {
+  gvjs_dO.call(this, a);
+  this.mc = [];
+  this.ug = new gvjs_VO
+}
+gvjs_o(gvjs_fP, gvjs_dO);
+gvjs_ = gvjs_fP.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.GH);
+  gvjs_dO.prototype.M.call(this)
+}
+;
+gvjs_.getState = function() {
+  for (var a = {
+    selectedValues: []
+  }, b = this.ug.ob(), c = 0; c < b.length; c++)
+    a.selectedValues.push(b[c].get());
+  return a
+}
+;
+gvjs_.draw = function(a, b) {
+  b = gvjs_x(b || {});
+  b.caption || (b.caption = "Choose a value...");
+  b.valuesMediator = b.valuesMediator || new gvjs_UO;
+  b.cssClass = b.cssClass ? String(b.cssClass) : "google-visualization-controls-categoryfilter";
+  "allowMultiple"in b || (b.allowMultiple = !0);
+  "allowNone"in b || (b.allowNone = !0);
+  "allowTyping"in b || (b.allowTyping = !0);
+  "sortValues"in b || (b.sortValues = !0);
+  var c = !1, d;
+  for (d in gvjs_gP)
+    if (b.selectedValuesLayout == gvjs_gP[d]) {
+      c = !0;
+      break
+    }
+  c || (b.selectedValuesLayout = gvjs_3N);
+  this.m = b;
+  gvjs_fia(this, a);
+  (a = gvjs_SO(this.m)) || (a = new gvjs_MC);
+  a.R(this.getContainer());
+  gvjs_VC(a.j(), this.m.cssClass);
+  gvjs_E(this.GH);
+  this.GH = this.m.allowTyping ? this.m.allowMultiple ? new gvjs_hP(this) : new gvjs_iP(this) : this.m.allowMultiple ? new gvjs_jP(this) : new gvjs_kP(this);
+  this.GH.R(a);
+  this.ug.isEmpty() || this.GH.AE()
+}
+;
+function gvjs_fia(a, b) {
+  b = b || {};
+  var c = a.m.valuesMediator
+    , d = new Set;
+  if (null != b.selectedValues) {
+    if (!Array.isArray(b.selectedValues))
+      throw Error(gvjs_YN);
+    a.m.allowMultiple ? gvjs_u(b.selectedValues, function(g) {
+      d.add((new gvjs_TO(g,c)).getId())
+    }) : b.selectedValues.length && d.add((new gvjs_TO(b.selectedValues[0],c)).getId())
+  }
+  b = Array.isArray(a.m.values) ? a.m.values : [];
+  for (var e = 0; e < b.length; e++) {
+    var f = new gvjs_TO(b[e],c);
+    a.mc.push(f);
+    d.has(f.getId()) && a.ug.set(f.getId(), f)
+  }
+  a.m.sortValues && gvjs_Qe(a.mc, gvjs_eia);
+  !gvjs_lP(a) && 0 < a.mc.length && 0 == a.ug.Cd() && a.ug.set(a.mc[0].getId(), a.mc[0])
+}
+gvjs_.ru = function() {
+  gvjs_I(this, gvjs_9N, null)
+}
+;
+function gvjs_mP(a) {
+  return a.ug.Cd() == a.mc.length
+}
+function gvjs_lP(a) {
+  return !!a.m.allowNone
+}
+gvjs_.m = null;
+gvjs_.GH = null;
+var gvjs_gP = {
+  vza: gvjs_3N,
+  Aza: gvjs_qt,
+  Cza: "belowWrapping",
+  Bza: gvjs_4N
+};
+function gvjs_nP(a) {
+  gvjs_F.call(this);
+  this.bc = a;
+  this.Ce = null
+}
+gvjs_o(gvjs_nP, gvjs_F);
+gvjs_ = gvjs_nP.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.Ce);
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_.R = function(a) {
+  gvjs_E(this.Ce);
+  this.Ce = new gvjs_DE(this.bc.m.caption);
+  this.sX();
+  a.addChild(this.Ce, !0);
+  this.bc.addEventListener(this.Ce, gvjs_Ss, this.No, !1, this);
+  this.Ce.Gb(0 < this.bc.mc.length)
+}
+;
+gvjs_.sX = function() {
+  for (var a = this.bc.mc, b = 0; b < a.length; b++)
+    this.Ce.Bj(new gvjs_eP(a[b].Dd(),a[b]))
+}
+;
+gvjs_.AE = function() {}
+;
+gvjs_.No = function() {
+  this.bc.ru()
+}
+;
+function gvjs_kP(a) {
+  gvjs_nP.call(this, a)
+}
+gvjs_o(gvjs_kP, gvjs_nP);
+gvjs_kP.prototype.sX = function() {
+  var a = this.bc;
+  gvjs_lP(a) && this.Ce.Bj(new gvjs_eP(a.m.caption));
+  gvjs_nP.prototype.sX.call(this)
+}
+;
+gvjs_kP.prototype.AE = function() {
+  for (var a = this.bc.ug.ob()[0], b = 0, c = this.Ce.bh(); b < c; b++)
+    if (this.Ce.od(b).Zh == a) {
+      this.Ce.rk(b);
+      break
+    }
+}
+;
+gvjs_kP.prototype.No = function(a) {
+  this.bc.ug.clear();
+  var b = this.Ce.Be().Zh;
+  b && this.bc.ug.set(b.getId(), b);
+  gvjs_nP.prototype.No.call(this, a)
+}
+;
+function gvjs_jP(a) {
+  gvjs_nP.call(this, a);
+  this.pk = null
+}
+gvjs_o(gvjs_jP, gvjs_nP);
+gvjs_ = gvjs_jP.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.pk);
+  gvjs_nP.prototype.M.call(this)
+}
+;
+gvjs_.R = function(a) {
+  gvjs_nP.prototype.R.call(this, a);
+  var b = this.bc.m.selectedValuesLayout;
+  b == gvjs_3N && this.Ce.Xr(gvjs_Y);
+  gvjs_E(this.pk);
+  this.pk = new gvjs_oP(b,gvjs_Dz(this.Ce.j()).width,gvjs_lP(this.bc) ? 0 : 1);
+  a.addChild(this.pk, !0);
+  this.bc.addEventListener(this.pk, gvjs_Ss, this.HI, !1, this)
+}
+;
+gvjs_.AE = function() {
+  for (var a = this.bc.ug, b = 0, c = this.Ce.bh(); b < c; b++)
+    a.tf(this.Ce.od(b).Zh.getId()) && this.Ce.od(b).setVisible(!1);
+  gvjs_pP(this.pk, a.ob());
+  this.Ce.gl(null);
+  this.Ce.Gb(!gvjs_mP(this.bc))
+}
+;
+gvjs_.No = function(a) {
+  var b = this.Ce.Be().Zh;
+  this.Ce.Be().setVisible(!1);
+  this.Ce.gl(null);
+  this.bc.ug.set(b.getId(), b);
+  this.Ce.Gb(!gvjs_mP(this.bc));
+  gvjs_pP(this.pk, this.bc.ug.ob());
+  gvjs_nP.prototype.No.call(this, a)
+}
+;
+gvjs_.HI = function(a) {
+  (a = a.item) && this.bc.ug.remove(a.getId());
+  this.Ce.Gb(!0);
+  for (var b = 0, c = this.Ce.bh(); b < c; b++)
+    if (this.Ce.od(b).Zh == a) {
+      this.Ce.od(b).setVisible(!0);
+      break
+    }
+  this.bc.ru()
+}
+;
+function gvjs_qP(a) {
+  gvjs_F.call(this);
+  this.bc = a;
+  this.ae = null
+}
+gvjs_o(gvjs_qP, gvjs_F);
+gvjs_ = gvjs_qP.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.ae);
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_.R = function(a) {
+  var b = this.bc.mc;
+  gvjs_E(this.ae);
+  this.ae = new gvjs_9O;
+  this.ae.iha = !0;
+  var c = this.ae;
+  c.RX = this.bc.m.caption;
+  c.lj && c.lj.In(c.RX);
+  for (c = 0; c < b.length; c++)
+    this.ae.Bj(new gvjs_bP(b[c].Dd(),b[c]));
+  a.addChild(this.ae, !0);
+  this.ae.Gb(0 < b.length);
+  this.bc.addEventListener(this.ae, gvjs_Ss, this.No, !1, this);
+  a = gvjs_zh(gvjs_Oh(), gvjs_fv, null, this.ae.j())[0];
+  this.bc.addEventListener(a, gvjs_Yo, this.PZ, !1, this)
+}
+;
+gvjs_.AE = function() {}
+;
+gvjs_.No = function() {
+  this.bc.ru()
+}
+;
+gvjs_.PZ = function() {}
+;
+function gvjs_iP(a) {
+  gvjs_qP.call(this, a)
+}
+gvjs_o(gvjs_iP, gvjs_qP);
+gvjs_iP.prototype.AE = function() {
+  this.ae.Wa(this.bc.ug.ob()[0].Dd())
+}
+;
+gvjs_iP.prototype.No = function(a) {
+  this.bc.ug.clear();
+  var b = a.item.getValue();
+  b && this.bc.ug.set(b.getId(), b);
+  gvjs_qP.prototype.No.call(this, a)
+}
+;
+gvjs_iP.prototype.PZ = function() {
+  var a = this.bc.ug;
+  if (!this.ae.getValue() && gvjs_lP(this.bc)) {
+    var b = !a.isEmpty();
+    a.clear();
+    b && this.bc.ru()
+  } else
+    a.isEmpty() ? this.ae.Wa("") : this.ae.Wa(a.ob()[0].Dd())
+}
+;
+function gvjs_hP(a) {
+  gvjs_qP.call(this, a);
+  this.pk = null
+}
+gvjs_o(gvjs_hP, gvjs_qP);
+gvjs_ = gvjs_hP.prototype;
+gvjs_.M = function() {
+  gvjs_E(this.pk);
+  gvjs_qP.prototype.M.call(this)
+}
+;
+gvjs_.R = function(a) {
+  gvjs_qP.prototype.R.call(this, a);
+  var b = this.bc.m.selectedValuesLayout;
+  b == gvjs_3N && gvjs_VC(this.ae.j(), gvjs_Y);
+  gvjs_E(this.pk);
+  this.pk = new gvjs_oP(b,gvjs_Dz(this.ae.j()).width,gvjs_lP(this.bc) ? 0 : 1);
+  a.addChild(this.pk, !0);
+  this.bc.addEventListener(this.pk, gvjs_Ss, this.HI, !1, this)
+}
+;
+gvjs_.AE = function() {
+  for (var a = this.bc.ug, b = 0, c = this.ae.bh(); b < c; b++)
+    a.tf(this.ae.od(b).Zh.getId()) && this.ae.od(b).Gb(!1);
+  gvjs_pP(this.pk, a.ob());
+  this.ae.Wa("");
+  this.ae.Gb(!gvjs_mP(this.bc))
+}
+;
+gvjs_.No = function(a) {
+  var b = a.item.getValue();
+  a.item.Gb(!1);
+  a.preventDefault();
+  this.ae.eC();
+  this.ae.Wa("");
+  this.bc.ug.set(b.getId(), b);
+  this.ae.Gb(!gvjs_mP(this.bc));
+  gvjs_pP(this.pk, this.bc.ug.ob());
+  gvjs_qP.prototype.No.call(this, a)
+}
+;
+gvjs_.HI = function(a) {
+  a = a.item;
+  this.bc.ug.remove(a.getId());
+  this.ae.Gb(!0);
+  for (var b = 0, c = this.ae.bh(); b < c; b++)
+    if (this.ae.od(b).Zh == a) {
+      this.ae.od(b).Gb(!0);
+      break
+    }
+  this.bc.ru()
+}
+;
+gvjs_.PZ = function() {
+  this.ae.Wa("")
+}
+;
+function gvjs_oP(a, b, c, d) {
+  gvjs_MC.call(this, d);
+  this.EE = a;
+  this.Pq = b;
+  this.b1 = c;
+  this.Uz = 0;
+  this.gU = []
+}
+gvjs_o(gvjs_oP, gvjs_MC);
+gvjs_oP.prototype.J = function() {
+  var a = this.D.J("UL");
+  this.H = a;
+  this.vf(a)
+}
+;
+gvjs_oP.prototype.Fh = function(a) {
+  return "UL" == a.tagName
+}
+;
+gvjs_oP.prototype.vf = function(a) {
+  gvjs_VC(a, "google-visualization-controls-categoryfilter-selected");
+  this.EE == gvjs_3N ? gvjs_VC(a, gvjs_Y) : ("belowWrapping" == this.EE || this.EE == gvjs_4N) && gvjs_C(a, gvjs_Hv, this.Pq + gvjs_T)
+}
+;
+function gvjs_pP(a, b) {
+  a.qc(!0);
+  a.gU = [];
+  a.Uz = b.length;
+  for (var c = 0; c < a.Uz; c++) {
+    var d = a
+      , e = b[c];
+    var f = new gvjs_8D(gvjs_S,new gvjs_rP(d.EE));
+    f.jp(!1);
+    var g = new gvjs_4D("\u00d7",new gvjs_dP);
+    gvjs_G(g, gvjs_Ss, gvjs_re(d.HI, e, f), !1, d);
+    f.addChild(g, !0);
+    g.j().setAttribute(gvjs_9w, 0);
+    g.Gb(d.Uz > d.b1);
+    d = new gvjs_LD(e.Dd());
+    d.Xr(gvjs_Y);
+    f.addChild(d, !0);
+    a.gU.push(f);
+    a.addChild(f, !0)
+  }
+}
+gvjs_oP.prototype.HI = function(a, b, c) {
+  this.Uz <= this.b1 || (this.removeChild(c.target.getParent(), !0),
+    gvjs_Ie(this.gU, b),
+    this.Uz--,
+  this.Uz <= this.b1 && 0 < this.Uz && gvjs_u(this.gU, function(d) {
+    d.Ye(0).Gb(!1)
+  }),
+    this.dispatchEvent(new gvjs_3O(gvjs_Ss,this,a)),
+    c.stopPropagation())
+}
+;
+function gvjs_rP(a) {
+  this.dN = void 0;
+  this.EE = a
+}
+gvjs_o(gvjs_rP, gvjs_5D);
+gvjs_rP.prototype.J = function(a) {
+  var b = this.EE == gvjs_4N ? "" : gvjs_Y;
+  return a.wa().J("LI", this.Rl(a).join(" ") + " " + b)
+}
+;
+gvjs_rP.prototype.Fh = function(a) {
+  return "LI" == a.tagName
+}
+;
+function gvjs_sP(a) {
+  gvjs_QO.call(this, a)
+}
+gvjs_o(gvjs_sP, gvjs_QO);
+gvjs_sP.prototype.vv = function() {
+  return gvjs_fP
+}
+;
+var gvjs_gia = gvjs_gO.eCa
+  , gvjs_hia = gvjs_gO.fCa
+  , gvjs_iia = gvjs_D.removeAll;
+function gvjs_tP(a) {
+  gvjs_Qn.call(this, a);
+  this.Ai = this.fo = this.Ea = this.theme = this.Fa = null;
+  this.QM = [];
+  this.ly = this.Vp = this.pi = this.animation = this.sb = this.Ns = this.Ui = null;
+  this.height = this.width = 0;
+  this.options = null;
+  this.orientation = gvjs_S;
+  this.tQ = new gvjs_H;
+  this.Tu = new gvjs_8q(this);
+  gvjs_6x(this, this.Tu)
+}
+gvjs_o(gvjs_tP, gvjs_Qn);
+gvjs_ = gvjs_tP.prototype;
+gvjs_.M = function() {
+  this.He();
+  gvjs_E(this.tQ);
+  gvjs_E(this.pi);
+  gvjs_E(this.Vp);
+  gvjs_E(this.ly);
+  gvjs_Qn.prototype.M.call(this)
+}
+;
+gvjs_.us = function(a, b, c, d, e, f) {
+  if (this.Fa === gvjs_fw)
+    throw Error("This should never happen.");
+  a = this.Fa === gvjs_4u ? new gvjs_QK(a,b,c,d,e) : new gvjs_eJ(a,b,c,d,e);
+  this.oQ(a, f);
+  return a
+}
+;
+gvjs_.oQ = function(a, b) {
+  a.init(this.BB, b)
+}
+;
+gvjs_.hH = function(a, b, c, d, e, f, g) {
+  return new gvjs_jK(a,b,c,d,e,f,g)
+}
+;
+gvjs_.gH = function(a, b, c, d) {
+  return new gvjs_WJ(a,b,c,d)
+}
+;
+gvjs_.Wx = function(a, b) {
+  return new gvjs_aH(a,b)
+}
+;
+gvjs_.cc = function(a, b, c, d) {
+  this.Fa = a;
+  null != b && (this.DH = b);
+  null != c && (this.orientation = c);
+  null != d && (this.theme = d)
+}
+;
+gvjs_.draw = function(a, b, c) {
+  gvjs_Qn.prototype.draw.call(this, a, b, c)
+}
+;
+gvjs_.Rd = function(a, b, c, d) {
+  var e = this;
+  c = void 0 === c ? {} : c;
+  this.BB = a;
+  c = gvjs_Li(gvjs_Ii(c));
+  gvjs_jia(this, c);
+  gvjs_kia(this, c);
+  c.orientation = c.orientation || this.orientation;
+  c.theme = c.theme || this.theme;
+  this.Fa !== gvjs_f && gvjs_lia(c);
+  if (this.Fa !== gvjs_fw && gvjs_Jj(c.reverseCategories)) {
+    var f = c.orientation === gvjs_U ? gvjs_Ud : gvjs_Xu;
+    c[f] = c[f] || {};
+    c[f].direction = -1;
+    delete c.reverseCategories
+  }
+  gvjs_mia(c);
+  f = this.getContainer();
+  gvjs_iia(f);
+  if (!b)
+    throw Error(gvjs_as);
+  gvjs_Fe(gvjs_Ky(b.$()), function(k) {
+    return b.Jg(k) === gvjs_3v
+  }) && (c.isDiff = !0);
+  b.W(0);
+  b.ca();
+  gvjs_uP(this);
+  c = gvjs_nia(c);
+  var g = []
+    , h = gvjs_7K();
+  gvjs_u(c, function(k) {
+    g.push.apply(g, gvjs_9d(gvjs_Vz(k, h)))
+  });
+  this.bfa = c;
+  this.options = new gvjs_Aj(gvjs_Le(this.bfa));
+  this.Fa = gvjs_J(this.options, gvjs_Sd, gvjs_f, gvjs_eC);
+  this.width = this.La(this.options);
+  this.height = this.getHeight(this.options);
+  c = new gvjs_A(this.width,this.height);
+  f = gvjs_K(this.options, gvjs_Eu);
+  if (!this.sb || this.sb.xf)
+    try {
+      this.sb = new gvjs_3B(this.container,c,a,f)
+    } catch (k) {
+      throw Error(gvjs_As);
+    }
+  else
+    this.sb.update(c, a);
+  this.Ui = new gvjs_bG(d);
+  this.Ta = b;
+  g.length && this.Lh ? (this.Lh.promise.then(function() {
+    e.sb.rl(e.hX.bind(e), a)
+  }),
+    gvjs_sy(this, function() {
+      e.sb.rl(e.hX.bind(e), a)
+    }),
+    new gvjs_6K(g,this.Lh)) : this.sb.rl(this.hX.bind(this), a)
+}
+;
+function gvjs_nia(a) {
+  if (a.isStacked && a.vAxis && a.vAxis.baseline)
+    throw Error(gvjs_5r);
+  var b = a.theme || [];
+  b && !Array.isArray(b) && (b = [b]);
+  for (var c = [a], d = 0; d < b.length; d++) {
+    var e = b[d];
+    if (typeof e === gvjs_l)
+      e = gvjs_4F(e);
+    else if (gvjs_r(e))
+      e instanceof gvjs_Aj && (e = gvjs_jq(e));
+    else
+      throw Error(gvjs_ws);
+    e && c.push(e)
+  }
+  a = a.type.toLowerCase();
+  gvjs_PF[a] && c.push(gvjs_PF[a]);
+  c.push(gvjs_QF);
+  return c
+}
+gvjs_.hX = function() {
+  var a = this
+    , b = this.sb.Oa()
+    , c = this.sb.yq()
+    , d = this.options;
+  this.us(this.Ta, d, b.me.bind(b), this.width, this.height, function(e) {
+    gvjs_vP(a);
+    e = e.ti();
+    var f = new gvjs_fL(d,a.Ui,a.Ql.bind(a),e);
+    gvjs_E(a.pi);
+    a.pi = new gvjs_MK(e,a.Ui,a.tQ,a.Tu,a.refresh.bind(a, !0),f);
+    a.Ai = a.hH(a.options, new gvjs_A(a.width,a.height), {
+      bb: e.Hj,
+      fontSize: e.Dl
+    }, e.qz, e.Ig, e.C.length, a.Ai ? a.Ai.le : void 0);
+    gvjs_oia(a);
+    a.fo = a.Wx(c, b);
+    gvjs_pia(a, e) || (a.Ea = e,
+      gvjs_wP(a),
+      gvjs_xP(a));
+    a.fY();
+    a.Tu.dispatchEvent(gvjs_i);
+    a.pi.Bq()
+  })
+}
+;
+gvjs_.fY = function() {
+  var a = this
+    , b = this.sb.Oa();
+  setTimeout(function() {
+    if (b && b.ws) {
+      var c = b.ws();
+      if (c && a.Ta) {
+        var d = gvjs_gL(a.Ta);
+        gvjs_cg(c, d)
+      }
+    }
+  }, 0)
+}
+;
+gvjs_.Jm = function(a, b) {
+  if (this.Fa === gvjs_fw)
+    return this.av(a, b);
+  throw Error(gvjs_4r);
+}
+;
+gvjs_.av = function(a, b) {
+  if (!a || !b)
+    throw Error("Old and New DataTables must exist.");
+  var c = new gvjs_M
+    , d = b.ca()
+    , e = b.$()
+    , f = a.W(0) !== gvjs_g;
+  f && c.xd(a.W(0), a.Ga(0));
+  for (var g = f ? 1 : 0, h = g; h < e; ++h)
+    c.xd({
+      type: a.W(h),
+      label: a.Ga(h),
+      role: gvjs_3v
+    }),
+      c.xd({
+        type: b.W(h),
+        label: b.Ga(h),
+        role: gvjs_$t
+      });
+  c.Yn(d);
+  for (h = 0; h < d; ++h) {
+    if (f) {
+      var k = b.getValue(h, 0);
+      c.Wb(h, 0, k)
+    }
+    for (var l = k = g; l < e; ++l) {
+      var m = a.getValue(h, l);
+      c.Wb(h, k, m);
+      k += 1;
+      m = b.getValue(h, l);
+      c.Wb(h, k, m);
+      k += 1
+    }
+  }
+  return c
+}
+;
+function gvjs_jia(a, b) {
+  switch (b.type) {
+    case gvjs_yP.LINE:
+      a.cc(gvjs_d, gvjs_e, gvjs_S);
+      b.type = null;
+      break;
+    case gvjs_yP.AREA:
+      a.cc(gvjs_d, gvjs_at, gvjs_S);
+      b.type = null;
+      break;
+    case gvjs_yP.cia:
+      a.cc(gvjs_d, gvjs_lt, gvjs_S);
+      b.type = null;
+      break;
+    case gvjs_yP.nV:
+      a.cc(gvjs_d, gvjs_lt, gvjs_U);
+      b.type = null;
+      break;
+    case gvjs_yP.wV:
+      a.cc(gvjs_Dd);
+      b.type = null;
+      break;
+    case gvjs_yP.z6:
+      a.cc(gvjs_fw),
+        b.type = null
+  }
+  a = a.Fa;
+  a === gvjs_f && (a = null);
+  var c = b.type || gvjs_f;
+  c === gvjs_f && (c = null);
+  if (!a && !c)
+    throw Error(gvjs_zs);
+  if (a && c && a !== c)
+    throw Error(gvjs_es);
+  b.type = a || c
+}
+function gvjs_kia(a, b) {
+  if (b.type === gvjs_d) {
+    a = a.DH;
+    a === gvjs_f && (a = null);
+    var c = b.seriesType || gvjs_f;
+    c === gvjs_f && (c = null);
+    if (a && c && a !== c)
+      throw Error(gvjs_fs);
+    b.seriesType = a || c
+  }
+}
+function gvjs_lia(a) {
+  a.hAxis = a.hAxis || {};
+  a.vAxis = a.vAxis || {};
+  var b = a.hAxis
+    , c = a.vAxis
+    , d = null;
+  switch (a.type) {
+    case gvjs_Dd:
+      d = c;
+      break;
+    case gvjs_d:
+      a.targetAxis = a.targetAxis || {},
+        d = a.targetAxis
+  }
+  d && (gvjs_zP(a, gvjs_Ov, d, gvjs_ed),
+    gvjs_zP(a, gvjs_Gv, d, gvjs_cd),
+    gvjs_zP(a, gvjs_Cv, d, gvjs_Cv));
+  b && (gvjs_zP(a, "logScaleX", b, gvjs_Cv),
+    gvjs_zP(a, "titleX", b, gvjs_fx));
+  c && gvjs_zP(a, gvjs_jx, c, gvjs_fx);
+  a.smoothLine && void 0 === a.curveType && (a.curveType = gvjs_d);
+  gvjs_zP(a, "lineSize", a, gvjs_Bv);
+  gvjs_zP(a, gvjs_ww, a, gvjs_xw);
+  a.chartArea = a.chartArea || {};
+  gvjs_zP(a, gvjs_gt, a.chartArea, gvjs_ht)
+}
+function gvjs_mia(a) {
+  gvjs_AP(a, gvjs_gx, gvjs_hx, gvjs_ix);
+  gvjs_AP(a, gvjs_xv, gvjs_wv, gvjs_yv);
+  gvjs_BP(a.hAxis);
+  var b = a.hAxes || {}, c;
+  for (c in b)
+    b.hasOwnProperty(c) && gvjs_BP(b[c]);
+  b = a.vAxes || {};
+  gvjs_BP(a.vAxis);
+  for (var d in b)
+    b.hasOwnProperty(d) && gvjs_BP(b[d]);
+  d = a.tooltip;
+  null == d && (d = {},
+    a.tooltip = d);
+  gvjs_AP(a, gvjs_sx, gvjs_rx, gvjs_tx);
+  gvjs_zP(a, gvjs_tx, d, gvjs_bx);
+  gvjs_zP(a, "tooltipText", d, gvjs_m);
+  gvjs_zP(a, gvjs_ux, d, "trigger");
+  "hover" === d.trigger && (d.trigger = gvjs_xu);
+  d = a.legend;
+  null == d ? (d = {},
+    a.legend = d) : typeof d === gvjs_l && (b = d,
+    d = {},
+    a.legend = d,
+    d.position = b);
+  gvjs_zP(a, gvjs_yv, d, gvjs_bx);
+  d = a.animation;
+  null == d ? (d = {},
+    a.animation = d) : typeof d === gvjs_g && (b = 1E3 * d,
+    d = {},
+    a.animation = d,
+    d.duration = b);
+  gvjs_zP(a, gvjs_Xs, d, "easing")
+}
+function gvjs_BP(a) {
+  if (null != a) {
+    gvjs_AP(a, "textColor", "textFontSize", gvjs_bx);
+    gvjs_AP(a, gvjs_gx, gvjs_hx, gvjs_ix);
+    a.gridlines = a.gridlines || {};
+    var b = a.gridlines
+      , c = a.numberOfSections;
+    void 0 === b.count && void 0 !== c && typeof c === gvjs_g && (b.count = c + 1);
+    a = a.gridlineColor;
+    void 0 === b.color && void 0 !== a && (b.color = a)
+  }
+}
+function gvjs_AP(a, b, c, d) {
+  a[d] = a[d] || {};
+  d = a[d];
+  gvjs_zP(a, b, d, gvjs_1);
+  gvjs_zP(a, c, d, gvjs_zp)
+}
+function gvjs_zP(a, b, c, d) {
+  void 0 !== a[b] && void 0 === c[d] && (c[d] = a[b])
+}
+gvjs_.He = function() {
+  gvjs_CP(this);
+  gvjs_uP(this);
+  gvjs_vP(this);
+  gvjs_E(this.sb);
+  gvjs_li(this)
+}
+;
+function gvjs_uP(a) {
+  if (a.pi && !a.pi.xf) {
+    var b = a.pi.zb;
+    b.fq = Infinity;
+    b.Hc.stop()
+  }
+  gvjs_E(a.pi);
+  if (a.sb && !a.sb.xf) {
+    b = a.sb.Oa();
+    var c = a.sb.yq();
+    a.ly = b;
+    c.clear()
+  }
+  gvjs_E(a.Vp);
+  gvjs_li(a.tQ)
+}
+function gvjs_vP(a) {
+  var b = a.ly || a.sb && a.sb.Oa();
+  a.ly = null;
+  b && b.clear()
+}
+function gvjs_oia(a) {
+  gvjs_u(a.QM, function(b) {
+    typeof b === gvjs_l ? a.th(b) : a.xh(b)
+  });
+  a.QM = []
+}
+gvjs_.xh = function(a) {
+  null != this.Ai ? this.Ai.xh(a) : this.QM.push(a)
+}
+;
+function gvjs_qia(a, b) {
+  var c = new gvjs_$n;
+  c.setSelection(b);
+  b = gvjs_co(c);
+  c = !1;
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = e.column;
+    e = e.row;
+    f = a.Ea.Jk && a.Ea.Jk[f];
+    if (!f)
+      return !1;
+    var g = f.Vb
+      , h = void 0
+      , k = void 0;
+    null != g ? k = a.Ea.C[g].points[e] : h = a.Ea.$a[e];
+    if (!k && !h)
+      return !1;
+    if (f.role === gvjs_Zs) {
+      if (c)
+        return !1;
+      c = !0;
+      if (!(k || h).Bc)
+        return !1
+    }
+  }
+  return !0
+}
+gvjs_.setSelection = function(a) {
+  if (gvjs_qia(this, a)) {
+    var b = null;
+    if (this.Ea.Fa !== gvjs_fw) {
+      var c = new gvjs_$n;
+      c.setSelection(a);
+      c = gvjs_co(c);
+      for (var d = 0; d < c.length; d++) {
+        var e = c[d]
+          , f = this.Ea.Jk[e.column];
+        if (f.role === gvjs_Zs) {
+          b = {
+            Vb: f.Vb,
+            oO: e.row
+          };
+          break
+        }
+      }
+    }
+    this.refresh(!0);
+    this.Ui.selected.setSelection(a);
+    b && (this.Ui.annotations.dI = b);
+    this.refresh(!1)
+  }
+}
+;
+gvjs_.refresh = function(a) {
+  if (this.Ns) {
+    var b = this.Ns;
+    if (!this.Ai.xY(this.Ui, this.Ns)) {
+      var c = this.Ui.gm;
+      if (c) {
+        this.options = new gvjs_Aj(gvjs_Le(this.bfa));
+        gvjs_hq(this.options, 0, c);
+        c = this.sb.Oa();
+        var d = this.us(this.Ta, this.options, c.me.bind(c), this.width, this.height).ti();
+        this.pi.ha = d;
+        this.ly && (this.ly.clear(),
+          this.ly = null);
+        this.Vp && this.Vp instanceof gvjs_WJ && this.Vp.I5(d);
+        c = gvjs_iK(this.Ai, d, this.Ui);
+        this.Ea = d;
+        this.fo.VK(this.Ea);
+        gvjs_OG(this.fo, this.Ea, c);
+        this.Ui.gm = null;
+        this.Ns = this.Ui.clone()
+      } else
+        this.Ns = this.Ui.clone(),
+          c = gvjs_iK(this.Ai, this.Ea, this.Ui),
+          gvjs_PG(this.fo, this.Ea, c)
+    }
+    a && this.Tu.Is(b, this.Ns, this.Ea.Fa, this.Ea.C)
+  }
+}
+;
+gvjs_.getSelection = function() {
+  return this.Ns ? this.Ns.selected.getSelection() : []
+}
+;
+gvjs_.ng = function(a) {
+  if (this.Ai)
+    return this.Ai.ng(a)
+}
+;
+gvjs_.th = function(a) {
+  null != this.Ai ? this.Ai.th(a) : this.QM.push(a)
+}
+;
+gvjs_.dump = function() {
+  var a = this.sb.Oa();
+  return a instanceof gvjs_PB ? a.container.innerHTML : ""
+}
+;
+function gvjs_wP(a) {
+  var b = gvjs_iK(a.Ai, a.Ea, a.Ui);
+  a.fo.Fl(a.Ea, b);
+  a.Ns = a.Ui.clone()
+}
+function gvjs_xP(a) {
+  var b = a.sb.Oa()
+    , c = a.sb.yq();
+  gvjs_E(a.Vp);
+  a.Vp = a.gH(a.tQ, b, c, a.Ea);
+  gvjs_QJ(a.Vp);
+  gvjs_SJ(a.Vp);
+  gvjs_TJ(a.Vp)
+}
+function gvjs_pia(a, b) {
+  var c = gvjs_5K(a.options, 0, gvjs_Hp);
+  if (a.animation) {
+    var d = a.animation.zK;
+    gvjs_CP(a)
+  } else
+    d = a.Ea;
+  if (!c || !(c.iga || d && d.Fa === b.Fa) || b.Fa === gvjs_4u || b.Fa === gvjs_fw)
+    return !1;
+  if (!d) {
+    var e = gvjs_Ky(a.Ta.$());
+    d = a.Ta instanceof gvjs_N;
+    var f = a.Ta.Do();
+    if (!d) {
+      var g = a.Ta;
+      f = gvjs_v(g.Do(), function(u) {
+        return typeof u === gvjs_h ? u : {
+          sourceColumn: u,
+          properties: g.Rj(u)
+        }
+      })
+    }
+    var h = b.C;
+    d = b.Jk;
+    b.Fa === gvjs_yt && (d = [{
+      role: gvjs_5c
+    }, {
+      role: gvjs_mu
+    }, {
+      role: gvjs_$t,
+      Vb: 0
+    }]);
+    var k, l;
+    gvjs_u(d, function(u, v) {
+      if (u.role === gvjs_$t || u.role === gvjs_iv) {
+        var w = gvjs_x(f[v]);
+        if (u.role === gvjs_$t) {
+          u = h[u.Vb];
+          if (u.ag)
+            return;
+          u = u.Qc || 0;
+          if (null != u) {
+            var x = b.orientation && b.orientation !== gvjs_S ? b.jd[u] : b.wc[u];
+            k = function() {
+              return x.baseline.za
+            }
+            ;
+            l = x.dataType
+          }
+        } else
+          w.role = gvjs_iv;
+        w.calc = k;
+        w.type = l;
+        e[v] = w
+      }
+    });
+    d = new gvjs_N(a.Ta);
+    d.Hn(e);
+    var m = {}
+      , n = b.jd;
+    if (n) {
+      var p = Object.keys(n);
+      p = gvjs_8d(p);
+      for (var q = p.next(); !q.done; q = p.next()) {
+        var r = q.value;
+        typeof r === gvjs_g && (q = n[r],
+        q.Tn && (m[r] = {
+          viewWindow: {
+            numericMin: q.Tn.min,
+            numericMax: q.Tn.max
+          }
+        }))
+      }
+    }
+    p = {};
+    if (n = b.wc)
+      for (r = Object.keys(n),
+             r = gvjs_8d(r),
+             q = r.next(); !q.done; q = r.next())
+        if (q = q.value,
+        typeof q === gvjs_g) {
+          var t = n[q];
+          t.Tn && (p[q] = {
+            viewWindow: {
+              numericMin: t.Tn.min,
+              numericMax: t.Tn.max
+            }
+          })
+        }
+    gvjs_hq(a.options, 0, {
+      hAxes: m,
+      vAxes: p
+    });
+    m = a.sb.Oa();
+    d = a.us(d, a.options, m.me.bind(m), a.width, a.height).ti()
+  }
+  a.Ea = null;
+  m = Date.now();
+  n = a.animation && a.animation.iA || 0;
+  gvjs_CP(a);
+  a.animation = {
+    bua: d,
+    $J: b,
+    interpolator: new gvjs_zK(d,b),
+    zK: d,
+    startTime: m,
+    endTime: m + c.duration,
+    iA: n,
+    timer: new gvjs_IA(10),
+    oY: c.easing,
+    HD: c.HD,
+    done: !1
+  };
+  a.Kaa();
+  gvjs_G(a.animation.timer, gvjs_dx, a.Kaa.bind(a));
+  a.animation.timer.start();
+  a.Ea = b;
+  return !0
+}
+gvjs_.Kaa = function() {
+  var a = this.animation;
+  this.Ea = null;
+  if (a.done)
+    gvjs_CP(this),
+      this.Ea = a.$J,
+      gvjs_wP(this),
+      gvjs_xP(this),
+      this.Tu.dispatchEvent(gvjs_gia);
+  else {
+    var b = Date.now()
+      , c = (b - a.startTime) / (a.endTime - a.startTime);
+    if (1 > c) {
+      if (b - a.iA < 1E3 / this.animation.HD)
+        return
+    } else
+      c = 1,
+        a.done = !0;
+    c = a.interpolator.interpolate(a.oY(c));
+    a.zK = c;
+    a.iA = b;
+    this.fo.Fl(c, {});
+    this.Tu.dispatchEvent(gvjs_hia)
+  }
+  this.Ea = a.$J
+}
+;
+function gvjs_CP(a) {
+  a.animation && (gvjs_E(a.animation.timer),
+    a.animation = null)
+}
+gvjs_.fZ = function() {
+  var a = this.Ea.O;
+  return {
+    left: a.left,
+    top: a.top,
+    width: a.width,
+    height: a.height
+  }
+}
+;
+gvjs_.Qj = function(a) {
+  return null == this.fo ? null : (a = this.fo.Qj(a)) ? {
+    left: a.left,
+    top: a.top,
+    width: a.right - a.left,
+    height: a.bottom - a.top
+  } : null
+}
+;
+gvjs_.Ql = function() {
+  var a = this.Ea;
+  if (null == a)
+    throw Error("redundant error checking");
+  return {
+    getChartAreaBoundingBox: this.fZ.bind(this),
+    getBoundingBox: this.Qj.bind(this),
+    getXLocation: gvjs_5G.bind(null, a),
+    getYLocation: gvjs_6G.bind(null, a),
+    getHAxisValue: gvjs_7G.bind(null, a),
+    getVAxisValue: gvjs_8G.bind(null, a),
+    getPointDatum: gvjs_9G.bind(null, a)
+  }
+}
+;
+gvjs_.pZ = function() {
+  return this.sb
+}
+;
+gvjs_.ti = function() {
+  return this.Ea
+}
+;
+gvjs_.ah = function() {
+  if (!this.options || !this.Ea || !this.Ui)
+    throw Error(gvjs_6r);
+  var a = new gvjs_A(this.width,this.height)
+    , b = gvjs_3g(this.container).createElement(gvjs_Ob);
+  a = gvjs_1B(b, a);
+  a = new gvjs_rB(b,a);
+  a = this.Wx(new gvjs_MB(b), a);
+  var c = gvjs_iK(this.Ai, this.Ea, this.Ui);
+  a.Fl(this.Ea, c);
+  return b.childNodes[0].toDataURL(gvjs_bv)
+}
+;
+var gvjs_yP = {
+  LINE: gvjs_e,
+  AREA: gvjs_at,
+  cia: "columns",
+  nV: gvjs_lt,
+  wV: gvjs_Dd,
+  z6: gvjs_fw
+};
+function gvjs_DP(a) {
+  gvjs_tP.call(this, a);
+  this.cc(gvjs_d, gvjs_at, gvjs_S)
+}
+gvjs_o(gvjs_DP, gvjs_tP);
+function gvjs_EP(a) {
+  gvjs_tP.call(this, a);
+  this.cc(gvjs_d, gvjs_e, gvjs_S)
+}
+gvjs_o(gvjs_EP, gvjs_tP);
+function gvjs_FP(a) {
+  gvjs_tP.call(this, a);
+  this.cc(gvjs_Dd)
+}
+gvjs_o(gvjs_FP, gvjs_tP);
+gvjs_FP.prototype.Jm = function(a, b) {
+  return this.av(a, b)
+}
+;
+function gvjs_GP(a) {
+  gvjs_tP.call(this, a);
+  this.cc(gvjs_d, gvjs_f, gvjs_S)
+}
+gvjs_o(gvjs_GP, gvjs_tP);
+function gvjs_HP(a) {
+  gvjs_Qn.call(this, a);
+  this.Fd = {};
+  this.da = null;
+  this.Ek = {
+    Cu: !1
+  };
+  this.aI = this.JK = this.ea = this.F = this.Ag = this.ha = this.wk = this.Z = null;
+  this.FK = 50;
+  this.Tca = 0;
+  this.zR = 1;
+  this.HW = this.x4 = this.fV = !1;
+  this.gR = this.sR = this.WY = this.j4 = null;
+  this.Ff = !1;
+  this.Cc = null;
+  this.K = {
+    range: null,
+    DO: null,
+    eh: null
+  };
+  this.Dj = {
+    cl: {
+      min: 0,
+      max: 0
+    },
+    value: {
+      min: 0,
+      max: 0
+    }
+  };
+  this.bW = null;
+  this.jX = !1;
+  this.Gu = null;
+  this.ZO = !1
+}
+gvjs_o(gvjs_HP, gvjs_Qn);
+gvjs_ = gvjs_HP.prototype;
+gvjs_.draw = function(a, b, c) {
+  this.Jb();
+  gvjs_Kk(a);
+  this.Z = a;
+  this.wk = gvjs_7H(a.W(0));
+  null == this.JK && (this.JK = new gvjs_KK(this.Nya.bind(this)));
+  null == this.aI && (this.aI = new gvjs_KK(this.t5.bind(this, !0)));
+  b = new gvjs_Aj([b || {}]);
+  this.Kt(b);
+  this.Cc = this.J$(b);
+  c = c || {};
+  if (!this.da) {
+    switch (gvjs_J(b, gvjs_St, gvjs_ya, gvjs_ria)) {
+      case gvjs_na:
+        b = new gvjs_DP(this.container);
+        break;
+      case gvjs_ya:
+        b = new gvjs_GP(this.container);
+        break;
+      case gvjs_9a:
+        b = new gvjs_FP(this.container);
+        break;
+      case gvjs_Va:
+        b = new gvjs_EP(this.container);
+        break;
+      default:
+        b = new gvjs_GP(this.container)
+    }
+    this.da = b;
+    gvjs_si(this.da, gvjs_i, this.iua.bind(this, c))
+  }
+  this.fV && (this.sR = this.Z.getValue(0, 0),
+    this.gR = this.Z.getValue(Math.max(0, this.Z.ca() - 1), 0),
+    b = {
+      min: this.sR,
+      max: this.gR
+    },
+  c.range && gvjs_IP(this, b, c.range),
+    this.Cc.domainAxis = this.Cc.domainAxis || {},
+    this.Cc.domainAxis.viewWindow = b);
+  this.da.draw(a, this.Cc)
+}
+;
+gvjs_.Rd = function() {}
+;
+gvjs_.Kt = function(a) {
+  this.FK = gvjs_Oj(a, "rangeChangeEventFiringRate", 50);
+  this.Tca = gvjs_Oj(a, "minRangeSize", 0);
+  this.ZO = gvjs_K(a, "fixedRangeSize", !1);
+  this.fV = gvjs_K(a, "zoomAroundSelection", !1);
+  this.x4 = gvjs_K(a, "snapToData", !1);
+  this.HW = gvjs_K(a, "centerSelectionAroundData", !1);
+  this.j4 = gvjs_qy(a, "sideScreenColor", new gvjs_3(gvjs_sia));
+  this.WY = new gvjs_3(gvjs_iy);
+  this.Ff = gvjs_J(a, gvjs_9v, gvjs_S, gvjs_iC) === gvjs_U
+}
+;
+gvjs_.J$ = function(a) {
+  a = gvjs_jj(a.pb("chartOptions"));
+  a.theme = this.Ff ? gvjs_tia : gvjs_uia;
+  return a
+}
+;
+function gvjs_via(a, b) {
+  var c = gvjs_lA(a.ca(), function(d) {
+    return a.getValue(d, 0)
+  });
+  c = gvjs_De(c, function(d) {
+    return null != d
+  });
+  return gvjs_v(c, b)
+}
+gvjs_.iua = function(a) {
+  gvjs_vi(this.da);
+  this.Ek = {
+    Cu: !0
+  };
+  gvjs_JP(this, a);
+  gvjs_E(this.F);
+  this.F = this.da.pZ().Oa(1);
+  gvjs_E(this.ea);
+  this.ea = new gvjs_KA;
+  gvjs_wia(this)
+}
+;
+gvjs_.Ada = function(a) {
+  gvjs_vi(this.da);
+  gvjs_JP(this, a);
+  gvjs_KP(this, gvjs_ut)
+}
+;
+function gvjs_JP(a, b) {
+  a.ha = a.da.ti();
+  a.Ag = a.Ff ? a.ha.wc[0] : a.ha.jd[0];
+  a.Dj.cl = {
+    min: Math.min(a.Ag.Pf, a.Ag.ef),
+    max: Math.max(a.Ag.Pf, a.Ag.ef)
+  };
+  var c = a.Dj
+    , d = a.Ag.position.ol(a.Ag.Pf)
+    , e = a.Ag.position.ol(a.Ag.ef);
+  c.value = {
+    min: Math.min(d, e),
+    max: Math.max(d, e)
+  };
+  d = a.Tca;
+  if (0 >= d)
+    a.zR = 1;
+  else {
+    c = a.Dj.cl.min;
+    e = a.Ag.position.ol(c);
+    if (gvjs_oe(e)) {
+      var f = new Date;
+      f.setTime(e.getTime() + d)
+    } else
+      f = e + d;
+    d = a.Ag.position.hf(f);
+    c = Math.max(Math.ceil(Math.abs(d - c)), 1);
+    a.zR = c < a.Dj.cl.max - a.Dj.cl.min ? c : 1
+  }
+  if (a.x4 || a.HW)
+    c = a.Ag,
+      d = gvjs_via(a.Z, c.position.hf),
+      c = a.Ff ? 1 === c.ro ? d.reverse() : d : 1 === c.ro ? d : d.reverse(),
+      a.bW = c;
+  b && (b = b.range,
+    a.K.range = gvjs_LP(a, gvjs_r(b) ? b.start : null, gvjs_r(b) ? b.end : null))
+}
+function gvjs_wia(a) {
+  var b = a.F
+    , c = a.ha
+    , d = b.Lm(c.width, c.height)
+    , e = b.Sa(!1);
+  b.appendChild(d, e);
+  d = c.O;
+  b.yb(0, 0, c.width, c.height, a.WY, e);
+  c = b.yb(d.left, d.top, d.width, d.height, a.WY, e);
+  var f = gvjs_MP(a);
+  f = b.yb(f.left, f.top, f.width, f.height, a.j4, e);
+  a.Fd.rangeSelectorMinScreen = f;
+  f = gvjs_NP(a);
+  f = b.yb(f.left, f.top, f.width, f.height, a.j4, e);
+  a.Fd.rangeSelectorMaxScreen = f;
+  f = gvjs_OP(a, a.K.range.Yh, d, b, e);
+  a.Fd.rangeSelectorMinHandle = f;
+  b = gvjs_OP(a, a.K.range.Xh, d, b, e);
+  a.Fd.rangeSelectorMaxHandle = b;
+  var g = gvjs_5g(a.container);
+  a.ea.o(g.body, gvjs_jd, a.Spa.bind(a, a.Ek));
+  a.ea.o(g.body, gvjs_md, a.RP.bind(a, a.Ek));
+  e = e.j();
+  a.ea.o(e, gvjs_jd, a.Vqa.bind(a, a.Ek));
+  a.ea.o(e, gvjs_kd, a.EI.bind(a, a.Ek, {
+    type: gvjs_Fw,
+    Ro: !1
+  }));
+  a.jX = gvjs_yh(e, function(h) {
+    return h === g.body
+  });
+  a.jX || a.ea.o(e, gvjs_md, a.RP.bind(a, a.Ek));
+  a.ZO || (gvjs_PP(a, f, gvjs_Ov, gvjs_Ov),
+    gvjs_PP(a, b, gvjs_Gv, gvjs_Gv));
+  a.ea.o(c, gvjs_gd, a.UC.bind(a, a.Ek, {
+    eh: gvjs_ut
+  }));
+  a.ea.o(c, gvjs_ld, a.EI.bind(a, a.Ek, {
+    type: gvjs_Fw,
+    Ro: !0
+  }));
+  a.ea.o(c, gvjs_kd, a.EI.bind(a, a.Ek, {
+    type: gvjs_Fw,
+    Ro: !1
+  }));
+  gvjs_I(a, gvjs_i, null)
+}
+function gvjs_PP(a, b, c, d) {
+  a.ea.o(b, gvjs_gd, a.UC.bind(a, a.Ek, {
+    eh: d
+  }));
+  a.ea.o(b, gvjs_ld, a.EI.bind(a, a.Ek, {
+    type: c,
+    Ro: !0
+  }));
+  a.ea.o(b, gvjs_kd, a.EI.bind(a, a.Ek, {
+    type: c,
+    Ro: !1
+  }))
+}
+function gvjs_OP(a, b, c, d, e) {
+  var f = gvjs_QP
+    , g = gvjs_xia
+    , h = gvjs_yia
+    , k = d.Sa(!1);
+  d.appendChild(e, k);
+  e = .5 * f.width;
+  var l = .5 * f.height
+    , m = a.Ff ? c.left : Math.floor(b - e) + .5;
+  b = a.Ff ? Math.floor(b - l) + .5 : c.top;
+  d.mp(k.j(), m, b);
+  a.Ff ? (b = Math.round(l),
+    b = gvjs_UA(a.Ff ? [{
+      x: 0,
+      y: b
+    }, {
+      x: 0 + c.width,
+      y: b
+    }] : [{
+      x: 0,
+      y: b
+    }, {
+      x: 0,
+      y: b + c.height
+    }]),
+    d.Ia(b, h, k),
+  a.ZO || gvjs_RP(a, .5 * (c.width - f.height), 0, f.height, f.width, g, d, h, k)) : (b = Math.round(e),
+    b = gvjs_UA(a.Ff ? [{
+      x: b,
+      y: 0
+    }, {
+      x: b + c.width,
+      y: 0
+    }] : [{
+      x: b,
+      y: 0
+    }, {
+      x: b,
+      y: 0 + c.height
+    }]),
+    d.Ia(b, h, k),
+  a.ZO || gvjs_RP(a, 0, .5 * (c.height - f.height), f.width, f.height, g, d, h, k));
+  return k.j()
+}
+function gvjs_RP(a, b, c, d, e, f, g, h, k) {
+  d = b + d;
+  e = c + e;
+  var l = gvjs_UA([{
+    x: b + f,
+    y: c
+  }, {
+    x: d - f,
+    y: c
+  }, {
+    x: d,
+    y: c + f
+  }, {
+    x: d,
+    y: e - f
+  }, {
+    x: d - f,
+    y: e
+  }, {
+    x: b + f,
+    y: e
+  }, {
+    x: b,
+    y: e - f
+  }, {
+    x: b,
+    y: c + f
+  }], !1);
+  g.Ia(l, h, k);
+  f += 1;
+  a.Ff ? (a = gvjs_UA([{
+    x: b + f,
+    y: c + f
+  }, {
+    x: d - f,
+    y: c + f
+  }]),
+    b = gvjs_UA([{
+      x: b + f,
+      y: e - f
+    }, {
+      x: d - f,
+      y: e - f
+    }])) : (a = gvjs_UA([{
+    x: b + f,
+    y: c + f
+  }, {
+    x: b + f,
+    y: e - f
+  }]),
+    b = gvjs_UA([{
+      x: d - f,
+      y: c + f
+    }, {
+      x: d - f,
+      y: e - f
+    }]));
+  g.Ia(a, h, k);
+  g.Ia(b, h, k)
+}
+function gvjs_MP(a) {
+  var b = a.ha.O
+    , c = a.K.range.Yh;
+  return a.Ff ? new gvjs_5(b.left,b.top,b.width,c - b.top) : new gvjs_5(b.left,b.top,c - b.left,b.height)
+}
+function gvjs_NP(a) {
+  var b = a.ha.O
+    , c = a.K.range.Xh;
+  return a.Ff ? new gvjs_5(b.left,c,b.width,b.bottom - c) : new gvjs_5(c,b.top,b.right - c,b.height)
+}
+function gvjs_LP(a, b, c) {
+  var d = a.Dj.cl.min
+    , e = a.Dj.cl.max
+    , f = 1 === a.Ag.ro && !a.Ff;
+  null != b && (b = a.Ag.position.hf(b),
+    f ? d = Math.max(b, d) : e = Math.min(b, e));
+  null != c && (a = a.Ag.position.hf(c),
+    f ? e = Math.min(a, e) : d = Math.max(a, d));
+  return {
+    Yh: d,
+    Xh: e
+  }
+}
+gvjs_.vP = function() {
+  var a = this.K.range
+    , b = this.Ag.position.ol(a.Yh);
+  a = this.Ag.position.ol(a.Xh);
+  var c = 1 === this.Ag.ro && !this.Ff;
+  return {
+    start: c ? b : a,
+    end: c ? a : b
+  }
+}
+;
+gvjs_.Ewa = function(a, b) {
+  if (!this.Ek.Cu)
+    return !1;
+  var c = this.K.range;
+  if (null == c.Yh || null == c.Xh)
+    return !1;
+  a = gvjs_LP(this, a, b);
+  a = gvjs_SP(this, a.Yh, a.Xh, gvjs_ut);
+  this.K.eh = null;
+  return a
+}
+;
+function gvjs_SP(a, b, c, d) {
+  var e = a.K.range;
+  if (e.Yh === b && e.Xh === c)
+    return !1;
+  a.K.range = {
+    Yh: b,
+    Xh: c
+  };
+  gvjs_KP(a, d);
+  return !0
+}
+function gvjs_KP(a, b) {
+  var c = a.Ff ? gvjs_QP.height : gvjs_QP.width
+    , d = a.Ff ? gvjs_QP.width : gvjs_QP.height;
+  if (b != gvjs_Gv) {
+    var e = gvjs_MP(a)
+      , f = a.Fd.rangeSelectorMinScreen
+      , g = a.Fd.rangeSelectorMinHandle;
+    a.Ff ? (a.F.mp(g, 0, Math.floor(e.top + e.height - .5 * d) + .5),
+      a.F.xA(f, e.top),
+      a.F.fl(f, e.height)) : (a.F.mp(g, Math.floor(e.left + e.width - .5 * c) + .5, 0),
+      a.F.tA(f, e.left),
+      a.F.Ug(f, e.width))
+  }
+  b != gvjs_Ov && (b = gvjs_NP(a),
+    e = a.Fd.rangeSelectorMaxScreen,
+    f = a.Fd.rangeSelectorMaxHandle,
+    a.Ff ? (a.F.mp(f, 0, Math.floor(b.top - .5 * d) + .5),
+      a.F.xA(e, b.top),
+      a.F.fl(e, b.height)) : (a.F.mp(f, Math.floor(b.left - .5 * c) + .5, 0),
+      a.F.tA(e, b.left),
+      a.F.Ug(e, b.width)))
+}
+gvjs_.Nya = function() {
+  gvjs_KP(this, this.K.eh)
+}
+;
+function gvjs_TP(a) {
+  var b = a.Dj.cl.max - a.Dj.cl.min
+    , c = a.Ag.ro
+    , d = (a.K.range.Yh - a.Dj.cl.min) / b;
+  if (.1 > d)
+    return {
+      direction: -1 * c,
+      ratio: d / .1
+    };
+  a = (a.Dj.cl.max - a.K.range.Xh) / b;
+  return .1 > a ? {
+    direction: 1 * c,
+    ratio: a / .1
+  } : null
+}
+function gvjs_UP(a) {
+  if (a.fV) {
+    var b = !1;
+    a.K.eh === gvjs_ut && gvjs_TP(a) && (b = !0);
+    b && !a.Gu ? (a.Gu = new gvjs_IA(a.FK),
+      a.ea.o(a.Gu, gvjs_dx, a.rpa.bind(a)),
+      a.Gu.start(),
+      gvjs_oi(a.da, gvjs_i, a.Ada.bind(a))) : !b && a.Gu && (gvjs_E(a.Gu),
+      a.Gu = null)
+  }
+}
+gvjs_.rpa = function() {
+  if (this.Gu) {
+    var a = gvjs_TP(this)
+      , b = this.FK / gvjs_4y(1E3, 6E4, a.ratio)
+      , c = this.wk.toNumber(this.sR)
+      , d = this.wk.toNumber(this.gR)
+      , e = (d - c) * b;
+    b = this.Cc.domainAxis.viewWindow;
+    var f = b.max
+      , g = this.wk.toNumber(b.min);
+    f = this.wk.toNumber(f);
+    0 > a.direction ? (a = Math.max(g - e, c),
+      c = f - (g - a)) : (c = Math.min(f + e, d),
+      a = g + (c - f));
+    d = this.wk.Hy(a);
+    e = this.wk.Hy(c);
+    if (g != a || f != c)
+      b.min = d,
+        b.max = e,
+        this.da.draw(this.Z, this.Cc),
+        this.t5(!0)
+  }
+}
+;
+gvjs_.Vqa = function(a, b) {
+  a.Cu && null != this.K.eh && (this.jX || gvjs_VP(this, b),
+    b.target.style.cursor = gvjs_Xv)
+}
+;
+gvjs_.Spa = function(a, b) {
+  a.Cu && null != this.K.eh && gvjs_VP(this, b)
+}
+;
+function gvjs_VP(a, b) {
+  var c = a.K;
+  c.range && null != c.range.Yh && null != c.range.Xh || (c.range = {
+    Yh: a.Dj.cl.min,
+    Xh: a.Dj.cl.max
+  });
+  b = gvjs_zz(b);
+  var d = a.K.range
+    , e = a.Dj.cl;
+  switch (a.K.eh) {
+    case gvjs_ut:
+      var f = e.min - d.Yh;
+      var g = e.max - d.Xh;
+      break;
+    case gvjs_Ov:
+      f = e.min - d.Yh;
+      g = d.Xh - a.zR - d.Yh;
+      break;
+    case gvjs_Gv:
+      f = d.Yh + a.zR - d.Xh,
+        g = e.max - d.Xh
+  }
+  f = gvjs_0g((a.Ff ? b.y : b.x) - (c.DO || 0), f, g);
+  c.DO += f;
+  c.eh != gvjs_Gv && (c.range.Yh += f);
+  c.eh != gvjs_Ov && (c.range.Xh += f);
+  gvjs_UP(a);
+  gvjs_LK(a.JK, a.FK);
+  gvjs_LK(a.aI, a.FK)
+}
+gvjs_.UC = function(a, b, c) {
+  if (a.Cu && gvjs_7x(c)) {
+    a = gvjs_zz(c);
+    var d = this.K;
+    d.DO = this.Ff ? a.y : a.x;
+    d.eh = b.eh;
+    gvjs_UP(this);
+    c.preventDefault();
+    c.stopPropagation()
+  }
+}
+;
+gvjs_.RP = function(a) {
+  if (a.Cu && (a = this.K,
+  null !== a.eh)) {
+    if (this.x4) {
+      var b = this.bW;
+      var c = a.range.Xh
+        , d = gvjs_fO(b, a.range.Yh);
+      b = gvjs_fO(b, c);
+      gvjs_SP(this, d, b, a.eh)
+    } else if (this.HW) {
+      c = new gvjs_O(a.range.Yh,a.range.Xh);
+      d = c.end - c.start;
+      b = this.Dj.cl;
+      var e = this.bW
+        , f = gvjs_Bl.bind(null, c)
+        , g = gvjs_Yx(e, f);
+      f = gvjs_Ey(e, f);
+      if (null === g || null === f)
+        g = gvjs_fO(e, c.start),
+          e = gvjs_fO(e, c.end),
+          f = g = e = Math.abs(c.start - g) <= Math.abs(c.end - e) ? g : e;
+      c = c.end - c.start;
+      g = gvjs_bz(g, f) - c / 2;
+      c = new gvjs_O(g,g + c);
+      c.start = Math.max(c.start, b.min);
+      c.end = c.start + d;
+      c.end = Math.min(c.end, b.max);
+      c.start = c.end - d;
+      gvjs_SP(this, c.start, c.end, a.eh)
+    } else
+      this.fV && a.eh != gvjs_ut && (b = this.Cc.domainAxis.viewWindow,
+        d = this.vP(),
+        b = gvjs_IP(this, b, d)) && (gvjs_oi(this.da, gvjs_i, this.Ada.bind(this, {
+        range: d
+      })),
+        this.da.draw(this.Z, this.Cc));
+    this.t5(!1);
+    a.eh = null;
+    gvjs_UP(this)
+  }
+}
+;
+function gvjs_IP(a, b, c) {
+  var d = b.max
+    , e = a.wk.toNumber(b.min);
+  d = a.wk.toNumber(d);
+  var f = d - e;
+  0 === f && (--e,
+    d += 1,
+    f = 2);
+  var g = c.start;
+  c = c.end;
+  if (null == g || null == c)
+    return !1;
+  var h = a.wk.toNumber(g)
+    , k = a.wk.toNumber(c);
+  c = k - h;
+  g = .1 * f;
+  var l = .6 * f;
+  if (c >= g && c <= l)
+    return !1;
+  h = (h + k) / 2;
+  f /= (c < g ? .9 * l : 1.1 * g) / c;
+  f = new gvjs_O(h - f / 2,h + f / 2);
+  c < g ? gvjs_WP(f, new gvjs_O(e,d)) : (c = a.wk.toNumber(a.sR),
+    g = a.wk.toNumber(a.gR),
+    gvjs_WP(f, new gvjs_O(c,g)));
+  c = a.wk.Hy(f.start);
+  a = a.wk.Hy(f.end);
+  e = e != f.start || d != f.end;
+  b.min = c;
+  b.max = a;
+  return e
+}
+function gvjs_WP(a, b) {
+  a.start < b.start && (a.end += b.start - a.start,
+    a.start = b.start);
+  a.end > b.end && (a.start -= a.end - b.end,
+    a.end = b.end);
+  a.start < b.start && (a.start = b.start)
+}
+gvjs_.EI = function(a, b, c) {
+  a.Cu && !this.K.eh && (c.target.style.cursor = b.Ro ? b.type === gvjs_Fw ? gvjs_Xv : this.Ff ? "row-resize" : gvjs__t : gvjs_eu)
+}
+;
+gvjs_.t5 = function(a) {
+  var b = this.K.eh
+    , c = this.vP();
+  if (null != b && null != c) {
+    var d = this.Ag.ro;
+    gvjs_I(this, gvjs_8N, {
+      start: c.start,
+      end: c.end,
+      startChanged: b === (1 === d ? gvjs_Ov : gvjs_Gv) || b === gvjs_ut,
+      endChanged: b === (1 === d ? gvjs_Gv : gvjs_Ov) || b === gvjs_ut,
+      inProgress: a
+    })
+  }
+}
+;
+gvjs_.Jb = function() {
+  this.da && (gvjs_vi(this.da),
+    gvjs_E(this.JK),
+    this.JK = null,
+    gvjs_E(this.aI),
+    this.aI = null,
+    this.Ek.Cu = !1,
+    gvjs_E(this.F),
+    this.F = null,
+    gvjs_E(this.ea),
+    this.ea = null,
+    this.da.Jb(),
+    this.da = null,
+    gvjs_li(this),
+    this.Fd = {})
+}
+;
+var gvjs_ria = {
+  Eia: gvjs_Va,
+  Uha: gvjs_na,
+  dia: gvjs_ya,
+  sja: gvjs_9a
+}
+  , gvjs_sia = {
+  fill: gvjs_yr,
+  fillOpacity: .5
+}
+  , gvjs_uia = {
+  chartArea: {
+    top: "0",
+    height: gvjs_So
+  },
+  enableInteractivity: !1,
+  legend: {
+    position: gvjs_f
+  },
+  hAxis: {
+    textPosition: gvjs_Fp
+  },
+  vAxis: {
+    textPosition: gvjs_f,
+    gridlines: {
+      color: gvjs_f
+    }
+  }
+}
+  , gvjs_tia = {
+  chartArea: {
+    left: "0",
+    width: gvjs_So
+  },
+  enableInteractivity: !1,
+  legend: {
+    position: gvjs_f
+  },
+  vAxis: {
+    textPosition: gvjs_Fp
+  },
+  hAxis: {
+    textPosition: gvjs_f,
+    gridlines: {
+      color: gvjs_f
+    }
+  }
+}
+  , gvjs_yia = new gvjs_3({
+  stroke: gvjs_kr,
+  fill: gvjs_Br
+})
+  , gvjs_QP = new gvjs_A(10,16)
+  , gvjs_xia = 3;
+function gvjs_XP(a) {
+  gvjs_dO.call(this, a);
+  this.Tv = this.GK = this.nE = null
+}
+gvjs_o(gvjs_XP, gvjs_dO);
+gvjs_ = gvjs_XP.prototype;
+gvjs_.M = function() {
+  this.nE && this.nE.Jb();
+  gvjs_dO.prototype.M.call(this)
+}
+;
+gvjs_.getState = function() {
+  function a() {
+    return null === b.Tv ? {} : {
+      range: b.Tv.range
+    }
+  }
+  var b = this;
+  if (!this.nE)
+    return a();
+  var c = this.nE.vP();
+  return null == c.start || null == c.end ? a() : {
+    range: c
+  }
+}
+;
+gvjs_.draw = function(a, b) {
+  this.Tv = a;
+  this.GK || (this.GK = new gvjs_Q({
+    chartType: gvjs_HP,
+    dataTable: a.__data__,
+    options: b,
+    state: a,
+    view: b.chartView
+  }),
+    gvjs_oi(this.GK, gvjs_i, this.zua.bind(this)));
+  this.GK.draw(this.getContainer())
+}
+;
+gvjs_.zua = function() {
+  this.nE = this.GK.zf();
+  gvjs_oi(this.nE, gvjs_8N, this.yua.bind(this))
+}
+;
+gvjs_.yua = function(a) {
+  gvjs_I(this, gvjs_9N, {
+    startChanged: a.startChanged,
+    endChanged: a.endChanged,
+    inProgress: a.inProgress
+  })
+}
+;
+function gvjs_YP(a) {
+  gvjs_eO.call(this, a);
+  this.ye = null
+}
+gvjs_o(gvjs_YP, gvjs_IO);
+gvjs_YP.prototype.vv = function() {
+  return gvjs_XP
+}
+;
+gvjs_YP.prototype.Mt = function(a, b, c) {
+  this.clear();
+  this.ye = gvjs_PO(a, b);
+  b = a.W(this.ye);
+  if (b == gvjs_l || b == gvjs_zb)
+    throw Error("The filter cannot operate on a column of type " + b + ". Column type must be one of: number, date, datetime or timeofday. Column role must be domain, and correlate to a continuous axis.");
+  c.__data__ = a
+}
+;
+gvjs_YP.prototype.pG = function(a, b, c) {
+  a = new gvjs_N(a);
+  b = c.range;
+  if (gvjs_me(b) != gvjs_h)
+    return a;
+  c = b.start;
+  b = b.end;
+  if (null == c && null == b)
+    return a;
+  a.pp(a.at([{
+    column: this.ye,
+    minValue: c,
+    maxValue: b
+  }]));
+  return a
+}
+;
+function gvjs_ZP(a) {
+  gvjs_GO.call(this, a);
+  this.Sp = -1;
+  this.ig = this.LW = this.eX = null
+}
+gvjs_o(gvjs_ZP, gvjs_GO);
+gvjs_ = gvjs_ZP.prototype;
+gvjs_.og = function() {
+  return {
+    columns: null
+  }
+}
+;
+gvjs_.Xl = function(a, b) {
+  a = gvjs_GO.prototype.Xl.call(this, a, b);
+  a.values = this.ig;
+  b = a.label;
+  null == b && (b = this.nP(),
+  1 <= b.length && (b = b[0].mb(),
+  null != this.Sp && (b = b.Ga(this.Sp),
+    a.label = b)));
+  return a
+}
+;
+gvjs_.Mt = function(a, b, c) {
+  this.clear();
+  this.Sp = b.Aa("chartColumnIndex");
+  this.LW = b.cb("chartColumnId");
+  if (null == this.Sp) {
+    if (null == this.LW)
+      throw Error("Either chartColumnIndex or chartColumnId must be specified.");
+    for (var d = a.$(), e = 0; e < d; e++)
+      a.Ne(e) === this.LW && (this.Sp = e);
+    if (null == this.Sp || 0 > this.Sp)
+      throw Error("Invalid column id");
+  }
+  if (null == this.Sp || 0 > this.Sp)
+    throw Error("Invalid column index");
+  d = b.fa("columns");
+  if (Array.isArray(d) && d.length)
+    this.ig = d;
+  else {
+    d = {
+      string: {
+        string: !0
+      },
+      discrete: {
+        string: !0
+      },
+      number: {
+        number: !0
+      },
+      dateortime: {
+        date: !0,
+        datetime: !0,
+        timeofday: !0
+      },
+      continuous: {
+        number: !0,
+        date: !0,
+        datetime: !0,
+        timeofday: !0
+      }
+    };
+    b = (b = gvjs_J(b, "columnType")) && d[b];
+    this.eX = {};
+    d = [];
+    e = a.$();
+    for (var f = 0; f < e; f++) {
+      var g = a.Ga(f)
+        , h = a.Ne(f)
+        , k = a.W(f);
+      if (!b || b[k])
+        this.eX[g] = {
+          index: f,
+          id: h,
+          label: g
+        },
+          d.push(g)
+    }
+    this.ig = d
+  }
+  this.GT = [{
+    input: "dataColumnIndex",
+    bg: "view.columns." + this.Sp
+  }];
+  this.mM(c)
+}
+;
+gvjs_.mM = function(a) {
+  a = a.selectedValues;
+  if (null != a && (!Array.isArray(a) || 1 < a.length))
+    throw Error("Invalid selectedValues: should be an array of length zero or one.");
+}
+;
+gvjs_.UV = function(a, b, c) {
+  var d = c.selectedValues;
+  return Array.isArray(d) && 1 === d.length ? (c.dataColumnIndex = this.eX[d[0]].index,
+    gvjs_GO.prototype.UV.call(this, a, b, c)) : a
+}
+;
+function gvjs__P(a) {
+  gvjs_ZP.call(this, a)
+}
+gvjs_o(gvjs__P, gvjs_ZP);
+gvjs__P.prototype.vv = function() {
+  return gvjs_fP
+}
+;
+var gvjs_zia = {
+  day: 864E5,
+  hour: 36E5,
+  minute: 6E4,
+  second: 1E3,
+  millisecond: 1
+};
+function gvjs_0P(a) {
+  var b = gvjs_1P(a);
+  var c = a.split(" ");
+  if (2 === c.length) {
+    if (c = Number(c[0]),
+    typeof c !== gvjs_g || isNaN(c))
+      throw Error('Invalid number for increment: "' + a + '".');
+  } else
+    c = 1;
+  b = gvjs_zia[b];
+  if (!b)
+    throw Error('Invalid number for increment "' + a + '".');
+  return c * b
+}
+function gvjs_1P(a) {
+  var b = a.length - 1;
+  a = "s" === a.charAt(b) ? a.substring(0, b) : a;
+  a = a.split(" ");
+  return 2 === a.length ? a[1] : a[0]
+}
+function gvjs_2P(a, b, c) {
+  a = Number(a);
+  b = (a - c) % gvjs_0P(b);
+  return a = new Date(a - b)
+}
+function gvjs_3P(a, b, c) {
+  a = Number(a);
+  c = a - c;
+  b = gvjs_0P(b);
+  c %= b;
+  return a = 0 === c ? new Date(a) : new Date(a + b - c)
+}
+;function gvjs_4P(a) {
+  gvjs_MO.call(this, a);
+  this.sj = this.Yc = null
+}
+gvjs_o(gvjs_4P, gvjs_MO);
+gvjs_ = gvjs_4P.prototype;
+gvjs_.K5 = function() {
+  var a = this.Fc.getValue() + this.Op
+    , b = a + this.Fc.Tl();
+  this.hw && gvjs_th(this.hw, this.Yc.Ob(new Date(a)));
+  this.Pv && gvjs_th(this.Pv, this.Yc.Ob(new Date(b)))
+}
+;
+gvjs_.v2 = function(a) {
+  var b = a.pb(gvjs_Fu);
+  (a = String(a.fa("step"))) && !b.pattern && (b.pattern = gvjs_Aia[gvjs_1P(a)]);
+  this.Yc = new gvjs_Tj(b)
+}
+;
+gvjs_.draw = function(a, b) {
+  b = b || {};
+  var c = new gvjs_Aj([b, gvjs_5P]);
+  (b = gvjs_SO(b)) || (b = new gvjs_MC);
+  b.R(this.getContainer());
+  var d = gvjs_J(c, "cssClass");
+  d && gvjs_VC(b.j(), d);
+  gvjs_OO(this, b, a, c, gvjs_5P)
+}
+;
+gvjs_.Ifa = function(a) {
+  this.sj = String(a.fa("step", gvjs_5P.step));
+  var b = gvjs_0P(this.sj);
+  this.Fc.ET(b);
+  b = gvjs_0P(String(a.fa("unitIncrement", gvjs_5P.unitIncrement)));
+  this.Fc.ZA = b;
+  a = gvjs_0P(String(a.fa(gvjs_5N, gvjs_5P.blockIncrement)));
+  this.Fc.Dm = a
+}
+;
+gvjs_.xZ = function(a, b) {
+  return a.Aa(b)
+}
+;
+gvjs_.pea = function(a, b, c) {
+  var d = String(this.sj);
+  a = new Date(a);
+  var e = gvjs_1P(d);
+  a = gvjs_2P(a, e, Number(new Date(1970,0,1))).valueOf();
+  b = gvjs_3P(new Date(b), d, a).valueOf();
+  c.lowValue = gvjs_2P(new Date(c.lowValue), d, a).valueOf();
+  c.highValue = gvjs_3P(new Date(c.highValue), d, a).valueOf();
+  return {
+    minValue: a,
+    maxValue: b,
+    state: c
+  }
+}
+;
+gvjs_.getState = function() {
+  var a = gvjs_MO.prototype.getState.call(this);
+  a.lowValue && (a.lowValue = new Date(a.lowValue.valueOf()));
+  a.highValue && (a.highValue = new Date(a.highValue.valueOf()));
+  return a
+}
+;
+var gvjs_Aia = {
+  year: "yyyy",
+  month: "yyyy-MM",
+  day: "yyyy-MM-dd",
+  hour: gvjs_aO,
+  minute: gvjs_aO,
+  second: "yy/MM/dd hh:mm:ssa",
+  millisecond: "yy/MM/dd hh:mm:ss:SSSSa"
+}
+  , gvjs_5P = {
+  showRangeValues: !0,
+  minValue: null,
+  maxValue: null,
+  cssClass: gvjs_6N,
+  step: "day",
+  unitIncrement: "day",
+  blockIncrement: "day",
+  orientation: gvjs_S
+};
+function gvjs_6P(a) {
+  gvjs_JO.call(this, a)
+}
+gvjs_o(gvjs_6P, gvjs_JO);
+gvjs_ = gvjs_6P.prototype;
+gvjs_.vv = function() {
+  return gvjs_4P
+}
+;
+gvjs_.Xl = function(a, b) {
+  a = gvjs_JO.prototype.Xl.call(this, a, b);
+  a.minValue = this.Xa;
+  a.maxValue = this.Cb;
+  null == a.label && (a.label = this.sq);
+  return a
+}
+;
+gvjs_.x_ = function(a, b) {
+  this.yT(gvjs_L(b, gvjs_ed, gvjs_7P(this, a, gvjs_Ov)));
+  this.xT(gvjs_L(b, gvjs_cd, gvjs_7P(this, a, gvjs_Gv)))
+}
+;
+gvjs_.Mt = function(a, b, c) {
+  this.clear();
+  this.ye = gvjs_PO(a, b);
+  this.sq = a.Ga(this.ye);
+  var d = a.W(this.ye);
+  if (d != gvjs_Lb && d != gvjs_Mb)
+    throw Error(gvjs_wa + this.ye + " is not a date");
+  this.x_(a, b);
+  gvjs_KO(this, c)
+}
+;
+function gvjs_7P(a, b, c) {
+  a = b.Sj(a.ye)[c];
+  return Number(a)
+}
+gvjs_.U5 = function(a) {
+  return Number(a)
+}
+;
+gvjs_.getState = function() {
+  var a = gvjs_JO.prototype.getState.call(this);
+  a.lowValue && (a.lowValue = new Date(a.lowValue.valueOf()));
+  a.highValue && (a.highValue = new Date(a.highValue.valueOf()));
+  return a
+}
+;
+gvjs_.rZ = function(a, b, c) {
+  (a = gvjs_my(a, "ui", {}).step) || (a = "day");
+  return function(d) {
+    d = Number(d);
+    return b <= d && c >= d
+  }
+}
+;
+function gvjs_8P(a) {
+  gvjs_dO.call(this, a);
+  this.K = {}
+}
+gvjs_t(gvjs_8P, gvjs_dO);
+gvjs_8P.prototype.draw = function(a) {
+  this.K = a
+}
+;
+gvjs_8P.prototype.getState = function() {
+  return this.K
+}
+;
+function gvjs_9P(a) {
+  gvjs_MO.call(this, a);
+  this.sj = this.Yc = null;
+  this.wn = 0
+}
+gvjs_o(gvjs_9P, gvjs_MO);
+gvjs_ = gvjs_9P.prototype;
+gvjs_.K5 = function() {
+  var a = this.Fc.getValue() + this.Op
+    , b = a + this.Fc.Tl();
+  a /= this.wn;
+  b /= this.wn;
+  this.hw && gvjs_th(this.hw, this.Yc.Ob(a));
+  this.Pv && gvjs_th(this.Pv, this.Yc.Ob(b))
+}
+;
+gvjs_.v2 = function(a) {
+  var b = a.pb(gvjs_Fu);
+  (a = Number(a.Aa("step"))) && null == b.fractionDigits && (b.fractionDigits = a);
+  this.Yc = new gvjs_gk(b)
+}
+;
+gvjs_.draw = function(a, b) {
+  b = b || {};
+  var c = new gvjs_Aj([b, gvjs_$P]);
+  (b = gvjs_SO(b)) || (b = new gvjs_MC);
+  b.R(this.getContainer());
+  var d = gvjs_J(c, "cssClass");
+  d && gvjs_VC(b.j(), d);
+  gvjs_OO(this, b, a, c, gvjs_$P)
+}
+;
+gvjs_.Ifa = function(a) {
+  var b = gvjs_$P.step
+    , c = a.Aa(gvjs_ex);
+  null != c && (c = Math.max(2, c),
+    b = (this.Fc.kf() - this.Fc.lf()) / c);
+  b = Number(gvjs_L(a, "step", b));
+  c = gvjs_L(a, "unitIncrement", gvjs_$P.unitIncrement);
+  a = gvjs_L(a, gvjs_5N, gvjs_$P.blockIncrement);
+  this.wn = Math.pow(10, gvjs_pA(b));
+  b = Math.round(b * this.wn);
+  c = Math.round(c * this.wn);
+  a = Math.round(a * this.wn);
+  this.Fc.ET(b);
+  this.Fc.ZA = c;
+  this.Fc.Dm = a;
+  this.sj = b
+}
+;
+gvjs_.xZ = function(a, b) {
+  return a.Aa(b)
+}
+;
+gvjs_.pea = function(a, b, c) {
+  var d = this.sj;
+  a = Math.floor(a * this.wn);
+  a -= (a - 0) % d;
+  b = gvjs_aQ(Math.ceil(b * this.wn), d, a);
+  var e = c.lowValue * this.wn;
+  c.lowValue = e - (e - a) % d;
+  c.highValue = gvjs_aQ(c.highValue * this.wn, d, a);
+  return {
+    minValue: a,
+    maxValue: b,
+    state: c
+  }
+}
+;
+gvjs_.getState = function() {
+  var a = this.Fc;
+  if (!a)
+    return {
+      lowValue: null,
+      highValue: null,
+      lowThumbAtMinimum: null,
+      highThumbAtMaxium: null
+    };
+  var b = a.getValue()
+    , c = a.Tl();
+  return {
+    lowValue: (b + this.Op) / this.wn,
+    highValue: (b + c + this.Op) / this.wn,
+    lowThumbAtMinimum: b === a.lf(),
+    highThumbAtMaximum: b + c === a.kf()
+  }
+}
+;
+function gvjs_aQ(a, b, c) {
+  c = (a - c) % b;
+  return 0 === c ? a : a + b - c
+}
+var gvjs_$P = {
+  showRangeValues: !0,
+  minValue: null,
+  maxValue: null,
+  ticks: null,
+  cssClass: gvjs_6N,
+  format: {},
+  step: 1,
+  unitIncrement: 1,
+  blockIncrement: 10,
+  orientation: gvjs_S
+};
+function gvjs_bQ(a) {
+  gvjs_JO.call(this, a)
+}
+gvjs_o(gvjs_bQ, gvjs_JO);
+gvjs_ = gvjs_bQ.prototype;
+gvjs_.vv = function() {
+  return gvjs_9P
+}
+;
+gvjs_.Xl = function(a, b) {
+  a = gvjs_JO.prototype.Xl.call(this, a, b);
+  a.minValue = this.Xa;
+  a.maxValue = this.Cb;
+  null == a.label && (a.label = this.sq);
+  return a
+}
+;
+gvjs_.x_ = function(a, b) {
+  this.yT(gvjs_L(b, gvjs_ed, a.Sj(this.ye).min));
+  this.xT(gvjs_L(b, gvjs_cd, a.Sj(this.ye).max))
+}
+;
+gvjs_.Mt = function(a, b, c) {
+  this.clear();
+  this.ye = gvjs_PO(a, b);
+  this.sq = a.Ga(this.ye);
+  if (a.W(this.ye) !== gvjs_g)
+    throw Error(gvjs_wa + this.ye + " is not numeric");
+  this.x_(a, b);
+  gvjs_KO(this, c)
+}
+;
+gvjs_.U5 = function(a) {
+  return gvjs_jg(String(a))
+}
+;
+gvjs_.rZ = function(a, b, c) {
+  (a = gvjs_my(a, "ui", {}).step) || (a = 1);
+  return function(d) {
+    return b <= d && c >= d
+  }
+}
+;
+function gvjs_cQ(a) {
+  gvjs_HO.call(this, a)
+}
+gvjs_o(gvjs_cQ, gvjs_HO);
+gvjs_cQ.prototype.vv = function() {
+  return gvjs_9P
+}
+;
+function gvjs_dQ(a, b) {
+  this.Pya = a;
+  this.ig = b
+}
+gvjs_dQ.prototype.getUrl = function() {
+  return this.Pya
+}
+;
+gvjs_dQ.prototype.Ne = function(a) {
+  return this.ig[a].id
+}
+;
+gvjs_dQ.prototype.W = function(a) {
+  return this.ig[a].type
+}
+;
+gvjs_dQ.prototype.$ = function() {
+  return this.ig.length
+}
+;
+function gvjs_eQ(a) {
+  gvjs_eO.call(this, a);
+  this.ye = -1
+}
+gvjs_o(gvjs_eQ, gvjs_IO);
+gvjs_ = gvjs_eQ.prototype;
+gvjs_.og = function() {
+  return {
+    matchType: gvjs_wd,
+    caseSensitive: !1,
+    useFormattedValue: !1
+  }
+}
+;
+gvjs_.Xl = function(a, b) {
+  a = gvjs_IO.prototype.Xl.call(this, a, b);
+  null == a.label && (a.label = this.sq);
+  return a
+}
+;
+gvjs_.Mt = function(a, b) {
+  this.clear();
+  this.ye = gvjs_PO(a, b);
+  this.sq = a.Ga(this.ye)
+}
+;
+gvjs_.pG = function(a, b, c) {
+  var d = gvjs_K(b, "caseSensitive")
+    , e = gvjs_J(b, "matchType")
+    , f = gvjs_K(b, gvjs_$N)
+    , g = this.ye;
+  b = [];
+  c = String(c.value);
+  if (!c)
+    return new gvjs_N(a);
+  d || (c = c.toLowerCase());
+  for (var h = 0; h < a.ca(); h++) {
+    var k = f ? a.Ha(h, g) : "" + a.getValue(h, g);
+    d || (k = k.toLowerCase());
+    switch (e) {
+      case "exact":
+        k == c && b.push(h);
+        break;
+      case "any":
+        -1 != k.indexOf(c) && b.push(h);
+        break;
+      default:
+        0 == k.indexOf(c) && b.push(h)
+    }
+  }
+  a = new gvjs_N(a);
+  a.pp(b);
+  return a
+}
+;
+gvjs_.sq = null;
+function gvjs_fQ(a) {
+  gvjs_dO.call(this, a);
+  this.tm = 0;
+  this.zi = null
+}
+gvjs_o(gvjs_fQ, gvjs_dO);
+gvjs_fQ.prototype.getState = function() {
+  return {
+    value: this.zi ? this.zi.value : null
+  }
+}
+;
+gvjs_fQ.prototype.draw = function(a, b) {
+  b = b || {};
+  var c = gvjs_SO(b);
+  c || (c = new gvjs_MC);
+  c.R(this.getContainer());
+  var d = b.cssClass ? String(b.cssClass) : "google-visualization-controls-stringfilter";
+  gvjs_VC(c.j(), d);
+  d = gvjs_4(gvjs_Na);
+  d.setAttribute(gvjs_5c, gvjs_pe(this.getContainer()) + "-input");
+  gvjs_Vd in a && a.value && (d.value = String(a.value));
+  gvjs_7N in b && d.setAttribute(gvjs_7N, b.placeholder);
+  "realtimeTrigger"in b && !b.realtimeTrigger ? (this.addEventListener(d, gvjs_lv, this.rba, !1, this),
+    this.addEventListener(d, gvjs_Kt, this.ru, !1, this)) : this.addEventListener(d, gvjs_mv, this.rba);
+  this.zi = d;
+  c.ib().appendChild(this.zi)
+}
+;
+gvjs_fQ.prototype.rba = function(a) {
+  this.tm && gvjs_ql(this.tm);
+  13 == a.keyCode ? (this.ru(),
+    a.preventDefault()) : this.tm = gvjs_pl(function() {
+    this.tm = 0;
+    this.ru()
+  }, 200, this)
+}
+;
+gvjs_fQ.prototype.ru = function() {
+  gvjs_I(this, gvjs_9N, null)
+}
+;
+function gvjs_gQ(a) {
+  gvjs_eQ.call(this, a)
+}
+gvjs_o(gvjs_gQ, gvjs_eQ);
+gvjs_gQ.prototype.vv = function() {
+  return gvjs_fQ
+}
+;
+function gvjs_hQ(a) {
+  gvjs_eO.call(this, a)
+}
+gvjs_o(gvjs_hQ, gvjs_eO);
+gvjs_hQ.prototype.i7 = function() {
+  return this.apply()
+}
+;
+gvjs_hQ.prototype.apply = function() {
+  if (!this.mb())
+    throw Error(gvjs_ZN);
+  this.Zc();
+  this.getState();
+  return this.mb()
+}
+;
+gvjs_q("google.visualization.Choreographer", gvjs_ho, void 0);
+gvjs_ho.prototype.bind = gvjs_ho.prototype.bind;
+gvjs_ho.prototype.clear = gvjs_ho.prototype.clear;
+gvjs_ho.prototype.dispose = gvjs_ho.prototype.pa;
+gvjs_ho.prototype.isDisposed = gvjs_ho.prototype.fh;
+gvjs_ho.prototype.draw = gvjs_ho.prototype.draw;
+gvjs_q(gvjs_gc, gvjs_so, void 0);
+gvjs_so.prototype.bind = gvjs_so.prototype.bind;
+gvjs_so.prototype.getSelection = gvjs_so.prototype.getSelection;
+gvjs_so.prototype.clear = gvjs_so.prototype.clear;
+gvjs_so.prototype.dispose = gvjs_so.prototype.pa;
+gvjs_so.prototype.isDisposed = gvjs_so.prototype.fh;
+gvjs_so.prototype.draw = gvjs_so.prototype.draw;
+gvjs_q("google.visualization.Control", gvjs_eO, void 0);
+gvjs_eO.prototype.draw = gvjs_eO.prototype.draw;
+gvjs_eO.prototype.getState = gvjs_eO.prototype.getState;
+gvjs_eO.prototype.resetControl = gvjs_eO.prototype.Gw;
+gvjs_eO.prototype.clear = gvjs_eO.prototype.clear;
+gvjs_eO.prototype.dispose = gvjs_eO.prototype.pa;
+gvjs_eO.prototype.isDisposed = gvjs_eO.prototype.fh;
+gvjs_q(gvjs_kc, gvjs_IO, void 0);
+gvjs_IO.prototype.applyFilter = gvjs_IO.prototype.xB;
+gvjs_q(gvjs_Hc, gvjs_hQ, void 0);
+gvjs_hQ.prototype.applyOperator = gvjs_hQ.prototype.i7;
+gvjs_q("google.visualization.ControlUi", gvjs_dO, void 0);
+gvjs_dO.prototype.draw = gvjs_dO.prototype.draw;
+gvjs_dO.prototype.getState = gvjs_dO.prototype.getState;
+gvjs_dO.prototype.clear = gvjs_dO.prototype.clear;
+gvjs_dO.prototype.dispose = gvjs_dO.prototype.pa;
+gvjs_dO.prototype.isDisposed = gvjs_dO.prototype.fh;
+gvjs_q(gvjs_Sc, gvjs_gQ, void 0);
+gvjs_gQ.prototype.draw = gvjs_gQ.prototype.draw;
+gvjs_gQ.prototype.applyFilter = gvjs_gQ.prototype.xB;
+gvjs_gQ.prototype.getState = gvjs_gQ.prototype.getState;
+gvjs_gQ.prototype.resetControl = gvjs_gQ.prototype.Gw;
+gvjs_gQ.prototype.clear = gvjs_gQ.prototype.clear;
+gvjs_gQ.prototype.dispose = gvjs_gQ.prototype.pa;
+gvjs_gQ.prototype.isDisposed = gvjs_gQ.prototype.fh;
+gvjs_q(gvjs_Tc, gvjs_fQ, void 0);
+gvjs_fQ.prototype.draw = gvjs_fQ.prototype.draw;
+gvjs_fQ.prototype.getState = gvjs_fQ.prototype.getState;
+gvjs_fQ.prototype.clear = gvjs_fQ.prototype.clear;
+gvjs_fQ.prototype.isDisposed = gvjs_fQ.prototype.fh;
+gvjs_q(gvjs_Ec, gvjs_bQ, void 0);
+gvjs_bQ.prototype.draw = gvjs_bQ.prototype.draw;
+gvjs_bQ.prototype.applyFilter = gvjs_bQ.prototype.xB;
+gvjs_bQ.prototype.getState = gvjs_bQ.prototype.getState;
+gvjs_bQ.prototype.resetControl = gvjs_bQ.prototype.Gw;
+gvjs_bQ.prototype.clear = gvjs_bQ.prototype.clear;
+gvjs_bQ.prototype.dispose = gvjs_bQ.prototype.pa;
+gvjs_bQ.prototype.isDisposed = gvjs_bQ.prototype.fh;
+gvjs_q(gvjs_ic, gvjs_6P, void 0);
+gvjs_6P.prototype.draw = gvjs_6P.prototype.draw;
+gvjs_6P.prototype.applyFilter = gvjs_6P.prototype.xB;
+gvjs_6P.prototype.getState = gvjs_6P.prototype.getState;
+gvjs_6P.prototype.resetControl = gvjs_6P.prototype.Gw;
+gvjs_6P.prototype.clear = gvjs_6P.prototype.clear;
+gvjs_6P.prototype.dispose = gvjs_6P.prototype.pa;
+gvjs_6P.prototype.isDisposed = gvjs_6P.prototype.fh;
+gvjs_q(gvjs_Gc, gvjs_9P, void 0);
+gvjs_9P.prototype.draw = gvjs_9P.prototype.draw;
+gvjs_9P.prototype.getState = gvjs_9P.prototype.getState;
+gvjs_9P.prototype.clear = gvjs_9P.prototype.clear;
+gvjs_9P.prototype.dispose = gvjs_9P.prototype.pa;
+gvjs_9P.prototype.isDisposed = gvjs_9P.prototype.fh;
+gvjs_q(gvjs_jc, gvjs_4P, void 0);
+gvjs_4P.prototype.draw = gvjs_4P.prototype.draw;
+gvjs_4P.prototype.getState = gvjs_4P.prototype.getState;
+gvjs_4P.prototype.clear = gvjs_4P.prototype.clear;
+gvjs_4P.prototype.dispose = gvjs_4P.prototype.pa;
+gvjs_4P.prototype.isDisposed = gvjs_4P.prototype.fh;
+gvjs_q(gvjs_Fc, gvjs_cQ, void 0);
+gvjs_cQ.prototype.draw = gvjs_cQ.prototype.draw;
+gvjs_cQ.prototype.apply = gvjs_cQ.prototype.apply;
+gvjs_cQ.prototype.getState = gvjs_cQ.prototype.getState;
+gvjs_cQ.prototype.resetControl = gvjs_cQ.prototype.Gw;
+gvjs_cQ.prototype.clear = gvjs_cQ.prototype.clear;
+gvjs_cQ.prototype.dispose = gvjs_cQ.prototype.pa;
+gvjs_cQ.prototype.isDisposed = gvjs_cQ.prototype.fh;
+gvjs_q(gvjs_dc, gvjs__P, void 0);
+gvjs__P.prototype.draw = gvjs__P.prototype.draw;
+gvjs__P.prototype.apply = gvjs__P.prototype.apply;
+gvjs__P.prototype.getState = gvjs__P.prototype.getState;
+gvjs__P.prototype.resetControl = gvjs__P.prototype.Gw;
+gvjs__P.prototype.clear = gvjs__P.prototype.clear;
+gvjs__P.prototype.dispose = gvjs__P.prototype.pa;
+gvjs__P.prototype.isDisposed = gvjs__P.prototype.fh;
+gvjs_q(gvjs_9b, gvjs_sP, void 0);
+gvjs_sP.prototype.draw = gvjs_sP.prototype.draw;
+gvjs_sP.prototype.applyFilter = gvjs_sP.prototype.xB;
+gvjs_sP.prototype.getState = gvjs_sP.prototype.getState;
+gvjs_sP.prototype.resetControl = gvjs_sP.prototype.Gw;
+gvjs_sP.prototype.clear = gvjs_sP.prototype.clear;
+gvjs_sP.prototype.dispose = gvjs_sP.prototype.pa;
+gvjs_sP.prototype.isDisposed = gvjs_sP.prototype.fh;
+gvjs_q(gvjs_Oc, gvjs_fP, void 0);
+gvjs_fP.prototype.draw = gvjs_fP.prototype.draw;
+gvjs_fP.prototype.getState = gvjs_fP.prototype.getState;
+gvjs_fP.prototype.clear = gvjs_fP.prototype.clear;
+gvjs_fP.prototype.dispose = gvjs_fP.prototype.pa;
+gvjs_fP.prototype.isDisposed = gvjs_fP.prototype.fh;
+gvjs_q(gvjs_$b, gvjs_YP, void 0);
+gvjs_YP.prototype.draw = gvjs_YP.prototype.draw;
+gvjs_YP.prototype.applyFilter = gvjs_YP.prototype.xB;
+gvjs_YP.prototype.getState = gvjs_YP.prototype.getState;
+gvjs_YP.prototype.resetControl = gvjs_YP.prototype.Gw;
+gvjs_YP.prototype.clear = gvjs_YP.prototype.clear;
+gvjs_YP.prototype.dispose = gvjs_YP.prototype.pa;
+gvjs_YP.prototype.isDisposed = gvjs_YP.prototype.fh;
+gvjs_q(gvjs_ac, gvjs_XP, void 0);
+gvjs_XP.prototype.draw = gvjs_XP.prototype.draw;
+gvjs_XP.prototype.getState = gvjs_XP.prototype.getState;
+gvjs_XP.prototype.clear = gvjs_XP.prototype.clear;
+gvjs_XP.prototype.dispose = gvjs_XP.prototype.pa;
+gvjs_XP.prototype.isDisposed = gvjs_XP.prototype.fh;
+gvjs_q(gvjs_pc, gvjs_8P, void 0);
+gvjs_8P.prototype.draw = gvjs_8P.prototype.draw;
+gvjs_8P.prototype.getState = gvjs_8P.prototype.getState;
+gvjs_8P.prototype.clear = gvjs_8P.prototype.clear;
+gvjs_8P.prototype.dispose = gvjs_8P.prototype.pa;
+gvjs_8P.prototype.isDisposed = gvjs_8P.prototype.fh;
+gvjs_q("google.visualization.RemoteDataSource", gvjs_dQ, void 0);
+gvjs_dQ.prototype.getUrl = gvjs_dQ.prototype.getUrl;
+gvjs_dQ.prototype.getColumnId = gvjs_dQ.prototype.Ne;
+gvjs_dQ.prototype.getColumnType = gvjs_dQ.prototype.W;
+gvjs_dQ.prototype.getNumberOfColumns = gvjs_dQ.prototype.$;
+gvjs_q(gvjs_Lc, gvjs_HP, void 0);
+gvjs_HP.prototype.draw = gvjs_HP.prototype.draw;
+gvjs_HP.prototype.clearChart = gvjs_HP.prototype.Jb;
+gvjs_HP.prototype.getRange = gvjs_HP.prototype.vP;
+gvjs_HP.prototype.setRange = gvjs_HP.prototype.Ewa;

--- a/cypress/fixtures/charts/jsapi_compiled_corechart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_corechart_module
@@ -1,0 +1,227 @@
+var gvjs_iQ = "#990000"
+  , gvjs_jQ = "annotationText"
+  , gvjs_kQ = "certainty";
+gvjs_iL.prototype.Jm = gvjs_V(70, function(a, b) {
+  if (this.Xg === gvjs_fw)
+    return this.av(a, b);
+  throw Error(gvjs_4r);
+});
+gvjs_jL.prototype.Jm = gvjs_V(69, function(a, b) {
+  return this.av(a, b)
+});
+function gvjs_lQ(a) {
+  var b = new gvjs_OE;
+  b.sa = function() {
+    return a
+  }
+  ;
+  return b
+}
+function gvjs_mQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_at, gvjs_S)
+}
+gvjs_o(gvjs_mQ, gvjs_iL);
+function gvjs_nQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_4w, gvjs_S)
+}
+gvjs_o(gvjs_nQ, gvjs_iL);
+function gvjs_oQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_f, gvjs_S, "sparkline")
+}
+gvjs_o(gvjs_oQ, gvjs_iL);
+function gvjs_pQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_e, gvjs_S)
+}
+gvjs_o(gvjs_pQ, gvjs_iL);
+function gvjs_qQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_Dd)
+}
+gvjs_o(gvjs_qQ, gvjs_iL);
+gvjs_qQ.prototype.Jm = function(a, b) {
+  return this.av(a, b)
+}
+;
+function gvjs_rQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_yt)
+}
+gvjs_o(gvjs_rQ, gvjs_iL);
+function gvjs_sQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_lt, gvjs_U)
+}
+gvjs_o(gvjs_sQ, gvjs_iL);
+gvjs_sQ.prototype.Jm = function(a, b) {
+  return this.av(a, b)
+}
+;
+function gvjs_tQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_Ft, gvjs_S)
+}
+gvjs_o(gvjs_tQ, gvjs_iL);
+function gvjs_uQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_lt, gvjs_S)
+}
+gvjs_o(gvjs_uQ, gvjs_iL);
+gvjs_uQ.prototype.Jm = function(a, b) {
+  return this.av(a, b)
+}
+;
+function gvjs_vQ(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_4u, gvjs_lt, gvjs_S)
+}
+gvjs_o(gvjs_vQ, gvjs_iL);
+gvjs_q(gvjs_fc, gvjs_iL, void 0);
+gvjs_iL.prototype.draw = gvjs_iL.prototype.draw;
+gvjs_iL.prototype.clearChart = gvjs_iL.prototype.Jb;
+gvjs_iL.prototype.getImageURI = gvjs_iL.prototype.ah;
+gvjs_iL.prototype.getSelection = gvjs_iL.prototype.getSelection;
+gvjs_iL.prototype.setSelection = gvjs_iL.prototype.setSelection;
+gvjs_iL.prototype.dump = gvjs_iL.prototype.dump;
+gvjs_iL.prototype.getChartLayoutInterface = gvjs_iL.prototype.Ql;
+gvjs_iL.prototype.getContainer = gvjs_iL.prototype.getContainer;
+gvjs_iL.prototype.setAction = gvjs_iL.prototype.xh;
+gvjs_iL.prototype.getAction = gvjs_iL.prototype.ng;
+gvjs_iL.prototype.removeAction = gvjs_iL.prototype.th;
+gvjs_q(gvjs_4b, gvjs_mQ, void 0);
+gvjs_mQ.prototype.draw = gvjs_mQ.prototype.draw;
+gvjs_mQ.prototype.clearChart = gvjs_mQ.prototype.Jb;
+gvjs_mQ.prototype.getImageURI = gvjs_mQ.prototype.ah;
+gvjs_mQ.prototype.getSelection = gvjs_mQ.prototype.getSelection;
+gvjs_mQ.prototype.setSelection = gvjs_mQ.prototype.setSelection;
+gvjs_mQ.prototype.setAction = gvjs_mQ.prototype.xh;
+gvjs_mQ.prototype.getAction = gvjs_mQ.prototype.ng;
+gvjs_mQ.prototype.removeAction = gvjs_mQ.prototype.th;
+gvjs_q(gvjs_5b, gvjs_sQ, void 0);
+gvjs_sQ.prototype.computeDiff = gvjs_sQ.prototype.Jm;
+gvjs_sQ.prototype.draw = gvjs_sQ.prototype.draw;
+gvjs_sQ.prototype.clearChart = gvjs_sQ.prototype.Jb;
+gvjs_sQ.prototype.getImageURI = gvjs_sQ.prototype.ah;
+gvjs_sQ.prototype.getSelection = gvjs_sQ.prototype.getSelection;
+gvjs_sQ.prototype.setSelection = gvjs_sQ.prototype.setSelection;
+gvjs_sQ.prototype.setAction = gvjs_sQ.prototype.xh;
+gvjs_sQ.prototype.getAction = gvjs_sQ.prototype.ng;
+gvjs_sQ.prototype.removeAction = gvjs_sQ.prototype.th;
+gvjs_q(gvjs_6b, gvjs_rQ, void 0);
+gvjs_rQ.prototype.draw = gvjs_rQ.prototype.draw;
+gvjs_rQ.prototype.clearChart = gvjs_rQ.prototype.Jb;
+gvjs_rQ.prototype.getImageURI = gvjs_rQ.prototype.ah;
+gvjs_rQ.prototype.getSelection = gvjs_rQ.prototype.getSelection;
+gvjs_rQ.prototype.setSelection = gvjs_rQ.prototype.setSelection;
+gvjs_rQ.prototype.setAction = gvjs_rQ.prototype.xh;
+gvjs_rQ.prototype.getAction = gvjs_rQ.prototype.ng;
+gvjs_rQ.prototype.removeAction = gvjs_rQ.prototype.th;
+gvjs_q(gvjs_8b, gvjs_tQ, void 0);
+gvjs_tQ.prototype.draw = gvjs_tQ.prototype.draw;
+gvjs_tQ.prototype.clearChart = gvjs_tQ.prototype.Jb;
+gvjs_tQ.prototype.getImageURI = gvjs_tQ.prototype.ah;
+gvjs_tQ.prototype.getSelection = gvjs_tQ.prototype.getSelection;
+gvjs_tQ.prototype.setSelection = gvjs_tQ.prototype.setSelection;
+gvjs_tQ.prototype.setAction = gvjs_tQ.prototype.xh;
+gvjs_tQ.prototype.getAction = gvjs_tQ.prototype.ng;
+gvjs_tQ.prototype.removeAction = gvjs_tQ.prototype.th;
+gvjs_q(gvjs_rc, gvjs_vQ, void 0);
+gvjs_vQ.prototype.draw = gvjs_vQ.prototype.draw;
+gvjs_vQ.prototype.clearChart = gvjs_vQ.prototype.Jb;
+gvjs_vQ.prototype.getImageURI = gvjs_vQ.prototype.ah;
+gvjs_vQ.prototype.getSelection = gvjs_vQ.prototype.getSelection;
+gvjs_vQ.prototype.setSelection = gvjs_vQ.prototype.setSelection;
+gvjs_vQ.prototype.setAction = gvjs_vQ.prototype.xh;
+gvjs_vQ.prototype.getAction = gvjs_vQ.prototype.ng;
+gvjs_vQ.prototype.removeAction = gvjs_vQ.prototype.th;
+gvjs_q(gvjs_cc, gvjs_uQ, void 0);
+gvjs_uQ.prototype.computeDiff = gvjs_uQ.prototype.Jm;
+gvjs_uQ.prototype.draw = gvjs_uQ.prototype.draw;
+gvjs_uQ.prototype.clearChart = gvjs_uQ.prototype.Jb;
+gvjs_uQ.prototype.getImageURI = gvjs_uQ.prototype.ah;
+gvjs_uQ.prototype.getSelection = gvjs_uQ.prototype.getSelection;
+gvjs_uQ.prototype.setSelection = gvjs_uQ.prototype.setSelection;
+gvjs_uQ.prototype.setAction = gvjs_uQ.prototype.xh;
+gvjs_uQ.prototype.getAction = gvjs_uQ.prototype.ng;
+gvjs_uQ.prototype.removeAction = gvjs_uQ.prototype.th;
+gvjs_q(gvjs_ec, gvjs_rL, void 0);
+gvjs_rL.prototype.draw = gvjs_rL.prototype.draw;
+gvjs_rL.prototype.clearChart = gvjs_rL.prototype.Jb;
+gvjs_rL.prototype.getImageURI = gvjs_rL.prototype.ah;
+gvjs_rL.prototype.getSelection = gvjs_rL.prototype.getSelection;
+gvjs_rL.prototype.setSelection = gvjs_rL.prototype.setSelection;
+gvjs_rL.prototype.setAction = gvjs_rL.prototype.xh;
+gvjs_rL.prototype.getAction = gvjs_rL.prototype.ng;
+gvjs_rL.prototype.removeAction = gvjs_rL.prototype.th;
+gvjs_q(gvjs_zc, gvjs_pQ, void 0);
+gvjs_pQ.prototype.draw = gvjs_pQ.prototype.draw;
+gvjs_pQ.prototype.clearChart = gvjs_pQ.prototype.Jb;
+gvjs_pQ.prototype.getImageURI = gvjs_pQ.prototype.ah;
+gvjs_pQ.prototype.getSelection = gvjs_pQ.prototype.getSelection;
+gvjs_pQ.prototype.setSelection = gvjs_pQ.prototype.setSelection;
+gvjs_pQ.prototype.setAction = gvjs_pQ.prototype.xh;
+gvjs_pQ.prototype.getAction = gvjs_pQ.prototype.ng;
+gvjs_pQ.prototype.removeAction = gvjs_pQ.prototype.th;
+gvjs_q(gvjs_Jc, gvjs_jL, void 0);
+gvjs_jL.prototype.computeDiff = gvjs_jL.prototype.Jm;
+gvjs_jL.prototype.draw = gvjs_jL.prototype.draw;
+gvjs_jL.prototype.clearChart = gvjs_jL.prototype.Jb;
+gvjs_jL.prototype.getImageURI = gvjs_jL.prototype.ah;
+gvjs_jL.prototype.getSelection = gvjs_jL.prototype.getSelection;
+gvjs_jL.prototype.setSelection = gvjs_jL.prototype.setSelection;
+gvjs_jL.prototype.setAction = gvjs_jL.prototype.xh;
+gvjs_jL.prototype.getAction = gvjs_jL.prototype.ng;
+gvjs_jL.prototype.removeAction = gvjs_jL.prototype.th;
+gvjs_q(gvjs_Nc, gvjs_qQ, void 0);
+gvjs_qQ.prototype.computeDiff = gvjs_qQ.prototype.Jm;
+gvjs_qQ.prototype.draw = gvjs_qQ.prototype.draw;
+gvjs_qQ.prototype.clearChart = gvjs_qQ.prototype.Jb;
+gvjs_qQ.prototype.getImageURI = gvjs_qQ.prototype.ah;
+gvjs_qQ.prototype.getSelection = gvjs_qQ.prototype.getSelection;
+gvjs_qQ.prototype.setSelection = gvjs_qQ.prototype.setSelection;
+gvjs_qQ.prototype.setAction = gvjs_qQ.prototype.xh;
+gvjs_qQ.prototype.getAction = gvjs_qQ.prototype.ng;
+gvjs_qQ.prototype.removeAction = gvjs_qQ.prototype.th;
+gvjs_q(gvjs_Pc, gvjs_oQ, void 0);
+gvjs_oQ.prototype.draw = gvjs_oQ.prototype.draw;
+gvjs_oQ.prototype.clearChart = gvjs_oQ.prototype.Jb;
+gvjs_oQ.prototype.getImageURI = gvjs_oQ.prototype.ah;
+gvjs_oQ.prototype.getSelection = gvjs_oQ.prototype.getSelection;
+gvjs_oQ.prototype.setSelection = gvjs_oQ.prototype.setSelection;
+gvjs_oQ.prototype.setAction = gvjs_oQ.prototype.xh;
+gvjs_oQ.prototype.getAction = gvjs_oQ.prototype.ng;
+gvjs_oQ.prototype.removeAction = gvjs_oQ.prototype.th;
+gvjs_q(gvjs_Qc, gvjs_nQ, void 0);
+gvjs_nQ.prototype.draw = gvjs_nQ.prototype.draw;
+gvjs_nQ.prototype.clearChart = gvjs_nQ.prototype.Jb;
+gvjs_nQ.prototype.getImageURI = gvjs_nQ.prototype.ah;
+gvjs_nQ.prototype.getSelection = gvjs_nQ.prototype.getSelection;
+gvjs_nQ.prototype.setSelection = gvjs_nQ.prototype.setSelection;
+gvjs_nQ.prototype.setAction = gvjs_nQ.prototype.xh;
+gvjs_nQ.prototype.getAction = gvjs_nQ.prototype.ng;
+gvjs_nQ.prototype.removeAction = gvjs_nQ.prototype.th;
+/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+function gvjs_wQ(a, b, c, d) {
+  gvjs_qC.call(this, a, b, c, null, d)
+}
+gvjs_t(gvjs_wQ, gvjs_qC);
+gvjs_wQ.prototype.rg = function() {
+  do
+    gvjs_wQ.G.next.call(this);
+  while (-1 == this.tj);
+  return this.node
+}
+;
+gvjs_wQ.prototype.next = gvjs_wQ.prototype.rg;
+gvjs_dh(gvjs_b);
+function gvjs_xQ(a) {
+  return (new gvjs_wm).cd().sanitize(a)
+}
+;

--- a/cypress/fixtures/charts/jsapi_compiled_default_module
+++ b/cypress/fixtures/charts/jsapi_compiled_default_module
@@ -1,0 +1,14209 @@
+/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+var gvjs_aa = " does not match type ", gvjs_ba = " must be of type '", gvjs_ca = "#000000", gvjs_da = "#808080", gvjs_ea = "#ffffff", gvjs_fa = "&lt;", gvjs_ga = "&quot;", gvjs_ha = ", ", gvjs_ia = ', for column "', gvjs_ja = ".format", gvjs_ka = "0000000000000000", gvjs_a = "</div>", gvjs_la = "<br>", gvjs_ma = "AnnotatedTimeLine", gvjs_na = "AreaChart", gvjs_oa = "AreaChart-stacked", gvjs_pa = "August", gvjs_qa = "BarChart", gvjs_ra = "BubbleChart", gvjs_sa = "CSSStyleDeclaration", gvjs_ta = "Can't combine significant digits and minimum fraction digits", gvjs_ua = "CandlestickChart", gvjs_va = "Clobbering detected", gvjs_wa = "Column ", gvjs_xa = "ColumnChart", gvjs_ya = "ComboChart", gvjs_za = "Container is not defined", gvjs_Aa = "Custom response handler must be a function.", gvjs_b = "DIV", gvjs_Ba = "December", gvjs_Ca = "Edge", gvjs_Da = "Element", gvjs_Ea = "February", gvjs_Fa = "Friday", gvjs_Ga = "Gauge", gvjs_Ha = "GeoChart", gvjs_Ia = "HH:mm", gvjs_Ja = "HH:mm:ss", gvjs_Ka = "HH:mm:ss.SSS", gvjs_La = "Histogram", gvjs_Ma = "IFRAME", gvjs_Na = "INPUT", gvjs_Oa = "ImageRadarChart", gvjs_Pa = "ImageSparkLine", gvjs_Qa = "Inconsistent use of percent/permill characters", gvjs_Ra = "Invalid DataView column type.", gvjs_Sa = "Invalid data table format: column #", gvjs_Ta = "Invalid value for numOrArray: ", gvjs_Ua = "January", gvjs_Va = "LineChart", gvjs_Wa = "Map", gvjs_Xa = "May", gvjs_Ya = "Monday", gvjs_Za = "MotionChart", gvjs__a = "November", gvjs_0a = "OBJECT", gvjs_1a = "October", gvjs_2a = "OrgChart", gvjs_3a = "PieChart", gvjs_4a = "Request timed out", gvjs_5a = "SOURCE", gvjs_6a = "SPAN", gvjs_7a = "STYLE", gvjs_8a = "Saturday", gvjs_9a = "ScatterChart", gvjs_$a = "September", gvjs_ab = "SteppedAreaChart", gvjs_bb = "Sunday", gvjs_cb = "Symbol.iterator", gvjs_db = "Table", gvjs_eb = "Thursday", gvjs_fb = "Timeline", gvjs_gb = "Too many percent/permill", gvjs_hb = "TreeMap", gvjs_ib = "Tuesday", gvjs_jb = "Type mismatch. Value ", gvjs_kb = "Uneven number of arguments", gvjs_lb = "Wednesday", gvjs_mb = "WordTree", gvjs_nb = "_bar_format_old_value", gvjs_ob = "about:invalid#zClosurez", gvjs_c = "absolute", gvjs_pb = "addTrendLine", gvjs_qb = "annotatedtimeline", gvjs_rb = "annotationchart", gvjs_sb = "array", gvjs_tb = "attributes", gvjs_ub = "auto", gvjs_vb = "background-color:", gvjs_wb = "bar", gvjs_xb = "block", gvjs_yb = "body", gvjs_zb = "boolean", gvjs_Ab = "cancel", gvjs_Bb = "chart", gvjs_Cb = "class", gvjs_Db = "className", gvjs_Eb = "color:", gvjs_Fb = "column", gvjs_Gb = "columnFilters[", gvjs_Hb = "complete", gvjs_Ib = "controls", gvjs_Jb = "corechart", gvjs_Kb = "data-sanitizer-", gvjs_Lb = "date", gvjs_Mb = "datetime", gvjs_Nb = "decimal", gvjs_Ob = "div", gvjs_Pb = "domainAxis", gvjs_Qb = "drawing", gvjs_Rb = "error", gvjs_Sb = "false", gvjs_Tb = "full", gvjs_d = "function", gvjs_Ub = "geochart", gvjs_Vb = "getAttribute", gvjs_Wb = "getElementsByTagName", gvjs_Xb = "getPropertyValue", gvjs_Yb = "google.charts.", gvjs_Zb = "google.charts.Bar", gvjs__b = "google.charts.Line", gvjs_0b = "google.charts.Scatter", gvjs_1b = "google.visualization.", gvjs_2b = "google.visualization.AnnotatedTimeLine", gvjs_3b = "google.visualization.AnnotationChart", gvjs_4b = "google.visualization.AreaChart", gvjs_5b = "google.visualization.BarChart", gvjs_6b = "google.visualization.BubbleChart", gvjs_7b = "google.visualization.Bubbles", gvjs_8b = "google.visualization.CandlestickChart", gvjs_9b = "google.visualization.CategoryFilter", gvjs_$b = "google.visualization.ChartRangeFilter", gvjs_ac = "google.visualization.ChartRangeFilterUi", gvjs_bc = "google.visualization.ClusterChart", gvjs_cc = "google.visualization.ColumnChart", gvjs_dc = "google.visualization.ColumnSelector", gvjs_ec = "google.visualization.ComboChart", gvjs_fc = "google.visualization.CoreChart", gvjs_gc = "google.visualization.Dashboard", gvjs_hc = "google.visualization.DashboardWrapper", gvjs_ic = "google.visualization.DateRangeFilter", gvjs_jc = "google.visualization.DateRangeFilterUi", gvjs_kc = "google.visualization.Filter", gvjs_lc = "google.visualization.Gantt", gvjs_mc = "google.visualization.Gauge", gvjs_nc = "google.visualization.GeoChart", gvjs_oc = "google.visualization.GeoMap", gvjs_pc = "google.visualization.HeadlessUi", gvjs_qc = "google.visualization.HelloWorld", gvjs_rc = "google.visualization.Histogram", gvjs_sc = "google.visualization.ImageAreaChart", gvjs_tc = "google.visualization.ImageBarChart", gvjs_uc = "google.visualization.ImageCandlestickChart", gvjs_vc = "google.visualization.ImageChart", gvjs_wc = "google.visualization.ImageLineChart", gvjs_xc = "google.visualization.ImagePieChart", gvjs_yc = "google.visualization.ImageSparkLine", gvjs_zc = "google.visualization.LineChart", gvjs_Ac = "google.visualization.Map", gvjs_Bc = "google.visualization.Matrix", gvjs_Cc = "google.visualization.MotionChart", gvjs_Dc = "google.visualization.NumberFormat", gvjs_Ec = "google.visualization.NumberRangeFilter", gvjs_Fc = "google.visualization.NumberRangeSetter", gvjs_Gc = "google.visualization.NumberRangeUi", gvjs_Hc = "google.visualization.Operator", gvjs_Ic = "google.visualization.OrgChart", gvjs_Jc = "google.visualization.PieChart", gvjs_Kc = "google.visualization.Query", gvjs_Lc = "google.visualization.RangeSelector", gvjs_Mc = "google.visualization.Sankey", gvjs_Nc = "google.visualization.ScatterChart", gvjs_Oc = "google.visualization.SelectorUi", gvjs_Pc = "google.visualization.SparklineChart", gvjs_Qc = "google.visualization.SteppedAreaChart", gvjs_Rc = "google.visualization.Streamgraph", gvjs_Sc = "google.visualization.StringFilter", gvjs_Tc = "google.visualization.StringFilterUi", gvjs_Uc = "google.visualization.Sunburst", gvjs_Vc = "google.visualization.Table", gvjs_Wc = "google.visualization.TableTextChart", gvjs_Xc = "google.visualization.Timeline", gvjs_Yc = "google.visualization.TreeMap", gvjs_Zc = "google.visualization.VegaChart", gvjs__c = "google.visualization.Version", gvjs_0c = "google.visualization.WordTree", gvjs_1c = "google.visualization.WordcloudChart", gvjs_2c = "hasAttribute", gvjs_3c = "hasLabelsColumn", gvjs_4c = "height", gvjs_5c = "id", gvjs_6c = "imagechart", gvjs_7c = "keypress", gvjs_8c = "label", gvjs_9c = "latlng", gvjs_$c = "left", gvjs_e = "line", gvjs_ad = "makeRequest", gvjs_bd = "markers", gvjs_cd = "maxValue", gvjs_dd = "medium", gvjs_ed = "minValue", gvjs_fd = "motionchart", gvjs_gd = "mousedown", gvjs_hd = "mouseenter", gvjs_id = "mouseleave", gvjs_jd = "mousemove", gvjs_kd = "mouseout", gvjs_ld = "mouseover", gvjs_md = "mouseup", gvjs_nd = "msMatchesSelector", gvjs_od = "nodeName", gvjs_pd = "nodeType", gvjs_qd = "nonce", gvjs_f = "none", gvjs_rd = "null", gvjs_g = "number", gvjs_h = "object", gvjs_sd = "orgchart", gvjs_td = "pattern", gvjs_ud = "percent", gvjs_vd = "position", gvjs_wd = "prefix", gvjs_i = "ready", gvjs_xd = "regioncode", gvjs_yd = "regions", gvjs_zd = "relative", gvjs_Ad = "removeAttribute", gvjs_j = "right", gvjs_Bd = "role", gvjs_Cd = "row", gvjs_Dd = "scatter", gvjs_Ed = "script[nonce]", gvjs_k = "select", gvjs_Fd = "setAttribute", gvjs_Gd = "short", gvjs_Hd = "statechange", gvjs_l = "string", gvjs_Id = "stringify", gvjs_Jd = "style", gvjs_Kd = "suffix", gvjs_Ld = "table", gvjs_Md = "targetAxis", gvjs_m = "text", gvjs_Nd = "timeline", gvjs_Od = "timeofday", gvjs_Pd = "tooltip", gvjs_Qd = "transparent", gvjs_Rd = "true", gvjs_Sd = "type", gvjs_Td = "unhandledrejection", gvjs_Ud = "vAxis", gvjs_Vd = "value", gvjs_Wd = "warning", gvjs_Xd = "width", gvjs_Yd = "withCredentials", gvjs_Zd = "wordtree", gvjs__d = "zClosurez", gvjs_0d = "{1} 'at' {0}", gvjs_1d = "{1}, {0}", gvjs_, gvjs_2d = [];
+function gvjs_n(a) {
+  return function() {
+    return gvjs_2d[a].apply(this, arguments)
+  }
+}
+function gvjs_3d(a) {
+  var b = 0;
+  return function() {
+    return b < a.length ? {
+      done: !1,
+      value: a[b++]
+    } : {
+      done: !0
+    }
+  }
+}
+var gvjs_4d = typeof Object.defineProperties == gvjs_d ? Object.defineProperty : function(a, b, c) {
+    if (a == Array.prototype || a == Object.prototype)
+      return a;
+    a[b] = c.value;
+    return a
+  }
+;
+function gvjs_aaa(a) {
+  a = [gvjs_h == typeof globalThis && globalThis, a, gvjs_h == typeof window && window, gvjs_h == typeof self && self, gvjs_h == typeof global && global];
+  for (var b = 0; b < a.length; ++b) {
+    var c = a[b];
+    if (c && c.Math == Math)
+      return c
+  }
+  throw Error("Cannot find global object");
+}
+var gvjs_5d = gvjs_aaa(this);
+function gvjs_6d(a, b) {
+  if (b)
+    a: {
+      var c = gvjs_5d;
+      a = a.split(".");
+      for (var d = 0; d < a.length - 1; d++) {
+        var e = a[d];
+        if (!(e in c))
+          break a;
+        c = c[e]
+      }
+      a = a[a.length - 1];
+      d = c[a];
+      b = b(d);
+      b != d && null != b && gvjs_4d(c, a, {
+        configurable: !0,
+        writable: !0,
+        value: b
+      })
+    }
+}
+gvjs_6d("Symbol", function(a) {
+  function b(f) {
+    if (this instanceof b)
+      throw new TypeError("Symbol is not a constructor");
+    return new c(d + (f || "") + "_" + e++,f)
+  }
+  function c(f, g) {
+    this.Nha = f;
+    gvjs_4d(this, "description", {
+      configurable: !0,
+      writable: !0,
+      value: g
+    })
+  }
+  if (a)
+    return a;
+  c.prototype.toString = function() {
+    return this.Nha
+  }
+  ;
+  var d = "jscomp_symbol_" + (1E9 * Math.random() >>> 0) + "_"
+    , e = 0;
+  return b
+});
+gvjs_6d(gvjs_cb, function(a) {
+  if (a)
+    return a;
+  a = Symbol(gvjs_cb);
+  for (var b = "Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array".split(" "), c = 0; c < b.length; c++) {
+    var d = gvjs_5d[b[c]];
+    typeof d === gvjs_d && typeof d.prototype[a] != gvjs_d && gvjs_4d(d.prototype, a, {
+      configurable: !0,
+      writable: !0,
+      value: function() {
+        return gvjs_7d(gvjs_3d(this))
+      }
+    })
+  }
+  return a
+});
+function gvjs_7d(a) {
+  a = {
+    next: a
+  };
+  a[Symbol.iterator] = function() {
+    return this
+  }
+  ;
+  return a
+}
+function gvjs_8d(a) {
+  var b = "undefined" != typeof Symbol && Symbol.iterator && a[Symbol.iterator];
+  return b ? b.call(a) : {
+    next: gvjs_3d(a)
+  }
+}
+function gvjs_9d(a) {
+  if (!(a instanceof Array)) {
+    a = gvjs_8d(a);
+    for (var b, c = []; !(b = a.next()).done; )
+      c.push(b.value);
+    a = c
+  }
+  return a
+}
+var gvjs_baa = typeof Object.create == gvjs_d ? Object.create : function(a) {
+  function b() {}
+  b.prototype = a;
+  return new b
+}
+  , gvjs_$d;
+if (typeof Object.setPrototypeOf == gvjs_d)
+  gvjs_$d = Object.setPrototypeOf;
+else {
+  var gvjs_ae;
+  a: {
+    var gvjs_caa = {
+      a: !0
+    }
+      , gvjs_be = {};
+    try {
+      gvjs_be.__proto__ = gvjs_caa;
+      gvjs_ae = gvjs_be.a;
+      break a
+    } catch (a) {}
+    gvjs_ae = !1
+  }
+  gvjs_$d = gvjs_ae ? function(a, b) {
+      a.__proto__ = b;
+      if (a.__proto__ !== b)
+        throw new TypeError(a + " is not extensible");
+      return a
+    }
+    : null
+}
+var gvjs_ce = gvjs_$d;
+function gvjs_o(a, b) {
+  a.prototype = gvjs_baa(b.prototype);
+  a.prototype.constructor = a;
+  if (gvjs_ce)
+    gvjs_ce(a, b);
+  else
+    for (var c in b)
+      if ("prototype" != c)
+        if (Object.defineProperties) {
+          var d = Object.getOwnPropertyDescriptor(b, c);
+          d && Object.defineProperty(a, c, d)
+        } else
+          a[c] = b[c];
+  a.G = b.prototype
+}
+function gvjs_de(a, b) {
+  return Object.prototype.hasOwnProperty.call(a, b)
+}
+gvjs_6d("WeakMap", function(a) {
+  function b(k) {
+    this.ac = (h += Math.random() + 1).toString();
+    if (k) {
+      k = gvjs_8d(k);
+      for (var l; !(l = k.next()).done; )
+        l = l.value,
+          this.set(l[0], l[1])
+    }
+  }
+  function c() {}
+  function d(k) {
+    var l = typeof k;
+    return l === gvjs_h && null !== k || l === gvjs_d
+  }
+  function e(k) {
+    if (!gvjs_de(k, g)) {
+      var l = new c;
+      gvjs_4d(k, g, {
+        value: l
+      })
+    }
+  }
+  function f(k) {
+    var l = Object[k];
+    l && (Object[k] = function(m) {
+        if (m instanceof c)
+          return m;
+        Object.isExtensible(m) && e(m);
+        return l(m)
+      }
+    )
+  }
+  if (function() {
+    if (!a || !Object.seal)
+      return !1;
+    try {
+      var k = Object.seal({})
+        , l = Object.seal({})
+        , m = new a([[k, 2], [l, 3]]);
+      if (2 != m.get(k) || 3 != m.get(l))
+        return !1;
+      m.delete(k);
+      m.set(l, 4);
+      return !m.has(k) && 4 == m.get(l)
+    } catch (n) {
+      return !1
+    }
+  }())
+    return a;
+  var g = "$jscomp_hidden_" + Math.random();
+  f("freeze");
+  f("preventExtensions");
+  f("seal");
+  var h = 0;
+  b.prototype.set = function(k, l) {
+    if (!d(k))
+      throw Error("Invalid WeakMap key");
+    e(k);
+    if (!gvjs_de(k, g))
+      throw Error("WeakMap key fail: " + k);
+    k[g][this.ac] = l;
+    return this
+  }
+  ;
+  b.prototype.get = function(k) {
+    return d(k) && gvjs_de(k, g) ? k[g][this.ac] : void 0
+  }
+  ;
+  b.prototype.has = function(k) {
+    return d(k) && gvjs_de(k, g) && gvjs_de(k[g], this.ac)
+  }
+  ;
+  b.prototype.delete = function(k) {
+    return d(k) && gvjs_de(k, g) && gvjs_de(k[g], this.ac) ? delete k[g][this.ac] : !1
+  }
+  ;
+  return b
+});
+gvjs_6d(gvjs_Wa, function(a) {
+  function b() {
+    var h = {};
+    return h.he = h.next = h.head = h
+  }
+  function c(h, k) {
+    var l = h.pc;
+    return gvjs_7d(function() {
+      if (l) {
+        for (; l.head != h.pc; )
+          l = l.he;
+        for (; l.next != l.head; )
+          return l = l.next,
+            {
+              done: !1,
+              value: k(l)
+            };
+        l = null
+      }
+      return {
+        done: !0,
+        value: void 0
+      }
+    })
+  }
+  function d(h, k) {
+    var l = k && typeof k;
+    l == gvjs_h || l == gvjs_d ? f.has(k) ? l = f.get(k) : (l = "" + ++g,
+      f.set(k, l)) : l = "p_" + k;
+    var m = h.ra[l];
+    if (m && gvjs_de(h.ra, l))
+      for (h = 0; h < m.length; h++) {
+        var n = m[h];
+        if (k !== k && n.key !== n.key || k === n.key)
+          return {
+            id: l,
+            list: m,
+            index: h,
+            Xc: n
+          }
+      }
+    return {
+      id: l,
+      list: m,
+      index: -1,
+      Xc: void 0
+    }
+  }
+  function e(h) {
+    this.ra = {};
+    this.pc = b();
+    this.size = 0;
+    if (h) {
+      h = gvjs_8d(h);
+      for (var k; !(k = h.next()).done; )
+        k = k.value,
+          this.set(k[0], k[1])
+    }
+  }
+  if (function() {
+    if (!a || typeof a != gvjs_d || !a.prototype.entries || typeof Object.seal != gvjs_d)
+      return !1;
+    try {
+      var h = Object.seal({
+        x: 4
+      })
+        , k = new a(gvjs_8d([[h, "s"]]));
+      if ("s" != k.get(h) || 1 != k.size || k.get({
+        x: 4
+      }) || k.set({
+        x: 4
+      }, "t") != k || 2 != k.size)
+        return !1;
+      var l = k.entries()
+        , m = l.next();
+      if (m.done || m.value[0] != h || "s" != m.value[1])
+        return !1;
+      m = l.next();
+      return m.done || 4 != m.value[0].x || "t" != m.value[1] || !l.next().done ? !1 : !0
+    } catch (n) {
+      return !1
+    }
+  }())
+    return a;
+  var f = new WeakMap;
+  e.prototype.set = function(h, k) {
+    h = 0 === h ? 0 : h;
+    var l = d(this, h);
+    l.list || (l.list = this.ra[l.id] = []);
+    l.Xc ? l.Xc.value = k : (l.Xc = {
+      next: this.pc,
+      he: this.pc.he,
+      head: this.pc,
+      key: h,
+      value: k
+    },
+      l.list.push(l.Xc),
+      this.pc.he.next = l.Xc,
+      this.pc.he = l.Xc,
+      this.size++);
+    return this
+  }
+  ;
+  e.prototype.delete = function(h) {
+    h = d(this, h);
+    return h.Xc && h.list ? (h.list.splice(h.index, 1),
+    h.list.length || delete this.ra[h.id],
+      h.Xc.he.next = h.Xc.next,
+      h.Xc.next.he = h.Xc.he,
+      h.Xc.head = null,
+      this.size--,
+      !0) : !1
+  }
+  ;
+  e.prototype.clear = function() {
+    this.ra = {};
+    this.pc = this.pc.he = b();
+    this.size = 0
+  }
+  ;
+  e.prototype.has = function(h) {
+    return !!d(this, h).Xc
+  }
+  ;
+  e.prototype.get = function(h) {
+    return (h = d(this, h).Xc) && h.value
+  }
+  ;
+  e.prototype.entries = function() {
+    return c(this, function(h) {
+      return [h.key, h.value]
+    })
+  }
+  ;
+  e.prototype.keys = function() {
+    return c(this, function(h) {
+      return h.key
+    })
+  }
+  ;
+  e.prototype.values = function() {
+    return c(this, function(h) {
+      return h.value
+    })
+  }
+  ;
+  e.prototype.forEach = function(h, k) {
+    for (var l = this.entries(), m; !(m = l.next()).done; )
+      m = m.value,
+        h.call(k, m[1], m[0], this)
+  }
+  ;
+  e.prototype[Symbol.iterator] = e.prototype.entries;
+  var g = 0;
+  return e
+});
+function gvjs_ee(a, b, c) {
+  if (null == a)
+    throw new TypeError("The 'this' value for String.prototype." + c + " must not be null or undefined");
+  if (b instanceof RegExp)
+    throw new TypeError("First argument to String.prototype." + c + " must not be a regular expression");
+  return a + ""
+}
+gvjs_6d("String.prototype.endsWith", function(a) {
+  return a ? a : function(b, c) {
+    var d = gvjs_ee(this, b, "endsWith");
+    b += "";
+    void 0 === c && (c = d.length);
+    c = Math.max(0, Math.min(c | 0, d.length));
+    for (var e = b.length; 0 < e && 0 < c; )
+      if (d[--c] != b[--e])
+        return !1;
+    return 0 >= e
+  }
+});
+function gvjs_fe(a, b, c) {
+  a instanceof String && (a = String(a));
+  for (var d = a.length, e = 0; e < d; e++) {
+    var f = a[e];
+    if (b.call(c, f, e, a))
+      return {
+        Ud: e,
+        v: f
+      }
+  }
+  return {
+    Ud: -1,
+    v: void 0
+  }
+}
+gvjs_6d("Array.prototype.find", function(a) {
+  return a ? a : function(b, c) {
+    return gvjs_fe(this, b, c).v
+  }
+});
+gvjs_6d("String.prototype.startsWith", function(a) {
+  return a ? a : function(b, c) {
+    var d = gvjs_ee(this, b, "startsWith");
+    b += "";
+    var e = d.length
+      , f = b.length;
+    c = Math.max(0, Math.min(c | 0, d.length));
+    for (var g = 0; g < f && c < e; )
+      if (d[c++] != b[g++])
+        return !1;
+    return g >= f
+  }
+});
+gvjs_6d("String.prototype.repeat", function(a) {
+  return a ? a : function(b) {
+    var c = gvjs_ee(this, null, "repeat");
+    if (0 > b || 1342177279 < b)
+      throw new RangeError("Invalid count value");
+    b |= 0;
+    for (var d = ""; b; )
+      if (b & 1 && (d += c),
+        b >>>= 1)
+        c += c;
+    return d
+  }
+});
+function gvjs_ge(a, b) {
+  a instanceof String && (a += "");
+  var c = 0
+    , d = !1
+    , e = {
+    next: function() {
+      if (!d && c < a.length) {
+        var f = c++;
+        return {
+          value: b(f, a[f]),
+          done: !1
+        }
+      }
+      d = !0;
+      return {
+        done: !0,
+        value: void 0
+      }
+    }
+  };
+  e[Symbol.iterator] = function() {
+    return e
+  }
+  ;
+  return e
+}
+gvjs_6d("Array.prototype.entries", function(a) {
+  return a ? a : function() {
+    return gvjs_ge(this, function(b, c) {
+      return [b, c]
+    })
+  }
+});
+var gvjs_daa = typeof Object.assign == gvjs_d ? Object.assign : function(a, b) {
+    for (var c = 1; c < arguments.length; c++) {
+      var d = arguments[c];
+      if (d)
+        for (var e in d)
+          gvjs_de(d, e) && (a[e] = d[e])
+    }
+    return a
+  }
+;
+gvjs_6d("Object.assign", function(a) {
+  return a || gvjs_daa
+});
+gvjs_6d("Promise", function(a) {
+  function b(g) {
+    this.K = 0;
+    this.ik = void 0;
+    this.WD = [];
+    this.Mba = !1;
+    var h = this.vX();
+    try {
+      g(h.resolve, h.reject)
+    } catch (k) {
+      h.reject(k)
+    }
+  }
+  function c() {
+    this.Iu = null
+  }
+  function d(g) {
+    return g instanceof b ? g : new b(function(h) {
+        h(g)
+      }
+    )
+  }
+  if (a)
+    return a;
+  c.prototype.u7 = function(g) {
+    if (null == this.Iu) {
+      this.Iu = [];
+      var h = this;
+      this.v7(function() {
+        h.Wna()
+      })
+    }
+    this.Iu.push(g)
+  }
+  ;
+  var e = gvjs_5d.setTimeout;
+  c.prototype.v7 = function(g) {
+    e(g, 0)
+  }
+  ;
+  c.prototype.Wna = function() {
+    for (; this.Iu && this.Iu.length; ) {
+      var g = this.Iu;
+      this.Iu = [];
+      for (var h = 0; h < g.length; ++h) {
+        var k = g[h];
+        g[h] = null;
+        try {
+          k()
+        } catch (l) {
+          this.Aka(l)
+        }
+      }
+    }
+    this.Iu = null
+  }
+  ;
+  c.prototype.Aka = function(g) {
+    this.v7(function() {
+      throw g;
+    })
+  }
+  ;
+  b.prototype.vX = function() {
+    function g(l) {
+      return function(m) {
+        k || (k = !0,
+          l.call(h, m))
+      }
+    }
+    var h = this
+      , k = !1;
+    return {
+      resolve: g(this.Kva),
+      reject: g(this.T2)
+    }
+  }
+  ;
+  b.prototype.Kva = function(g) {
+    if (g === this)
+      this.T2(new TypeError("A Promise cannot resolve to itself"));
+    else if (g instanceof b)
+      this.Mwa(g);
+    else {
+      a: switch (typeof g) {
+        case gvjs_h:
+          var h = null != g;
+          break a;
+        case gvjs_d:
+          h = !0;
+          break a;
+        default:
+          h = !1
+      }
+      h ? this.Jva(g) : this.B$(g)
+    }
+  }
+  ;
+  b.prototype.Jva = function(g) {
+    var h = void 0;
+    try {
+      h = g.then
+    } catch (k) {
+      this.T2(k);
+      return
+    }
+    typeof h == gvjs_d ? this.Nwa(h, g) : this.B$(g)
+  }
+  ;
+  b.prototype.T2 = function(g) {
+    this.Kfa(2, g)
+  }
+  ;
+  b.prototype.B$ = function(g) {
+    this.Kfa(1, g)
+  }
+  ;
+  b.prototype.Kfa = function(g, h) {
+    if (0 != this.K)
+      throw Error("Cannot settle(" + g + gvjs_ha + h + "): Promise already settled in state" + this.K);
+    this.K = g;
+    this.ik = h;
+    2 === this.K && this.cwa();
+    this.Yna()
+  }
+  ;
+  b.prototype.cwa = function() {
+    var g = this;
+    e(function() {
+      if (g.Xta()) {
+        var h = gvjs_5d.console;
+        "undefined" !== typeof h && h.error(g.ik)
+      }
+    }, 1)
+  }
+  ;
+  b.prototype.Xta = function() {
+    if (this.Mba)
+      return !1;
+    var g = gvjs_5d.CustomEvent
+      , h = gvjs_5d.Event
+      , k = gvjs_5d.dispatchEvent;
+    if ("undefined" === typeof k)
+      return !0;
+    typeof g === gvjs_d ? g = new g(gvjs_Td,{
+      cancelable: !0
+    }) : typeof h === gvjs_d ? g = new h(gvjs_Td,{
+      cancelable: !0
+    }) : (g = gvjs_5d.document.createEvent("CustomEvent"),
+      g.initCustomEvent(gvjs_Td, !1, !0, g));
+    g.promise = this;
+    g.reason = this.ik;
+    return k(g)
+  }
+  ;
+  b.prototype.Yna = function() {
+    if (null != this.WD) {
+      for (var g = 0; g < this.WD.length; ++g)
+        f.u7(this.WD[g]);
+      this.WD = null
+    }
+  }
+  ;
+  var f = new c;
+  b.prototype.Mwa = function(g) {
+    var h = this.vX();
+    g.xN(h.resolve, h.reject)
+  }
+  ;
+  b.prototype.Nwa = function(g, h) {
+    var k = this.vX();
+    try {
+      g.call(h, k.resolve, k.reject)
+    } catch (l) {
+      k.reject(l)
+    }
+  }
+  ;
+  b.prototype.then = function(g, h) {
+    function k(p, q) {
+      return typeof p == gvjs_d ? function(r) {
+          try {
+            l(p(r))
+          } catch (t) {
+            m(t)
+          }
+        }
+        : q
+    }
+    var l, m, n = new b(function(p, q) {
+        l = p;
+        m = q
+      }
+    );
+    this.xN(k(g, l), k(h, m));
+    return n
+  }
+  ;
+  b.prototype.catch = function(g) {
+    return this.then(void 0, g)
+  }
+  ;
+  b.prototype.xN = function(g, h) {
+    function k() {
+      switch (l.K) {
+        case 1:
+          g(l.ik);
+          break;
+        case 2:
+          h(l.ik);
+          break;
+        default:
+          throw Error("Unexpected state: " + l.K);
+      }
+    }
+    var l = this;
+    null == this.WD ? f.u7(k) : this.WD.push(k);
+    this.Mba = !0
+  }
+  ;
+  b.resolve = d;
+  b.reject = function(g) {
+    return new b(function(h, k) {
+        k(g)
+      }
+    )
+  }
+  ;
+  b.race = function(g) {
+    return new b(function(h, k) {
+        for (var l = gvjs_8d(g), m = l.next(); !m.done; m = l.next())
+          d(m.value).xN(h, k)
+      }
+    )
+  }
+  ;
+  b.all = function(g) {
+    var h = gvjs_8d(g)
+      , k = h.next();
+    return k.done ? d([]) : new b(function(l, m) {
+        function n(r) {
+          return function(t) {
+            p[r] = t;
+            q--;
+            0 == q && l(p)
+          }
+        }
+        var p = []
+          , q = 0;
+        do
+          p.push(void 0),
+            q++,
+            d(k.value).xN(n(p.length - 1), m),
+            k = h.next();
+        while (!k.done)
+      }
+    )
+  }
+  ;
+  return b
+});
+gvjs_6d("Array.prototype.keys", function(a) {
+  return a ? a : function() {
+    return gvjs_ge(this, function(b) {
+      return b
+    })
+  }
+});
+gvjs_6d("Array.from", function(a) {
+  return a ? a : function(b, c, d) {
+    c = null != c ? c : function(h) {
+      return h
+    }
+    ;
+    var e = []
+      , f = "undefined" != typeof Symbol && Symbol.iterator && b[Symbol.iterator];
+    if (typeof f == gvjs_d) {
+      b = f.call(b);
+      for (var g = 0; !(f = b.next()).done; )
+        e.push(c.call(d, f.value, g++))
+    } else
+      for (f = b.length,
+             g = 0; g < f; g++)
+        e.push(c.call(d, b[g], g));
+    return e
+  }
+});
+gvjs_6d("Array.prototype.values", function(a) {
+  return a ? a : function() {
+    return gvjs_ge(this, function(b, c) {
+      return c
+    })
+  }
+});
+gvjs_6d("Set", function(a) {
+  function b(c) {
+    this.qa = new Map;
+    if (c) {
+      c = gvjs_8d(c);
+      for (var d; !(d = c.next()).done; )
+        this.add(d.value)
+    }
+    this.size = this.qa.size
+  }
+  if (function() {
+    if (!a || typeof a != gvjs_d || !a.prototype.entries || typeof Object.seal != gvjs_d)
+      return !1;
+    try {
+      var c = Object.seal({
+        x: 4
+      })
+        , d = new a(gvjs_8d([c]));
+      if (!d.has(c) || 1 != d.size || d.add(c) != d || 1 != d.size || d.add({
+        x: 4
+      }) != d || 2 != d.size)
+        return !1;
+      var e = d.entries()
+        , f = e.next();
+      if (f.done || f.value[0] != c || f.value[1] != c)
+        return !1;
+      f = e.next();
+      return f.done || f.value[0] == c || 4 != f.value[0].x || f.value[1] != f.value[0] ? !1 : e.next().done
+    } catch (g) {
+      return !1
+    }
+  }())
+    return a;
+  b.prototype.add = function(c) {
+    c = 0 === c ? 0 : c;
+    this.qa.set(c, c);
+    this.size = this.qa.size;
+    return this
+  }
+  ;
+  b.prototype.delete = function(c) {
+    c = this.qa.delete(c);
+    this.size = this.qa.size;
+    return c
+  }
+  ;
+  b.prototype.clear = function() {
+    this.qa.clear();
+    this.size = 0
+  }
+  ;
+  b.prototype.has = function(c) {
+    return this.qa.has(c)
+  }
+  ;
+  b.prototype.entries = function() {
+    return this.qa.entries()
+  }
+  ;
+  b.prototype.values = function() {
+    return this.qa.values()
+  }
+  ;
+  b.prototype.keys = b.prototype.values;
+  b.prototype[Symbol.iterator] = b.prototype.values;
+  b.prototype.forEach = function(c, d) {
+    var e = this;
+    this.qa.forEach(function(f) {
+      return c.call(d, f, f, e)
+    })
+  }
+  ;
+  return b
+});
+gvjs_6d("Array.prototype.fill", function(a) {
+  return a ? a : function(b, c, d) {
+    var e = this.length || 0;
+    0 > c && (c = Math.max(0, e + c));
+    if (null == d || d > e)
+      d = e;
+    d = Number(d);
+    0 > d && (d = Math.max(0, e + d));
+    for (c = Number(c || 0); c < d; c++)
+      this[c] = b;
+    return this
+  }
+});
+function gvjs_he(a) {
+  return a ? a : Array.prototype.fill
+}
+gvjs_6d("Int8Array.prototype.fill", gvjs_he);
+gvjs_6d("Uint8Array.prototype.fill", gvjs_he);
+gvjs_6d("Uint8ClampedArray.prototype.fill", gvjs_he);
+gvjs_6d("Int16Array.prototype.fill", gvjs_he);
+gvjs_6d("Uint16Array.prototype.fill", gvjs_he);
+gvjs_6d("Int32Array.prototype.fill", gvjs_he);
+gvjs_6d("Uint32Array.prototype.fill", gvjs_he);
+gvjs_6d("Float32Array.prototype.fill", gvjs_he);
+gvjs_6d("Float64Array.prototype.fill", gvjs_he);
+gvjs_6d("Object.values", function(a) {
+  return a ? a : function(b) {
+    var c = [], d;
+    for (d in b)
+      gvjs_de(b, d) && c.push(b[d]);
+    return c
+  }
+});
+gvjs_6d("Math.hypot", function(a) {
+  return a ? a : function(b) {
+    if (2 > arguments.length)
+      return arguments.length ? Math.abs(arguments[0]) : 0;
+    var c, d, e;
+    for (c = e = 0; c < arguments.length; c++)
+      e = Math.max(e, Math.abs(arguments[c]));
+    if (1E100 < e || 1E-100 > e) {
+      if (!e)
+        return e;
+      for (c = d = 0; c < arguments.length; c++) {
+        var f = Number(arguments[c]) / e;
+        d += f * f
+      }
+      return Math.sqrt(d) * e
+    }
+    for (c = d = 0; c < arguments.length; c++)
+      f = Number(arguments[c]),
+        d += f * f;
+    return Math.sqrt(d)
+  }
+});
+gvjs_6d("Array.prototype.findIndex", function(a) {
+  return a ? a : function(b, c) {
+    return gvjs_fe(this, b, c).Ud
+  }
+});
+gvjs_6d("Math.log10", function(a) {
+  return a ? a : function(b) {
+    return Math.log(b) / Math.LN10
+  }
+});
+gvjs_6d("Object.is", function(a) {
+  return a ? a : function(b, c) {
+    return b === c ? 0 !== b || 1 / b === 1 / c : b !== b && c !== c
+  }
+});
+gvjs_6d("Array.prototype.includes", function(a) {
+  return a ? a : function(b, c) {
+    var d = this;
+    d instanceof String && (d = String(d));
+    var e = d.length;
+    c = c || 0;
+    for (0 > c && (c = Math.max(c + e, 0)); c < e; c++) {
+      var f = d[c];
+      if (f === b || Object.is(f, b))
+        return !0
+    }
+    return !1
+  }
+});
+gvjs_6d("String.prototype.includes", function(a) {
+  return a ? a : function(b, c) {
+    return -1 !== gvjs_ee(this, b, "includes").indexOf(b, c || 0)
+  }
+});
+gvjs_6d("Object.entries", function(a) {
+  return a ? a : function(b) {
+    var c = [], d;
+    for (d in b)
+      gvjs_de(b, d) && c.push([d, b[d]]);
+    return c
+  }
+});
+gvjs_6d("Number.isFinite", function(a) {
+  return a ? a : function(b) {
+    return typeof b !== gvjs_g ? !1 : !isNaN(b) && Infinity !== b && -Infinity !== b
+  }
+});
+gvjs_6d("Number.isInteger", function(a) {
+  return a ? a : function(b) {
+    return Number.isFinite(b) ? b === Math.floor(b) : !1
+  }
+});
+gvjs_6d("Math.cbrt", function(a) {
+  return a ? a : function(b) {
+    if (0 === b)
+      return b;
+    b = Number(b);
+    var c = Math.pow(Math.abs(b), 1 / 3);
+    return 0 > b ? -c : c
+  }
+});
+gvjs_6d("Math.log2", function(a) {
+  return a ? a : function(b) {
+    return Math.log(b) / Math.LN2
+  }
+});
+gvjs_6d("Number.isNaN", function(a) {
+  return a ? a : function(b) {
+    return typeof b === gvjs_g && isNaN(b)
+  }
+});
+var gvjs_ie = gvjs_ie || {}
+  , gvjs_p = this || self;
+function gvjs_q(a, b, c) {
+  a = a.split(".");
+  c = c || gvjs_p;
+  a[0]in c || "undefined" == typeof c.execScript || c.execScript("var " + a[0]);
+  for (var d; a.length && (d = a.shift()); )
+    a.length || void 0 === b ? c = c[d] && c[d] !== Object.prototype[d] ? c[d] : c[d] = {} : c[d] = b
+}
+function gvjs_je(a, b) {
+  a = a.split(".");
+  b = b || gvjs_p;
+  for (var c = 0; c < a.length; c++)
+    if (b = b[a[c]],
+    null == b)
+      return null;
+  return b
+}
+function gvjs_ke() {}
+function gvjs_le(a) {
+  a.pz = void 0;
+  a.Lc = function() {
+    return a.pz ? a.pz : a.pz = new a
+  }
+}
+function gvjs_me(a) {
+  var b = typeof a;
+  return b != gvjs_h ? b : a ? Array.isArray(a) ? gvjs_sb : b : gvjs_rd
+}
+function gvjs_ne(a) {
+  var b = gvjs_me(a);
+  return b == gvjs_sb || b == gvjs_h && typeof a.length == gvjs_g
+}
+function gvjs_oe(a) {
+  return gvjs_r(a) && typeof a.getFullYear == gvjs_d
+}
+function gvjs_r(a) {
+  var b = typeof a;
+  return b == gvjs_h && null != a || b == gvjs_d
+}
+function gvjs_pe(a) {
+  return Object.prototype.hasOwnProperty.call(a, gvjs_qe) && a[gvjs_qe] || (a[gvjs_qe] = ++gvjs_eaa)
+}
+var gvjs_qe = "closure_uid_" + (1E9 * Math.random() >>> 0)
+  , gvjs_eaa = 0;
+function gvjs_faa(a, b, c) {
+  return a.call.apply(a.bind, arguments)
+}
+function gvjs_gaa(a, b, c) {
+  if (!a)
+    throw Error();
+  if (2 < arguments.length) {
+    var d = Array.prototype.slice.call(arguments, 2);
+    return function() {
+      var e = Array.prototype.slice.call(arguments);
+      Array.prototype.unshift.apply(e, d);
+      return a.apply(b, e)
+    }
+  }
+  return function() {
+    return a.apply(b, arguments)
+  }
+}
+function gvjs_s(a, b, c) {
+  gvjs_s = Function.prototype.bind && -1 != Function.prototype.bind.toString().indexOf("native code") ? gvjs_faa : gvjs_gaa;
+  return gvjs_s.apply(null, arguments)
+}
+function gvjs_re(a, b) {
+  var c = Array.prototype.slice.call(arguments, 1);
+  return function() {
+    var d = c.slice();
+    d.push.apply(d, arguments);
+    return a.apply(this, d)
+  }
+}
+function gvjs_se() {
+  return Date.now()
+}
+function gvjs_te(a) {
+  (0,
+    eval)(a)
+}
+function gvjs_t(a, b) {
+  function c() {}
+  c.prototype = b.prototype;
+  a.G = b.prototype;
+  a.prototype = new c;
+  a.prototype.constructor = a;
+  a.base = function(d, e, f) {
+    for (var g = Array(arguments.length - 2), h = 2; h < arguments.length; h++)
+      g[h - 2] = arguments[h];
+    return b.prototype[e].apply(d, g)
+  }
+}
+function gvjs_ue(a) {
+  return a
+}
+;function gvjs_ve(a) {
+  if (Error.captureStackTrace)
+    Error.captureStackTrace(this, gvjs_ve);
+  else {
+    var b = Error().stack;
+    b && (this.stack = b)
+  }
+  a && (this.message = String(a))
+}
+gvjs_t(gvjs_ve, Error);
+gvjs_ve.prototype.name = "CustomError";
+var gvjs_we;
+function gvjs_xe(a, b) {
+  a = a.split("%s");
+  for (var c = "", d = a.length - 1, e = 0; e < d; e++)
+    c += a[e] + (e < b.length ? b[e] : "%s");
+  gvjs_ve.call(this, c + a[d])
+}
+gvjs_t(gvjs_xe, gvjs_ve);
+gvjs_xe.prototype.name = "AssertionError";
+function gvjs_ye() {
+  return null
+}
+function gvjs_ze(a) {
+  var b = !1, c;
+  return function() {
+    b || (c = a(),
+      b = !0);
+    return c
+  }
+}
+;function gvjs_Ae(a) {
+  return a[a.length - 1]
+}
+var gvjs_Be = Array.prototype.indexOf ? function(a, b) {
+    return Array.prototype.indexOf.call(a, b, void 0)
+  }
+  : function(a, b) {
+    if (typeof a === gvjs_l)
+      return typeof b !== gvjs_l || 1 != b.length ? -1 : a.indexOf(b, 0);
+    for (var c = 0; c < a.length; c++)
+      if (c in a && a[c] === b)
+        return c;
+    return -1
+  }
+  , gvjs_haa = Array.prototype.lastIndexOf ? function(a, b) {
+    return Array.prototype.lastIndexOf.call(a, b, a.length - 1)
+  }
+  : function(a, b) {
+    var c = a.length - 1;
+    0 > c && (c = Math.max(0, a.length + c));
+    if (typeof a === gvjs_l)
+      return typeof b !== gvjs_l || 1 != b.length ? -1 : a.lastIndexOf(b, c);
+    for (; 0 <= c; c--)
+      if (c in a && a[c] === b)
+        return c;
+    return -1
+  }
+  , gvjs_u = Array.prototype.forEach ? function(a, b, c) {
+    Array.prototype.forEach.call(a, b, c)
+  }
+  : function(a, b, c) {
+    for (var d = a.length, e = typeof a === gvjs_l ? a.split("") : a, f = 0; f < d; f++)
+      f in e && b.call(c, e[f], f, a)
+  }
+;
+function gvjs_Ce(a, b) {
+  for (var c = typeof a === gvjs_l ? a.split("") : a, d = a.length - 1; 0 <= d; --d)
+    d in c && b.call(void 0, c[d], d, a)
+}
+var gvjs_De = Array.prototype.filter ? function(a, b, c) {
+    return Array.prototype.filter.call(a, b, c)
+  }
+  : function(a, b, c) {
+    for (var d = a.length, e = [], f = 0, g = typeof a === gvjs_l ? a.split("") : a, h = 0; h < d; h++)
+      if (h in g) {
+        var k = g[h];
+        b.call(c, k, h, a) && (e[f++] = k)
+      }
+    return e
+  }
+  , gvjs_v = Array.prototype.map ? function(a, b, c) {
+    return Array.prototype.map.call(a, b, c)
+  }
+  : function(a, b, c) {
+    for (var d = a.length, e = Array(d), f = typeof a === gvjs_l ? a.split("") : a, g = 0; g < d; g++)
+      g in f && (e[g] = b.call(c, f[g], g, a));
+    return e
+  }
+  , gvjs_Ee = Array.prototype.reduce ? function(a, b, c, d) {
+    d && (b = gvjs_s(b, d));
+    return Array.prototype.reduce.call(a, b, c)
+  }
+  : function(a, b, c, d) {
+    var e = c;
+    gvjs_u(a, function(f, g) {
+      e = b.call(d, e, f, g, a)
+    });
+    return e
+  }
+  , gvjs_iaa = Array.prototype.reduceRight ? function(a, b, c) {
+    return Array.prototype.reduceRight.call(a, b, c)
+  }
+  : function(a, b, c) {
+    var d = c;
+    gvjs_Ce(a, function(e, f) {
+      d = b.call(void 0, d, e, f, a)
+    });
+    return d
+  }
+  , gvjs_Fe = Array.prototype.some ? function(a, b, c) {
+    return Array.prototype.some.call(a, b, c)
+  }
+  : function(a, b, c) {
+    for (var d = a.length, e = typeof a === gvjs_l ? a.split("") : a, f = 0; f < d; f++)
+      if (f in e && b.call(c, e[f], f, a))
+        return !0;
+    return !1
+  }
+  , gvjs_Ge = Array.prototype.every ? function(a, b, c) {
+    return Array.prototype.every.call(a, b, c)
+  }
+  : function(a, b, c) {
+    for (var d = a.length, e = typeof a === gvjs_l ? a.split("") : a, f = 0; f < d; f++)
+      if (f in e && !b.call(c, e[f], f, a))
+        return !1;
+    return !0
+  }
+;
+function gvjs_He(a, b) {
+  return 0 <= gvjs_Be(a, b)
+}
+function gvjs_Ie(a, b) {
+  b = gvjs_Be(a, b);
+  var c;
+  (c = 0 <= b) && gvjs_Je(a, b);
+  return c
+}
+function gvjs_Je(a, b) {
+  Array.prototype.splice.call(a, b, 1)
+}
+function gvjs_Ke(a) {
+  return Array.prototype.concat.apply([], arguments)
+}
+function gvjs_Le(a) {
+  var b = a.length;
+  if (0 < b) {
+    for (var c = Array(b), d = 0; d < b; d++)
+      c[d] = a[d];
+    return c
+  }
+  return []
+}
+function gvjs_Me(a, b) {
+  for (var c = 1; c < arguments.length; c++) {
+    var d = arguments[c];
+    if (gvjs_ne(d)) {
+      var e = a.length || 0
+        , f = d.length || 0;
+      a.length = e + f;
+      for (var g = 0; g < f; g++)
+        a[e + g] = d[g]
+    } else
+      a.push(d)
+  }
+}
+function gvjs_Ne(a, b, c, d) {
+  return Array.prototype.splice.apply(a, gvjs_Oe(arguments, 1))
+}
+function gvjs_Oe(a, b, c) {
+  return 2 >= arguments.length ? Array.prototype.slice.call(a, b) : Array.prototype.slice.call(a, b, c)
+}
+function gvjs_Pe(a, b, c) {
+  function d(l) {
+    return gvjs_r(l) ? "o" + gvjs_pe(l) : (typeof l).charAt(0) + l
+  }
+  b = b || a;
+  c = c || d;
+  for (var e = 0, f = 0, g = {}; f < a.length; ) {
+    var h = a[f++]
+      , k = c(h);
+    Object.prototype.hasOwnProperty.call(g, k) || (g[k] = !0,
+      b[e++] = h)
+  }
+  b.length = e
+}
+function gvjs_Qe(a, b) {
+  a.sort(b || gvjs_Re)
+}
+function gvjs_Se(a, b) {
+  for (var c = Array(a.length), d = 0; d < a.length; d++)
+    c[d] = {
+      index: d,
+      value: a[d]
+    };
+  var e = b || gvjs_Re;
+  gvjs_Qe(c, function(f, g) {
+    return e(f.value, g.value) || f.index - g.index
+  });
+  for (b = 0; b < a.length; b++)
+    a[b] = c[b].value
+}
+function gvjs_Re(a, b) {
+  return a > b ? 1 : a < b ? -1 : 0
+}
+function gvjs_Te(a, b) {
+  for (var c = [], d = 0; d < b; d++)
+    c[d] = a;
+  return c
+}
+function gvjs_jaa(a, b) {
+  return gvjs_Ke.apply([], gvjs_v(a, b, void 0))
+}
+;function gvjs_w(a, b, c) {
+  for (var d in a)
+    b.call(c, a[d], d, a)
+}
+function gvjs_Ue(a, b) {
+  for (var c in a)
+    if (b.call(void 0, a[c], c, a))
+      return !0;
+  return !1
+}
+function gvjs_Ve(a, b, c) {
+  for (var d in a)
+    if (!b.call(c, a[d], d, a))
+      return !1;
+  return !0
+}
+function gvjs_We(a) {
+  var b = 0, c;
+  for (c in a)
+    b++;
+  return b
+}
+function gvjs_Xe(a) {
+  var b = [], c = 0, d;
+  for (d in a)
+    b[c++] = a[d];
+  return b
+}
+function gvjs_Ye(a) {
+  var b = [], c = 0, d;
+  for (d in a)
+    b[c++] = d;
+  return b
+}
+function gvjs_Ze(a, b) {
+  return null !== a && b in a
+}
+function gvjs__e(a, b) {
+  for (var c in a)
+    if (a[c] == b)
+      return !0;
+  return !1
+}
+function gvjs_x(a) {
+  var b = {}, c;
+  for (c in a)
+    b[c] = a[c];
+  return b
+}
+function gvjs_0e(a) {
+  if (!a || typeof a !== gvjs_h)
+    return a;
+  if (typeof a.clone === gvjs_d)
+    return a.clone();
+  if ("undefined" !== typeof Map && a instanceof Map)
+    return new Map(a);
+  if ("undefined" !== typeof Set && a instanceof Set)
+    return new Set(a);
+  var b = Array.isArray(a) ? [] : typeof ArrayBuffer !== gvjs_d || typeof ArrayBuffer.isView !== gvjs_d || !ArrayBuffer.isView(a) || a instanceof DataView ? {} : new a.constructor(a.length), c;
+  for (c in a)
+    b[c] = gvjs_0e(a[c]);
+  return b
+}
+var gvjs_1e = "constructor hasOwnProperty isPrototypeOf propertyIsEnumerable toLocaleString toString valueOf".split(" ");
+function gvjs_2e(a, b) {
+  for (var c, d, e = 1; e < arguments.length; e++) {
+    d = arguments[e];
+    for (c in d)
+      a[c] = d[c];
+    for (var f = 0; f < gvjs_1e.length; f++)
+      c = gvjs_1e[f],
+      Object.prototype.hasOwnProperty.call(d, c) && (a[c] = d[c])
+  }
+}
+;var gvjs_kaa = {
+  area: !0,
+  base: !0,
+  br: !0,
+  col: !0,
+  command: !0,
+  embed: !0,
+  hr: !0,
+  img: !0,
+  input: !0,
+  keygen: !0,
+  link: !0,
+  meta: !0,
+  param: !0,
+  source: !0,
+  track: !0,
+  wbr: !0
+};
+var gvjs_3e;
+function gvjs_4e() {
+  if (void 0 === gvjs_3e) {
+    var a = null
+      , b = gvjs_p.trustedTypes;
+    if (b && b.createPolicy)
+      try {
+        a = b.createPolicy("goog#html", {
+          createHTML: gvjs_ue,
+          createScript: gvjs_ue,
+          createScriptURL: gvjs_ue
+        })
+      } catch (c) {
+        gvjs_p.console && gvjs_p.console.error(c.message)
+      }
+    gvjs_3e = a
+  }
+  return gvjs_3e
+}
+;function gvjs_5e(a, b) {
+  this.nga = a === gvjs_6e && b || "";
+  this.Hja = gvjs_7e
+}
+gvjs_5e.prototype.Po = !0;
+gvjs_5e.prototype.Tk = function() {
+  return this.nga
+}
+;
+function gvjs_8e(a) {
+  return a instanceof gvjs_5e && a.constructor === gvjs_5e && a.Hja === gvjs_7e ? a.nga : "type_error:Const"
+}
+function gvjs_9e(a) {
+  return new gvjs_5e(gvjs_6e,a)
+}
+var gvjs_7e = {}
+  , gvjs_6e = {};
+var gvjs_$e = {};
+function gvjs_af(a, b) {
+  this.B2 = b === gvjs_$e ? a : "";
+  this.Po = !0
+}
+gvjs_af.prototype.Tk = function() {
+  return this.B2.toString()
+}
+;
+function gvjs_bf(a) {
+  if (a instanceof gvjs_af && a.constructor === gvjs_af)
+    return a.B2;
+  gvjs_me(a);
+  return "type_error:SafeScript"
+}
+function gvjs_laa(a) {
+  var b = gvjs_4e();
+  a = b ? b.createScript(a) : a;
+  return new gvjs_af(a,gvjs_$e)
+}
+gvjs_af.prototype.toString = function() {
+  return this.B2.toString()
+}
+;
+function gvjs_cf(a, b) {
+  this.G2 = b === gvjs_df ? a : ""
+}
+gvjs_ = gvjs_cf.prototype;
+gvjs_.Po = !0;
+gvjs_.Tk = function() {
+  return this.G2.toString()
+}
+;
+gvjs_.s_ = !0;
+gvjs_.getDirection = function() {
+  return 1
+}
+;
+gvjs_.toString = function() {
+  return this.G2 + ""
+}
+;
+function gvjs_ef(a) {
+  return gvjs_ff(a).toString()
+}
+function gvjs_ff(a) {
+  if (a instanceof gvjs_cf && a.constructor === gvjs_cf)
+    return a.G2;
+  gvjs_me(a);
+  return "type_error:TrustedResourceUrl"
+}
+var gvjs_df = {};
+function gvjs_gf(a) {
+  var b = gvjs_4e();
+  a = b ? b.createScriptURL(a) : a;
+  return new gvjs_cf(a,gvjs_df)
+}
+;function gvjs_hf(a, b) {
+  return 0 == a.lastIndexOf(b, 0)
+}
+function gvjs_if(a) {
+  var b = a.length - 1;
+  return 0 <= b && a.indexOf("%", b) == b
+}
+function gvjs_jf(a) {
+  return /^[\s\xa0]*$/.test(a)
+}
+var gvjs_kf = String.prototype.trim ? function(a) {
+    return a.trim()
+  }
+  : function(a) {
+    return /^[\s\xa0]*([\s\S]*?)[\s\xa0]*$/.exec(a)[1]
+  }
+;
+function gvjs_lf(a, b) {
+  if (b)
+    a = a.replace(gvjs_mf, "&amp;").replace(gvjs_nf, gvjs_fa).replace(gvjs_of, "&gt;").replace(gvjs_pf, gvjs_ga).replace(gvjs_qf, "&#39;").replace(gvjs_rf, "&#0;");
+  else {
+    if (!gvjs_maa.test(a))
+      return a;
+    -1 != a.indexOf("&") && (a = a.replace(gvjs_mf, "&amp;"));
+    -1 != a.indexOf("<") && (a = a.replace(gvjs_nf, gvjs_fa));
+    -1 != a.indexOf(">") && (a = a.replace(gvjs_of, "&gt;"));
+    -1 != a.indexOf('"') && (a = a.replace(gvjs_pf, gvjs_ga));
+    -1 != a.indexOf("'") && (a = a.replace(gvjs_qf, "&#39;"));
+    -1 != a.indexOf("\x00") && (a = a.replace(gvjs_rf, "&#0;"))
+  }
+  return a
+}
+var gvjs_mf = /&/g
+  , gvjs_nf = /</g
+  , gvjs_of = />/g
+  , gvjs_pf = /"/g
+  , gvjs_qf = /'/g
+  , gvjs_rf = /\x00/g
+  , gvjs_maa = /[\x00&<>"']/;
+function gvjs_sf(a, b) {
+  return -1 != a.indexOf(b)
+}
+function gvjs_tf(a, b) {
+  var c = 0;
+  a = gvjs_kf(String(a)).split(".");
+  b = gvjs_kf(String(b)).split(".");
+  for (var d = Math.max(a.length, b.length), e = 0; 0 == c && e < d; e++) {
+    var f = a[e] || ""
+      , g = b[e] || "";
+    do {
+      f = /(\d*)(\D*)(.*)/.exec(f) || ["", "", "", ""];
+      g = /(\d*)(\D*)(.*)/.exec(g) || ["", "", "", ""];
+      if (0 == f[0].length && 0 == g[0].length)
+        break;
+      c = gvjs_uf(0 == f[1].length ? 0 : parseInt(f[1], 10), 0 == g[1].length ? 0 : parseInt(g[1], 10)) || gvjs_uf(0 == f[2].length, 0 == g[2].length) || gvjs_uf(f[2], g[2]);
+      f = f[3];
+      g = g[3]
+    } while (0 == c)
+  }
+  return c
+}
+function gvjs_uf(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+;function gvjs_vf(a, b) {
+  this.E2 = b === gvjs_wf ? a : ""
+}
+gvjs_ = gvjs_vf.prototype;
+gvjs_.Po = !0;
+gvjs_.Tk = function() {
+  return this.E2.toString()
+}
+;
+gvjs_.s_ = !0;
+gvjs_.getDirection = function() {
+  return 1
+}
+;
+gvjs_.toString = function() {
+  return this.E2.toString()
+}
+;
+function gvjs_xf(a) {
+  if (a instanceof gvjs_vf && a.constructor === gvjs_vf)
+    return a.E2;
+  gvjs_me(a);
+  return "type_error:SafeUrl"
+}
+var gvjs_naa = /^(?:audio\/(?:3gpp2|3gpp|aac|L16|midi|mp3|mp4|mpeg|oga|ogg|opus|x-m4a|x-matroska|x-wav|wav|webm)|font\/\w+|image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp|x-icon)|video\/(?:mpeg|mp4|ogg|webm|quicktime|x-matroska))(?:;\w+=(?:\w+|"[\w;,= ]+"))*$/i
+  , gvjs_oaa = /^data:(.*);base64,[a-z0-9+\/]+=*$/i;
+function gvjs_yf(a) {
+  a = String(a);
+  a = a.replace(/(%0A|%0D)/g, "");
+  var b = a.match(gvjs_oaa);
+  return b && gvjs_naa.test(b[1]) ? gvjs_zf(a) : null
+}
+var gvjs_Af = /^(?:(?:https?|mailto|ftp):|[^:/?#]*(?:[/?#]|$))/i;
+function gvjs_Bf(a) {
+  a instanceof gvjs_vf || (a = typeof a == gvjs_h && a.Po ? a.Tk() : String(a),
+    a = gvjs_Af.test(a) ? gvjs_zf(a) : gvjs_yf(a));
+  return a || gvjs_Cf
+}
+var gvjs_wf = {};
+function gvjs_zf(a) {
+  return new gvjs_vf(a,gvjs_wf)
+}
+var gvjs_Cf = gvjs_zf(gvjs_ob);
+function gvjs_Df(a, b) {
+  this.D2 = b === gvjs_Ef ? a : ""
+}
+gvjs_Df.prototype.Po = !0;
+gvjs_Df.prototype.Tk = function() {
+  return this.D2
+}
+;
+gvjs_Df.prototype.toString = function() {
+  return this.D2.toString()
+}
+;
+function gvjs_Ff(a) {
+  if (a instanceof gvjs_Df && a.constructor === gvjs_Df)
+    return a.D2;
+  gvjs_me(a);
+  return "type_error:SafeStyle"
+}
+var gvjs_Ef = {}
+  , gvjs_Gf = new gvjs_Df("",gvjs_Ef);
+function gvjs_Hf(a) {
+  var b = "", c;
+  for (c in a)
+    if (Object.prototype.hasOwnProperty.call(a, c)) {
+      if (!/^[-_a-zA-Z0-9]+$/.test(c))
+        throw Error("Name allows only [-_a-zA-Z0-9], got: " + c);
+      var d = a[c];
+      null != d && (d = Array.isArray(d) ? d.map(gvjs_If).join(" ") : gvjs_If(d),
+        b += c + ":" + d + ";")
+    }
+  return b ? new gvjs_Df(b,gvjs_Ef) : gvjs_Gf
+}
+function gvjs_If(a) {
+  if (a instanceof gvjs_vf)
+    return 'url("' + gvjs_xf(a).replace(/</g, "%3c").replace(/[\\"]/g, "\\$&") + '")';
+  a = a instanceof gvjs_5e ? gvjs_8e(a) : gvjs_paa(String(a));
+  if (/[{;}]/.test(a))
+    throw new gvjs_xe("Value does not allow [{;}], got: %s.",[a]);
+  return a
+}
+function gvjs_paa(a) {
+  var b = a.replace(gvjs_Jf, "$1").replace(gvjs_Jf, "$1").replace(gvjs_Kf, "url");
+  if (gvjs_qaa.test(b)) {
+    if (gvjs_raa.test(a))
+      return gvjs__d;
+    for (var c = b = !0, d = 0; d < a.length; d++) {
+      var e = a.charAt(d);
+      "'" == e && c ? b = !b : '"' == e && b && (c = !c)
+    }
+    if (!b || !c || !gvjs_saa(a))
+      return gvjs__d
+  } else
+    return gvjs__d;
+  return gvjs_taa(a)
+}
+function gvjs_saa(a) {
+  for (var b = !0, c = /^[-_a-zA-Z0-9]$/, d = 0; d < a.length; d++) {
+    var e = a.charAt(d);
+    if ("]" == e) {
+      if (b)
+        return !1;
+      b = !0
+    } else if ("[" == e) {
+      if (!b)
+        return !1;
+      b = !1
+    } else if (!b && !c.test(e))
+      return !1
+  }
+  return b
+}
+var gvjs_qaa = /^[-,."'%_!# a-zA-Z0-9\[\]]+$/
+  , gvjs_Kf = /\b(url\([ \t\n]*)('[ -&(-\[\]-~]*'|"[ !#-\[\]-~]*"|[!#-&*-\[\]-~]*)([ \t\n]*\))/g
+  , gvjs_Jf = /\b(calc|cubic-bezier|fit-content|hsl|hsla|linear-gradient|matrix|minmax|repeat|rgb|rgba|(rotate|scale|translate)(X|Y|Z|3d)?)\([-+*/0-9a-z.%\[\], ]+\)/g
+  , gvjs_raa = /\/\*/;
+function gvjs_taa(a) {
+  return a.replace(gvjs_Kf, function(b, c, d, e) {
+    var f = "";
+    d = d.replace(/^(['"])(.*)\1$/, function(g, h, k) {
+      f = h;
+      return k
+    });
+    b = gvjs_Bf(d).Tk();
+    return c + f + b + f + e
+  })
+}
+;var gvjs_Lf = {};
+function gvjs_Mf(a, b) {
+  this.C2 = b === gvjs_Lf ? a : "";
+  this.Po = !0
+}
+function gvjs_Nf(a, b) {
+  if (gvjs_sf(a, "<"))
+    throw Error("Selector does not allow '<', got: " + a);
+  var c = a.replace(/('|")((?!\1)[^\r\n\f\\]|\\[\s\S])*\1/g, "");
+  if (!/^[-_a-zA-Z0-9#.:* ,>+~[\]()=^$|]+$/.test(c))
+    throw Error("Selector allows only [-_a-zA-Z0-9#.:* ,>+~[\\]()=^$|] and strings, got: " + a);
+  a: {
+    for (var d = {
+      "(": ")",
+      "[": "]"
+    }, e = [], f = 0; f < c.length; f++) {
+      var g = c[f];
+      if (d[g])
+        e.push(d[g]);
+      else if (gvjs__e(d, g) && e.pop() != g) {
+        c = !1;
+        break a
+      }
+    }
+    c = 0 == e.length
+  }
+  if (!c)
+    throw Error("() and [] in selector must be balanced, got: " + a);
+  b instanceof gvjs_Df || (b = gvjs_Hf(b));
+  a = a + "{" + gvjs_Ff(b).replace(/</g, "\\3C ") + "}";
+  return new gvjs_Mf(a,gvjs_Lf)
+}
+function gvjs_Of(a) {
+  function b(d) {
+    Array.isArray(d) ? d.forEach(b) : c += gvjs_Pf(d)
+  }
+  var c = "";
+  Array.prototype.forEach.call(arguments, b);
+  return new gvjs_Mf(c,gvjs_Lf)
+}
+gvjs_Mf.prototype.Tk = function() {
+  return this.C2
+}
+;
+function gvjs_Pf(a) {
+  if (a instanceof gvjs_Mf && a.constructor === gvjs_Mf)
+    return a.C2;
+  gvjs_me(a);
+  return "type_error:SafeStyleSheet"
+}
+gvjs_Mf.prototype.toString = function() {
+  return this.C2.toString()
+}
+;
+var gvjs_Qf = new gvjs_Mf("",gvjs_Lf);
+var gvjs_Rf;
+a: {
+  var gvjs_Sf = gvjs_p.navigator;
+  if (gvjs_Sf) {
+    var gvjs_Tf = gvjs_Sf.userAgent;
+    if (gvjs_Tf) {
+      gvjs_Rf = gvjs_Tf;
+      break a
+    }
+  }
+  gvjs_Rf = ""
+}
+function gvjs_Uf(a) {
+  return gvjs_sf(gvjs_Rf, a)
+}
+;function gvjs_Vf() {
+  return gvjs_Uf("Firefox") || gvjs_Uf("FxiOS")
+}
+function gvjs_Wf() {
+  return gvjs_Uf("Safari") && !(gvjs_Xf() || gvjs_Uf("Coast") || gvjs_Uf("Opera") || gvjs_Uf(gvjs_Ca) || gvjs_Uf("Edg/") || gvjs_Uf("OPR") || gvjs_Vf() || gvjs_Uf("Silk") || gvjs_Uf("Android"))
+}
+function gvjs_Xf() {
+  return (gvjs_Uf("Chrome") || gvjs_Uf("CriOS")) && !gvjs_Uf(gvjs_Ca)
+}
+function gvjs_Yf() {
+  return gvjs_Uf("Android") && !(gvjs_Xf() || gvjs_Vf() || gvjs_Uf("Opera") || gvjs_Uf("Silk"))
+}
+;function gvjs_Zf(a, b, c) {
+  this.A2 = c === gvjs__f ? a : "";
+  this.Rma = b
+}
+gvjs_ = gvjs_Zf.prototype;
+gvjs_.s_ = !0;
+gvjs_.getDirection = function() {
+  return this.Rma
+}
+;
+gvjs_.Po = !0;
+gvjs_.Tk = function() {
+  return this.A2.toString()
+}
+;
+gvjs_.toString = function() {
+  return this.A2.toString()
+}
+;
+function gvjs_0f(a) {
+  return gvjs_1f(a).toString()
+}
+function gvjs_1f(a) {
+  if (a instanceof gvjs_Zf && a.constructor === gvjs_Zf)
+    return a.A2;
+  gvjs_me(a);
+  return "type_error:SafeHtml"
+}
+function gvjs_2f(a) {
+  if (a instanceof gvjs_Zf)
+    return a;
+  var b = typeof a == gvjs_h
+    , c = null;
+  b && a.s_ && (c = a.getDirection());
+  return gvjs_3f(gvjs_lf(b && a.Po ? a.Tk() : String(a)), c)
+}
+var gvjs_4f = /^[a-zA-Z0-9-]+$/
+  , gvjs_uaa = {
+  action: !0,
+  cite: !0,
+  data: !0,
+  formaction: !0,
+  href: !0,
+  manifest: !0,
+  poster: !0,
+  src: !0
+}
+  , gvjs_vaa = {
+  APPLET: !0,
+  BASE: !0,
+  EMBED: !0,
+  IFRAME: !0,
+  LINK: !0,
+  MATH: !0,
+  META: !0,
+  OBJECT: !0,
+  SCRIPT: !0,
+  STYLE: !0,
+  SVG: !0,
+  TEMPLATE: !0
+};
+function gvjs_5f(a, b, c) {
+  gvjs_6f(String(a));
+  return gvjs_7f(String(a), b, c)
+}
+function gvjs_6f(a) {
+  if (!gvjs_4f.test(a))
+    throw Error("");
+  if (a.toUpperCase()in gvjs_vaa)
+    throw Error("");
+}
+function gvjs_waa(a) {
+  var b = {
+    nonce: gvjs_8f(gvjs_Ed, void 0)
+  };
+  for (d in b)
+    if (Object.prototype.hasOwnProperty.call(b, d)) {
+      var c = d.toLowerCase();
+      if ("language" == c || "src" == c || c == gvjs_m || c == gvjs_Sd)
+        throw Error("");
+    }
+  var d = "";
+  a = gvjs_Ke(a);
+  for (c = 0; c < a.length; c++)
+    d += gvjs_bf(a[c]).toString();
+  a = gvjs_3f(d, 0);
+  return gvjs_7f("script", b, a)
+}
+function gvjs_xaa(a) {
+  function b(f) {
+    Array.isArray(f) ? f.forEach(b) : (f = gvjs_2f(f),
+      e.push(gvjs_0f(f)),
+      f = f.getDirection(),
+      0 == d ? d = f : 0 != f && d != f && (d = null))
+  }
+  var c = gvjs_2f(gvjs_9f)
+    , d = c.getDirection()
+    , e = [];
+  a.forEach(b);
+  return gvjs_3f(e.join(gvjs_0f(c)), d)
+}
+function gvjs_$f(a) {
+  return gvjs_xaa(Array.prototype.slice.call(arguments))
+}
+var gvjs__f = {};
+function gvjs_3f(a, b) {
+  var c = gvjs_4e();
+  a = c ? c.createHTML(a) : a;
+  return new gvjs_Zf(a,b,gvjs__f)
+}
+function gvjs_7f(a, b, c) {
+  var d = null;
+  var e = "<" + a + gvjs_ag(b);
+  null == c ? c = [] : Array.isArray(c) || (c = [c]);
+  !0 === gvjs_kaa[a.toLowerCase()] ? e += ">" : (d = gvjs_$f(c),
+    e += ">" + gvjs_0f(d) + "</" + a + ">",
+    d = d.getDirection());
+  (a = b && b.dir) && (d = /^(ltr|rtl|auto)$/i.test(a) ? 0 : null);
+  return gvjs_3f(e, d)
+}
+function gvjs_ag(a) {
+  var b = "";
+  if (a)
+    for (var c in a)
+      if (Object.prototype.hasOwnProperty.call(a, c)) {
+        if (!gvjs_4f.test(c))
+          throw Error("");
+        var d = a[c];
+        if (null != d) {
+          var e = c;
+          if (d instanceof gvjs_5e)
+            d = gvjs_8e(d);
+          else if (e.toLowerCase() == gvjs_Jd) {
+            if (!gvjs_r(d))
+              throw Error("");
+            d instanceof gvjs_Df || (d = gvjs_Hf(d));
+            d = gvjs_Ff(d)
+          } else {
+            if (/^on/i.test(e))
+              throw Error("");
+            if (e.toLowerCase()in gvjs_uaa)
+              if (d instanceof gvjs_cf)
+                d = gvjs_ef(d);
+              else if (d instanceof gvjs_vf)
+                d = gvjs_xf(d);
+              else if (typeof d === gvjs_l)
+                d = gvjs_Bf(d).Tk();
+              else
+                throw Error("");
+          }
+          d.Po && (d = d.Tk());
+          e = e + '="' + gvjs_lf(String(d)) + '"';
+          b += " " + e
+        }
+      }
+  return b
+}
+var gvjs_yaa = gvjs_3f("<!DOCTYPE html>", 0)
+  , gvjs_9f = new gvjs_Zf(gvjs_p.trustedTypes && gvjs_p.trustedTypes.emptyHTML || "",0,gvjs__f)
+  , gvjs_bg = gvjs_3f(gvjs_la, 0);
+var gvjs_zaa = gvjs_ze(function() {
+  var a = document.createElement(gvjs_Ob)
+    , b = document.createElement(gvjs_Ob);
+  b.appendChild(document.createElement(gvjs_Ob));
+  a.appendChild(b);
+  b = a.firstChild.firstChild;
+  a.innerHTML = gvjs_1f(gvjs_9f);
+  return !b.parentElement
+});
+function gvjs_cg(a, b) {
+  if (gvjs_zaa())
+    for (; a.lastChild; )
+      a.removeChild(a.lastChild);
+  a.innerHTML = gvjs_1f(b)
+}
+var gvjs_Aaa = /^[\w+/_-]+[=]{0,2}$/;
+function gvjs_8f(a, b) {
+  b = (b || gvjs_p).document;
+  return b.querySelector ? (a = b.querySelector(a)) && (a = a.nonce || a.getAttribute(gvjs_qd)) && gvjs_Aaa.test(a) ? a : "" : ""
+}
+;function gvjs_dg(a, b) {
+  return a = gvjs_lf(a, b)
+}
+var gvjs_eg = String.prototype.repeat ? function(a, b) {
+    return a.repeat(b)
+  }
+  : function(a, b) {
+    return Array(b + 1).join(a)
+  }
+;
+function gvjs_fg(a, b) {
+  a = String(a);
+  var c = a.indexOf(".");
+  -1 == c && (c = a.length);
+  return gvjs_eg("0", Math.max(0, b - c)) + a
+}
+function gvjs_gg(a) {
+  return null == a ? "" : String(a)
+}
+function gvjs_hg() {
+  return Math.floor(2147483648 * Math.random()).toString(36) + Math.abs(Math.floor(2147483648 * Math.random()) ^ gvjs_se()).toString(36)
+}
+var gvjs_ig = 2147483648 * Math.random() | 0;
+function gvjs_jg(a) {
+  var b = Number(a);
+  return 0 == b && gvjs_jf(a) ? NaN : b
+}
+function gvjs_kg(a) {
+  return String(a).replace(/\-([a-z])/g, function(b, c) {
+    return c.toUpperCase()
+  })
+}
+function gvjs_Baa(a) {
+  return a.replace(/(^|[\s]+)([a-z])/g, function(b, c, d) {
+    return c + d.toUpperCase()
+  })
+}
+;function gvjs_lg() {
+  return gvjs_Uf("iPhone") && !gvjs_Uf("iPod") && !gvjs_Uf("iPad")
+}
+function gvjs_mg() {
+  return gvjs_lg() || gvjs_Uf("iPad") || gvjs_Uf("iPod")
+}
+;function gvjs_ng(a) {
+  gvjs_ng[" "](a);
+  return a
+}
+gvjs_ng[" "] = gvjs_ke;
+function gvjs_og(a, b) {
+  try {
+    return gvjs_ng(a[b]),
+      !0
+  } catch (c) {}
+  return !1
+}
+function gvjs_pg(a, b, c) {
+  return Object.prototype.hasOwnProperty.call(a, b) ? a[b] : a[b] = c(b)
+}
+;var gvjs_qg = gvjs_Uf("Opera")
+  , gvjs_y = gvjs_Uf("Trident") || gvjs_Uf("MSIE")
+  , gvjs_rg = gvjs_Uf(gvjs_Ca)
+  , gvjs_Caa = gvjs_rg || gvjs_y
+  , gvjs_sg = gvjs_Uf("Gecko") && !(gvjs_sf(gvjs_Rf.toLowerCase(), "webkit") && !gvjs_Uf(gvjs_Ca)) && !(gvjs_Uf("Trident") || gvjs_Uf("MSIE")) && !gvjs_Uf(gvjs_Ca)
+  , gvjs_tg = gvjs_sf(gvjs_Rf.toLowerCase(), "webkit") && !gvjs_Uf(gvjs_Ca)
+  , gvjs_Daa = gvjs_tg && gvjs_Uf("Mobile")
+  , gvjs_ug = gvjs_Uf("Macintosh")
+  , gvjs_vg = gvjs_Uf("Windows")
+  , gvjs_wg = gvjs_Uf("Linux") || gvjs_Uf("CrOS")
+  , gvjs_xg = gvjs_p.navigator || null;
+gvjs_xg && gvjs_sf(gvjs_xg.appVersion || "", "X11");
+var gvjs_Eaa = gvjs_Uf("Android")
+  , gvjs_Faa = gvjs_lg()
+  , gvjs_Gaa = gvjs_Uf("iPad")
+  , gvjs_Haa = gvjs_Uf("iPod")
+  , gvjs_Iaa = gvjs_mg();
+gvjs_sf(gvjs_Rf.toLowerCase(), "kaios");
+function gvjs_yg() {
+  var a = gvjs_p.document;
+  return a ? a.documentMode : void 0
+}
+var gvjs_zg;
+a: {
+  var gvjs_Ag = ""
+    , gvjs_Bg = function() {
+    var a = gvjs_Rf;
+    if (gvjs_sg)
+      return /rv:([^\);]+)(\)|;)/.exec(a);
+    if (gvjs_rg)
+      return /Edge\/([\d\.]+)/.exec(a);
+    if (gvjs_y)
+      return /\b(?:MSIE|rv)[: ]([^\);]+)(\)|;)/.exec(a);
+    if (gvjs_tg)
+      return /WebKit\/(\S+)/.exec(a);
+    if (gvjs_qg)
+      return /(?:Version)[ \/]?(\S+)/.exec(a)
+  }();
+  gvjs_Bg && (gvjs_Ag = gvjs_Bg ? gvjs_Bg[1] : "");
+  if (gvjs_y) {
+    var gvjs_Cg = gvjs_yg();
+    if (null != gvjs_Cg && gvjs_Cg > parseFloat(gvjs_Ag)) {
+      gvjs_zg = String(gvjs_Cg);
+      break a
+    }
+  }
+  gvjs_zg = gvjs_Ag
+}
+var gvjs_Dg = gvjs_zg
+  , gvjs_Jaa = {};
+function gvjs_Eg(a) {
+  return gvjs_pg(gvjs_Jaa, a, function() {
+    return 0 <= gvjs_tf(gvjs_Dg, a)
+  })
+}
+function gvjs_Fg(a) {
+  return Number(gvjs_Kaa) >= a
+}
+var gvjs_Gg;
+if (gvjs_p.document && gvjs_y) {
+  var gvjs_Hg = gvjs_yg();
+  gvjs_Gg = gvjs_Hg ? gvjs_Hg : parseInt(gvjs_Dg, 10) || void 0
+} else
+  gvjs_Gg = void 0;
+var gvjs_Kaa = gvjs_Gg;
+var gvjs_Laa = gvjs_Vf()
+  , gvjs_Ig = gvjs_lg() || gvjs_Uf("iPod")
+  , gvjs_Jg = gvjs_Uf("iPad")
+  , gvjs_Maa = gvjs_Yf()
+  , gvjs_Kg = gvjs_Xf()
+  , gvjs_Lg = gvjs_Wf() && !gvjs_mg();
+var gvjs_Mg = {}
+  , gvjs_Ng = null;
+var gvjs_Og = typeof Uint8Array === gvjs_d;
+function gvjs_Naa(a) {
+  return gvjs_Pg(a, function(b) {
+    return b
+  }, function(b) {
+    return new Uint8Array(b)
+  })
+}
+function gvjs_Qg(a, b, c) {
+  return typeof a === gvjs_h ? gvjs_Og && !Array.isArray(a) && a instanceof Uint8Array ? c(a) : gvjs_Pg(a, b, c) : b(a)
+}
+function gvjs_Pg(a, b, c) {
+  if (Array.isArray(a)) {
+    for (var d = Array(a.length), e = 0; e < a.length; e++) {
+      var f = a[e];
+      null != f && (d[e] = gvjs_Qg(f, b, c))
+    }
+    Array.isArray(a) && a.osa && gvjs_Rg(d);
+    return d
+  }
+  d = {};
+  for (e in a)
+    f = a[e],
+    null != f && (d[e] = gvjs_Qg(f, b, c));
+  return d
+}
+var gvjs_Oaa = {
+  osa: {
+    value: !0,
+    configurable: !0
+  }
+};
+function gvjs_Rg(a) {
+  Array.isArray(a) && !Object.isFrozen(a) && Object.defineProperties(a, gvjs_Oaa);
+  return a
+}
+;function gvjs_Sg() {}
+var gvjs_Tg;
+function gvjs_Ug(a, b, c) {
+  a.se = null;
+  gvjs_Tg && (b || (b = gvjs_Tg),
+    gvjs_Tg = null);
+  var d = a.constructor.aEa;
+  b || (b = d ? [d] : []);
+  a.qG = d ? 0 : -1;
+  a.array = b;
+  a: {
+    if (b = a.array.length)
+      if (--b,
+        d = a.array[b],
+        !(null === d || typeof d != gvjs_h || Array.isArray(d) || gvjs_Og && d instanceof Uint8Array)) {
+        a.tK = b - a.qG;
+        a.Kl = d;
+        break a
+      }
+    a.tK = Number.MAX_VALUE
+  }
+  a.xCa = {};
+  if (c)
+    for (b = 0; b < c.length; b++)
+      if (d = c[b],
+      d < a.tK) {
+        d += a.qG;
+        var e = a.array[d];
+        e ? gvjs_Rg(e) : a.array[d] = gvjs_Vg
+      } else
+        gvjs_Wg(a),
+          (e = a.Kl[d]) ? gvjs_Rg(e) : a.Kl[d] = gvjs_Vg
+}
+var gvjs_Vg = Object.freeze(gvjs_Rg([]));
+function gvjs_Wg(a) {
+  var b = a.tK + a.qG;
+  a.array[b] || (a.Kl = a.array[b] = {})
+}
+function gvjs_Xg(a, b) {
+  if (b < a.tK) {
+    b += a.qG;
+    var c = a.array[b];
+    return c !== gvjs_Vg ? c : a.array[b] = gvjs_Rg([])
+  }
+  if (a.Kl)
+    return c = a.Kl[b],
+      c !== gvjs_Vg ? c : a.Kl[b] = gvjs_Rg([])
+}
+gvjs_ = gvjs_Sg.prototype;
+gvjs_.um = function() {
+  if (this.se)
+    for (var a in this.se) {
+      var b = this.se[a];
+      if (Array.isArray(b))
+        for (var c = 0; c < b.length; c++)
+          b[c] && b[c].um();
+      else
+        b && b.um()
+    }
+  return this.array
+}
+;
+gvjs_.ie = function() {
+  return JSON.stringify(this.array && this.um(), gvjs_Paa)
+}
+;
+function gvjs_Paa(a, b) {
+  switch (typeof b) {
+    case gvjs_g:
+      return isNaN(b) || Infinity === b || -Infinity === b ? String(b) : b;
+    case gvjs_h:
+      if (gvjs_Og && null != b && b instanceof Uint8Array) {
+        var c;
+        void 0 === c && (c = 0);
+        if (!gvjs_Ng) {
+          gvjs_Ng = {};
+          a = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split("");
+          for (var d = ["+/=", "+/", "-_=", "-_.", "-_"], e = 0; 5 > e; e++) {
+            var f = a.concat(d[e].split(""));
+            gvjs_Mg[e] = f;
+            for (var g = 0; g < f.length; g++) {
+              var h = f[g];
+              void 0 === gvjs_Ng[h] && (gvjs_Ng[h] = g)
+            }
+          }
+        }
+        c = gvjs_Mg[c];
+        a = Array(Math.floor(b.length / 3));
+        d = c[64] || "";
+        for (e = f = 0; f < b.length - 2; f += 3) {
+          var k = b[f]
+            , l = b[f + 1];
+          h = b[f + 2];
+          g = c[k >> 2];
+          k = c[(k & 3) << 4 | l >> 4];
+          l = c[(l & 15) << 2 | h >> 6];
+          h = c[h & 63];
+          a[e++] = "" + g + k + l + h
+        }
+        g = 0;
+        h = d;
+        switch (b.length - f) {
+          case 2:
+            g = b[f + 1],
+              h = c[(g & 15) << 2] || d;
+          case 1:
+            b = b[f],
+              a[e] = "" + c[b >> 2] + c[(b & 3) << 4 | g >> 4] + h + d
+        }
+        return a.join("")
+      }
+  }
+  return b
+}
+gvjs_.toString = function() {
+  return this.um().toString()
+}
+;
+gvjs_.getExtension = function(a) {
+  gvjs_Wg(this);
+  this.se || (this.se = {});
+  var b = a.vDa;
+  return a.WDa ? a.jsa() ? (this.se[b] || (this.se[b] = gvjs_v(this.Kl[b] || [], function(c) {
+    return new a.nma(c)
+  })),
+    this.se[b]) : this.Kl[b] = this.Kl[b] || gvjs_Rg([]) : a.jsa() ? (!this.se[b] && this.Kl[b] && (this.se[b] = new a.nma(this.Kl[b])),
+    this.se[b]) : this.Kl[b]
+}
+;
+gvjs_.clone = function() {
+  var a = gvjs_Naa(this.um());
+  gvjs_Tg = a;
+  a = new this.constructor(a);
+  gvjs_Tg = null;
+  return a
+}
+;
+/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+
+*/
+function gvjs_Yg(a) {
+  this.vQ = !1;
+  this.Hg = a || null
+}
+gvjs_Yg.prototype.xha = function(a, b) {
+  var c = this;
+  return function(d) {
+    for (var e = [], f = 0; f < arguments.length; ++f)
+      e[f - 0] = arguments[f];
+    if (!c.vQ)
+      return c.Hg ? gvjs_Zg(c.Hg, function() {
+        return a.apply(b, e)
+      }) : a.apply(b, e)
+  }
+}
+;
+try {
+  (new self.OffscreenCanvas(0,0)).getContext("2d")
+} catch (a) {}
+var gvjs_Qaa = !gvjs_y || gvjs_Fg(9)
+  , gvjs_Raa = !gvjs_sg && !gvjs_y || gvjs_y && gvjs_Fg(9) || gvjs_sg && gvjs_Eg("1.9.1")
+  , gvjs__g = gvjs_y && !gvjs_Eg("9")
+  , gvjs_Saa = gvjs_y || gvjs_qg || gvjs_tg;
+function gvjs_0g(a, b, c) {
+  return Math.min(Math.max(a, b), c)
+}
+function gvjs_1g(a) {
+  return isFinite(a) && 0 == a % 1
+}
+;function gvjs_z(a, b) {
+  this.x = void 0 !== a ? a : 0;
+  this.y = void 0 !== b ? b : 0
+}
+gvjs_ = gvjs_z.prototype;
+gvjs_.clone = function() {
+  return new gvjs_z(this.x,this.y)
+}
+;
+gvjs_.equals = function(a) {
+  return a instanceof gvjs_z && gvjs_2g(this, a)
+}
+;
+function gvjs_2g(a, b) {
+  return a == b ? !0 : a && b ? a.x == b.x && a.y == b.y : !1
+}
+gvjs_.ceil = function() {
+  this.x = Math.ceil(this.x);
+  this.y = Math.ceil(this.y);
+  return this
+}
+;
+gvjs_.floor = function() {
+  this.x = Math.floor(this.x);
+  this.y = Math.floor(this.y);
+  return this
+}
+;
+gvjs_.round = function() {
+  this.x = Math.round(this.x);
+  this.y = Math.round(this.y);
+  return this
+}
+;
+gvjs_.translate = function(a, b) {
+  a instanceof gvjs_z ? (this.x += a.x,
+    this.y += a.y) : (this.x += Number(a),
+  typeof b === gvjs_g && (this.y += b));
+  return this
+}
+;
+gvjs_.scale = function(a, b) {
+  this.x *= a;
+  this.y *= typeof b === gvjs_g ? b : a;
+  return this
+}
+;
+function gvjs_A(a, b) {
+  this.width = a;
+  this.height = b
+}
+gvjs_ = gvjs_A.prototype;
+gvjs_.clone = function() {
+  return new gvjs_A(this.width,this.height)
+}
+;
+gvjs_.area = function() {
+  return this.width * this.height
+}
+;
+gvjs_.aspectRatio = function() {
+  return this.width / this.height
+}
+;
+gvjs_.isEmpty = function() {
+  return !this.area()
+}
+;
+gvjs_.ceil = function() {
+  this.width = Math.ceil(this.width);
+  this.height = Math.ceil(this.height);
+  return this
+}
+;
+gvjs_.floor = function() {
+  this.width = Math.floor(this.width);
+  this.height = Math.floor(this.height);
+  return this
+}
+;
+gvjs_.round = function() {
+  this.width = Math.round(this.width);
+  this.height = Math.round(this.height);
+  return this
+}
+;
+gvjs_.scale = function(a, b) {
+  this.width *= a;
+  this.height *= typeof b === gvjs_g ? b : a;
+  return this
+}
+;
+function gvjs_3g(a) {
+  return a ? new gvjs_4g(gvjs_5g(a)) : gvjs_we || (gvjs_we = new gvjs_4g)
+}
+function gvjs_6g(a, b) {
+  return typeof b === gvjs_l ? a.getElementById(b) : b
+}
+function gvjs_7g(a, b, c, d) {
+  a = d || a;
+  b = b && "*" != b ? String(b).toUpperCase() : "";
+  if (a.querySelectorAll && a.querySelector && (b || c))
+    return a.querySelectorAll(b + (c ? "." + c : ""));
+  if (c && a.getElementsByClassName) {
+    a = a.getElementsByClassName(c);
+    if (b) {
+      d = {};
+      for (var e = 0, f = 0, g; g = a[f]; f++)
+        b == g.nodeName && (d[e++] = g);
+      d.length = e;
+      return d
+    }
+    return a
+  }
+  a = a.getElementsByTagName(b || "*");
+  if (c) {
+    d = {};
+    for (f = e = 0; g = a[f]; f++)
+      b = g.className,
+      typeof b.split == gvjs_d && gvjs_He(b.split(/\s+/), c) && (d[e++] = g);
+    d.length = e;
+    return d
+  }
+  return a
+}
+function gvjs_8g(a, b) {
+  gvjs_w(b, function(c, d) {
+    c && typeof c == gvjs_h && c.Po && (c = c.Tk());
+    d == gvjs_Jd ? a.style.cssText = c : d == gvjs_Cb ? a.className = c : "for" == d ? a.htmlFor = c : gvjs_9g.hasOwnProperty(d) ? a.setAttribute(gvjs_9g[d], c) : gvjs_hf(d, "aria-") || gvjs_hf(d, "data-") ? a.setAttribute(d, c) : a[d] = c
+  })
+}
+var gvjs_9g = {
+  cellpadding: "cellPadding",
+  cellspacing: "cellSpacing",
+  colspan: "colSpan",
+  frameborder: "frameBorder",
+  height: gvjs_4c,
+  maxlength: "maxLength",
+  nonce: gvjs_qd,
+  role: gvjs_Bd,
+  rowspan: "rowSpan",
+  type: gvjs_Sd,
+  usemap: "useMap",
+  valign: "vAlign",
+  width: gvjs_Xd
+};
+function gvjs_$g(a, b) {
+  var c = String(b[0])
+    , d = b[1];
+  if (!gvjs_Qaa && d && (d.name || d.type)) {
+    c = ["<", c];
+    d.name && c.push(' name="', gvjs_dg(d.name), '"');
+    if (d.type) {
+      c.push(' type="', gvjs_dg(d.type), '"');
+      var e = {};
+      gvjs_2e(e, d);
+      delete e.type;
+      d = e
+    }
+    c.push(">");
+    c = c.join("")
+  }
+  c = gvjs_ah(a, c);
+  d && (typeof d === gvjs_l ? c.className = d : Array.isArray(d) ? c.className = d.join(" ") : gvjs_8g(c, d));
+  2 < b.length && gvjs_bh(a, c, b, 2);
+  return c
+}
+function gvjs_bh(a, b, c, d) {
+  function e(h) {
+    h && b.appendChild(typeof h === gvjs_l ? a.createTextNode(h) : h)
+  }
+  for (; d < c.length; d++) {
+    var f = c[d];
+    if (gvjs_ne(f) && !gvjs_ch(f)) {
+      a: {
+        if (f && typeof f.length == gvjs_g) {
+          if (gvjs_r(f)) {
+            var g = typeof f.item == gvjs_d || typeof f.item == gvjs_l;
+            break a
+          }
+          if (typeof f === gvjs_d) {
+            g = typeof f.item == gvjs_d;
+            break a
+          }
+        }
+        g = !1
+      }
+      gvjs_u(g ? gvjs_Le(f) : f, e)
+    } else
+      e(f)
+  }
+}
+function gvjs_dh(a) {
+  return gvjs_ah(document, a)
+}
+function gvjs_ah(a, b) {
+  b = String(b);
+  "application/xhtml+xml" === a.contentType && (b = b.toLowerCase());
+  return a.createElement(b)
+}
+function gvjs_eh(a) {
+  return "CSS1Compat" == a.compatMode
+}
+function gvjs_fh(a) {
+  if (1 != a.nodeType)
+    return !1;
+  switch (a.tagName) {
+    case "APPLET":
+    case "AREA":
+    case "BASE":
+    case "BR":
+    case "COL":
+    case "COMMAND":
+    case "EMBED":
+    case "FRAME":
+    case "HR":
+    case "IMG":
+    case gvjs_Na:
+    case gvjs_Ma:
+    case "ISINDEX":
+    case "KEYGEN":
+    case "LINK":
+    case "NOFRAMES":
+    case "NOSCRIPT":
+    case "META":
+    case gvjs_0a:
+    case "PARAM":
+    case "SCRIPT":
+    case gvjs_5a:
+    case gvjs_7a:
+    case "TRACK":
+    case "WBR":
+      return !1
+  }
+  return !0
+}
+function gvjs_gh(a, b) {
+  gvjs_bh(gvjs_5g(a), a, arguments, 1)
+}
+function gvjs_hh(a) {
+  for (var b; b = a.firstChild; )
+    a.removeChild(b)
+}
+function gvjs_ih(a, b) {
+  b.parentNode && b.parentNode.insertBefore(a, b)
+}
+function gvjs_jh(a, b) {
+  b.parentNode && b.parentNode.insertBefore(a, b.nextSibling)
+}
+function gvjs_kh(a) {
+  return a && a.parentNode ? a.parentNode.removeChild(a) : null
+}
+function gvjs_lh(a) {
+  return gvjs_Raa && void 0 != a.children ? a.children : Array.prototype.filter.call(a.childNodes, function(b) {
+    return 1 == b.nodeType
+  })
+}
+function gvjs_mh(a) {
+  return void 0 !== a.firstElementChild ? a.firstElementChild : gvjs_nh(a.firstChild, !0)
+}
+function gvjs_oh(a) {
+  return void 0 !== a.nextElementSibling ? a.nextElementSibling : gvjs_nh(a.nextSibling, !0)
+}
+function gvjs_nh(a, b) {
+  for (; a && 1 != a.nodeType; )
+    a = b ? a.nextSibling : a.previousSibling;
+  return a
+}
+function gvjs_ch(a) {
+  return gvjs_r(a) && 0 < a.nodeType
+}
+function gvjs_ph(a) {
+  return gvjs_r(a) && 1 == a.nodeType
+}
+function gvjs_qh(a) {
+  var b;
+  if (gvjs_Saa && !(gvjs_y && gvjs_Eg("9") && !gvjs_Eg("10") && gvjs_p.SVGElement && a instanceof gvjs_p.SVGElement) && (b = a.parentElement))
+    return b;
+  b = a.parentNode;
+  return gvjs_ph(b) ? b : null
+}
+function gvjs_rh(a, b) {
+  if (!a || !b)
+    return !1;
+  if (a.contains && 1 == b.nodeType)
+    return a == b || a.contains(b);
+  if ("undefined" != typeof a.compareDocumentPosition)
+    return a == b || !!(a.compareDocumentPosition(b) & 16);
+  for (; b && a != b; )
+    b = b.parentNode;
+  return b == a
+}
+function gvjs_5g(a) {
+  return 9 == a.nodeType ? a : a.ownerDocument || a.document
+}
+function gvjs_sh(a) {
+  return a.contentDocument || a.contentWindow.document
+}
+function gvjs_th(a, b) {
+  if ("textContent"in a)
+    a.textContent = b;
+  else if (3 == a.nodeType)
+    a.data = String(b);
+  else if (a.firstChild && 3 == a.firstChild.nodeType) {
+    for (; a.lastChild != a.firstChild; )
+      a.removeChild(a.lastChild);
+    a.firstChild.data = String(b)
+  } else
+    gvjs_hh(a),
+      a.appendChild(gvjs_5g(a).createTextNode(String(b)))
+}
+function gvjs_uh(a) {
+  if ("outerHTML"in a)
+    return a.outerHTML;
+  var b = gvjs_ah(gvjs_5g(a), gvjs_b);
+  b.appendChild(a.cloneNode(!0));
+  return b.innerHTML
+}
+var gvjs_Taa = {
+  SCRIPT: 1,
+  STYLE: 1,
+  HEAD: 1,
+  IFRAME: 1,
+  OBJECT: 1
+}
+  , gvjs_vh = {
+  IMG: " ",
+  BR: "\n"
+};
+function gvjs_wh(a) {
+  if (gvjs__g && null !== a && "innerText"in a)
+    a = a.innerText.replace(/(\r\n|\r|\n)/g, "\n");
+  else {
+    var b = [];
+    gvjs_xh(a, b, !0);
+    a = b.join("")
+  }
+  a = a.replace(/ \xAD /g, " ").replace(/\xAD/g, "");
+  a = a.replace(/\u200B/g, "");
+  gvjs__g || (a = a.replace(/ +/g, " "));
+  " " != a && (a = a.replace(/^\s*/, ""));
+  return a
+}
+function gvjs_xh(a, b, c) {
+  if (!(a.nodeName in gvjs_Taa))
+    if (3 == a.nodeType)
+      c ? b.push(String(a.nodeValue).replace(/(\r\n|\r|\n)/g, "")) : b.push(a.nodeValue);
+    else if (a.nodeName in gvjs_vh)
+      b.push(gvjs_vh[a.nodeName]);
+    else
+      for (a = a.firstChild; a; )
+        gvjs_xh(a, b, c),
+          a = a.nextSibling
+}
+function gvjs_yh(a, b, c, d) {
+  a && !c && (a = a.parentNode);
+  for (c = 0; a && (null == d || c <= d); ) {
+    if (b(a))
+      return a;
+    a = a.parentNode;
+    c++
+  }
+  return null
+}
+function gvjs_4g(a) {
+  this.dd = a || gvjs_p.document || document
+}
+gvjs_ = gvjs_4g.prototype;
+gvjs_.wa = gvjs_3g;
+gvjs_.kc = function() {
+  return this.dd
+}
+;
+gvjs_.j = function(a) {
+  return gvjs_6g(this.dd, a)
+}
+;
+gvjs_.getElementsByTagName = function(a, b) {
+  return (b || this.dd).getElementsByTagName(String(a))
+}
+;
+function gvjs_zh(a, b, c, d) {
+  return gvjs_7g(a.dd, b, c, d)
+}
+gvjs_.wq = gvjs_n(0);
+gvjs_.hd = gvjs_n(2);
+gvjs_.yP = gvjs_n(4);
+gvjs_.sr = gvjs_8g;
+gvjs_.J = function(a, b, c) {
+  return gvjs_$g(this.dd, arguments)
+}
+;
+gvjs_.createElement = function(a) {
+  return gvjs_ah(this.dd, a)
+}
+;
+gvjs_.createTextNode = function(a) {
+  return this.dd.createTextNode(String(a))
+}
+;
+gvjs_.wX = gvjs_n(5);
+gvjs_.Vj = function() {
+  var a = this.dd;
+  return a.parentWindow || a.defaultView
+}
+;
+gvjs_.Ly = gvjs_n(6);
+gvjs_.appendChild = function(a, b) {
+  a.appendChild(b)
+}
+;
+gvjs_.append = gvjs_gh;
+gvjs_.canHaveChildren = gvjs_fh;
+gvjs_.qc = gvjs_hh;
+gvjs_.H_ = gvjs_ih;
+gvjs_.Sra = gvjs_jh;
+gvjs_.removeNode = gvjs_kh;
+gvjs_.getChildren = gvjs_lh;
+gvjs_.O$ = gvjs_mh;
+gvjs_.P$ = gvjs_oh;
+gvjs_.Qo = gvjs_ch;
+gvjs_.O_ = gvjs_ph;
+gvjs_.isWindow = function(a) {
+  return gvjs_r(a) && a.window == a
+}
+;
+gvjs_.tP = gvjs_qh;
+gvjs_.contains = gvjs_rh;
+gvjs_.Toa = gvjs_5g;
+gvjs_.Noa = gvjs_sh;
+gvjs_.V3 = gvjs_th;
+gvjs_.Gq = gvjs_n(8);
+gvjs_.Voa = gvjs_wh;
+gvjs_.G$ = gvjs_yh;
+function gvjs_B(a, b, c, d) {
+  this.top = a;
+  this.right = b;
+  this.bottom = c;
+  this.left = d
+}
+gvjs_ = gvjs_B.prototype;
+gvjs_.La = gvjs_n(10);
+gvjs_.getHeight = function() {
+  return this.bottom - this.top
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_B(this.top,this.right,this.bottom,this.left)
+}
+;
+gvjs_.contains = function(a) {
+  return this && a ? a instanceof gvjs_B ? a.left >= this.left && a.right <= this.right && a.top >= this.top && a.bottom <= this.bottom : a.x >= this.left && a.x <= this.right && a.y >= this.top && a.y <= this.bottom : !1
+}
+;
+gvjs_.expand = function(a, b, c, d) {
+  gvjs_r(a) ? (this.top -= a.top,
+    this.right += a.right,
+    this.bottom += a.bottom,
+    this.left -= a.left) : (this.top -= a,
+    this.right += Number(b),
+    this.bottom += Number(c),
+    this.left -= Number(d));
+  return this
+}
+;
+gvjs_.ceil = function() {
+  this.top = Math.ceil(this.top);
+  this.right = Math.ceil(this.right);
+  this.bottom = Math.ceil(this.bottom);
+  this.left = Math.ceil(this.left);
+  return this
+}
+;
+gvjs_.floor = function() {
+  this.top = Math.floor(this.top);
+  this.right = Math.floor(this.right);
+  this.bottom = Math.floor(this.bottom);
+  this.left = Math.floor(this.left);
+  return this
+}
+;
+gvjs_.round = function() {
+  this.top = Math.round(this.top);
+  this.right = Math.round(this.right);
+  this.bottom = Math.round(this.bottom);
+  this.left = Math.round(this.left);
+  return this
+}
+;
+gvjs_.translate = function(a, b) {
+  a instanceof gvjs_z ? (this.left += a.x,
+    this.right += a.x,
+    this.top += a.y,
+    this.bottom += a.y) : (this.left += a,
+    this.right += a,
+  typeof b === gvjs_g && (this.top += b,
+    this.bottom += b));
+  return this
+}
+;
+gvjs_.scale = function(a, b) {
+  b = typeof b === gvjs_g ? b : a;
+  this.left *= a;
+  this.right *= a;
+  this.top *= b;
+  this.bottom *= b;
+  return this
+}
+;
+function gvjs_C(a, b, c) {
+  if (typeof b === gvjs_l)
+    (b = gvjs_Ah(a, b)) && (a.style[b] = c);
+  else
+    for (var d in b) {
+      c = a;
+      var e = b[d]
+        , f = gvjs_Ah(c, d);
+      f && (c.style[f] = e)
+    }
+}
+var gvjs_Bh = {};
+function gvjs_Ah(a, b) {
+  var c = gvjs_Bh[b];
+  if (!c) {
+    var d = gvjs_kg(b);
+    c = d;
+    void 0 === a.style[d] && (d = (gvjs_tg ? "Webkit" : gvjs_sg ? "Moz" : gvjs_y ? "ms" : gvjs_qg ? "O" : null) + gvjs_Baa(d),
+    void 0 !== a.style[d] && (c = d));
+    gvjs_Bh[b] = c
+  }
+  return c
+}
+function gvjs_Ch(a, b) {
+  var c = gvjs_5g(a);
+  return c.defaultView && c.defaultView.getComputedStyle && (a = c.defaultView.getComputedStyle(a, null)) ? a[b] || a.getPropertyValue(b) || "" : ""
+}
+function gvjs_Dh(a, b) {
+  return gvjs_Ch(a, b) || (a.currentStyle ? a.currentStyle[b] : null) || a.style && a.style[b]
+}
+function gvjs_Eh(a) {
+  return gvjs_Dh(a, gvjs_vd)
+}
+var gvjs_Fh = gvjs_sg ? "MozUserSelect" : gvjs_tg || gvjs_rg ? "WebkitUserSelect" : null;
+function gvjs_Gh(a) {
+  var b = gvjs_5g(a)
+    , c = gvjs_y && a.currentStyle;
+  if (c && gvjs_eh(gvjs_3g(b).dd) && c.width != gvjs_ub && c.height != gvjs_ub && !c.boxSizing)
+    return b = gvjs_Hh(a, c.width, gvjs_Xd, "pixelWidth"),
+      a = gvjs_Hh(a, c.height, gvjs_4c, "pixelHeight"),
+      new gvjs_A(b,a);
+  c = new gvjs_A(a.offsetWidth,a.offsetHeight);
+  b = gvjs_Ih(a);
+  a = gvjs_Jh(a);
+  return new gvjs_A(c.width - a.left - b.left - b.right - a.right,c.height - a.top - b.top - b.bottom - a.bottom)
+}
+function gvjs_Hh(a, b, c, d) {
+  if (/^\d+px?$/.test(b))
+    return parseInt(b, 10);
+  var e = a.style[c]
+    , f = a.runtimeStyle[c];
+  a.runtimeStyle[c] = a.currentStyle[c];
+  a.style[c] = b;
+  b = a.style[d];
+  a.style[c] = e;
+  a.runtimeStyle[c] = f;
+  return +b
+}
+function gvjs_Kh(a, b) {
+  return (b = a.currentStyle ? a.currentStyle[b] : null) ? gvjs_Hh(a, b, gvjs_$c, "pixelLeft") : 0
+}
+function gvjs_Ih(a) {
+  if (gvjs_y) {
+    var b = gvjs_Kh(a, "paddingLeft")
+      , c = gvjs_Kh(a, "paddingRight")
+      , d = gvjs_Kh(a, "paddingTop");
+    a = gvjs_Kh(a, "paddingBottom");
+    return new gvjs_B(d,c,a,b)
+  }
+  b = gvjs_Ch(a, "paddingLeft");
+  c = gvjs_Ch(a, "paddingRight");
+  d = gvjs_Ch(a, "paddingTop");
+  a = gvjs_Ch(a, "paddingBottom");
+  return new gvjs_B(parseFloat(d),parseFloat(c),parseFloat(a),parseFloat(b))
+}
+var gvjs_Lh = {
+  thin: 2,
+  medium: 4,
+  thick: 6
+};
+function gvjs_Mh(a, b) {
+  if ((a.currentStyle ? a.currentStyle[b + "Style"] : null) == gvjs_f)
+    return 0;
+  b = a.currentStyle ? a.currentStyle[b + "Width"] : null;
+  return b in gvjs_Lh ? gvjs_Lh[b] : gvjs_Hh(a, b, gvjs_$c, "pixelLeft")
+}
+function gvjs_Jh(a) {
+  if (gvjs_y && !gvjs_Fg(9)) {
+    var b = gvjs_Mh(a, "borderLeft")
+      , c = gvjs_Mh(a, "borderRight")
+      , d = gvjs_Mh(a, "borderTop");
+    a = gvjs_Mh(a, "borderBottom");
+    return new gvjs_B(d,c,a,b)
+  }
+  b = gvjs_Ch(a, "borderLeftWidth");
+  c = gvjs_Ch(a, "borderRightWidth");
+  d = gvjs_Ch(a, "borderTopWidth");
+  a = gvjs_Ch(a, "borderBottomWidth");
+  return new gvjs_B(parseFloat(d),parseFloat(c),parseFloat(a),parseFloat(b))
+}
+;/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+*/
+var gvjs_Nh = null;
+function gvjs_Oh() {
+  null == gvjs_Nh && (gvjs_Nh = new gvjs_4g);
+  return gvjs_Nh
+}
+function gvjs_Ph() {
+  return gvjs_Oh().kc()
+}
+function gvjs_Qh(a) {
+  var b = gvjs_Oh();
+  if (!a || !b.Qo(a))
+    throw Error(gvjs_za);
+  return a
+}
+;var gvjs_D = {
+  rV: "google-visualization-errors"
+};
+gvjs_D.s6 = gvjs_D.rV + "-";
+gvjs_D.v6 = gvjs_D.rV + ":";
+gvjs_D.mV = gvjs_D.rV + "-all-";
+gvjs_D.r6 = gvjs_D.v6 + " container is null";
+gvjs_D.tia = "background-color: #c00000; color: white; padding: 2px;";
+gvjs_D.Qja = "background-color: #fff4c2; color: black; white-space: nowrap; padding: 2px; border: 1px solid black;";
+gvjs_D.Sja = "font: normal 0.8em arial,sans-serif; margin-bottom: 5px;";
+gvjs_D.qja = "font-size: 1.1em; color: #00c; font-weight: bold; cursor: pointer; padding-left: 10px; color: black;text-align: right; vertical-align: top;";
+var gvjs_Rh = 0;
+function gvjs_Sh(a, b, c, d) {
+  if (!gvjs_Th(a))
+    throw Error(gvjs_D.r6 + ". message: " + b);
+  d = gvjs_Uh(b, c, d);
+  var e = d.errorMessage;
+  c = d.detailedMessage;
+  d = d.options;
+  var f = null != d.showInTooltip ? !!d.showInTooltip : !0
+    , g = (d.type === gvjs_Wd ? gvjs_Wd : gvjs_Rb) === gvjs_Rb ? gvjs_D.tia : gvjs_D.Qja;
+  g += d.style ? d.style : "";
+  var h = !!d.removable;
+  b = gvjs_Oh();
+  e = b.J(gvjs_6a, {
+    style: g
+  }, b.createTextNode(e));
+  g = "" + gvjs_D.s6 + gvjs_Rh++;
+  var k = b.J(gvjs_b, {
+    id: g,
+    style: gvjs_D.Sja
+  }, e);
+  c && (f ? e.title = c : (c = b.J(gvjs_6a, {}, b.createTextNode(c)),
+    b.appendChild(k, b.J(gvjs_b, {
+      style: "padding: 2px"
+    }, c))));
+  h && (c = b.J(gvjs_6a, {
+    style: gvjs_D.qja
+  }, b.createTextNode("\u00d7")),
+    c.onclick = gvjs_re(gvjs_Vh, k),
+    b.appendChild(e, c));
+  gvjs_Wh(a, k);
+  d.removeDuplicates && gvjs_Xh(a, k);
+  return g
+}
+gvjs_D.Sc = gvjs_Sh;
+gvjs_D.removeAll = function(a) {
+  gvjs_Yh(a);
+  if (a = gvjs_Zh(a, !1))
+    a.style.display = gvjs_f,
+      gvjs_hh(a)
+}
+;
+gvjs_D.yva = function(a) {
+  a = gvjs_Ph().getElementById(a);
+  return null != a && gvjs__h(a) ? (gvjs_Vh(a),
+    !0) : !1
+}
+;
+gvjs_D.getContainer = function(a) {
+  a = gvjs_Ph().getElementById(a);
+  return null != a && gvjs__h(a) && null != a.parentNode && null != a.parentNode.parentNode ? a.parentNode.parentNode : null
+}
+;
+gvjs_D.uX = function(a, b) {
+  return function() {
+    try {
+      a.apply(null, arguments)
+    } catch (c) {
+      typeof b === gvjs_d ? b(c) : gvjs_Sh(b, c.message)
+    }
+  }
+}
+;
+function gvjs_Vh(a) {
+  var b = a.parentNode;
+  gvjs_kh(a);
+  b && 0 === b.childNodes.length && (b.style.display = gvjs_f)
+}
+gvjs_D.LDa = gvjs_Vh;
+function gvjs__h(a) {
+  return gvjs_ch(a) && a.id && gvjs_hf(a.id, gvjs_D.s6) && (a = a.parentNode) && a.id && gvjs_hf(a.id, gvjs_D.mV) && a.parentNode ? !0 : !1
+}
+gvjs_D.FEa = gvjs__h;
+function gvjs_Uh(a, b, c) {
+  var d = null != a && a ? a : gvjs_Rb
+    , e = "";
+  c = c || {};
+  var f = arguments.length;
+  2 === f ? b && typeof b === gvjs_h ? c = b : e = null != b ? b : e : 3 === f && (e = null != b ? b : e);
+  d = gvjs_kf(d);
+  e = gvjs_kf(e || "");
+  return {
+    errorMessage: d,
+    detailedMessage: e,
+    options: c
+  }
+}
+gvjs_D.SDa = gvjs_Uh;
+function gvjs_Th(a) {
+  return null != a && gvjs_ch(a)
+}
+gvjs_D.EEa = gvjs_Th;
+function gvjs_Yh(a, b) {
+  if (!gvjs_Th(a))
+    throw Error((void 0 === b ? "" : b) || gvjs_D.r6);
+}
+gvjs_D.Vya = gvjs_Yh;
+function gvjs_Zh(a, b) {
+  for (var c = a.childNodes, d = null, e = gvjs_Oh(), f = 0; f < c.length; f++) {
+    var g = c[f];
+    if (g.id && gvjs_hf(g.id, gvjs_D.mV)) {
+      d = g;
+      e.removeNode(d);
+      break
+    }
+  }
+  !d && b && (d = "" + gvjs_D.mV + gvjs_Rh++,
+    d = e.J(gvjs_b, {
+      id: d,
+      style: "display: none; padding-top: 2px"
+    }, null));
+  d && ((b = a.firstChild) ? e.H_(d, b) : e.appendChild(a, d));
+  return d
+}
+gvjs_D.CDa = gvjs_Zh;
+function gvjs_Wh(a, b) {
+  a = gvjs_Zh(a, !0);
+  a.style.display = gvjs_xb;
+  a.appendChild(b)
+}
+gvjs_D.addElement = gvjs_Wh;
+function gvjs_0h(a, b) {
+  a = (a = gvjs_Zh(a, !0)) && gvjs_lh(a);
+  gvjs_u(a, function(c) {
+    gvjs__h(c) && b(c)
+  })
+}
+gvjs_D.zDa = gvjs_0h;
+function gvjs_Xh(a, b) {
+  var c = /id="?google-visualization-errors-[0-9]*"?/
+    , d = gvjs_uh(b);
+  d = d.replace(c, "");
+  var e = [];
+  gvjs_0h(a, function(f) {
+    if (f !== b) {
+      var g = gvjs_uh(f);
+      g = g.replace(c, "");
+      g === d && e.push(f)
+    }
+  });
+  gvjs_u(e, gvjs_Vh);
+  return e.length
+}
+gvjs_D.mEa = gvjs_Xh;
+function gvjs_E(a) {
+  a && typeof a.pa == gvjs_d && a.pa()
+}
+;function gvjs_F() {
+  this.xf = this.xf;
+  this.Wz = this.Wz
+}
+gvjs_F.prototype.xf = !1;
+gvjs_F.prototype.fh = gvjs_n(11);
+gvjs_F.prototype.pa = function() {
+  this.xf || (this.xf = !0,
+    this.M())
+}
+;
+gvjs_F.prototype.M = function() {
+  if (this.Wz)
+    for (; this.Wz.length; )
+      this.Wz.shift()()
+}
+;
+function gvjs_1h(a, b) {
+  this.type = a;
+  this.currentTarget = this.target = b;
+  this.defaultPrevented = this.CK = !1
+}
+gvjs_1h.prototype.stopPropagation = function() {
+  this.CK = !0
+}
+;
+gvjs_1h.prototype.preventDefault = function() {
+  this.defaultPrevented = !0
+}
+;
+var gvjs_2h = "PointerEvent"in gvjs_p
+  , gvjs_3h = "MSPointerEvent"in gvjs_p && !(!gvjs_p.navigator || !gvjs_p.navigator.msPointerEnabled)
+  , gvjs_Uaa = function() {
+  if (!gvjs_p.addEventListener || !Object.defineProperty)
+    return !1;
+  var a = !1
+    , b = Object.defineProperty({}, "passive", {
+    get: function() {
+      a = !0
+    }
+  });
+  try {
+    gvjs_p.addEventListener("test", gvjs_ke, b),
+      gvjs_p.removeEventListener("test", gvjs_ke, b)
+  } catch (c) {}
+  return a
+}();
+var gvjs_4h = {
+  ux: gvjs_2h ? "pointerdown" : gvjs_3h ? "MSPointerDown" : gvjs_gd,
+  wx: gvjs_2h ? "pointerup" : gvjs_3h ? "MSPointerUp" : gvjs_md,
+  mB: gvjs_2h ? "pointercancel" : gvjs_3h ? "MSPointerCancel" : "mousecancel",
+  Yia: gvjs_2h ? "pointermove" : gvjs_3h ? "MSPointerMove" : gvjs_jd,
+  $ia: gvjs_2h ? "pointerover" : gvjs_3h ? "MSPointerOver" : gvjs_ld,
+  Zia: gvjs_2h ? "pointerout" : gvjs_3h ? "MSPointerOut" : gvjs_kd,
+  Wia: gvjs_2h ? "pointerenter" : gvjs_3h ? "MSPointerEnter" : gvjs_hd,
+  Xia: gvjs_2h ? "pointerleave" : gvjs_3h ? "MSPointerLeave" : gvjs_id
+};
+function gvjs_5h(a, b) {
+  gvjs_1h.call(this, a ? a.type : "");
+  this.relatedTarget = this.currentTarget = this.target = null;
+  this.button = this.screenY = this.screenX = this.clientY = this.clientX = this.offsetY = this.offsetX = 0;
+  this.key = "";
+  this.charCode = this.keyCode = 0;
+  this.metaKey = this.shiftKey = this.altKey = this.ctrlKey = !1;
+  this.state = null;
+  this.m2 = !1;
+  this.pointerId = 0;
+  this.pointerType = "";
+  this.$i = null;
+  a && this.init(a, b)
+}
+gvjs_t(gvjs_5h, gvjs_1h);
+var gvjs_Vaa = {
+  2: "touch",
+  3: "pen",
+  4: "mouse"
+};
+gvjs_5h.prototype.init = function(a, b) {
+  var c = this.type = a.type
+    , d = a.changedTouches && a.changedTouches.length ? a.changedTouches[0] : null;
+  this.target = a.target || a.srcElement;
+  this.currentTarget = b;
+  (b = a.relatedTarget) ? gvjs_sg && (gvjs_og(b, gvjs_od) || (b = null)) : c == gvjs_ld ? b = a.fromElement : c == gvjs_kd && (b = a.toElement);
+  this.relatedTarget = b;
+  d ? (this.clientX = void 0 !== d.clientX ? d.clientX : d.pageX,
+    this.clientY = void 0 !== d.clientY ? d.clientY : d.pageY,
+    this.screenX = d.screenX || 0,
+    this.screenY = d.screenY || 0) : (this.offsetX = gvjs_tg || void 0 !== a.offsetX ? a.offsetX : a.layerX,
+    this.offsetY = gvjs_tg || void 0 !== a.offsetY ? a.offsetY : a.layerY,
+    this.clientX = void 0 !== a.clientX ? a.clientX : a.pageX,
+    this.clientY = void 0 !== a.clientY ? a.clientY : a.pageY,
+    this.screenX = a.screenX || 0,
+    this.screenY = a.screenY || 0);
+  this.button = a.button;
+  this.keyCode = a.keyCode || 0;
+  this.key = a.key || "";
+  this.charCode = a.charCode || (c == gvjs_7c ? a.keyCode : 0);
+  this.ctrlKey = a.ctrlKey;
+  this.altKey = a.altKey;
+  this.shiftKey = a.shiftKey;
+  this.metaKey = a.metaKey;
+  this.m2 = gvjs_ug ? a.metaKey : a.ctrlKey;
+  this.pointerId = a.pointerId || 0;
+  this.pointerType = typeof a.pointerType === gvjs_l ? a.pointerType : gvjs_Vaa[a.pointerType] || "";
+  this.state = a.state;
+  this.$i = a;
+  a.defaultPrevented && gvjs_5h.G.preventDefault.call(this)
+}
+;
+gvjs_5h.prototype.stopPropagation = function() {
+  gvjs_5h.G.stopPropagation.call(this);
+  this.$i.stopPropagation ? this.$i.stopPropagation() : this.$i.cancelBubble = !0
+}
+;
+gvjs_5h.prototype.preventDefault = function() {
+  gvjs_5h.G.preventDefault.call(this);
+  var a = this.$i;
+  a.preventDefault ? a.preventDefault() : a.returnValue = !1
+}
+;
+var gvjs_6h = "closure_listenable_" + (1E6 * Math.random() | 0);
+function gvjs_7h(a) {
+  return !(!a || !a[gvjs_6h])
+}
+;var gvjs_Waa = 0;
+function gvjs_Xaa(a, b, c, d, e) {
+  this.listener = a;
+  this.pS = null;
+  this.src = b;
+  this.type = c;
+  this.capture = !!d;
+  this.handler = e;
+  this.key = ++gvjs_Waa;
+  this.An = this.wN = !1
+}
+function gvjs_8h(a) {
+  a.An = !0;
+  a.listener = null;
+  a.pS = null;
+  a.src = null;
+  a.handler = null
+}
+;function gvjs_9h(a) {
+  this.src = a;
+  this.Rh = {};
+  this.ZL = 0
+}
+gvjs_ = gvjs_9h.prototype;
+gvjs_.add = function(a, b, c, d, e) {
+  var f = a.toString();
+  a = this.Rh[f];
+  a || (a = this.Rh[f] = [],
+    this.ZL++);
+  var g = gvjs_$h(a, b, d, e);
+  -1 < g ? (b = a[g],
+  c || (b.wN = !1)) : (b = new gvjs_Xaa(b,this.src,f,!!d,e),
+    b.wN = c,
+    a.push(b));
+  return b
+}
+;
+gvjs_.remove = function(a, b, c, d) {
+  a = a.toString();
+  if (!(a in this.Rh))
+    return !1;
+  var e = this.Rh[a];
+  b = gvjs_$h(e, b, c, d);
+  return -1 < b ? (gvjs_8h(e[b]),
+    gvjs_Je(e, b),
+  0 == e.length && (delete this.Rh[a],
+    this.ZL--),
+    !0) : !1
+}
+;
+function gvjs_ai(a, b) {
+  var c = b.type;
+  if (!(c in a.Rh))
+    return !1;
+  var d = gvjs_Ie(a.Rh[c], b);
+  d && (gvjs_8h(b),
+  0 == a.Rh[c].length && (delete a.Rh[c],
+    a.ZL--));
+  return d
+}
+gvjs_.removeAll = function(a) {
+  a = a && a.toString();
+  var b = 0, c;
+  for (c in this.Rh)
+    if (!a || c == a) {
+      for (var d = this.Rh[c], e = 0; e < d.length; e++)
+        ++b,
+          gvjs_8h(d[e]);
+      delete this.Rh[c];
+      this.ZL--
+    }
+  return b
+}
+;
+gvjs_.EC = gvjs_n(13);
+gvjs_.uI = function(a, b, c, d) {
+  a = this.Rh[a.toString()];
+  var e = -1;
+  a && (e = gvjs_$h(a, b, c, d));
+  return -1 < e ? a[e] : null
+}
+;
+gvjs_.hasListener = function(a, b) {
+  var c = void 0 !== a
+    , d = c ? a.toString() : ""
+    , e = void 0 !== b;
+  return gvjs_Ue(this.Rh, function(f) {
+    for (var g = 0; g < f.length; ++g)
+      if (!(c && f[g].type != d || e && f[g].capture != b))
+        return !0;
+    return !1
+  })
+}
+;
+function gvjs_$h(a, b, c, d) {
+  for (var e = 0; e < a.length; ++e) {
+    var f = a[e];
+    if (!f.An && f.listener == b && f.capture == !!c && f.handler == d)
+      return e
+  }
+  return -1
+}
+;var gvjs_bi = "closure_lm_" + (1E6 * Math.random() | 0)
+  , gvjs_ci = {}
+  , gvjs_di = 0;
+function gvjs_G(a, b, c, d, e) {
+  if (d && d.once)
+    return gvjs_ei(a, b, c, d, e);
+  if (Array.isArray(b)) {
+    for (var f = 0; f < b.length; f++)
+      gvjs_G(a, b[f], c, d, e);
+    return null
+  }
+  c = gvjs_fi(c);
+  return gvjs_7h(a) ? a.o(b, c, gvjs_r(d) ? !!d.capture : !!d, e) : gvjs_gi(a, b, c, !1, d, e)
+}
+function gvjs_gi(a, b, c, d, e, f) {
+  if (!b)
+    throw Error("Invalid event type");
+  var g = gvjs_r(e) ? !!e.capture : !!e
+    , h = gvjs_hi(a);
+  h || (a[gvjs_bi] = h = new gvjs_9h(a));
+  c = h.add(b, c, d, g, f);
+  if (c.pS)
+    return c;
+  d = gvjs_Yaa();
+  c.pS = d;
+  d.src = a;
+  d.listener = c;
+  if (a.addEventListener)
+    gvjs_Uaa || (e = g),
+    void 0 === e && (e = !1),
+      a.addEventListener(b.toString(), d, e);
+  else if (a.attachEvent)
+    a.attachEvent(gvjs_ii(b.toString()), d);
+  else if (a.addListener && a.removeListener)
+    a.addListener(d);
+  else
+    throw Error("addEventListener and attachEvent are unavailable.");
+  gvjs_di++;
+  return c
+}
+function gvjs_Yaa() {
+  function a(c) {
+    return b.call(a.src, a.listener, c)
+  }
+  var b = gvjs_Zaa;
+  return a
+}
+function gvjs_ei(a, b, c, d, e) {
+  if (Array.isArray(b)) {
+    for (var f = 0; f < b.length; f++)
+      gvjs_ei(a, b[f], c, d, e);
+    return null
+  }
+  c = gvjs_fi(c);
+  return gvjs_7h(a) ? a.vD(b, c, gvjs_r(d) ? !!d.capture : !!d, e) : gvjs_gi(a, b, c, !0, d, e)
+}
+function gvjs_ji(a, b, c, d, e) {
+  if (Array.isArray(b))
+    for (var f = 0; f < b.length; f++)
+      gvjs_ji(a, b[f], c, d, e);
+  else
+    d = gvjs_r(d) ? !!d.capture : !!d,
+      c = gvjs_fi(c),
+      gvjs_7h(a) ? a.Ab(b, c, d, e) : a && (a = gvjs_hi(a)) && (b = a.uI(b, c, d, e)) && gvjs_ki(b)
+}
+function gvjs_ki(a) {
+  if (typeof a === gvjs_g || !a || a.An)
+    return !1;
+  var b = a.src;
+  if (gvjs_7h(b))
+    return gvjs_ai(b.Jl, a);
+  var c = a.type
+    , d = a.pS;
+  b.removeEventListener ? b.removeEventListener(c, d, a.capture) : b.detachEvent ? b.detachEvent(gvjs_ii(c), d) : b.addListener && b.removeListener && b.removeListener(d);
+  gvjs_di--;
+  (c = gvjs_hi(b)) ? (gvjs_ai(c, a),
+  0 == c.ZL && (c.src = null,
+    b[gvjs_bi] = null)) : gvjs_8h(a);
+  return !0
+}
+function gvjs_li(a) {
+  if (!a)
+    return 0;
+  if (gvjs_7h(a))
+    return a.Jl ? a.Jl.removeAll(void 0) : 0;
+  a = gvjs_hi(a);
+  if (!a)
+    return 0;
+  var b = 0, c;
+  for (c in a.Rh)
+    for (var d = a.Rh[c].concat(), e = 0; e < d.length; ++e)
+      gvjs_ki(d[e]) && ++b;
+  return b
+}
+function gvjs_ii(a) {
+  return a in gvjs_ci ? gvjs_ci[a] : gvjs_ci[a] = "on" + a
+}
+function gvjs_Zaa(a, b) {
+  if (a.An)
+    a = !0;
+  else {
+    b = new gvjs_5h(b,this);
+    var c = a.listener
+      , d = a.handler || a.src;
+    a.wN && gvjs_ki(a);
+    a = c.call(d, b)
+  }
+  return a
+}
+function gvjs_hi(a) {
+  a = a[gvjs_bi];
+  return a instanceof gvjs_9h ? a : null
+}
+var gvjs_mi = "__closure_events_fn_" + (1E9 * Math.random() >>> 0);
+function gvjs_fi(a) {
+  if (typeof a === gvjs_d)
+    return a;
+  a[gvjs_mi] || (a[gvjs_mi] = function(b) {
+      return a.handleEvent(b)
+    }
+  );
+  return a[gvjs_mi]
+}
+;function gvjs_H() {
+  gvjs_F.call(this);
+  this.Jl = new gvjs_9h(this);
+  this.cka = this;
+  this.g2 = null
+}
+gvjs_t(gvjs_H, gvjs_F);
+gvjs_H.prototype[gvjs_6h] = !0;
+gvjs_ = gvjs_H.prototype;
+gvjs_.GC = function() {
+  return this.g2
+}
+;
+gvjs_.uA = gvjs_n(14);
+gvjs_.addEventListener = function(a, b, c, d) {
+  gvjs_G(this, a, b, c, d)
+}
+;
+gvjs_.removeEventListener = function(a, b, c, d) {
+  gvjs_ji(this, a, b, c, d)
+}
+;
+gvjs_.dispatchEvent = function(a) {
+  var b, c = this.GC();
+  if (c)
+    for (b = []; c; c = c.GC())
+      b.push(c);
+  c = this.cka;
+  var d = a.type || a;
+  if (typeof a === gvjs_l)
+    a = new gvjs_1h(a,c);
+  else if (a instanceof gvjs_1h)
+    a.target = a.target || c;
+  else {
+    var e = a;
+    a = new gvjs_1h(d,c);
+    gvjs_2e(a, e)
+  }
+  e = !0;
+  if (b)
+    for (var f = b.length - 1; !a.CK && 0 <= f; f--) {
+      var g = a.currentTarget = b[f];
+      e = gvjs_ni(g, d, !0, a) && e
+    }
+  a.CK || (g = a.currentTarget = c,
+    e = gvjs_ni(g, d, !0, a) && e,
+  a.CK || (e = gvjs_ni(g, d, !1, a) && e));
+  if (b)
+    for (f = 0; !a.CK && f < b.length; f++)
+      g = a.currentTarget = b[f],
+        e = gvjs_ni(g, d, !1, a) && e;
+  return e
+}
+;
+gvjs_.M = function() {
+  gvjs_H.G.M.call(this);
+  this.Jl && this.Jl.removeAll(void 0);
+  this.g2 = null
+}
+;
+gvjs_.o = function(a, b, c, d) {
+  return this.Jl.add(String(a), b, !1, c, d)
+}
+;
+gvjs_.vD = function(a, b, c, d) {
+  return this.Jl.add(String(a), b, !0, c, d)
+}
+;
+gvjs_.Ab = function(a, b, c, d) {
+  return this.Jl.remove(String(a), b, c, d)
+}
+;
+function gvjs_ni(a, b, c, d) {
+  b = a.Jl.Rh[String(b)];
+  if (!b)
+    return !0;
+  b = b.concat();
+  for (var e = !0, f = 0; f < b.length; ++f) {
+    var g = b[f];
+    if (g && !g.An && g.capture == c) {
+      var h = g.listener
+        , k = g.handler || g.src;
+      g.wN && gvjs_ai(a.Jl, g);
+      e = !1 !== h.call(k, d) && e
+    }
+  }
+  return e && !d.defaultPrevented
+}
+gvjs_.EC = gvjs_n(12);
+gvjs_.uI = function(a, b, c, d) {
+  return this.Jl.uI(String(a), b, c, d)
+}
+;
+gvjs_.hasListener = function(a, b) {
+  return this.Jl.hasListener(void 0 !== a ? String(a) : void 0, b)
+}
+;
+function gvjs_oi(a, b, c) {
+  a = gvjs_pi(a);
+  b = gvjs_G(a, b, gvjs_qi(c));
+  return new gvjs_ri(b)
+}
+function gvjs_si(a, b, c) {
+  a = gvjs_pi(a);
+  b = gvjs_ei(a, b, gvjs_qi(c));
+  return new gvjs_ri(b)
+}
+function gvjs_I(a, b, c) {
+  gvjs_pi(a).dispatchEvent(new gvjs_ti(b,c))
+}
+function gvjs_ui(a) {
+  return (a = a && typeof a.getKey === gvjs_d && a.getKey()) ? gvjs_ki(a) : !1
+}
+function gvjs_vi(a) {
+  var b = gvjs_pi(a);
+  b = gvjs_li(b);
+  gvjs_E(a.__eventTarget);
+  a.__eventTarget = void 0;
+  return b
+}
+function gvjs_pi(a) {
+  var b = a.__eventTarget;
+  null != b ? a = b : (b = new gvjs_H,
+    a = a.__eventTarget = b);
+  return a
+}
+function gvjs_qi(a) {
+  return function(b) {
+    b && b.Loa ? a(b.properties) : a()
+  }
+}
+function gvjs_ri(a) {
+  this.key = a
+}
+gvjs_ri.prototype.getKey = function() {
+  return this.key
+}
+;
+function gvjs_ti(a, b) {
+  gvjs_1h.call(this, a);
+  this.properties = b
+}
+gvjs_o(gvjs_ti, gvjs_1h);
+gvjs_ti.prototype.Loa = function() {
+  return this.properties
+}
+;
+function gvjs_wi(a, b, c) {
+  this.visualization = a;
+  this.container = b;
+  this.lC = null;
+  this.visualization = a;
+  this.container = b;
+  if (void 0 === c ? 0 : c)
+    a = gvjs_Eh(b),
+    "" !== a && "static" !== a || gvjs_C(b, gvjs_vd, gvjs_zd),
+      this.lC = document.createElement(gvjs_Ob),
+      gvjs_C(this.lC, {
+        position: gvjs_c,
+        top: 0,
+        left: 0,
+        "z-index": 1
+      })
+}
+function gvjs_xi(a) {
+  return a.lC ? (a.lC.parentNode !== a.container && a.container.appendChild(a.lC),
+    a.lC) : a.container
+}
+gvjs_wi.prototype.Sc = function(a) {
+  gvjs_yi(this, a, gvjs_Rb)
+}
+;
+function gvjs_yi(a, b, c, d) {
+  d = void 0 === d ? !0 : d;
+  var e = gvjs_xi(a);
+  c = {
+    removable: !0,
+    type: c
+  };
+  e = (0,
+    gvjs_D.Sc)(e, b, null, c);
+  (null == d || d) && gvjs_I(a.visualization, gvjs_Rb, {
+    id: e,
+    message: b,
+    detailedMessage: "",
+    options: c
+  })
+}
+gvjs_wi.prototype.removeAll = function() {
+  var a = gvjs_xi(this);
+  (0,
+    gvjs_D.removeAll)(a)
+}
+;
+function gvjs_Zg(a, b, c) {
+  try {
+    return c ? b.call(c) : b()
+  } catch (d) {
+    a.Sc(d.message)
+  }
+}
+;var gvjs_zi = {
+  Dza: gvjs_zb,
+  UAa: gvjs_g,
+  BBa: gvjs_l,
+  aAa: gvjs_Lb,
+  bAa: gvjs_Mb,
+  TIME: "time",
+  JBa: gvjs_Od,
+  u6: gvjs_d
+};
+function gvjs_Ai() {
+  this.cq = null
+}
+gvjs_Ai.prototype.jf = function(a) {
+  if (typeof a === gvjs_g) {
+    var b = this.$();
+    return 0 > a || a >= b ? -1 : a
+  }
+  if (!this.cq) {
+    this.cq = {};
+    b = this.$();
+    for (var c = 0; c < b; c++) {
+      var d = this.Ne(c);
+      null == d || "" === d || d in this.cq || (this.cq[d] = c)
+    }
+    for (c = 0; c < b; c++)
+      d = this.Ga(c),
+      null == d || "" === d || d in this.cq || (this.cq[d] = c)
+  }
+  a = this.cq[a];
+  return null == a ? -1 : a
+}
+;
+gvjs_Ai.prototype.getStringValue = function(a, b) {
+  var c = this.W(b);
+  if (c !== gvjs_l)
+    throw Error(gvjs_wa + b + " must be of type string, but is " + (c + "."));
+  return this.getValue(a, b)
+}
+;
+function gvjs_Bi(a, b) {
+  return (new gvjs_Ci(b)).ie(a)
+}
+function gvjs_Ci(a) {
+  this.ES = a
+}
+gvjs_Ci.prototype.ie = function(a) {
+  var b = [];
+  gvjs_Di(this, a, b);
+  return b.join("")
+}
+;
+function gvjs_Di(a, b, c) {
+  if (null == b)
+    c.push(gvjs_rd);
+  else {
+    if (typeof b == gvjs_h) {
+      if (Array.isArray(b)) {
+        var d = b;
+        b = d.length;
+        c.push("[");
+        for (var e = "", f = 0; f < b; f++)
+          c.push(e),
+            e = d[f],
+            gvjs_Di(a, a.ES ? a.ES.call(d, String(f), e) : e, c),
+            e = ",";
+        c.push("]");
+        return
+      }
+      if (b instanceof String || b instanceof Number || b instanceof Boolean)
+        b = b.valueOf();
+      else {
+        c.push("{");
+        f = "";
+        for (d in b)
+          Object.prototype.hasOwnProperty.call(b, d) && (e = b[d],
+          typeof e != gvjs_d && (c.push(f),
+            gvjs_Ei(d, c),
+            c.push(":"),
+            gvjs_Di(a, a.ES ? a.ES.call(b, d, e) : e, c),
+            f = ","));
+        c.push("}");
+        return
+      }
+    }
+    switch (typeof b) {
+      case gvjs_l:
+        gvjs_Ei(b, c);
+        break;
+      case gvjs_g:
+        c.push(isFinite(b) && !isNaN(b) ? String(b) : gvjs_rd);
+        break;
+      case gvjs_zb:
+        c.push(String(b));
+        break;
+      case gvjs_d:
+        c.push(gvjs_rd);
+        break;
+      default:
+        throw Error("Unknown type: " + typeof b);
+    }
+  }
+}
+var gvjs_Fi = {
+  '"': '\\"',
+  "\\": "\\\\",
+  "/": "\\/",
+  "\b": "\\b",
+  "\f": "\\f",
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+  "\x0B": "\\u000b"
+}
+  , gvjs__aa = /\uffff/.test("\uffff") ? /[\\"\x00-\x1f\x7f-\uffff]/g : /[\\"\x00-\x1f\x7f-\xff]/g;
+function gvjs_Ei(a, b) {
+  b.push('"', a.replace(gvjs__aa, function(c) {
+    var d = gvjs_Fi[c];
+    d || (d = "\\u" + (c.charCodeAt(0) | 65536).toString(16).substr(1),
+      gvjs_Fi[c] = d);
+    return d
+  }), '"')
+}
+;var gvjs_Gi = JSON.parse
+  , gvjs_Hi = gvjs_p.JSON && gvjs_p.JSON.stringify || gvjs_Bi;
+function gvjs_Ii(a) {
+  return gvjs_Bi(gvjs_Ji(a, gvjs_Ki))
+}
+function gvjs_Li(a) {
+  return gvjs_Mi(JSON.parse(a))
+}
+function gvjs_Ji(a, b) {
+  a = b(a);
+  var c = gvjs_me(a);
+  if (c === gvjs_h || c === gvjs_sb) {
+    c = c === gvjs_sb ? [] : {};
+    for (var d in a)
+      if (!gvjs_sf(d, "___clazz$") && a.hasOwnProperty(d)) {
+        var e = gvjs_Ji(a[d], b);
+        void 0 !== e && (c[d] = e)
+      }
+  } else
+    c = a;
+  return c
+}
+function gvjs_Mi(a) {
+  if (typeof a === gvjs_l) {
+    var b = a.match(/^Date\(\s*([\d,\s]*)\)$/);
+    b && (a = b[1].split(/,\s*/),
+      a = 1 === a.length ? new Date(Number(a[0]) || 0) : new Date(Number(a[0]) || 0,Number(a[1]) || 0,Number(a[2]) || 1,Number(a[3]) || 0,Number(a[4]) || 0,Number(a[5]) || 0,Number(a[6]) || 0));
+    return a
+  }
+  if (Array.isArray(a))
+    return gvjs_v(a, gvjs_Mi);
+  if (gvjs_r(a))
+    for (b in a)
+      if (a.hasOwnProperty(b)) {
+        var c = a[b];
+        Object.prototype.hasOwnProperty.call(a, b) && (a[b] = gvjs_Mi(c))
+      }
+  return a
+}
+function gvjs_Ki(a) {
+  var b = a;
+  gvjs_oe(b) && (b = "Date(" + (0 !== a.getMilliseconds() ? [a.getFullYear(), a.getMonth(), a.getDate(), a.getHours(), a.getMinutes(), a.getSeconds(), a.getMilliseconds()] : 0 !== a.getSeconds() || 0 !== a.getMinutes() || 0 !== a.getHours() ? [a.getFullYear(), a.getMonth(), a.getDate(), a.getHours(), a.getMinutes(), a.getSeconds()] : [a.getFullYear(), a.getMonth(), a.getDate()]).join(gvjs_ha) + ")");
+  return b
+}
+;var gvjs_Ni = {
+  ERAS: ["BC", "AD"],
+  ERANAMES: ["Before Christ", "Anno Domini"],
+  NARROWMONTHS: "JFMAMJJASOND".split(""),
+  STANDALONENARROWMONTHS: "JFMAMJJASOND".split(""),
+  MONTHS: [gvjs_Ua, gvjs_Ea, "March", "April", gvjs_Xa, "June", "July", gvjs_pa, gvjs_$a, gvjs_1a, gvjs__a, gvjs_Ba],
+  STANDALONEMONTHS: [gvjs_Ua, gvjs_Ea, "March", "April", gvjs_Xa, "June", "July", gvjs_pa, gvjs_$a, gvjs_1a, gvjs__a, gvjs_Ba],
+  SHORTMONTHS: ["Jan", "Feb", "Mar", "Apr", gvjs_Xa, "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+  STANDALONESHORTMONTHS: ["Jan", "Feb", "Mar", "Apr", gvjs_Xa, "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+  WEEKDAYS: [gvjs_bb, gvjs_Ya, gvjs_ib, gvjs_lb, gvjs_eb, gvjs_Fa, gvjs_8a],
+  STANDALONEWEEKDAYS: [gvjs_bb, gvjs_Ya, gvjs_ib, gvjs_lb, gvjs_eb, gvjs_Fa, gvjs_8a],
+  SHORTWEEKDAYS: "Sun Mon Tue Wed Thu Fri Sat".split(" "),
+  STANDALONESHORTWEEKDAYS: "Sun Mon Tue Wed Thu Fri Sat".split(" "),
+  NARROWWEEKDAYS: "SMTWTFS".split(""),
+  STANDALONENARROWWEEKDAYS: "SMTWTFS".split(""),
+  SHORTQUARTERS: ["Q1", "Q2", "Q3", "Q4"],
+  QUARTERS: ["1st quarter", "2nd quarter", "3rd quarter", "4th quarter"],
+  AMPMS: ["AM", "PM"],
+  DATEFORMATS: ["EEEE, MMMM d, y", "MMMM d, y", "MMM d, y", "M/d/yy"],
+  TIMEFORMATS: ["h:mm:ss a zzzz", "h:mm:ss a z", "h:mm:ss a", "h:mm a"],
+  DATETIMEFORMATS: [gvjs_0d, gvjs_0d, gvjs_1d, gvjs_1d],
+  FIRSTDAYOFWEEK: 6,
+  WEEKENDRANGE: [5, 6],
+  FIRSTWEEKCUTOFFDAY: 5
+}
+  , gvjs_Oi = gvjs_Ni;
+gvjs_Oi = gvjs_Ni;
+function gvjs_Pi(a, b) {
+  switch (b) {
+    case 1:
+      return 0 != a % 4 || 0 == a % 100 && 0 != a % 400 ? 28 : 29;
+    case 5:
+    case 8:
+    case 10:
+    case 3:
+      return 30
+  }
+  return 31
+}
+function gvjs_Qi(a, b, c, d, e) {
+  a = new Date(a,b,c);
+  e = e || 0;
+  return a.valueOf() + 864E5 * (((void 0 !== d ? d : 3) - e + 7) % 7 - ((a.getDay() + 6) % 7 - e + 7) % 7)
+}
+function gvjs_Ri(a, b, c) {
+  typeof a === gvjs_g ? (this.date = gvjs_Si(a, b || 0, c || 1),
+    gvjs_Ti(this, c || 1)) : gvjs_r(a) ? (this.date = gvjs_Si(a.getFullYear(), a.getMonth(), a.getDate()),
+    gvjs_Ti(this, a.getDate())) : (this.date = new Date(gvjs_se()),
+    a = this.date.getDate(),
+    this.date.setHours(0),
+    this.date.setMinutes(0),
+    this.date.setSeconds(0),
+    this.date.setMilliseconds(0),
+    gvjs_Ti(this, a))
+}
+function gvjs_Si(a, b, c) {
+  b = new Date(a,b,c);
+  0 <= a && 100 > a && b.setFullYear(b.getFullYear() - 1900);
+  return b
+}
+gvjs_ = gvjs_Ri.prototype;
+gvjs_.tC = gvjs_Oi.FIRSTDAYOFWEEK;
+gvjs_.uC = gvjs_Oi.FIRSTWEEKCUTOFFDAY;
+gvjs_.clone = function() {
+  var a = new gvjs_Ri(this.date);
+  a.tC = this.tC;
+  a.uC = this.uC;
+  return a
+}
+;
+gvjs_.getFullYear = function() {
+  return this.date.getFullYear()
+}
+;
+gvjs_.getYear = function() {
+  return this.getFullYear()
+}
+;
+gvjs_.getMonth = function() {
+  return this.date.getMonth()
+}
+;
+gvjs_.getDate = function() {
+  return this.date.getDate()
+}
+;
+gvjs_.getTime = function() {
+  return this.date.getTime()
+}
+;
+gvjs_.getDay = function() {
+  return this.date.getDay()
+}
+;
+gvjs_.getUTCFullYear = function() {
+  return this.date.getUTCFullYear()
+}
+;
+gvjs_.getUTCMonth = function() {
+  return this.date.getUTCMonth()
+}
+;
+gvjs_.getUTCDate = function() {
+  return this.date.getUTCDate()
+}
+;
+gvjs_.getUTCDay = function() {
+  return this.date.getDay()
+}
+;
+gvjs_.getUTCHours = function() {
+  return this.date.getUTCHours()
+}
+;
+gvjs_.getUTCMinutes = function() {
+  return this.date.getUTCMinutes()
+}
+;
+gvjs_.getTimezoneOffset = function() {
+  return this.date.getTimezoneOffset()
+}
+;
+gvjs_.set = function(a) {
+  this.date = new Date(a.getFullYear(),a.getMonth(),a.getDate())
+}
+;
+gvjs_.setFullYear = function(a) {
+  this.date.setFullYear(a)
+}
+;
+gvjs_.setYear = function(a) {
+  this.setFullYear(a)
+}
+;
+gvjs_.setMonth = function(a) {
+  this.date.setMonth(a)
+}
+;
+gvjs_.setDate = function(a) {
+  this.date.setDate(a)
+}
+;
+gvjs_.setTime = function(a) {
+  this.date.setTime(a)
+}
+;
+gvjs_.setUTCFullYear = function(a) {
+  this.date.setUTCFullYear(a)
+}
+;
+gvjs_.setUTCMonth = function(a) {
+  this.date.setUTCMonth(a)
+}
+;
+gvjs_.setUTCDate = function(a) {
+  this.date.setUTCDate(a)
+}
+;
+gvjs_.add = function(a) {
+  if (a.Aj || a.months) {
+    var b = this.getMonth() + a.months + 12 * a.Aj
+      , c = this.getYear() + Math.floor(b / 12);
+    b %= 12;
+    0 > b && (b += 12);
+    var d = Math.min(gvjs_Pi(c, b), this.getDate());
+    this.setDate(1);
+    this.setFullYear(c);
+    this.setMonth(b);
+    this.setDate(d)
+  }
+  a.days && (a = new Date((new Date(this.getYear(),this.getMonth(),this.getDate(),12)).getTime() + 864E5 * a.days),
+    this.setDate(1),
+    this.setFullYear(a.getFullYear()),
+    this.setMonth(a.getMonth()),
+    this.setDate(a.getDate()),
+    gvjs_Ti(this, a.getDate()))
+}
+;
+gvjs_.TA = function(a) {
+  return [this.getFullYear(), gvjs_fg(this.getMonth() + 1, 2), gvjs_fg(this.getDate(), 2)].join(a ? "-" : "") + ""
+}
+;
+gvjs_.equals = function(a) {
+  return !(!a || this.getYear() != a.getYear() || this.getMonth() != a.getMonth() || this.getDate() != a.getDate())
+}
+;
+gvjs_.toString = function() {
+  return this.TA()
+}
+;
+function gvjs_Ti(a, b) {
+  a.getDate() != b && a.date.setUTCHours(a.date.getUTCHours() + (a.getDate() < b ? 1 : -1))
+}
+gvjs_.valueOf = function() {
+  return this.date.valueOf()
+}
+;
+function gvjs_Ui() {}
+function gvjs_Vi(a) {
+  if (typeof a == gvjs_g) {
+    var b = new gvjs_Ui;
+    b.D4 = a;
+    var c = a;
+    if (0 == c)
+      c = "Etc/GMT";
+    else {
+      var d = ["Etc/GMT", 0 > c ? "-" : "+"];
+      c = Math.abs(c);
+      d.push(Math.floor(c / 60) % 100);
+      c %= 60;
+      0 != c && d.push(":", gvjs_fg(c, 2));
+      c = d.join("")
+    }
+    b.f5 = c;
+    c = a;
+    0 == c ? c = "UTC" : (d = ["UTC", 0 > c ? "+" : "-"],
+      c = Math.abs(c),
+      d.push(Math.floor(c / 60) % 100),
+      c %= 60,
+    0 != c && d.push(":", c),
+      c = d.join(""));
+    a = gvjs_Wi(a);
+    b.IU = [c, c];
+    b.ix = {
+      xBa: a,
+      E6: a
+    };
+    b.YA = [];
+    return b
+  }
+  b = new gvjs_Ui;
+  b.f5 = a.id;
+  b.D4 = -a.std_offset;
+  b.IU = a.names;
+  b.ix = a.names_ext;
+  b.YA = a.transitions;
+  return b
+}
+function gvjs_Wi(a) {
+  var b = ["GMT"];
+  b.push(0 >= a ? "+" : "-");
+  a = Math.abs(a);
+  b.push(gvjs_fg(Math.floor(a / 60) % 100, 2), ":", gvjs_fg(a % 60, 2));
+  return b.join("")
+}
+gvjs_ = gvjs_Ui.prototype;
+gvjs_.getTimeZoneData = function() {
+  return {
+    id: this.f5,
+    std_offset: -this.D4,
+    names: gvjs_Le(this.IU),
+    names_ext: gvjs_x(this.ix),
+    transitions: gvjs_Le(this.YA)
+  }
+}
+;
+gvjs_.getDaylightAdjustment = function(a) {
+  a = Date.UTC(a.getUTCFullYear(), a.getUTCMonth(), a.getUTCDate(), a.getUTCHours(), a.getUTCMinutes()) / 36E5;
+  for (var b = 0; b < this.YA.length && a >= this.YA[b]; )
+    b += 2;
+  return 0 == b ? 0 : this.YA[b - 1]
+}
+;
+gvjs_.getGMTString = function(a) {
+  return gvjs_Wi(this.getOffset(a))
+}
+;
+gvjs_.getLongName = function(a) {
+  return this.IU[this.isDaylightTime(a) ? 3 : 1]
+}
+;
+gvjs_.getOffset = function(a) {
+  return this.D4 - this.getDaylightAdjustment(a)
+}
+;
+gvjs_.getRFCTimeZoneString = function(a) {
+  a = -this.getOffset(a);
+  var b = [0 > a ? "-" : "+"];
+  a = Math.abs(a);
+  b.push(gvjs_fg(Math.floor(a / 60) % 100, 2), gvjs_fg(a % 60, 2));
+  return b.join("")
+}
+;
+gvjs_.getShortName = function(a) {
+  return this.IU[this.isDaylightTime(a) ? 2 : 0]
+}
+;
+gvjs_.getTimeZoneId = function() {
+  return this.f5
+}
+;
+gvjs_.isDaylightTime = function(a) {
+  return 0 < this.getDaylightAdjustment(a)
+}
+;
+function gvjs_Xi(a) {
+  this.iS = [];
+  this.Ie = gvjs_Oi;
+  typeof a == gvjs_g ? this.aN(a) : this.Zr(a)
+}
+var gvjs_Yi = [/^'(?:[^']|'')*('|$)/, /^(?:G+|y+|Y+|M+|k+|S+|E+|a+|h+|K+|H+|c+|L+|Q+|d+|m+|s+|v+|V+|w+|z+|Z+)/, /^[^'GyYMkSEahKHcLQdmsvVwzZ]+/];
+function gvjs_Zi(a) {
+  return a.getHours ? a.getHours() : 0
+}
+gvjs_Xi.prototype.Zr = function(a) {
+  for (gvjs_0aa && (a = a.replace(/\u200f/g, "")); a; ) {
+    for (var b = a, c = 0; c < gvjs_Yi.length; ++c) {
+      var d = a.match(gvjs_Yi[c]);
+      if (d) {
+        var e = d[0];
+        a = a.substring(e.length);
+        0 == c && ("''" == e ? e = "'" : (e = e.substring(1, "'" == d[1] ? e.length - 1 : e.length),
+          e = e.replace(/''/g, "'")));
+        this.iS.push({
+          text: e,
+          type: c
+        });
+        break
+      }
+    }
+    if (b === a)
+      throw Error("Malformed pattern part: " + a);
+  }
+}
+;
+gvjs_Xi.prototype.format = function(a, b) {
+  if (!a)
+    throw Error("The date to format must be non-null.");
+  var c = b ? 6E4 * (a.getTimezoneOffset() - b.getOffset(a)) : 0
+    , d = c ? new Date(a.getTime() + c) : a
+    , e = d;
+  b && d.getTimezoneOffset() != a.getTimezoneOffset() && (e = 6E4 * (d.getTimezoneOffset() - a.getTimezoneOffset()),
+    d = new Date(d.getTime() + e),
+    c += 0 < c ? -864E5 : 864E5,
+    e = new Date(a.getTime() + c));
+  c = [];
+  for (var f = 0; f < this.iS.length; ++f) {
+    var g = this.iS[f].text;
+    1 == this.iS[f].type ? c.push(gvjs_1aa(this, g, a, d, e, b)) : c.push(g)
+  }
+  return c.join("")
+}
+;
+gvjs_Xi.prototype.aN = function(a) {
+  if (4 > a)
+    var b = this.Ie.DATEFORMATS[a];
+  else if (8 > a)
+    b = this.Ie.TIMEFORMATS[a - 4];
+  else if (12 > a)
+    b = this.Ie.DATETIMEFORMATS[a - 8],
+      b = b.replace("{1}", this.Ie.DATEFORMATS[a - 8]),
+      b = b.replace("{0}", this.Ie.TIMEFORMATS[a - 8]);
+  else {
+    this.aN(10);
+    return
+  }
+  this.Zr(b)
+}
+;
+function gvjs__i(a, b) {
+  b = String(b);
+  a = a.Ie || gvjs_Oi;
+  if (void 0 !== a.Tja) {
+    for (var c = [], d = 0; d < b.length; d++) {
+      var e = b.charCodeAt(d);
+      c.push(48 <= e && 57 >= e ? String.fromCharCode(a.Tja + e - 48) : b.charAt(d))
+    }
+    b = c.join("")
+  }
+  return b
+}
+var gvjs_0aa = !1;
+function gvjs_0i(a) {
+  if (!(a.getHours && a.getSeconds && a.getMinutes))
+    throw Error("The date to format has no time (probably a goog.date.Date). Use Date or goog.date.DateTime, or use a pattern without time fields.");
+}
+function gvjs_1aa(a, b, c, d, e, f) {
+  var g = b.length;
+  switch (b.charAt(0)) {
+    case "G":
+      return c = 0 < d.getFullYear() ? 1 : 0,
+        4 <= g ? a.Ie.ERANAMES[c] : a.Ie.ERAS[c];
+    case "y":
+      return c = d.getFullYear(),
+      0 > c && (c = -c),
+      2 == g && (c %= 100),
+        gvjs__i(a, gvjs_fg(c, g));
+    case "Y":
+      return c = (new Date(gvjs_Qi(d.getFullYear(), d.getMonth(), d.getDate(), a.Ie.FIRSTWEEKCUTOFFDAY, a.Ie.FIRSTDAYOFWEEK))).getFullYear(),
+      0 > c && (c = -c),
+      2 == g && (c %= 100),
+        gvjs__i(a, gvjs_fg(c, g));
+    case "M":
+      a: switch (c = d.getMonth(),
+        g) {
+        case 5:
+          g = a.Ie.NARROWMONTHS[c];
+          break a;
+        case 4:
+          g = a.Ie.MONTHS[c];
+          break a;
+        case 3:
+          g = a.Ie.SHORTMONTHS[c];
+          break a;
+        default:
+          g = gvjs__i(a, gvjs_fg(c + 1, g))
+      }
+      return g;
+    case "k":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(gvjs_Zi(e) || 24, g));
+    case "S":
+      return gvjs__i(a, (e.getMilliseconds() / 1E3).toFixed(Math.min(3, g)).substr(2) + (3 < g ? gvjs_fg(0, g - 3) : ""));
+    case "E":
+      return c = d.getDay(),
+        4 <= g ? a.Ie.WEEKDAYS[c] : a.Ie.SHORTWEEKDAYS[c];
+    case "a":
+      return gvjs_0i(e),
+        g = gvjs_Zi(e),
+        a.Ie.AMPMS[12 <= g && 24 > g ? 1 : 0];
+    case "h":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(gvjs_Zi(e) % 12 || 12, g));
+    case "K":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(gvjs_Zi(e) % 12, g));
+    case "H":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(gvjs_Zi(e), g));
+    case "c":
+      a: switch (c = d.getDay(),
+        g) {
+        case 5:
+          g = a.Ie.STANDALONENARROWWEEKDAYS[c];
+          break a;
+        case 4:
+          g = a.Ie.STANDALONEWEEKDAYS[c];
+          break a;
+        case 3:
+          g = a.Ie.STANDALONESHORTWEEKDAYS[c];
+          break a;
+        default:
+          g = gvjs__i(a, gvjs_fg(c, 1))
+      }
+      return g;
+    case "L":
+      a: switch (c = d.getMonth(),
+        g) {
+        case 5:
+          g = a.Ie.STANDALONENARROWMONTHS[c];
+          break a;
+        case 4:
+          g = a.Ie.STANDALONEMONTHS[c];
+          break a;
+        case 3:
+          g = a.Ie.STANDALONESHORTMONTHS[c];
+          break a;
+        default:
+          g = gvjs__i(a, gvjs_fg(c + 1, g))
+      }
+      return g;
+    case "Q":
+      return c = Math.floor(d.getMonth() / 3),
+        4 > g ? a.Ie.SHORTQUARTERS[c] : a.Ie.QUARTERS[c];
+    case "d":
+      return gvjs__i(a, gvjs_fg(d.getDate(), g));
+    case "m":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(e.getMinutes(), g));
+    case "s":
+      return gvjs_0i(e),
+        gvjs__i(a, gvjs_fg(e.getSeconds(), g));
+    case "v":
+      return g = f || gvjs_Vi(c.getTimezoneOffset()),
+        g.getTimeZoneId();
+    case "V":
+      return a = f || gvjs_Vi(c.getTimezoneOffset()),
+        2 >= g ? g = a.getTimeZoneId() : (g = a,
+          g = g.isDaylightTime(c) ? void 0 !== g.ix.qia ? g.ix.qia : g.ix.DST_GENERIC_LOCATION : void 0 !== g.ix.E6 ? g.ix.E6 : g.ix.STD_GENERIC_LOCATION),
+        g;
+    case "w":
+      return c = gvjs_Qi(e.getFullYear(), e.getMonth(), e.getDate(), a.Ie.FIRSTWEEKCUTOFFDAY, a.Ie.FIRSTDAYOFWEEK),
+        gvjs__i(a, gvjs_fg(Math.floor(Math.round((c - (new Date((new Date(c)).getFullYear(),0,1)).valueOf()) / 864E5) / 7) + 1, g));
+    case "z":
+      return a = f || gvjs_Vi(c.getTimezoneOffset()),
+        4 > g ? a.getShortName(c) : a.getLongName(c);
+    case "Z":
+      return b = f || gvjs_Vi(c.getTimezoneOffset()),
+        4 > g ? b.getRFCTimeZoneString(c) : gvjs__i(a, b.getGMTString(c));
+    default:
+      return ""
+  }
+}
+;var gvjs_1i = {
+  YEAR_FULL: "y",
+  YEAR_FULL_WITH_ERA: "y G",
+  YEAR_MONTH_ABBR: "MMM y",
+  YEAR_MONTH_FULL: "MMMM y",
+  YBa: "MM/y",
+  MONTH_DAY_ABBR: "MMM d",
+  MONTH_DAY_FULL: "MMMM dd",
+  MONTH_DAY_SHORT: "M/d",
+  MONTH_DAY_MEDIUM: "MMMM d",
+  MONTH_DAY_YEAR_MEDIUM: "MMM d, y",
+  WEEKDAY_MONTH_DAY_MEDIUM: "EEE, MMM d",
+  WEEKDAY_MONTH_DAY_YEAR_MEDIUM: "EEE, MMM d, y",
+  DAY_ABBR: "d",
+  PAa: "MMM d, h:mm a zzzz"
+}
+  , gvjs_2i = gvjs_1i;
+gvjs_2i = gvjs_1i;
+function gvjs_3i(a, b) {
+  this.Ala = a[gvjs_p.Symbol.iterator]();
+  this.Zsa = b;
+  this.Mta = 0
+}
+gvjs_3i.prototype[Symbol.iterator] = function() {
+  return this
+}
+;
+gvjs_3i.prototype.next = function() {
+  var a = this.Ala.next();
+  return {
+    value: a.done ? void 0 : this.Zsa.call(void 0, a.value, this.Mta++),
+    done: a.done
+  }
+}
+;
+function gvjs_2aa(a, b) {
+  return new gvjs_3i(a,b)
+}
+;var gvjs_4i = "StopIteration"in gvjs_p ? gvjs_p.StopIteration : {
+  message: "StopIteration",
+  stack: ""
+};
+function gvjs_5i() {}
+gvjs_5i.prototype.next = function() {
+  return gvjs_5i.prototype.rg.call(this)
+}
+;
+gvjs_5i.prototype.rg = function() {
+  throw gvjs_4i;
+}
+;
+gvjs_5i.prototype.xk = function() {
+  return this
+}
+;
+function gvjs_6i(a) {
+  if (a instanceof gvjs_7i || a instanceof gvjs_8i || a instanceof gvjs_9i)
+    return a;
+  if (typeof a.next == gvjs_d)
+    return new gvjs_7i(function() {
+        return gvjs_$i(a)
+      }
+    );
+  if (typeof a[Symbol.iterator] == gvjs_d)
+    return new gvjs_7i(function() {
+        return a[Symbol.iterator]()
+      }
+    );
+  if (typeof a.xk == gvjs_d)
+    return new gvjs_7i(function() {
+        return gvjs_$i(a.xk())
+      }
+    );
+  throw Error("Not an iterator or iterable.");
+}
+function gvjs_$i(a) {
+  if (!(a instanceof gvjs_5i))
+    return a;
+  var b = !1;
+  return {
+    next: function() {
+      for (var c; !b; )
+        try {
+          c = a.next();
+          break
+        } catch (d) {
+          if (d !== gvjs_4i)
+            throw d;
+          b = !0
+        }
+      return {
+        value: c,
+        done: b
+      }
+    }
+  }
+}
+function gvjs_7i(a) {
+  this.YY = a
+}
+gvjs_7i.prototype.xk = function() {
+  return new gvjs_8i(this.YY())
+}
+;
+gvjs_7i.prototype[Symbol.iterator] = function() {
+  return new gvjs_9i(this.YY())
+}
+;
+gvjs_7i.prototype.k5 = function() {
+  return new gvjs_9i(this.YY())
+}
+;
+function gvjs_8i(a) {
+  this.oJ = a
+}
+gvjs_o(gvjs_8i, gvjs_5i);
+gvjs_8i.prototype.rg = function() {
+  var a = this.oJ.next();
+  if (a.done)
+    throw gvjs_4i;
+  return a.value
+}
+;
+gvjs_8i.prototype.next = function() {
+  return gvjs_8i.prototype.rg.call(this)
+}
+;
+gvjs_8i.prototype[Symbol.iterator] = function() {
+  return new gvjs_9i(this.oJ)
+}
+;
+gvjs_8i.prototype.k5 = function() {
+  return new gvjs_9i(this.oJ)
+}
+;
+function gvjs_9i(a) {
+  gvjs_7i.call(this, function() {
+    return a
+  });
+  this.oJ = a
+}
+gvjs_o(gvjs_9i, gvjs_7i);
+gvjs_9i.prototype.next = function() {
+  return this.oJ.next()
+}
+;
+function gvjs_aj(a, b) {
+  this.qa = {};
+  this.ad = [];
+  this.pM = this.size = 0;
+  var c = arguments.length;
+  if (1 < c) {
+    if (c % 2)
+      throw Error(gvjs_kb);
+    for (var d = 0; d < c; d += 2)
+      this.set(arguments[d], arguments[d + 1])
+  } else
+    a && this.addAll(a)
+}
+gvjs_ = gvjs_aj.prototype;
+gvjs_.Cd = function() {
+  return this.size
+}
+;
+gvjs_.ob = function() {
+  gvjs_bj(this);
+  for (var a = [], b = 0; b < this.ad.length; b++)
+    a.push(this.qa[this.ad[b]]);
+  return a
+}
+;
+gvjs_.cj = function() {
+  gvjs_bj(this);
+  return this.ad.concat()
+}
+;
+gvjs_.tf = function(a) {
+  return this.has(a)
+}
+;
+gvjs_.has = function(a) {
+  return gvjs_cj(this.qa, a)
+}
+;
+gvjs_.XB = function(a) {
+  for (var b = 0; b < this.ad.length; b++) {
+    var c = this.ad[b];
+    if (gvjs_cj(this.qa, c) && this.qa[c] == a)
+      return !0
+  }
+  return !1
+}
+;
+gvjs_.equals = function(a, b) {
+  if (this === a)
+    return !0;
+  if (this.size != a.Cd())
+    return !1;
+  b = b || gvjs_3aa;
+  gvjs_bj(this);
+  for (var c, d = 0; c = this.ad[d]; d++)
+    if (!b(this.get(c), a.get(c)))
+      return !1;
+  return !0
+}
+;
+function gvjs_3aa(a, b) {
+  return a === b
+}
+gvjs_.isEmpty = function() {
+  return 0 == this.size
+}
+;
+gvjs_.clear = function() {
+  this.qa = {};
+  this.ad.length = 0;
+  this.cu(0);
+  this.pM = 0
+}
+;
+gvjs_.remove = function(a) {
+  return this.delete(a)
+}
+;
+gvjs_.delete = function(a) {
+  return gvjs_cj(this.qa, a) ? (delete this.qa[a],
+    this.cu(this.size - 1),
+    this.pM++,
+  this.ad.length > 2 * this.size && gvjs_bj(this),
+    !0) : !1
+}
+;
+function gvjs_bj(a) {
+  if (a.size != a.ad.length) {
+    for (var b = 0, c = 0; b < a.ad.length; ) {
+      var d = a.ad[b];
+      gvjs_cj(a.qa, d) && (a.ad[c++] = d);
+      b++
+    }
+    a.ad.length = c
+  }
+  if (a.size != a.ad.length) {
+    var e = {};
+    for (c = b = 0; b < a.ad.length; )
+      d = a.ad[b],
+      gvjs_cj(e, d) || (a.ad[c++] = d,
+        e[d] = 1),
+        b++;
+    a.ad.length = c
+  }
+}
+gvjs_.get = function(a, b) {
+  return gvjs_cj(this.qa, a) ? this.qa[a] : b
+}
+;
+gvjs_.set = function(a, b) {
+  gvjs_cj(this.qa, a) || (this.cu(this.size + 1),
+    this.ad.push(a),
+    this.pM++);
+  this.qa[a] = b
+}
+;
+gvjs_.addAll = function(a) {
+  if (a instanceof gvjs_aj)
+    for (var b = a.cj(), c = 0; c < b.length; c++)
+      this.set(b[c], a.get(b[c]));
+  else
+    for (b in a)
+      this.set(b, a[b])
+}
+;
+gvjs_.forEach = function(a, b) {
+  for (var c = this.cj(), d = 0; d < c.length; d++) {
+    var e = c[d]
+      , f = this.get(e);
+    a.call(b, f, e, this)
+  }
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_aj(this)
+}
+;
+gvjs_.transpose = function() {
+  for (var a = new gvjs_aj, b = 0; b < this.ad.length; b++) {
+    var c = this.ad[b];
+    a.set(this.qa[c], c)
+  }
+  return a
+}
+;
+gvjs_.keys = function() {
+  return gvjs_6i(this.xk(!0)).k5()
+}
+;
+gvjs_.values = function() {
+  return gvjs_6i(this.xk(!1)).k5()
+}
+;
+gvjs_.entries = function() {
+  var a = this;
+  return gvjs_2aa(this.keys(), function(b) {
+    return [b, a.get(b)]
+  })
+}
+;
+gvjs_.xk = function(a) {
+  gvjs_bj(this);
+  var b = 0
+    , c = this.pM
+    , d = this
+    , e = new gvjs_5i;
+  e.rg = function() {
+    if (c != d.pM)
+      throw Error("The map has changed since the iterator was created");
+    if (b >= d.ad.length)
+      throw gvjs_4i;
+    var f = d.ad[b++];
+    return a ? f : d.qa[f]
+  }
+  ;
+  e.next = e.rg.bind(e);
+  return e
+}
+;
+gvjs_.cu = function(a) {
+  this.size = a
+}
+;
+function gvjs_cj(a, b) {
+  return Object.prototype.hasOwnProperty.call(a, b)
+}
+;function gvjs_dj(a) {
+  return a.Cd && typeof a.Cd == gvjs_d ? a.Cd() : gvjs_ne(a) || typeof a === gvjs_l ? a.length : gvjs_We(a)
+}
+function gvjs_ej(a) {
+  if (a.ob && typeof a.ob == gvjs_d)
+    return a.ob();
+  if ("undefined" !== typeof Map && a instanceof Map || "undefined" !== typeof Set && a instanceof Set)
+    return Array.from(a.values());
+  if (typeof a === gvjs_l)
+    return a.split("");
+  if (gvjs_ne(a)) {
+    for (var b = [], c = a.length, d = 0; d < c; d++)
+      b.push(a[d]);
+    return b
+  }
+  return gvjs_Xe(a)
+}
+function gvjs_fj(a) {
+  if (a.cj && typeof a.cj == gvjs_d)
+    return a.cj();
+  if (!a.ob || typeof a.ob != gvjs_d) {
+    if ("undefined" !== typeof Map && a instanceof Map)
+      return Array.from(a.keys());
+    if (!("undefined" !== typeof Set && a instanceof Set)) {
+      if (gvjs_ne(a) || typeof a === gvjs_l) {
+        var b = [];
+        a = a.length;
+        for (var c = 0; c < a; c++)
+          b.push(c);
+        return b
+      }
+      return gvjs_Ye(a)
+    }
+  }
+}
+function gvjs_gj(a, b, c) {
+  if (a.forEach && typeof a.forEach == gvjs_d)
+    a.forEach(b, c);
+  else if (gvjs_ne(a) || typeof a === gvjs_l)
+    Array.prototype.forEach.call(a, b, c);
+  else
+    for (var d = gvjs_fj(a), e = gvjs_ej(a), f = e.length, g = 0; g < f; g++)
+      b.call(c, e[g], d && d[g], a)
+}
+function gvjs_4aa(a, b) {
+  if (typeof a.every == gvjs_d)
+    return a.every(b, void 0);
+  if (gvjs_ne(a) || typeof a === gvjs_l)
+    return Array.prototype.every.call(a, b, void 0);
+  for (var c = gvjs_fj(a), d = gvjs_ej(a), e = d.length, f = 0; f < e; f++)
+    if (!b.call(void 0, d[f], c && c[f], a))
+      return !1;
+  return !0
+}
+;function gvjs_hj(a) {
+  this.qa = new gvjs_aj;
+  this.size = 0;
+  a && this.addAll(a)
+}
+function gvjs_ij(a) {
+  var b = typeof a;
+  return b == gvjs_h && a || b == gvjs_d ? "o" + gvjs_pe(a) : b.substr(0, 1) + a
+}
+gvjs_ = gvjs_hj.prototype;
+gvjs_.Cd = function() {
+  return this.qa.size
+}
+;
+gvjs_.add = function(a) {
+  this.qa.set(gvjs_ij(a), a);
+  this.cu(this.qa.size)
+}
+;
+gvjs_.addAll = function(a) {
+  a = gvjs_ej(a);
+  for (var b = a.length, c = 0; c < b; c++)
+    this.add(a[c]);
+  this.cu(this.qa.size)
+}
+;
+gvjs_.removeAll = function(a) {
+  a = gvjs_ej(a);
+  for (var b = a.length, c = 0; c < b; c++)
+    this.remove(a[c]);
+  this.cu(this.qa.size)
+}
+;
+gvjs_.delete = function(a) {
+  a = this.qa.remove(gvjs_ij(a));
+  this.cu(this.qa.size);
+  return a
+}
+;
+gvjs_.remove = function(a) {
+  return this.delete(a)
+}
+;
+gvjs_.clear = function() {
+  this.qa.clear();
+  this.cu(0)
+}
+;
+gvjs_.isEmpty = function() {
+  return 0 === this.qa.size
+}
+;
+gvjs_.has = function(a) {
+  return this.qa.tf(gvjs_ij(a))
+}
+;
+gvjs_.contains = function(a) {
+  return this.qa.tf(gvjs_ij(a))
+}
+;
+gvjs_.J_ = gvjs_n(15);
+gvjs_.ob = function() {
+  return this.qa.ob()
+}
+;
+gvjs_.values = function() {
+  return this.qa.values()
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_hj(this)
+}
+;
+gvjs_.equals = function(a) {
+  return this.Cd() == gvjs_dj(a) && this.kD(a)
+}
+;
+gvjs_.kD = function(a) {
+  var b = gvjs_dj(a);
+  if (this.Cd() > b)
+    return !1;
+  !(a instanceof gvjs_hj) && 5 < b && (a = new gvjs_hj(a));
+  return gvjs_4aa(this, function(c) {
+    var d = a;
+    return d.contains && typeof d.contains == gvjs_d ? d.contains(c) : d.XB && typeof d.XB == gvjs_d ? d.XB(c) : gvjs_ne(d) || typeof d === gvjs_l ? gvjs_He(d, c) : gvjs__e(d, c)
+  })
+}
+;
+gvjs_.xk = function() {
+  return this.qa.xk(!1)
+}
+;
+gvjs_hj.prototype[Symbol.iterator] = function() {
+  return this.values()
+}
+;
+gvjs_hj.prototype.cu = function(a) {
+  this.size = a
+}
+;
+function gvjs_jj(a) {
+  if (gvjs_oe(a)) {
+    var b = new Date;
+    b.setTime(a.valueOf());
+    return b
+  }
+  var c = gvjs_me(a);
+  if (c === gvjs_h || c === gvjs_sb) {
+    if (a.clone)
+      return a.clone();
+    c = c === gvjs_sb ? [] : {};
+    for (b in a)
+      c[b] = gvjs_jj(a[b]);
+    return c
+  }
+  return a
+}
+function gvjs_kj(a, b) {
+  a = a.split(".");
+  b = b || gvjs_p;
+  for (var c = 0; c < a.length; c++) {
+    var d = a[c];
+    if (Array.isArray(b) && !d.match(/[0-9]+/))
+      a: {
+        for (var e = 0; e < b.length; e++) {
+          var f = b[e];
+          if (f.name && f.name === d) {
+            b = f;
+            break a
+          }
+        }
+        b = null
+      }
+    else if (null != b[d])
+      b = b[d];
+    else
+      return null
+  }
+  return b
+}
+function gvjs_lj(a) {
+  return gvjs_me(a) !== gvjs_h || gvjs_oe(a) ? null : a
+}
+function gvjs_mj(a, b) {
+  for (var c = 1; c < arguments.length; ++c)
+    ;
+  a = gvjs_lj(a) || {};
+  if (2 === arguments.length) {
+    c = arguments[1];
+    if (!gvjs_lj(c))
+      return a;
+    for (var d in c)
+      if (Array.isArray(c[d]))
+        a[d] = gvjs_Le(c[d]);
+      else if (gvjs_lj(a[d]))
+        a[d] = gvjs_mj(a[d], c[d]);
+      else if (gvjs_lj(c[d]))
+        a[d] = gvjs_mj({}, c[d]);
+      else if (null == a[d] || null != c[d])
+        a[d] = c[d]
+  } else if (2 < arguments.length)
+    for (d = 1,
+           c = arguments.length; d < c; d++)
+      a = gvjs_mj(a, arguments[d]);
+  return a
+}
+function gvjs_nj(a) {
+  var b = [];
+  a = gvjs_8d(a);
+  for (var c = a.next(); !c.done; c = a.next())
+    b.push(c.value);
+  return b
+}
+function gvjs_oj(a, b) {
+  var c = new Set;
+  b = gvjs_nj(b);
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d];
+    a.has(e) && c.add(e)
+  }
+  return c
+}
+;var gvjs_pj = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: gvjs_ca,
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: gvjs_da,
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: gvjs_da,
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: gvjs_ea,
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32"
+};
+function gvjs_qj(a) {
+  var b = {};
+  a = String(a);
+  var c = "#" == a.charAt(0) ? a : "#" + a;
+  if (gvjs_rj.test(c))
+    return b.hex = gvjs_sj(c),
+      b.type = "hex",
+      b;
+  c = gvjs_tj(a);
+  if (c.length)
+    return b.hex = gvjs_uj(c),
+      b.type = "rgb",
+      b;
+  if (gvjs_pj && (c = gvjs_pj[a.toLowerCase()]))
+    return b.hex = c,
+      b.type = "named",
+      b;
+  throw Error(a + " is not a valid color string");
+}
+var gvjs_5aa = /#(.)(.)(.)/;
+function gvjs_sj(a) {
+  if (!gvjs_rj.test(a))
+    throw Error("'" + a + "' is not a valid hex color");
+  4 == a.length && (a = a.replace(gvjs_5aa, "#$1$1$2$2$3$3"));
+  return a.toLowerCase()
+}
+function gvjs_vj(a) {
+  a = gvjs_sj(a);
+  a = parseInt(a.substr(1), 16);
+  return [a >> 16, a >> 8 & 255, a & 255]
+}
+function gvjs_wj(a, b, c) {
+  a = Number(a);
+  b = Number(b);
+  c = Number(c);
+  if (a != (a & 255) || b != (b & 255) || c != (c & 255))
+    throw Error('"(' + a + "," + b + "," + c + '") is not a valid RGB color');
+  b = a << 16 | b << 8 | c;
+  return 16 > a ? "#" + (16777216 | b).toString(16).substr(1) : "#" + b.toString(16)
+}
+function gvjs_uj(a) {
+  return gvjs_wj(a[0], a[1], a[2])
+}
+var gvjs_rj = /^#(?:[0-9a-f]{3}){1,2}$/i
+  , gvjs_6aa = /^(?:rgb)?\((0|[1-9]\d{0,2}),\s?(0|[1-9]\d{0,2}),\s?(0|[1-9]\d{0,2})\)$/i;
+function gvjs_tj(a) {
+  var b = a.match(gvjs_6aa);
+  if (b) {
+    a = Number(b[1]);
+    var c = Number(b[2]);
+    b = Number(b[3]);
+    if (0 <= a && 255 >= a && 0 <= c && 255 >= c && 0 <= b && 255 >= b)
+      return [a, c, b]
+  }
+  return []
+}
+function gvjs_xj(a, b, c) {
+  c = gvjs_0g(c, 0, 1);
+  return [Math.round(b[0] + c * (a[0] - b[0])), Math.round(b[1] + c * (a[1] - b[1])), Math.round(b[2] + c * (a[2] - b[2]))]
+}
+;function gvjs_yj(a, b) {
+  if (null != a && "" !== a && a !== gvjs_Qd && a !== gvjs_f) {
+    if (gvjs_r(a))
+      return a.color || "";
+    if (typeof a === gvjs_l) {
+      try {
+        return gvjs_qj(a).hex
+      } catch (c) {
+        if (!b)
+          throw Error("Invalid color: " + a);
+      }
+      return a
+    }
+  }
+  return gvjs_f
+}
+;var gvjs_zj;
+function gvjs_Aj(a, b, c, d) {
+  this.Gd = a || [{}];
+  this.AJ = d || gvjs_Te(1, this.Gd.length);
+  this.lN = b || null;
+  this.P_ = null != c ? c : !1
+}
+gvjs_ = gvjs_Aj.prototype;
+gvjs_.view = function(a) {
+  a = gvjs_Bj(this, a);
+  return new gvjs_Aj(gvjs_Le(this.Gd),a,this.P_,gvjs_Le(this.AJ))
+}
+;
+function gvjs_Bj(a, b) {
+  typeof b === gvjs_l && (b = [b]);
+  return null != a.lN ? gvjs_Cj(a.lN, b) : b
+}
+function gvjs_Cj(a, b) {
+  a = typeof a === gvjs_l ? [a] : a;
+  var c = typeof b === gvjs_l ? [b] : b;
+  if (0 === a.length)
+    return c;
+  if (0 === c.length)
+    return a;
+  var d = [];
+  gvjs_u(a, function(e) {
+    var f = gvjs_jf(e);
+    gvjs_u(c, function(g) {
+      var h = gvjs_jf(g);
+      f || h ? f ? h || d.push(g) : d.push(e) : d.push(e + "." + g)
+    })
+  });
+  return d
+}
+function gvjs_Dj(a, b, c, d) {
+  typeof b === gvjs_l && (b = [b]);
+  for (var e = 0; e < b.length; ++e) {
+    var f = gvjs_Ej(a, b[e], c, d);
+    if (null != f)
+      return f
+  }
+  return null
+}
+function gvjs_Ej(a, b, c, d) {
+  a = d ? a[b] : gvjs_kj(b, a);
+  return null != a && typeof c === gvjs_d ? c(a) : a
+}
+gvjs_.ob = function(a, b) {
+  var c = [];
+  null != b && c.push(b);
+  a = gvjs_Bj(this, a);
+  for (b = this.Gd.length - 1; 0 <= b; b--)
+    for (var d = a.length - 1; 0 <= d; d--) {
+      var e = gvjs_Ej(this.Gd[b], a[d], void 0, this.P_);
+      null != e && c.unshift(e)
+    }
+  return c
+}
+;
+function gvjs_7aa(a, b, c) {
+  var d = {};
+  a = a.ob(b, c);
+  gvjs_Ce(a, function(e) {
+    typeof e === gvjs_h && gvjs_mj(d, e)
+  });
+  return d
+}
+gvjs_.fa = function(a, b, c) {
+  a = gvjs_Bj(this, a);
+  for (var d = 0; d < this.Gd.length; d++) {
+    var e = gvjs_Dj(this.Gd[d], a, c, this.P_);
+    if (null != e)
+      return e
+  }
+  e = null != b && c ? c(b) : b;
+  return null != e ? e : null
+}
+;
+gvjs_.pb = function(a, b, c) {
+  a = gvjs_7aa(this, a, b);
+  c && (a = c(a));
+  return a || {}
+}
+;
+function gvjs_Fj(a, b, c, d, e, f) {
+  function g(h) {
+    return b(h, f)
+  }
+  a = a.fa(d, e, g);
+  null == a && (a = g(c),
+  null == a && (a = c));
+  if (null == a)
+    throw Error("Unexpected null value for " + d);
+  return a
+}
+function gvjs_Gj(a, b, c, d) {
+  a = a.fa(c, null, function(e) {
+    return b(e, d)
+  });
+  return null == a ? null : a
+}
+function gvjs_Hj(a, b) {
+  a = null != a && typeof a !== gvjs_h ? String(a) : null;
+  return b ? Array.isArray(b) ? gvjs_He(b, a) ? a : null : gvjs__e(b, a) ? a : null : a
+}
+function gvjs_J(a, b, c, d) {
+  return gvjs_Fj(a, gvjs_Hj, "", b, c, d)
+}
+gvjs_.cb = function(a, b) {
+  return gvjs_Gj(this, gvjs_Hj, a, b)
+}
+;
+function gvjs_Ij(a, b) {
+  if (null == a)
+    return null;
+  typeof a === gvjs_l && (a = [a]);
+  return Array.isArray(a) ? gvjs_De(gvjs_v(a, function(c) {
+    return gvjs_Hj(c, b)
+  }), function(c) {
+    return null != c
+  }) : null
+}
+gvjs_.cD = function(a, b) {
+  return gvjs_Gj(this, gvjs_Ij, a, b)
+}
+;
+function gvjs_Jj(a) {
+  if (null == a)
+    return null;
+  if (typeof a === gvjs_zb)
+    return a;
+  a = String(a);
+  return "1" === a || a.toLowerCase() === gvjs_Rd ? !0 : "0" === a || a.toLowerCase() === gvjs_Sb ? !1 : null
+}
+function gvjs_K(a, b, c) {
+  return gvjs_Fj(a, gvjs_Jj, !1, b, c)
+}
+gvjs_.Dq = function(a) {
+  return gvjs_Gj(this, gvjs_Jj, a)
+}
+;
+function gvjs_Kj(a) {
+  if (null == a)
+    return null;
+  if (typeof a === gvjs_g)
+    return a;
+  a = gvjs_jg(String(a));
+  return isNaN(a) ? null : a
+}
+function gvjs_L(a, b, c) {
+  return gvjs_Fj(a, gvjs_Kj, 0, b, c)
+}
+gvjs_.Aa = function(a) {
+  return gvjs_Gj(this, gvjs_Kj, a)
+}
+;
+function gvjs_Lj(a) {
+  return null == a ? null : typeof a === gvjs_g || typeof a === gvjs_l || typeof a === gvjs_zb ? a : null
+}
+gvjs_.kt = function(a) {
+  return gvjs_Gj(this, gvjs_Lj, a)
+}
+;
+function gvjs_Mj(a) {
+  return null == a ? null : Array.isArray(a) ? gvjs_De(gvjs_v(a, gvjs_Kj), function(b) {
+    return null != b
+  }) : null
+}
+gvjs_.$I = function(a) {
+  return gvjs_Gj(this, gvjs_Mj, a)
+}
+;
+function gvjs_Nj(a) {
+  a = gvjs_Kj(a);
+  return null != a && 0 <= a ? a : null
+}
+function gvjs_Oj(a, b, c) {
+  return gvjs_Fj(a, gvjs_Nj, 0, b, c)
+}
+gvjs_.bD = function(a) {
+  return gvjs_Gj(this, gvjs_Nj, a)
+}
+;
+function gvjs_Pj(a) {
+  a = gvjs_Kj(a);
+  return null != a ? gvjs_0g(a, 0, 1) : null
+}
+gvjs_.Hra = function(a) {
+  return gvjs_Gj(this, gvjs_Pj, a)
+}
+;
+function gvjs_Qj(a, b) {
+  if (null == a)
+    return null;
+  if ("" === a)
+    return gvjs_f;
+  if (typeof a === gvjs_h)
+    return a.color || a.lighter || a.darker ? a : null;
+  a = gvjs_Hj(a);
+  if (Array.isArray(b) && gvjs_He(b, a))
+    return a;
+  try {
+    return gvjs_yj(a)
+  } catch (c) {
+    return null
+  }
+}
+gvjs_.mz = function(a, b) {
+  return gvjs_Gj(this, gvjs_Qj, a, b)
+}
+;
+function gvjs_Rj(a, b) {
+  b = null != b ? b : 1;
+  var c = gvjs_Kj(a);
+  null == c && (a = gvjs_Hj(a),
+  null != a && gvjs_if(a) && (c = a.slice(0, -1),
+    c = b * Number(c) / 100));
+  null != c && (c = 0 === b ? 0 : b * gvjs_0g(c / b, 0, 1));
+  return c
+}
+gvjs_.Mg = function(a, b) {
+  return gvjs_Gj(this, gvjs_Rj, a, b)
+}
+;
+gvjs_zj = {
+  string: gvjs_Aj.prototype.cb,
+  number: gvjs_Aj.prototype.Aa,
+  "boolean": gvjs_Aj.prototype.Dq,
+  numberOrString: [gvjs_g, gvjs_l],
+  primitive: gvjs_Aj.prototype.kt,
+  ratio: gvjs_Aj.prototype.Hra,
+  nonNegative: gvjs_Aj.prototype.bD,
+  absOrPercentage: gvjs_Aj.prototype.Mg,
+  arrayOfNumber: gvjs_Aj.prototype.$I,
+  arrayOfString: gvjs_Aj.prototype.cD,
+  color: gvjs_Aj.prototype.mz,
+  object: gvjs_Aj.prototype.pb
+};
+function gvjs_Sj() {}
+gvjs_Sj.prototype.Ob = function(a) {
+  return this.cP(a) || ""
+}
+;
+gvjs_Sj.prototype.format = function(a, b, c) {
+  a.format(b, c || this)
+}
+;
+gvjs_Sj.prototype.dv = function() {
+  var a = this;
+  return {
+    format: function(b) {
+      return a.Ob(b)
+    }
+  }
+}
+;
+gvjs_Sj.prototype.QY = function(a, b) {
+  return a.format(b, null)
+}
+;
+function gvjs_Tj(a) {
+  this.gd = this.pattern = null;
+  this.init(a)
+}
+gvjs_o(gvjs_Tj, gvjs_Sj);
+gvjs_ = gvjs_Tj.prototype;
+gvjs_.init = function(a) {
+  a = new gvjs_Aj([a || {}, {
+    formatType: gvjs_Gd,
+    valueType: gvjs_Mb
+  }]);
+  this.pattern = a.fa(gvjs_td);
+  this.gd = null;
+  this.formatType = a.cb("formatType", Object.values(gvjs_8aa));
+  this.Nla = a.cb("valueType", Object.values(gvjs_zi));
+  this.Fla = gvjs_K(a, "clearMinutes", !1);
+  this.timeZone = null;
+  a = a.Aa("timeZone");
+  null != a && (this.timeZone = gvjs_Vi(60 * -a))
+}
+;
+function gvjs_9aa(a, b) {
+  switch (a) {
+    case gvjs_Lb:
+      switch (b) {
+        case gvjs_Tb:
+          return 0;
+        case "long":
+          return 1;
+        case gvjs_dd:
+          return 2;
+        case gvjs_Gd:
+          return 3;
+        default:
+          return 8
+      }
+    case gvjs_Mb:
+      switch (b) {
+        case gvjs_Tb:
+          return 8;
+        case "long":
+          return 9;
+        case gvjs_dd:
+          return 10;
+        case gvjs_Gd:
+          return 11;
+        default:
+          return 8
+      }
+    case "time":
+      switch (b) {
+        case gvjs_Tb:
+          return 4;
+        case "long":
+          return 5;
+        case gvjs_dd:
+          return 6;
+        case gvjs_Gd:
+          return 7;
+        default:
+          return 8
+      }
+    default:
+      return 8
+  }
+}
+gvjs_.pm = gvjs_n(16);
+gvjs_.cP = function(a) {
+  if (gvjs_Uj)
+    return gvjs_Uj.call(this, a, this.pattern);
+  this.gd || (this.gd = this.dv(this.Nla));
+  return this.QY(this.gd, a)
+}
+;
+gvjs_.Jo = function(a) {
+  a = gvjs_Hj(a, gvjs_zi);
+  return a !== gvjs_Lb && a !== gvjs_Mb ? null : a
+}
+;
+gvjs_.dv = function(a) {
+  var b = this.pattern;
+  null == b && (b = gvjs_9aa(a, this.formatType));
+  var c = new gvjs_Xi(b);
+  return {
+    format: function(d, e) {
+      return c.format(d, e)
+    }
+  }
+}
+;
+gvjs_.QY = function(a, b) {
+  if (null === b)
+    return "";
+  var c = this.timeZone;
+  null == c && (c = gvjs_Vi(b.getTimezoneOffset()));
+  b = new Date(b.getTime());
+  this.Fla && b.setMinutes(0);
+  return a.format(b, c)
+}
+;
+var gvjs_Uj = void 0
+  , gvjs_Vj = gvjs_2i
+  , gvjs_8aa = {
+  gAa: gvjs_Tb,
+  EAa: "long",
+  JAa: gvjs_dd,
+  SHORT: gvjs_Gd
+};
+var gvjs_Wj = {
+  q6: {
+    1E3: {
+      other: "0K"
+    },
+    1E4: {
+      other: "00K"
+    },
+    1E5: {
+      other: "000K"
+    },
+    1E6: {
+      other: "0M"
+    },
+    1E7: {
+      other: "00M"
+    },
+    1E8: {
+      other: "000M"
+    },
+    1E9: {
+      other: "0B"
+    },
+    1E10: {
+      other: "00B"
+    },
+    1E11: {
+      other: "000B"
+    },
+    1E12: {
+      other: "0T"
+    },
+    1E13: {
+      other: "00T"
+    },
+    1E14: {
+      other: "000T"
+    }
+  },
+  jia: {
+    1E3: {
+      other: "0 thousand"
+    },
+    1E4: {
+      other: "00 thousand"
+    },
+    1E5: {
+      other: "000 thousand"
+    },
+    1E6: {
+      other: "0 million"
+    },
+    1E7: {
+      other: "00 million"
+    },
+    1E8: {
+      other: "000 million"
+    },
+    1E9: {
+      other: "0 billion"
+    },
+    1E10: {
+      other: "00 billion"
+    },
+    1E11: {
+      other: "000 billion"
+    },
+    1E12: {
+      other: "0 trillion"
+    },
+    1E13: {
+      other: "00 trillion"
+    },
+    1E14: {
+      other: "000 trillion"
+    }
+  }
+}
+  , gvjs_Xj = gvjs_Wj;
+gvjs_Xj = gvjs_Wj;
+var gvjs_Yj = {
+  AED: [2, "dh", "\u062f.\u0625."],
+  ALL: [0, "Lek", "Lek"],
+  AUD: [2, "$", "AU$"],
+  BDT: [2, "\u09f3", "Tk"],
+  BGN: [2, "lev", "lev"],
+  BRL: [2, "R$", "R$"],
+  CAD: [2, "$", "C$"],
+  CDF: [2, "FrCD", "CDF"],
+  CHF: [2, "CHF", "CHF"],
+  CLP: [0, "$", "CL$"],
+  CNY: [2, "\u00a5", "RMB\u00a5"],
+  COP: [32, "$", "COL$"],
+  CRC: [0, "\u20a1", "CR\u20a1"],
+  CZK: [50, "K\u010d", "K\u010d"],
+  DKK: [50, "kr.", "kr."],
+  DOP: [2, "RD$", "RD$"],
+  EGP: [2, "\u00a3", "LE"],
+  ETB: [2, "Birr", "Birr"],
+  EUR: [2, "\u20ac", "\u20ac"],
+  GBP: [2, "\u00a3", "GB\u00a3"],
+  HKD: [2, "$", "HK$"],
+  HRK: [2, "kn", "kn"],
+  HUF: [34, "Ft", "Ft"],
+  IDR: [0, "Rp", "Rp"],
+  ILS: [34, "\u20aa", "IL\u20aa"],
+  INR: [2, "\u20b9", "Rs"],
+  IRR: [0, "Rial", "IRR"],
+  ISK: [0, "kr", "kr"],
+  JMD: [2, "$", "JA$"],
+  JPY: [0, "\u00a5", "JP\u00a5"],
+  KRW: [0, "\u20a9", "KR\u20a9"],
+  LKR: [2, "Rs", "SLRs"],
+  LTL: [2, "Lt", "Lt"],
+  MNT: [0, "\u20ae", "MN\u20ae"],
+  MVR: [2, "Rf", "MVR"],
+  MXN: [2, "$", "Mex$"],
+  MYR: [2, "RM", "RM"],
+  NOK: [50, "kr", "NOkr"],
+  PAB: [2, "B/.", "B/."],
+  PEN: [2, "S/.", "S/."],
+  PHP: [2, "\u20b1", "PHP"],
+  PKR: [0, "Rs", "PKRs."],
+  PLN: [50, "z\u0142", "z\u0142"],
+  RON: [2, "RON", "RON"],
+  RSD: [0, "din", "RSD"],
+  RUB: [50, "\u20bd", "RUB"],
+  SAR: [2, "Rial", "Rial"],
+  SEK: [50, "kr", "kr"],
+  SGD: [2, "$", "S$"],
+  THB: [2, "\u0e3f", "THB"],
+  TRY: [2, "\u20ba", "TRY"],
+  TWD: [2, "$", "NT$"],
+  TZS: [0, "TSh", "TSh"],
+  UAH: [2, "\u0433\u0440\u043d.", "UAH"],
+  USD: [2, "$", "US$"],
+  UYU: [2, "$", "$U"],
+  VND: [48, "\u20ab", "VN\u20ab"],
+  YER: [0, "Rial", "Rial"],
+  ZAR: [2, "R", "ZAR"]
+};
+var gvjs_Zj = {
+  DECIMAL_SEP: ".",
+  GROUP_SEP: ",",
+  PERCENT: "%",
+  BV: "0",
+  nja: "+",
+  w6: "-",
+  t6: "E",
+  y6: "\u2030",
+  sV: "\u221e",
+  cja: "NaN",
+  DECIMAL_PATTERN: "#,##0.###",
+  tja: "#E0",
+  vV: "#,##0%",
+  kia: "\u00a4#,##0.00",
+  mia: "USD"
+}
+  , gvjs__j = gvjs_Zj
+  , gvjs_0j = gvjs_Zj;
+gvjs_0j = gvjs__j = gvjs_Zj;
+function gvjs_1j(a) {
+  this.Wra = null;
+  this.oma = 0;
+  this.Mua = null;
+  this.MJ = 40;
+  this.Zo = 1;
+  this.hu = 0;
+  this.Qq = 3;
+  this.tR = this.Ht = 0;
+  this.h4 = this.jha = !1;
+  this.wK = this.hA = "";
+  this.sw = gvjs_2j(this).w6;
+  this.QD = "";
+  this.Jf = 1;
+  this.Pz = !1;
+  this.Yy = [];
+  this.NU = this.i9 = !1;
+  this.eH = 0;
+  this.kN = null;
+  typeof a == gvjs_g ? this.aN(a) : this.Zr(a)
+}
+var gvjs_3j = !1;
+function gvjs_2j(a) {
+  return a.Mua || (gvjs_3j ? gvjs_0j : gvjs__j)
+}
+function gvjs_4j(a) {
+  return a.Wra || gvjs_2j(a).mia
+}
+gvjs_ = gvjs_1j.prototype;
+gvjs_.setMinimumFractionDigits = function(a) {
+  if (0 < this.hu && 0 < a)
+    throw Error(gvjs_ta);
+  this.Ht = a;
+  return this
+}
+;
+gvjs_.setMaximumFractionDigits = function(a) {
+  if (308 < a)
+    throw Error("Unsupported maximum fraction digits: " + a);
+  this.Qq = a;
+  return this
+}
+;
+gvjs_.setSignificantDigits = function(a) {
+  if (0 < this.Ht && 0 <= a)
+    throw Error(gvjs_ta);
+  this.hu = a;
+  return this
+}
+;
+gvjs_.getSignificantDigits = function() {
+  return this.hu
+}
+;
+gvjs_.setShowTrailingZeros = function(a) {
+  this.h4 = a;
+  return this
+}
+;
+gvjs_.setBaseFormatting = function(a) {
+  this.kN = a;
+  return this
+}
+;
+gvjs_.getBaseFormatting = function() {
+  return this.kN
+}
+;
+gvjs_.Zr = function(a) {
+  this.cA = a.replace(/ /g, "\u00a0");
+  var b = [0];
+  this.hA = gvjs_5j(this, a, b);
+  for (var c = b[0], d = -1, e = 0, f = 0, g = 0, h = -1, k = a.length, l = !0; b[0] < k && l; b[0]++)
+    switch (a.charAt(b[0])) {
+      case "#":
+        0 < f ? g++ : e++;
+        0 <= h && 0 > d && h++;
+        break;
+      case "0":
+        if (0 < g)
+          throw Error('Unexpected "0" in pattern "' + a + '"');
+        f++;
+        0 <= h && 0 > d && h++;
+        break;
+      case ",":
+        0 < h && this.Yy.push(h);
+        h = 0;
+        break;
+      case ".":
+        if (0 <= d)
+          throw Error('Multiple decimal separators in pattern "' + a + '"');
+        d = e + f + g;
+        break;
+      case "E":
+        if (this.NU)
+          throw Error('Multiple exponential symbols in pattern "' + a + '"');
+        this.NU = !0;
+        this.tR = 0;
+        b[0] + 1 < k && "+" == a.charAt(b[0] + 1) && (b[0]++,
+          this.jha = !0);
+        for (; b[0] + 1 < k && "0" == a.charAt(b[0] + 1); )
+          b[0]++,
+            this.tR++;
+        if (1 > e + f || 1 > this.tR)
+          throw Error('Malformed exponential pattern "' + a + '"');
+        l = !1;
+        break;
+      default:
+        b[0]--,
+          l = !1
+    }
+  0 == f && 0 < e && 0 <= d && (f = d,
+  0 == f && f++,
+    g = e - f,
+    e = f - 1,
+    f = 1);
+  if (0 > d && 0 < g || 0 <= d && (d < e || d > e + f) || 0 == h)
+    throw Error('Malformed pattern "' + a + '"');
+  g = e + f + g;
+  this.Qq = 0 <= d ? g - d : 0;
+  0 <= d && (this.Ht = e + f - d,
+  0 > this.Ht && (this.Ht = 0));
+  this.Zo = (0 <= d ? d : g) - e;
+  this.NU && (this.MJ = e + this.Zo,
+  0 == this.Qq && 0 == this.Zo && (this.Zo = 1));
+  this.Yy.push(Math.max(0, h));
+  this.i9 = 0 == d || d == g;
+  c = b[0] - c;
+  this.wK = gvjs_5j(this, a, b);
+  b[0] < a.length && ";" == a.charAt(b[0]) ? (b[0]++,
+  1 != this.Jf && (this.Pz = !0),
+    this.sw = gvjs_5j(this, a, b),
+    b[0] += c,
+    this.QD = gvjs_5j(this, a, b)) : (this.sw += this.hA,
+    this.QD += this.wK)
+}
+;
+gvjs_.aN = function(a) {
+  switch (a) {
+    case 1:
+      this.Zr(gvjs_2j(this).DECIMAL_PATTERN);
+      break;
+    case 2:
+      this.Zr(gvjs_2j(this).tja);
+      break;
+    case 3:
+      this.Zr(gvjs_2j(this).vV);
+      break;
+    case 4:
+      a = this.Zr;
+      var b = gvjs_2j(this).kia;
+      var c = ["0"]
+        , d = gvjs_Yj[gvjs_4j(this)];
+      if (d) {
+        d = d[0] & 7;
+        if (0 < d) {
+          c.push(".");
+          for (var e = 0; e < d; e++)
+            c.push("0")
+        }
+        b = b.replace(/0.00/g, c.join(""))
+      }
+      a.call(this, b);
+      break;
+    case 5:
+      gvjs_6j(this, 1);
+      break;
+    case 6:
+      gvjs_6j(this, 2);
+      break;
+    default:
+      throw Error("Unsupported pattern type.");
+  }
+}
+;
+function gvjs_6j(a, b) {
+  a.eH = b;
+  a.Zr(gvjs_2j(a).DECIMAL_PATTERN);
+  a.setMinimumFractionDigits(0);
+  a.setMaximumFractionDigits(2);
+  a.setSignificantDigits(2)
+}
+gvjs_.parse = function(a, b) {
+  b = b || [0];
+  if (0 != this.eH)
+    throw Error("Parsing of compact numbers is unimplemented");
+  a = a.replace(/ |\u202f/g, "\u00a0");
+  var c = a.indexOf(this.hA, b[0]) == b[0]
+    , d = a.indexOf(this.sw, b[0]) == b[0];
+  c && d && (this.hA.length > this.sw.length ? d = !1 : this.hA.length < this.sw.length && (c = !1));
+  c ? b[0] += this.hA.length : d && (b[0] += this.sw.length);
+  if (a.indexOf(gvjs_2j(this).sV, b[0]) == b[0]) {
+    b[0] += gvjs_2j(this).sV.length;
+    var e = Infinity
+  } else {
+    e = a;
+    var f = !1
+      , g = !1
+      , h = !1
+      , k = -1
+      , l = 1
+      , m = gvjs_2j(this).DECIMAL_SEP
+      , n = gvjs_2j(this).GROUP_SEP
+      , p = gvjs_2j(this).t6;
+    if (0 != this.eH)
+      throw Error("Parsing of compact style numbers is not implemented");
+    n = n.replace(/\u202f/g, "\u00a0");
+    for (var q = ""; b[0] < e.length; b[0]++) {
+      var r = e.charAt(b[0])
+        , t = gvjs_7j(this, r);
+      if (0 <= t && 9 >= t)
+        q += t,
+          h = !0;
+      else if (r == m.charAt(0)) {
+        if (f || g)
+          break;
+        q += ".";
+        f = !0
+      } else if (r == n.charAt(0) && ("\u00a0" != n.charAt(0) || b[0] + 1 < e.length && 0 <= gvjs_7j(this, e.charAt(b[0] + 1)))) {
+        if (f || g)
+          break
+      } else if (r == p.charAt(0)) {
+        if (g)
+          break;
+        q += "E";
+        g = !0;
+        k = b[0]
+      } else if ("+" == r || "-" == r) {
+        if (h && k != b[0] - 1)
+          break;
+        q += r
+      } else if (1 == this.Jf && r == gvjs_2j(this).PERCENT.charAt(0)) {
+        if (1 != l)
+          break;
+        l = 100;
+        if (h) {
+          b[0]++;
+          break
+        }
+      } else if (1 == this.Jf && r == gvjs_2j(this).y6.charAt(0)) {
+        if (1 != l)
+          break;
+        l = 1E3;
+        if (h) {
+          b[0]++;
+          break
+        }
+      } else
+        break
+    }
+    1 != this.Jf && (l = this.Jf);
+    e = parseFloat(q) / l
+  }
+  if (c) {
+    if (a.indexOf(this.wK, b[0]) != b[0])
+      return NaN;
+    b[0] += this.wK.length
+  } else if (d) {
+    if (a.indexOf(this.QD, b[0]) != b[0])
+      return NaN;
+    b[0] += this.QD.length
+  }
+  return d ? -e : e
+}
+;
+gvjs_.format = function(a) {
+  if (isNaN(a))
+    return gvjs_2j(this).cja;
+  var b = [];
+  var c = null === this.kN ? a : this.kN;
+  if (0 == this.eH)
+    c = gvjs_8j;
+  else {
+    c = Math.abs(c);
+    var d = gvjs_9j(this, 1 >= c ? 0 : gvjs_$j(c)).divisorBase;
+    c = gvjs_9j(this, d + gvjs_$j(gvjs_ak(this, gvjs_bk(c, -d)).wba))
+  }
+  a = gvjs_bk(a, -c.divisorBase);
+  (d = 0 > a || 0 == a && 0 > 1 / a) ? c.p1 ? b.push(c.p1) : (b.push(c.prefix),
+    b.push(this.sw)) : (b.push(c.prefix),
+    b.push(this.hA));
+  if (isFinite(a))
+    if (a = a * (d ? -1 : 1) * this.Jf,
+      this.NU) {
+      var e = a;
+      if (0 == e)
+        gvjs_ck(this, e, this.Zo, b),
+          gvjs_dk(this, 0, b);
+      else {
+        var f = Math.floor(Math.log(e) / Math.log(10) + 2E-15);
+        e = gvjs_bk(e, -f);
+        var g = this.Zo;
+        1 < this.MJ && this.MJ > this.Zo ? (g = f % this.MJ,
+        0 > g && (g = this.MJ + g),
+          e = gvjs_bk(e, g),
+          f -= g,
+          g = 1) : 1 > this.Zo ? (f++,
+          e = gvjs_bk(e, -1)) : (f -= this.Zo - 1,
+          e = gvjs_bk(e, this.Zo - 1));
+        gvjs_ck(this, e, g, b);
+        gvjs_dk(this, f, b)
+      }
+    } else
+      gvjs_ck(this, a, this.Zo, b);
+  else
+    b.push(gvjs_2j(this).sV);
+  d ? c.q1 ? b.push(c.q1) : (isFinite(a) && b.push(c.suffix),
+    b.push(this.QD)) : (isFinite(a) && b.push(c.suffix),
+    b.push(this.wK));
+  return b.join("")
+}
+;
+function gvjs_ak(a, b) {
+  var c = gvjs_bk(b, a.Qq);
+  0 < a.hu && (c = gvjs_ek(c, a.hu, a.Qq));
+  c = Math.round(c);
+  isFinite(c) ? (b = Math.floor(gvjs_bk(c, -a.Qq)),
+    a = Math.floor(c - gvjs_bk(b, a.Qq))) : a = 0;
+  return {
+    wba: b,
+    qoa: a
+  }
+}
+function gvjs_ck(a, b, c, d) {
+  if (a.Ht > a.Qq)
+    throw Error("Min value must be less than max value");
+  d || (d = []);
+  b = gvjs_ak(a, b);
+  var e = b.wba
+    , f = b.qoa
+    , g = 0 == e ? 0 : gvjs_$j(e) + 1
+    , h = 0 < a.Ht || 0 < f || a.h4 && g < a.hu;
+  b = a.Ht;
+  h && (b = a.h4 && 0 < a.hu ? a.hu - g : a.Ht);
+  var k = "";
+  for (g = e; 1E20 < g; )
+    k = "0" + k,
+      g = Math.round(gvjs_bk(g, -1));
+  k = g + k;
+  var l = gvjs_2j(a).DECIMAL_SEP;
+  g = gvjs_2j(a).BV.charCodeAt(0);
+  var m = k.length
+    , n = 0;
+  if (0 < e || 0 < c) {
+    for (e = m; e < c; e++)
+      d.push(String.fromCharCode(g));
+    if (2 <= a.Yy.length)
+      for (c = 1; c < a.Yy.length; c++)
+        n += a.Yy[c];
+    c = m - n;
+    if (0 < c) {
+      e = a.Yy;
+      n = m = 0;
+      for (var p, q = gvjs_2j(a).GROUP_SEP, r = k.length, t = 0; t < r; t++)
+        if (d.push(String.fromCharCode(g + 1 * Number(k.charAt(t)))),
+        1 < r - t)
+          if (p = e[n],
+          t < c) {
+            var u = c - t;
+            (1 === p || 0 < p && 1 === u % p) && d.push(q)
+          } else
+            n < e.length && (t === c ? n += 1 : p === t - c - m + 1 && (d.push(q),
+              m += p,
+              n += 1))
+    } else {
+      c = k;
+      k = a.Yy;
+      e = gvjs_2j(a).GROUP_SEP;
+      p = c.length;
+      q = [];
+      for (m = k.length - 1; 0 <= m && 0 < p; m--) {
+        n = k[m];
+        for (r = 0; r < n && 0 <= p - r - 1; r++)
+          q.push(String.fromCharCode(g + 1 * Number(c.charAt(p - r - 1))));
+        p -= n;
+        0 < p && q.push(e)
+      }
+      d.push.apply(d, q.reverse())
+    }
+  } else
+    h || d.push(String.fromCharCode(g));
+  (a.i9 || h) && d.push(l);
+  f = String(f);
+  h = f.split("e+");
+  2 == h.length && (f = String(gvjs_ek(parseFloat(h[0]), a.hu, 1)),
+    f = f.replace(".", ""),
+    f += gvjs_eg("0", parseInt(h[1], 10) - f.length + 1));
+  a.Qq + 1 > f.length && (f = "1" + gvjs_eg("0", a.Qq - f.length) + f);
+  for (a = f.length; "0" == f.charAt(a - 1) && a > b + 1; )
+    a--;
+  for (e = 1; e < a; e++)
+    d.push(String.fromCharCode(g + 1 * Number(f.charAt(e))))
+}
+function gvjs_dk(a, b, c) {
+  c.push(gvjs_2j(a).t6);
+  0 > b ? (b = -b,
+    c.push(gvjs_2j(a).w6)) : a.jha && c.push(gvjs_2j(a).nja);
+  b = "" + b;
+  for (var d = gvjs_2j(a).BV, e = b.length; e < a.tR; e++)
+    c.push(d);
+  c.push(b)
+}
+function gvjs_7j(a, b) {
+  b = b.charCodeAt(0);
+  if (48 <= b && 58 > b)
+    return b - 48;
+  a = gvjs_2j(a).BV.charCodeAt(0);
+  return a <= b && b < a + 10 ? b - a : -1
+}
+function gvjs_5j(a, b, c) {
+  for (var d = "", e = !1, f = b.length; c[0] < f; c[0]++) {
+    var g = b.charAt(c[0]);
+    if ("'" == g)
+      c[0] + 1 < f && "'" == b.charAt(c[0] + 1) ? (c[0]++,
+        d += "'") : e = !e;
+    else if (e)
+      d += g;
+    else
+      switch (g) {
+        case "#":
+        case "0":
+        case ",":
+        case ".":
+        case ";":
+          return d;
+        case "\u00a4":
+          if (c[0] + 1 < f && "\u00a4" == b.charAt(c[0] + 1))
+            c[0]++,
+              d += gvjs_4j(a);
+          else
+            switch (a.oma) {
+              case 0:
+                g = gvjs_4j(a);
+                d += g in gvjs_Yj ? gvjs_Yj[g][1] : g;
+                break;
+              case 2:
+                g = gvjs_4j(a);
+                var h = gvjs_Yj[g];
+                d += h ? g == h[1] ? g : g + " " + h[1] : g;
+                break;
+              case 1:
+                g = gvjs_4j(a),
+                  d += g in gvjs_Yj ? gvjs_Yj[g][2] : g
+            }
+          break;
+        case "%":
+          if (!a.Pz && 1 != a.Jf)
+            throw Error(gvjs_gb);
+          if (a.Pz && 100 != a.Jf)
+            throw Error(gvjs_Qa);
+          a.Jf = 100;
+          a.Pz = !1;
+          d += gvjs_2j(a).PERCENT;
+          break;
+        case "\u2030":
+          if (!a.Pz && 1 != a.Jf)
+            throw Error(gvjs_gb);
+          if (a.Pz && 1E3 != a.Jf)
+            throw Error(gvjs_Qa);
+          a.Jf = 1E3;
+          a.Pz = !1;
+          d += gvjs_2j(a).y6;
+          break;
+        default:
+          d += g
+      }
+  }
+  return d
+}
+var gvjs_8j = {
+  divisorBase: 0,
+  p1: "",
+  q1: "",
+  prefix: "",
+  suffix: ""
+};
+function gvjs_9j(a, b) {
+  a = 1 == a.eH ? gvjs_Xj.q6 : gvjs_Xj.jia;
+  null == a && (a = gvjs_Xj.q6);
+  if (3 > b)
+    return gvjs_8j;
+  b = Math.min(14, b);
+  var c = a[gvjs_bk(1, b)];
+  for (--b; !c && 3 <= b; )
+    c = a[gvjs_bk(1, b)],
+      b--;
+  if (!c)
+    return gvjs_8j;
+  c = c.other;
+  var d = a = ""
+    , e = c.indexOf(";");
+  0 <= e && (c = c.substring(0, e),
+    e = c.substring(e + 1)) && (d = /([^0]*)(0+)(.*)/.exec(e),
+    a = d[1],
+    d = d[3]);
+  return c && "0" != c ? (c = /([^0]*)(0+)(.*)/.exec(c)) ? {
+    divisorBase: b + 1 - (c[2].length - 1),
+    p1: a,
+    q1: d,
+    prefix: c[1],
+    suffix: c[3]
+  } : gvjs_8j : gvjs_8j
+}
+function gvjs_$j(a) {
+  if (!isFinite(a))
+    return 0 < a ? a : 0;
+  for (var b = 0; 1 <= (a /= 10); )
+    b++;
+  return b
+}
+function gvjs_bk(a, b) {
+  if (!a || !isFinite(a) || 0 == b)
+    return a;
+  a = String(a).split("e");
+  return parseFloat(a[0] + "e" + (parseInt(a[1] || 0, 10) + b))
+}
+function gvjs_fk(a, b) {
+  return a && isFinite(a) ? gvjs_bk(Math.round(gvjs_bk(a, b)), -b) : a
+}
+function gvjs_ek(a, b, c) {
+  if (!a)
+    return a;
+  b = b - gvjs_$j(a) - 1;
+  return b < -c ? gvjs_fk(a, -c) : gvjs_fk(a, b)
+}
+gvjs_1j.prototype.isCurrencyCodeBeforeValue = function() {
+  var a = this.cA.indexOf("\u00a4")
+    , b = this.cA.indexOf("#")
+    , c = this.cA.indexOf("0")
+    , d = Number.MAX_VALUE;
+  0 <= b && b < d && (d = b);
+  0 <= c && c < d && (d = c);
+  return a < d
+}
+;
+function gvjs_gk(a) {
+  this.gd = null;
+  var b = new gvjs_Aj([a || {}, {
+    decimalSymbol: gvjs_hk,
+    groupingSymbol: gvjs_ik,
+    fractionDigits: 2,
+    significantDigits: null,
+    negativeParens: !1,
+    prefix: "",
+    suffix: "",
+    scaleFactor: 1
+  }]);
+  this.Ey = gvjs_Oj(b, "fractionDigits");
+  a && typeof a.fractionDigits === gvjs_g && isNaN(a.fractionDigits) && (this.Ey = NaN);
+  this.n4 = b.bD("significantDigits");
+  this.Cma = gvjs_J(b, "decimalSymbol");
+  this.MZ = gvjs_J(b, "groupingSymbol");
+  this.prefix = gvjs_J(b, gvjs_wd);
+  this.suffix = gvjs_J(b, gvjs_Kd);
+  this.o1 = b.mz("negativeColor");
+  this.mda = gvjs_K(b, "negativeParens");
+  this.pattern = b.cb(gvjs_td);
+  a = (this.pattern || "").toLowerCase();
+  a in gvjs_jk && (this.pattern = gvjs_jk[a]);
+  this.scaleFactor = gvjs_L(b, "scaleFactor");
+  if (0 >= this.scaleFactor)
+    throw Error("Scale factor must be a positive number.");
+}
+gvjs_o(gvjs_gk, gvjs_Sj);
+gvjs_ = gvjs_gk.prototype;
+gvjs_.format = function(a, b) {
+  if (a.W(b) === gvjs_g)
+    for (var c = 0; c < a.ca(); c++) {
+      var d = a.getValue(c, b);
+      if (null != d) {
+        var e = this.Ob(d);
+        a.Nw(c, b, e);
+        0 > d && !gvjs_jf(gvjs_gg(this.o1)) && a.setProperty(c, b, gvjs_Jd, gvjs_Eb + this.o1 + ";")
+      }
+    }
+}
+;
+gvjs_.Jo = function(a) {
+  return a === gvjs_g ? a : null
+}
+;
+gvjs_.dv = function() {
+  var a = this;
+  return {
+    format: function(b) {
+      if (null == b)
+        return null;
+      b = Number(b);
+      return a.Ob(b)
+    }
+  }
+}
+;
+gvjs_.cP = function(a) {
+  if (gvjs_kk)
+    return a = gvjs_kk.call(this, a / this.scaleFactor, this.pattern),
+    this.prefix + a + this.suffix;
+  var b = a / this.scaleFactor;
+  if (null !== this.pattern) {
+    a = gvjs_3j;
+    gvjs_3j = !gvjs_lk;
+    var c = new gvjs_1j(this.pattern);
+    5 !== this.pattern && 6 !== this.pattern || c.setSignificantDigits(3);
+    this.gd = c;
+    null != this.n4 && (c.setSignificantDigits(this.n4),
+      c.setMaximumFractionDigits(this.n4));
+    b = c.format(b);
+    b = this.prefix + b + this.suffix;
+    gvjs_3j = a
+  } else {
+    if (isNaN(this.Ey))
+      return String(a);
+    this.mda && (b = Math.abs(b));
+    c = b;
+    0 === this.Ey && (c = Math.round(c));
+    b = [];
+    0 > c && (c = -c,
+      b.push("-"));
+    var d = Math.pow(10, this.Ey)
+      , e = Math.round(c * d);
+    c = String(Math.floor(e / d));
+    d = String(e % d);
+    if (3 < c.length && this.MZ)
+      for (e = c.length % 3,
+           0 < e && (b.push(c.substring(0, e), this.MZ),
+             c = c.substring(e)); 3 < c.length; )
+        b.push(c.substring(0, 3), this.MZ),
+          c = c.substring(3);
+    b.push(c);
+    0 < this.Ey && (b.push(this.Cma),
+    d.length < this.Ey && (d = gvjs_ka + d),
+      b.push(d.substring(d.length - this.Ey)));
+    b = b.join("");
+    b = this.prefix + b + this.suffix;
+    this.mda && 0 > a && (b = "(" + b + ")");
+    this.o1 && (b += "")
+  }
+  return b
+}
+;
+gvjs_.parse = function(a) {
+  if (this.gd && this.gd.parse) {
+    var b = gvjs_3j;
+    gvjs_3j = !gvjs_lk;
+    a = this.gd.parse(a);
+    gvjs_3j = b;
+    return a
+  }
+  throw Error("Cannot parse without parser.");
+}
+;
+var gvjs_kk = void 0
+  , gvjs_hk = gvjs__j.DECIMAL_SEP
+  , gvjs_ik = gvjs__j.GROUP_SEP
+  , gvjs_mk = gvjs__j.DECIMAL_PATTERN
+  , gvjs_lk = !1
+  , gvjs_jk = {
+  decimal: 1,
+  scientific: 2,
+  percent: 3,
+  currency: 4,
+  "short": 5,
+  "long": 6
+};
+function gvjs_nk() {}
+gvjs_o(gvjs_nk, gvjs_Sj);
+gvjs_nk.prototype.Jo = function(a) {
+  return a === gvjs_l ? a : null
+}
+;
+gvjs_nk.prototype.cP = function(a) {
+  return String(a)
+}
+;
+function gvjs_ok(a, b) {
+  this.x = a;
+  this.y = b
+}
+gvjs_t(gvjs_ok, gvjs_z);
+gvjs_ = gvjs_ok.prototype;
+gvjs_.clone = function() {
+  return new gvjs_ok(this.x,this.y)
+}
+;
+gvjs_.scale = gvjs_z.prototype.scale;
+gvjs_.invert = function() {
+  this.x = -this.x;
+  this.y = -this.y;
+  return this
+}
+;
+gvjs_.normalize = function() {
+  return this.scale(1 / Math.hypot(this.x, this.y))
+}
+;
+gvjs_.add = function(a) {
+  this.x += a.x;
+  this.y += a.y;
+  return this
+}
+;
+gvjs_.aU = gvjs_n(17);
+gvjs_.rotate = function(a) {
+  var b = Math.cos(a);
+  a = Math.sin(a);
+  var c = this.y * b + this.x * a;
+  this.x = this.x * b - this.y * a;
+  this.y = c;
+  return this
+}
+;
+gvjs_.equals = function(a) {
+  return this === a ? !0 : a instanceof gvjs_ok && !!a && this.x == a.x && this.y == a.y
+}
+;
+/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+
+ Tested with IE 6.0, IE 7.0, Firefox 2.0 and Opera 9
+
+*/
+function gvjs_pk(a) {
+  a = 4 > a.length ? gvjs_Ke(a, gvjs_Te(0, 4 - a.length)) : gvjs_Le(a);
+  return a.reverse()
+}
+function gvjs_qk(a) {
+  a = gvjs_pk(a);
+  var b = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 0));
+  b.setUTCFullYear((a[6] || 0) + 1970);
+  b.setUTCMonth(a[5] || 0);
+  b.setUTCDate((a[4] || 0) + 1);
+  b.setUTCHours(a[3] || 0);
+  b.setUTCMinutes(a[2] || 0);
+  b.setUTCSeconds(a[1] || 0);
+  b.setUTCMilliseconds(a[0] || 0);
+  return b
+}
+var gvjs_rk = "milliseconds seconds minutes hours days months years".split(" ")
+  , gvjs_sk = {};
+gvjs_u(gvjs_rk, function(a, b) {
+  gvjs_sk[a] = b
+});
+function gvjs_tk(a) {
+  var b = a && a.granularity;
+  if (null == b || typeof b !== gvjs_g)
+    b = 1;
+  b = {
+    pattern: 1 < b ? gvjs_Ia : 1 === b ? gvjs_Ja : gvjs_Ka
+  };
+  a && gvjs_2e(b, a);
+  this.gd = new gvjs_Tj(b)
+}
+gvjs_o(gvjs_tk, gvjs_Sj);
+gvjs_tk.prototype.Jo = function(a) {
+  return a === gvjs_Od ? a : null
+}
+;
+gvjs_tk.prototype.cP = function(a) {
+  a = gvjs_qk(a);
+  return this.gd.Ob(a)
+}
+;
+function gvjs_uk(a) {
+  var b = {};
+  if (gvjs_me(a) !== gvjs_h || gvjs_oe(a))
+    b.v = null != a ? a : null;
+  else {
+    b.v = "undefined" === typeof a.v ? null : a.v;
+    if (null != a.f)
+      if (typeof a.f === gvjs_l)
+        b.f = a.f;
+      else
+        throw Error("Formatted value ('f'), if specified, must be a string.");
+    if (null != a.p)
+      if (typeof a.p === gvjs_h)
+        b.p = a.p;
+      else
+        throw Error("Properties ('p'), if specified, must be an object.");
+  }
+  return b
+}
+function gvjs_$aa(a, b, c) {
+  if (typeof b === gvjs_d)
+    return b(a, c);
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = a.jf(e.column)
+      , g = a.getValue(c, f)
+      , h = a.W(f);
+    if (gvjs_Vd in e) {
+      if (0 !== gvjs_vk(h, g, e.value))
+        return !1
+    } else if (null != e.minValue || null != e.maxValue)
+      if (null == g || null != e.minValue && 0 > gvjs_vk(h, g, e.minValue) || null != e.maxValue && 0 < gvjs_vk(h, g, e.maxValue))
+        return !1;
+    e = e.test;
+    if (null != e && typeof e === gvjs_d && !e(g, c, f, a))
+      return !1
+  }
+  return !0
+}
+function gvjs_wk(a, b) {
+  if (typeof b !== gvjs_d) {
+    if (!Array.isArray(b) || 0 === b.length)
+      throw Error("columnFilters must be a non-empty array");
+    for (var c = [], d = 0, e = gvjs_8d(b), f = e.next(); !f.done; f = e.next()) {
+      f = f.value;
+      if (typeof f !== gvjs_h || !(gvjs_Fb in f)) {
+        if (!(gvjs_Vd in f || gvjs_ed in f || gvjs_cd in f))
+          throw Error(gvjs_Gb + d + '] must have properties "column" and one of "value", "minValue" or "maxValue"');
+        if (gvjs_Vd in f && (gvjs_ed in f || gvjs_cd in f))
+          throw Error(gvjs_Gb + d + '] must specify either "value" or range properties ("minValue" and/or "maxValue"');
+      }
+      var g = f.column;
+      gvjs_xk(a, g);
+      var h = a.jf(g);
+      if (c[h])
+        throw Error(gvjs_wa + g + " is duplicate in columnFilters.");
+      gvjs_yk(a, h, f.value);
+      c[h] = !0;
+      d++
+    }
+  }
+  c = [];
+  d = a.ca();
+  for (e = 0; e < d; e++)
+    gvjs_$aa(a, b, e) && c.push(e);
+  return c
+}
+function gvjs_zk(a, b, c) {
+  if (typeof b === gvjs_h && gvjs_Fb in b) {
+    if ("desc"in b && typeof b.desc !== gvjs_zb)
+      throw Error('Property "desc" in ' + c + " must be boolean.");
+    if (null != b.compare && typeof b.compare !== gvjs_d)
+      throw Error('Property "compare" in ' + c + " must be a function.");
+  } else
+    throw Error(c + ' must be an object with a "column" property.');
+  gvjs_xk(a, b.column)
+}
+function gvjs_Ak(a, b, c) {
+  function d(l, m) {
+    for (var n = 0; n < e.length; n++) {
+      var p = e[n]
+        , q = p.column
+        , r = b(l, q)
+        , t = b(m, q)
+        , u = p.compare;
+      q = null != u ? null === r ? null === t ? 0 : -1 : null === t ? 1 : u(r, t) : gvjs_vk(a.W(q), r, t);
+      if (0 !== q)
+        return q * (p.desc ? -1 : 1)
+    }
+    return 0
+  }
+  var e = [];
+  if (typeof c === gvjs_d)
+    d = c;
+  else if (typeof c === gvjs_g || typeof c === gvjs_l)
+    gvjs_xk(a, c),
+      e = [{
+        column: a.jf(c)
+      }];
+  else if (gvjs_r(c))
+    if (Array.isArray(c)) {
+      if (0 === c.length)
+        throw Error("sortColumns is an empty array. Must have at least one element.");
+      e = [];
+      for (var f = [], g = 0, h = 0; h < c.length; h++) {
+        g = c[h];
+        if (typeof g === gvjs_g || typeof g === gvjs_l)
+          gvjs_xk(a, g),
+            g = a.jf(g),
+            e.push({
+              column: g
+            });
+        else if (gvjs_r(g)) {
+          var k = g;
+          gvjs_zk(a, k, "sortColumns[" + h + "]");
+          g = k.column;
+          g = a.jf(g);
+          k.column = g;
+          e.push(k)
+        } else
+          throw Error("sortColumns is an array, but not composed of only objects or numbers.");
+        if (g in f)
+          throw Error("Column index " + g + " is duplicated in sortColumns.");
+        f[g] = !0
+      }
+    } else
+      gvjs_zk(a, c, "sortColumns"),
+        e = [c];
+  return d
+}
+function gvjs_vk(a, b, c) {
+  if (null == b)
+    return null == c ? 0 : -1;
+  if (null == c)
+    return 1;
+  if (a === gvjs_Od) {
+    for (a = 0; 3 > a; a++) {
+      if (b[a] < c[a])
+        return -1;
+      if (c[a] < b[a])
+        return 1
+    }
+    b = 4 > b.length ? 0 : b[3];
+    c = 4 > c.length ? 0 : c[3];
+    return b < c ? -1 : c < b ? 1 : 0
+  }
+  return b < c ? -1 : c < b ? 1 : 0
+}
+function gvjs_Bk(a, b) {
+  b = gvjs_Ak(a, function(f, g) {
+    return a.getValue(f, g)
+  }, b);
+  for (var c = [], d = a.ca(), e = 0; e < d; e++)
+    c.push(e);
+  gvjs_Se(c, b);
+  return c
+}
+function gvjs_Ck(a, b) {
+  a = a.ca();
+  if (0 < a) {
+    if (Math.floor(b) !== b || 0 > b || b >= a)
+      throw Error("Invalid row index " + b + ". Should be in the range [0-" + (a - 1 + "]."));
+  } else
+    throw Error("Table has no rows.");
+}
+function gvjs_xk(a, b) {
+  if (typeof b === gvjs_g)
+    gvjs_Dk(a, b);
+  else {
+    if (typeof b !== gvjs_l)
+      throw Error("Column reference " + b + " must be a number or string");
+    if (-1 === a.jf(b))
+      throw Error('Invalid column id "' + b + '"');
+  }
+}
+function gvjs_Dk(a, b) {
+  a = a.$();
+  if (0 < a) {
+    if (Math.floor(b) !== b || 0 > b || b >= a)
+      throw Error("Invalid column index " + b + ".  Should be an integer in the range [0-" + (a - 1 + "]."));
+  } else
+    throw Error("Table has no columns.");
+}
+function gvjs_yk(a, b, c) {
+  a = a.W(b);
+  if (!gvjs_Ek(c, a))
+    throw Error(gvjs_jb + c + gvjs_aa + a + (" in column index " + b));
+}
+function gvjs_Ek(a, b) {
+  if (null == a)
+    return !0;
+  var c = typeof a;
+  switch (b) {
+    case gvjs_g:
+      if (c === gvjs_g)
+        return !0;
+      break;
+    case gvjs_l:
+      if (c === gvjs_l)
+        return !0;
+      break;
+    case gvjs_zb:
+      if (c === gvjs_zb)
+        return !0;
+      break;
+    case gvjs_d:
+      if (c === gvjs_d)
+        return !0;
+      break;
+    case gvjs_Lb:
+    case gvjs_Mb:
+      if (gvjs_oe(a))
+        return !0;
+      break;
+    case gvjs_Od:
+      if (Array.isArray(a) && 0 < a.length && 8 > a.length) {
+        b = !0;
+        for (c = 0; c < a.length; c++) {
+          var d = a[c];
+          if (typeof d !== gvjs_g || d !== Math.floor(d)) {
+            b = !1;
+            break
+          }
+        }
+        if (b)
+          return !0
+      }
+  }
+  return !1
+}
+function gvjs_Fk(a, b) {
+  gvjs_xk(a, b);
+  b = a.jf(b);
+  var c = a.W(b), d = null, e = null, f, g = a.ca();
+  for (f = 0; f < g; f++) {
+    var h = a.getValue(f, b);
+    if (null != h) {
+      e = d = h;
+      break
+    }
+  }
+  if (null == d)
+    return {
+      min: null,
+      max: null
+    };
+  for (f++; f < g; f++)
+    h = a.getValue(f, b),
+    null != h && (0 > gvjs_vk(c, h, d) ? d = h : 0 > gvjs_vk(c, e, h) && (e = h));
+  return {
+    min: d,
+    max: e
+  }
+}
+function gvjs_Gk(a, b) {
+  gvjs_xk(a, b);
+  var c = a.jf(b)
+    , d = a.ca();
+  if (0 === d)
+    return [];
+  b = [];
+  for (var e = 0; e < d; ++e)
+    b.push(a.getValue(e, c));
+  var f = a.W(c);
+  gvjs_Se(b, function(g, h) {
+    return gvjs_vk(f, g, h)
+  });
+  a = b[0];
+  c = [];
+  c.push(a);
+  for (d = 1; d < b.length; d++)
+    e = b[d],
+    0 !== gvjs_vk(f, e, a) && c.push(e),
+      a = e;
+  return c
+}
+function gvjs_Hk(a, b, c) {
+  if (null == a)
+    return "";
+  if (c)
+    return c.Ob(a);
+  switch (b) {
+    case gvjs_Od:
+      if (!(a instanceof Array))
+        throw Error("Type of value, " + a + ", is not timeofday");
+      b = new Date(1970,0,1,a[0],a[1],a[2],a[3] || 0);
+      c = gvjs_Ia;
+      if (a[2] || a[3])
+        c += ":ss";
+      a[3] && (c += ".SSS");
+      c = new gvjs_Tj({
+        pattern: c
+      });
+      a = c.Ob(b);
+      break;
+    case gvjs_Lb:
+      c = new gvjs_Tj({
+        formatType: gvjs_dd,
+        valueType: gvjs_Lb
+      });
+      a = c.Ob(a);
+      break;
+    case gvjs_Mb:
+      c = new gvjs_Tj({
+        formatType: gvjs_dd,
+        valueType: gvjs_Mb
+      });
+      a = c.Ob(a);
+      break;
+    case gvjs_g:
+      c = new gvjs_gk({
+        pattern: gvjs_Nb
+      });
+      a = c.Ob(a);
+      break;
+    default:
+      a = null != a ? String(a) : ""
+  }
+  return a
+}
+function gvjs_aba(a) {
+  switch (a) {
+    case gvjs_Od:
+      return new gvjs_tk;
+    case gvjs_Lb:
+      return new gvjs_Tj;
+    case gvjs_Mb:
+      return new gvjs_Tj({
+        formatType: gvjs_dd,
+        valueType: gvjs_Mb
+      });
+    case gvjs_g:
+      return new gvjs_gk({
+        pattern: gvjs_Nb
+      });
+    default:
+      return new gvjs_nk
+  }
+}
+function gvjs_Ik(a, b, c) {
+  var d = a.W(b);
+  if (null == c)
+    c = gvjs_aba(d);
+  else if (null == c.Jo(d))
+    return;
+  d = c.Jo(d);
+  d = c.dv(d);
+  for (var e = a.ca(), f = 0; f < e; f++) {
+    var g = a.getValue(f, b);
+    g = c.QY(d, g);
+    a.Nw(f, b, g)
+  }
+}
+function gvjs_Jk(a, b, c, d) {
+  for (var e = null, f = a.ca(); (d ? 0 <= b : b < f) && null === e; )
+    e = a.getValue(b, c),
+      b += d ? -1 : 1;
+  return e
+}
+function gvjs_Kk(a) {
+  if (!a)
+    throw Error("Data table is not defined.");
+  if (!(a instanceof gvjs_Ai)) {
+    var b = "the wrong type of data";
+    Array.isArray(a) ? b = "an Array" : typeof a === gvjs_l && (b = "a String");
+    throw Error("You called the draw() method with " + b + " rather than a DataTable or DataView");
+  }
+}
+;var gvjs_bba = {
+  UBa: "0.5",
+  VBa: "0.6"
+};
+function gvjs_M(a, b) {
+  gvjs_Ai.call(this);
+  this.bf = [];
+  this.Wf = [];
+  this.Br = null;
+  this.cache = [];
+  if (typeof this.Cv !== gvjs_d)
+    throw Error('You called google.visualization.DataTable() without the "new" keyword');
+  this.version = "0.5" === b ? "0.5" : "0.6";
+  if (null != a) {
+    if (typeof a === gvjs_l)
+      a = gvjs_Li(a);
+    else
+      a: {
+        b = a.cols || [];
+        for (var c = a.rows || [], d = b.length, e = 0; e < d; e++) {
+          var f = b[e].type;
+          if (f === gvjs_Lb || f === gvjs_Mb) {
+            f = c.length;
+            for (var g = 0; g < f; g++) {
+              var h = c[g].c[e];
+              if (h) {
+                var k = h.v;
+                if (gvjs_oe(k))
+                  break a;
+                typeof k === gvjs_l && (h = gvjs_Ii(h),
+                  h = gvjs_Li(h),
+                  c[g].c[e] = h)
+              }
+            }
+          }
+        }
+      }
+    this.Br = a.p || null;
+    if (null != a.cols)
+      for (b = gvjs_8d(a.cols),
+             c = b.next(); !c.done; c = b.next())
+        this.xd(c.value);
+    null != a.rows && (this.Wf = a.rows)
+  } else
+    this.bf = [],
+      this.Wf = [],
+      this.Br = null;
+  this.cache = []
+}
+gvjs_o(gvjs_M, gvjs_Ai);
+gvjs_ = gvjs_M.prototype;
+gvjs_.ca = function() {
+  return this.Wf.length
+}
+;
+gvjs_.$ = function() {
+  return this.bf.length
+}
+;
+gvjs_.Do = gvjs_n(20);
+gvjs_.Ne = function(a) {
+  gvjs_Dk(this, a);
+  return this.bf[a].id || ""
+}
+;
+gvjs_.Ga = function(a) {
+  gvjs_Dk(this, a);
+  return String(this.bf[a].label || "")
+}
+;
+gvjs_.Co = function(a) {
+  gvjs_Dk(this, a);
+  a = this.bf[a].pattern;
+  return "undefined" !== typeof a ? a : null
+}
+;
+gvjs_.Jg = function(a) {
+  a = this.Bd(a, gvjs_Bd);
+  return typeof a === gvjs_l ? a : ""
+}
+;
+gvjs_.W = function(a) {
+  gvjs_Dk(this, a);
+  a = this.bf[a].type;
+  return "undefined" !== typeof a ? a : gvjs_l
+}
+;
+gvjs_.getValue = function(a, b) {
+  gvjs_Ck(this, a);
+  gvjs_Dk(this, b);
+  a = this.si(a, b);
+  b = null;
+  a && (b = a.v,
+    b = "undefined" !== typeof b ? b : null);
+  return b
+}
+;
+gvjs_.si = function(a, b) {
+  return this.Wf[a].c[b]
+}
+;
+gvjs_.Ha = function(a, b, c) {
+  gvjs_Ck(this, a);
+  gvjs_Dk(this, b);
+  var d = this.si(a, b)
+    , e = "";
+  if (d)
+    if (null != d.f)
+      e = String(d.f);
+    else {
+      this.cache[a] = this.cache[a] || [];
+      var f = this.cache[a];
+      d = f[b] || {};
+      f[b] = d;
+      "undefined" !== typeof d.Me ? e = d.Me : (a = this.getValue(a, b),
+      null !== a && (e = gvjs_Hk(a, this.W(b), c),
+      null == e && (e = void 0)),
+        d.Me = e)
+    }
+  return null == e ? "" : e.toString()
+}
+;
+gvjs_.format = function(a, b) {
+  gvjs_Ik(this, a, b)
+}
+;
+gvjs_.getProperty = function(a, b, c) {
+  gvjs_Ck(this, a);
+  gvjs_Dk(this, b);
+  return (a = (a = this.si(a, b)) && a.p) && c in a ? a[c] : null
+}
+;
+gvjs_.getProperties = function(a, b) {
+  gvjs_Ck(this, a);
+  gvjs_Dk(this, b);
+  var c = this.si(a, b);
+  c || (c = {
+    v: null
+  },
+    this.Wf[a].c[b] = c);
+  c.p || (c.p = {});
+  return c.p
+}
+;
+gvjs_.Cv = function() {
+  return this.Br
+}
+;
+gvjs_.Sy = function(a) {
+  var b = this.Br;
+  return b && a in b ? b[a] : null
+}
+;
+gvjs_.Hwa = function(a) {
+  this.Br = a || {}
+}
+;
+gvjs_.Iwa = function(a, b) {
+  null == this.Br && (this.Br = {});
+  this.Br[a] = b
+}
+;
+gvjs_.Wa = function(a, b, c) {
+  this.Wb(a, b, c, void 0, void 0)
+}
+;
+gvjs_.Nw = function(a, b, c) {
+  this.Wb(a, b, void 0, c, void 0)
+}
+;
+gvjs_.sr = function(a, b, c) {
+  this.Wb(a, b, void 0, void 0, c)
+}
+;
+gvjs_.setProperty = function(a, b, c, d) {
+  this.getProperties(a, b)[c] = d
+}
+;
+gvjs_.Wb = function(a, b, c, d, e) {
+  gvjs_Ck(this, a);
+  gvjs_Dk(this, b);
+  var f = this.cache[a];
+  f && f[b] && (f[b] = {});
+  f = this.si(a, b);
+  f || (f = {},
+    this.Wf[a].c[b] = f);
+  "undefined" !== typeof c && (this.W(b) !== gvjs_g || typeof c !== gvjs_l || isNaN(c) ? (gvjs_yk(this, b, c),
+    f.v = c) : f.v = Number(c));
+  "undefined" !== typeof d && (f.f = d);
+  "undefined" !== typeof e && (f.p = gvjs_r(e) ? e : {})
+}
+;
+gvjs_.Gwa = function(a, b) {
+  gvjs_Ck(this, a);
+  this.Wf[a].p = b
+}
+;
+gvjs_.Gfa = function(a, b, c) {
+  this.zv(a)[b] = c
+}
+;
+gvjs_.Ul = function(a, b) {
+  gvjs_Ck(this, a);
+  return (a = (a = this.Wf[a]) && a.p) && b in a ? a[b] : null
+}
+;
+gvjs_.zv = function(a) {
+  gvjs_Ck(this, a);
+  a = this.Wf[a];
+  a.p || (a.p = {});
+  return a.p
+}
+;
+gvjs_.xfa = function(a, b) {
+  gvjs_Dk(this, a);
+  this.bf[a].label = b
+}
+;
+gvjs_.lT = function(a, b) {
+  gvjs_Dk(this, a);
+  this.bf[a].p = b
+}
+;
+gvjs_.rA = function(a, b, c) {
+  this.Rj(a)[b] = c
+}
+;
+gvjs_.Bd = function(a, b) {
+  gvjs_Dk(this, a);
+  return (a = (a = this.bf[a]) && a.p) && b in a ? a[b] : null
+}
+;
+gvjs_.Rj = function(a) {
+  gvjs_Dk(this, a);
+  a = this.bf[a];
+  a.p || (a.p = {});
+  return a.p
+}
+;
+gvjs_.uba = function(a, b, c, d) {
+  a !== this.bf.length && (this.cache = [],
+    gvjs_Dk(this, a));
+  if (typeof b === gvjs_l) {
+    var e = b;
+    c = c || "";
+    d = d || "";
+    b = {
+      id: d,
+      label: c,
+      pattern: "",
+      type: e
+    }
+  }
+  if (!gvjs_r(b))
+    throw Error("Invalid column specification, " + b + gvjs_ia + a + '".');
+  gvjs_8c in b && (c = b.label);
+  gvjs_5c in b && (d = b.id);
+  c = c || d || a;
+  gvjs_Sd in b && (e = b.type);
+  null == e && (e = gvjs_l);
+  if (!Object.values(gvjs_zi).includes(e))
+    throw Error("Invalid type, " + e + gvjs_ia + c + '".');
+  b = Object.assign(Object.assign({}, b), {
+    type: e
+  });
+  if (e = b.role)
+    c = b.p || {},
+    null == c.role && (c.role = e,
+      b.p = c);
+  this.bf.splice(a, 0, b);
+  this.cq = null;
+  for (b = 0; b < this.Wf.length; b++)
+    this.Wf[b].c.splice(a, 0, {
+      v: null
+    })
+}
+;
+gvjs_.xd = function(a, b, c) {
+  this.uba(this.bf.length, a, b, c);
+  return this.bf.length - 1
+}
+;
+gvjs_.G_ = function(a, b) {
+  a !== this.Wf.length && (this.cache = [],
+    gvjs_Ck(this, a));
+  if (Array.isArray(b))
+    var c = b;
+  else if (typeof b === gvjs_g) {
+    if (b !== Math.floor(b) || 0 > b)
+      throw Error(gvjs_Ta + b + ". If numOrArray is a number it must be a nonnegative integer.");
+    c = gvjs_Te(null, b)
+  } else
+    throw Error(gvjs_Ta + b + ".Must be a non-negative number or an array of arrays of cells.");
+  b = [];
+  for (var d = 0; d < c.length; d++) {
+    var e = c[d]
+      , f = [];
+    if (null === e)
+      for (e = 0; e < this.bf.length; e++)
+        f.push({
+          v: null
+        });
+    else if (Array.isArray(e)) {
+      if (e.length !== this.bf.length)
+        throw Error("Row " + d + " given with size different than " + this.bf.length + " (the number of columns in the table).");
+      for (var g = 0; g < e.length; g++) {
+        var h = f
+          , k = h.push
+          , l = g
+          , m = gvjs_uk(e[g]);
+        gvjs_yk(this, l, m.v);
+        k.call(h, m)
+      }
+    } else
+      throw Error("Row " + d + " is not null or an array.");
+    b.push({
+      c: f
+    });
+    1E4 === b.length && (f = b,
+      gvjs_re(gvjs_Ne, this.Wf, a, 0).apply(null, f),
+      a += b.length,
+      b = [])
+  }
+  c = b;
+  gvjs_re(gvjs_Ne, this.Wf, a, 0).apply(null, c);
+  return a + b.length - 1
+}
+;
+gvjs_.Yn = function(a) {
+  if (typeof a === gvjs_g || Array.isArray(a))
+    return this.G_(this.Wf.length, a);
+  throw Error("Argument given to addRows must be either a number or an array");
+}
+;
+gvjs_.Kp = function(a) {
+  if (Array.isArray(a))
+    return this.Yn([a]);
+  if (null == a)
+    return this.Yn(1);
+  throw Error("If argument is given to addRow, it must be an array, or null");
+}
+;
+gvjs_.Sj = function(a) {
+  return gvjs_Fk(this, a)
+}
+;
+gvjs_.bn = function(a) {
+  return gvjs_Bk(this, a)
+}
+;
+gvjs_.sort = function(a) {
+  this.cache = [];
+  a = gvjs_Ak(this, function(b, c) {
+    b = b.c[c];
+    return null != b && typeof b === gvjs_h && "v"in b ? b.v : null
+  }, a);
+  gvjs_Se(this.Wf, a)
+}
+;
+gvjs_.fj = function(a) {
+  return a
+}
+;
+gvjs_.Ty = function(a) {
+  gvjs_Dk(this, a);
+  return a
+}
+;
+gvjs_.Uy = function(a) {
+  gvjs_Ck(this, a);
+  return a
+}
+;
+gvjs_.Gr = function() {
+  return this.clone()
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_M(this.Bp())
+}
+;
+gvjs_.Bp = function() {
+  var a = {
+    cols: this.bf,
+    rows: this.Wf
+  };
+  this.Br && (a.p = this.Br);
+  return gvjs_Ji(a, gvjs_Ki)
+}
+;
+gvjs_.toJSON = function() {
+  for (var a = 0; a < this.bf.length; a++)
+    if (this.W(a) === gvjs_d)
+      throw Error("Cannot get JSON representation of data table due to function data type at column " + a);
+  return gvjs_Hi(this.Bp())
+}
+;
+gvjs_.Py = function(a) {
+  return gvjs_Gk(this, a)
+}
+;
+gvjs_.at = function(a) {
+  return gvjs_wk(this, a)
+}
+;
+gvjs_.Iea = function(a, b) {
+  0 >= b || (this.cache = [],
+    gvjs_Ck(this, a),
+  a + b > this.Wf.length && (b = this.Wf.length - a),
+    this.Wf.splice(a, b))
+}
+;
+gvjs_.qE = function(a) {
+  this.Iea(a, 1)
+}
+;
+gvjs_.Hea = function(a, b) {
+  if (!(0 >= b)) {
+    this.cache = [];
+    gvjs_Dk(this, a);
+    a + b > this.bf.length && (b = this.bf.length - a);
+    this.bf.splice(a, b);
+    this.cq = null;
+    for (var c = 0; c < this.Wf.length; c++)
+      this.Wf[c].c.splice(a, b)
+  }
+}
+;
+gvjs_.BS = function(a) {
+  this.Hea(a, 1)
+}
+;
+function gvjs_Lk(a) {
+  return null == a ? null : a instanceof gvjs_Ai ? a : Array.isArray(a) ? gvjs_Mk(a) : new gvjs_M(a)
+}
+function gvjs_cba(a, b) {
+  if (b) {
+    if (!Array.isArray(a))
+      throw Error("Column header row must be an array.");
+    b = a.map(function(d) {
+      if (typeof d === gvjs_l)
+        return {
+          label: d
+        };
+      if (gvjs_r(d))
+        return gvjs_x(d);
+      throw Error("Unknown type of column header: " + d);
+    })
+  } else {
+    b = [];
+    var c = 0;
+    Array.isArray(a) ? c = a.length : gvjs_r(a) && gvjs_Ze(a, "c") && Array.isArray(a.c) && (c = a.c.length);
+    for (a = 0; a < c; a++)
+      b.push({
+        type: void 0
+      })
+  }
+  return b
+}
+function gvjs_Mk(a, b) {
+  if (!Array.isArray(a))
+    throw Error("Data for arrayToDataTable is not an array.");
+  if (0 === a.length)
+    b = new gvjs_M;
+  else {
+    var c = !b;
+    if (0 === a.length)
+      throw Error("Array of rows must be non-empty");
+    b = gvjs_cba(a[0], c);
+    var d = [];
+    for (c = c ? 1 : 0; c < a.length; c++) {
+      var e = void 0
+        , f = a[c]
+        , g = c;
+      if (Array.isArray(f))
+        var h = f;
+      else if (gvjs_r(f) && gvjs_Ze(f, "c"))
+        h = f.c,
+          e = f.p;
+      else
+        throw Error("Invalid row #" + g);
+      if (h.length !== b.length)
+        throw Error("Row " + g + " has " + h.length + " columns, but must have " + b.length);
+      h = gvjs_Le(h);
+      e = {
+        c: h,
+        p: e
+      };
+      for (f = 0; f < b.length; f++)
+        if (g = h[f],
+          gvjs_r(g) && (gvjs_Ze(g, "v") || gvjs_Ze(g, "f")) ? g = g.v : h[f] = {
+            v: g
+          },
+        null == b[f].type || "date?" === b[f].type) {
+          var k = null;
+          if (null != g)
+            if (typeof g === gvjs_l)
+              k = gvjs_l;
+            else if (typeof g === gvjs_g)
+              k = gvjs_g;
+            else if (Array.isArray(g))
+              k = gvjs_Od;
+            else if (typeof g === gvjs_zb)
+              k = gvjs_zb;
+            else if (gvjs_oe(g))
+              g = new Date(g.getTime()),
+                k = 0 !== g.getHours() + g.getMinutes() + g.getSeconds() + g.getMilliseconds() ? gvjs_Mb : gvjs_Lb;
+            else
+              throw Error("Unknown type of value, " + g);
+          g = k;
+          null == b[f].type && g === gvjs_Lb && (g = "date?");
+          null != g && (b[f].type = g)
+        }
+      d.push(e)
+    }
+    for (a = 0; a < b.length; a++)
+      c = b[a],
+      "date?" === c.type && (c.type = gvjs_Lb);
+    b = new gvjs_M({
+      cols: b,
+      rows: d
+    })
+  }
+  return b
+}
+function gvjs_Nk(a) {
+  function b(k) {
+    for (var l = Object.keys(k), m = l.length, n = Array(m); m--; )
+      n[m] = [l[m], k[l[m]]];
+    return n
+  }
+  for (var c = {}, d = 0, e = gvjs_8d(a), f = e.next(); !f.done; f = e.next()) {
+    f = gvjs_8d(b(f.value));
+    for (var g = f.next(); !g.done; g = f.next()) {
+      g = gvjs_8d(g.value);
+      var h = g.next().value;
+      g.next();
+      c[h] || (c[h] = {
+        id: h,
+        index: d++
+      })
+    }
+  }
+  d = [];
+  e = [];
+  f = gvjs_8d(b(c));
+  for (g = f.next(); !g.done; g = f.next())
+    h = gvjs_8d(g.value),
+      g = h.next().value,
+      h = h.next().value,
+      e[h.index] = {
+        id: g
+      };
+  d.unshift(e);
+  a = gvjs_8d(a);
+  for (f = a.next(); !f.done; f = a.next())
+    for (f = f.value,
+           e = [],
+           d.push(e),
+           f = gvjs_8d(b(f)),
+           g = f.next(); !g.done; g = f.next())
+      h = gvjs_8d(g.value),
+        g = h.next().value,
+        h = h.next().value,
+        e[c[g].index] = h;
+  return gvjs_Mk(d)
+}
+function gvjs_dba(a) {
+  a = a.map(function(b) {
+    return {
+      data: b
+    }
+  });
+  return gvjs_Nk(a)
+}
+;function gvjs_N(a) {
+  gvjs_Ai.call(this);
+  this.Ta = a;
+  this.columns = [];
+  this.Fq = !0;
+  this.ir = null;
+  this.yW = [];
+  this.vW = !0;
+  var b = [];
+  a = a.$();
+  for (var c = 0; c < a; c++)
+    b.push(c);
+  this.columns = b
+}
+gvjs_o(gvjs_N, gvjs_Ai);
+gvjs_ = gvjs_N.prototype;
+gvjs_.mb = function() {
+  return this.Ta
+}
+;
+function gvjs_eba(a, b, c) {
+  return gvjs_v(c, function(d) {
+    if (typeof d === gvjs_l)
+      d = a.jf(d);
+    else if (gvjs_r(d)) {
+      d = gvjs_0e(d);
+      var e = d.properties || {};
+      delete d.properties;
+      d.p = e;
+      var f = d.role;
+      f && (e.role = f);
+      e = d.sourceColumn;
+      typeof e === gvjs_l && (e = d.sourceColumn = a.jf(e));
+      typeof e === gvjs_g && (gvjs_Dk(b, e),
+        d.calc = d.calc || "identity",
+        d.type = d.type || b.W(e))
+    }
+    return d
+  })
+}
+function gvjs_Ok(a) {
+  a.vW = !0;
+  a.cq = null
+}
+function gvjs_fba(a) {
+  for (var b = [], c = a.Ta.ca(), d = 0; d < c; d++)
+    b.push(d);
+  a.ir = b;
+  gvjs_Ok(a)
+}
+gvjs_.Hn = function(a) {
+  for (var b = this.Ta, c = gvjs_Ye(gvjs_Pk), d = 0; d < a.length; d++) {
+    var e = a[d];
+    if (typeof e === gvjs_g || typeof e === gvjs_l)
+      gvjs_xk(b, e);
+    else if (gvjs_r(e)) {
+      var f = e.sourceColumn
+        , g = e.calc;
+      if (typeof g === gvjs_l) {
+        if (!c || c && !gvjs_He(c, g))
+          throw Error('Unknown function "' + g + '"');
+        null != f && gvjs_xk(b, f)
+      } else if (null != g && !e.type)
+        throw Error('Calculated column must have a "type" property.');
+    } else
+      throw Error("Invalid column input, expected either a number, string, or an object.");
+  }
+  this.columns = gvjs_eba(this, this.Ta, a);
+  gvjs_Ok(this)
+}
+;
+gvjs_.Do = gvjs_n(19);
+function gvjs_Qk(a, b, c) {
+  if (Array.isArray(b)) {
+    if (void 0 !== c)
+      throw Error("If the first parameter is an array, no second parameter is expected");
+    for (c = 0; c < b.length; c++)
+      gvjs_Ck(a.Ta, b[c]);
+    return gvjs_Le(b)
+  }
+  if (typeof b === gvjs_g) {
+    if (typeof c !== gvjs_g)
+      throw Error("If first parameter is a number, second parameter must be specified and be a number.");
+    if (b > c)
+      throw Error("The first parameter (min) must be smaller than or equal to the second parameter (max).");
+    gvjs_Ck(a.Ta, b);
+    gvjs_Ck(a.Ta, c);
+    for (a = []; b <= c; b++)
+      a.push(b);
+    return a
+  }
+  throw Error("First parameter must be a number or an array.");
+}
+gvjs_.pp = function(a, b) {
+  this.ir = gvjs_Qk(this, a, b);
+  this.Fq = !1;
+  gvjs_Ok(this)
+}
+;
+gvjs_.FZ = function() {
+  return gvjs_0e(this.columns)
+}
+;
+gvjs_.T$ = function() {
+  if (this.Fq) {
+    for (var a = [], b = this.Ta.ca(), c = 0; c < b; c++)
+      a.push(c);
+    return a
+  }
+  return gvjs_Le(this.ir)
+}
+;
+gvjs_.ora = function(a) {
+  this.Hn(gvjs_De(this.columns, function(b) {
+    return !gvjs_He(a, b)
+  }));
+  gvjs_Ok(this)
+}
+;
+gvjs_.qra = function(a, b) {
+  var c = gvjs_Qk(this, a, b);
+  this.Fq && (gvjs_fba(this),
+    this.Fq = !1);
+  this.pp(gvjs_De(this.ir, function(d) {
+    return !gvjs_He(c, d)
+  }));
+  gvjs_Ok(this)
+}
+;
+gvjs_.S$ = function(a) {
+  for (var b = 0; b < this.columns.length; b++) {
+    var c = this.columns[b];
+    if (c === a || gvjs_r(c) && c.sourceColumn === a)
+      return b
+  }
+  return -1
+}
+;
+gvjs_.GZ = function(a) {
+  return this.Fq ? 0 > a || a >= this.Ta.ca() ? -1 : a : gvjs_Be(this.ir, a)
+}
+;
+gvjs_.CP = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? a : gvjs_r(a) && typeof a.sourceColumn === gvjs_g ? a.sourceColumn : -1
+}
+;
+gvjs_.Ty = function(a) {
+  a = this.CP(a);
+  return -1 === a ? a : a = this.Ta.Ty(a)
+}
+;
+gvjs_.fj = function(a) {
+  gvjs_Ck(this, a);
+  return this.Fq ? a : this.ir[a]
+}
+;
+gvjs_.Uy = function(a) {
+  a = this.fj(a);
+  return a = this.Ta.Uy(a)
+}
+;
+gvjs_.ca = function() {
+  return this.Fq ? this.Ta.ca() : this.ir.length
+}
+;
+gvjs_.$ = function() {
+  return this.columns.length
+}
+;
+gvjs_.Ne = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? this.Ta.Ne(a) : a.id || ""
+}
+;
+gvjs_.Ga = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? this.Ta.Ga(a) : a.label || ""
+}
+;
+gvjs_.Co = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? this.Ta.Co(a) : null
+}
+;
+gvjs_.Jg = function(a) {
+  a = this.Bd(a, gvjs_Bd);
+  return typeof a === gvjs_l ? a : ""
+}
+;
+gvjs_.W = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? this.Ta.W(a) : a.type
+}
+;
+gvjs_.si = function(a, b) {
+  gvjs_Dk(this, b);
+  var c = this.columns[b]
+    , d = null;
+  a = this.fj(a);
+  if (gvjs_r(c)) {
+    if (this.vW) {
+      for (c = 0; c < this.columns.length; c++)
+        gvjs_r(this.columns[c]) && (this.yW[c] = []);
+      this.vW = !1
+    }
+    c = this.yW[b][a];
+    if (void 0 !== c)
+      d = c;
+    else {
+      c = null;
+      d = this.columns[b];
+      var e = d.calc;
+      if (typeof e === gvjs_l) {
+        c = gvjs_Pk[e];
+        if (typeof d !== gvjs_h)
+          throw Error("Object expected for column " + d);
+        c = c(this.Ta, a, d)
+      } else
+        typeof e === gvjs_d && (c = e.call(null, this.Ta, a));
+      c = gvjs_uk(c);
+      d = d.type;
+      e = c.v;
+      if (gvjs_jf(gvjs_gg(d)))
+        throw Error('"type" must be specified');
+      if (!gvjs_Ek(e, d))
+        throw Error(gvjs_jb + e + gvjs_aa + d + ".");
+      d = this.yW[b][a] = c
+    }
+    d.p = gvjs_r(d.p) ? d.p : {}
+  } else if (typeof c === gvjs_g)
+    d = {
+      v: this.Ta.getValue(a, c)
+    };
+  else
+    throw Error("Invalid column definition: " + d + ".");
+  return d
+}
+;
+gvjs_.getValue = function(a, b) {
+  return this.si(a, b).v
+}
+;
+gvjs_.Ha = function(a, b, c) {
+  var d = this.si(a, b);
+  if (null == d.f) {
+    var e = this.columns[b];
+    gvjs_r(e) ? (e = this.W(b),
+      d.f = null == d.v ? "" : gvjs_Hk(d.v, e, c)) : typeof e === gvjs_g && (a = this.fj(a),
+      d.f = this.Ta.Ha(a, e, c))
+  }
+  c = d.f;
+  return null == c ? "" : c.toString()
+}
+;
+gvjs_.Nw = function() {}
+;
+gvjs_.format = function(a, b) {
+  gvjs_Ik(this, a, b)
+}
+;
+gvjs_.getProperty = function(a, b, c) {
+  a = this.getProperties(a, b)[c];
+  return void 0 !== a ? a : null
+}
+;
+gvjs_.getProperties = function(a, b) {
+  var c = this.si(a, b);
+  return c.p ? c.p : (a = this.fj(a),
+    b = this.CP(b),
+    this.Ta.getProperties(a, b))
+}
+;
+gvjs_.setProperty = function() {}
+;
+gvjs_.Bd = function(a, b) {
+  gvjs_Dk(this, a);
+  var c = this.columns[a];
+  return typeof c === gvjs_g ? this.Ta.Bd(c, b) : this.Rj(a)[b] || null
+}
+;
+gvjs_.Rj = function(a) {
+  gvjs_Dk(this, a);
+  a = this.columns[a];
+  return typeof a === gvjs_g ? this.Ta.Rj(a) : a.p || {}
+}
+;
+gvjs_.Sy = function(a) {
+  return this.Ta.Sy(a)
+}
+;
+gvjs_.Cv = function() {
+  return this.Ta.Cv()
+}
+;
+gvjs_.Ul = function(a, b) {
+  a = this.fj(a);
+  return this.Ta.Ul(a, b)
+}
+;
+gvjs_.zv = function(a) {
+  gvjs_Ck(this, a);
+  a = this.fj(a);
+  return this.Ta.zv(a)
+}
+;
+gvjs_.Sj = function(a) {
+  return gvjs_Fk(this, a)
+}
+;
+gvjs_.Py = function(a) {
+  return gvjs_Gk(this, a)
+}
+;
+gvjs_.bn = function(a) {
+  return gvjs_Bk(this, a)
+}
+;
+gvjs_.at = function(a) {
+  return gvjs_wk(this, a)
+}
+;
+gvjs_.Gr = function() {
+  var a = this.Ta;
+  typeof a.Gr === gvjs_d && (a = a.Gr());
+  a = a.Bp();
+  var b = this.$(), c = this.ca(), d, e = [], f = [];
+  for (d = 0; d < b; d++) {
+    var g = this.columns[d];
+    if (gvjs_r(g)) {
+      var h = gvjs_x(g);
+      delete h.calc;
+      delete h.sourceColumn
+    } else if (typeof g === gvjs_g)
+      h = (a.cols || [])[g];
+    else
+      throw Error(gvjs_Ra);
+    e.push(h)
+  }
+  if (!this.Fq && null == this.ir)
+    throw Error("Unexpected state of rowIndices");
+  var k = a.rows || [];
+  for (h = 0; h < c; h++) {
+    var l = k[this.Fq ? h : this.ir[h]]
+      , m = [];
+    for (d = 0; d < b; d++) {
+      g = this.columns[d];
+      if (gvjs_r(g))
+        g = {
+          v: this.getValue(h, d)
+        };
+      else if (typeof g === gvjs_g)
+        g = l.c[g];
+      else
+        throw Error(gvjs_Ra);
+      m.push(g)
+    }
+    l.c = m;
+    f.push(l)
+  }
+  a.cols = e;
+  a.rows = f;
+  return new gvjs_M(a)
+}
+;
+gvjs_.Bp = function() {
+  for (var a = {}, b = [], c = 0; c < this.columns.length; c++) {
+    var d = this.columns[c];
+    gvjs_r(d) && typeof d.calc !== gvjs_l || b.push(d)
+  }
+  0 == b.length || (a.columns = b);
+  this.Fq || (a.rows = gvjs_Le(this.ir));
+  return a
+}
+;
+gvjs_.toJSON = function() {
+  return gvjs_Ii(this.Bp())
+}
+;
+function gvjs_Rk(a, b) {
+  typeof b === gvjs_l && (b = gvjs_Li(b));
+  a = new gvjs_N(a);
+  var c = b.columns;
+  b = b.rows;
+  null != c && a.Hn(c);
+  null != b && a.pp(b);
+  return a
+}
+var gvjs_Pk = {
+  emptyString: function() {
+    return ""
+  },
+  error: function(a, b, c) {
+    var d = c.sourceColumn
+      , e = c.magnitude;
+    if (typeof d !== gvjs_g || typeof e !== gvjs_g)
+      return null;
+    a = a.getValue(b, d);
+    return typeof a !== gvjs_g ? null : c.errorType === gvjs_ud ? a + e / 100 * a : a + e
+  },
+  mapFromSource: function(a, b, c) {
+    var d = c.sourceColumn;
+    c = c.mapping;
+    return typeof d === gvjs_g && c && (a = a.getValue(b, d),
+    typeof a === gvjs_l) ? a in c ? c[a] : null : null
+  },
+  stringify: function(a, b, c) {
+    c = c.sourceColumn;
+    return typeof c !== gvjs_g ? "" : a.Ha(b, c)
+  },
+  fillFromTop: function(a, b, c) {
+    c = c.sourceColumn;
+    return typeof c !== gvjs_g ? null : gvjs_Jk(a, b, c, !0)
+  },
+  fillFromBottom: function(a, b, c) {
+    c = c.sourceColumn;
+    return typeof c !== gvjs_g ? null : gvjs_Jk(a, b, c, !1)
+  },
+  identity: function(a, b, c) {
+    c = c.sourceColumn;
+    return typeof c !== gvjs_g ? null : a.getValue(b, c)
+  }
+};
+function gvjs_Sk(a) {
+  this.Ta = this.m4 = null;
+  this.errors = [];
+  this.warnings = [];
+  this.Lva = gvjs_Tk(a);
+  this.DY = a.status;
+  this.warnings = a.warnings || [];
+  this.errors = a.errors || [];
+  gvjs_Uk(this.warnings);
+  gvjs_Uk(this.errors);
+  this.DY !== gvjs_Rb && (this.m4 = a.sig,
+    this.Ta = new gvjs_M(a.table,this.Lva))
+}
+function gvjs_Uk(a) {
+  for (var b = 0; b < a.length; b++) {
+    var c = a[b].detailed_message;
+    c && (a[b].detailed_message = c ? c.match(gvjs_gba) && !c.match(gvjs_hba) ? c : c.replace(/&/g, "&amp;").replace(/</g, gvjs_fa).replace(/>/g, "&gt;").replace(/"/g, gvjs_ga) : "")
+  }
+}
+function gvjs_Tk(a) {
+  a = a.version || "0.6";
+  return gvjs__e(gvjs_bba, a) ? a : "0.6"
+}
+gvjs_ = gvjs_Sk.prototype;
+gvjs_.Xk = function() {
+  return this.DY === gvjs_Rb
+}
+;
+gvjs_.j_ = function() {
+  return this.DY === gvjs_Wd
+}
+;
+function gvjs_Vk(a) {
+  for (var b = 0; b < a.errors.length; b++)
+    if ("not_modified" === a.errors[b].reason)
+      return !0;
+  for (b = 0; b < a.warnings.length; b++)
+    if ("not_modified" === a.warnings[b].reason)
+      return !0;
+  return !1
+}
+gvjs_.mb = function() {
+  return this.Ta
+}
+;
+function gvjs_Wk(a, b) {
+  return a.Xk() && a.errors && a.errors[0] && a.errors[0][b] ? a.errors[0][b] : a.j_() && a.warnings && a.warnings[0] && a.warnings[0][b] ? a.warnings[0][b] : null
+}
+gvjs_.Q$ = function() {
+  var a = gvjs_Wk(this, "reason");
+  return null != a && "" !== a ? [a] : []
+}
+;
+gvjs_.sP = function() {
+  return gvjs_Wk(this, "message") || ""
+}
+;
+gvjs_.nZ = function() {
+  return gvjs_Wk(this, "detailed_message") || ""
+}
+;
+function gvjs_Xk(a, b) {
+  (0,
+    gvjs_D.Vya)(a);
+  if (!b)
+    throw Error(gvjs_D.v6 + " response is null");
+  if (b.Xk() || b.j_()) {
+    var c = b.Q$()
+      , d = !0;
+    b.Xk() && (d = !(gvjs_He(c, "user_not_authenticated") || gvjs_He(c, "invalid_query")));
+    c = b.sP();
+    var e = b.nZ();
+    d = {
+      showInTooltip: d
+    };
+    d.type = b.Xk() ? gvjs_Rb : gvjs_Wd;
+    d.removeDuplicates = !0;
+    a = {
+      container: a,
+      message: c,
+      Oma: e,
+      options: d
+    }
+  } else
+    a = null;
+  return null == a ? null : (0,
+    gvjs_D.Sc)(a.container, a.message, a.Oma, a.options)
+}
+var gvjs_gba = /^[^<]*(<a(( )+target=('_blank')?("_blank")?)?( )+(href=('[^']*')?("[^"]*")?)>[^<]*<\/a>[^<]*)*$/
+  , gvjs_hba = /javascript((s)?( )?)*:/;
+var gvjs_iba = gvjs_D.removeAll;
+function gvjs_Yk() {
+  this.$m = [];
+  this.Np = []
+}
+function gvjs_Zk(a) {
+  0 === a.$m.length && (a.$m = a.Np,
+    a.$m.reverse(),
+    a.Np = [])
+}
+gvjs_ = gvjs_Yk.prototype;
+gvjs_.enqueue = function(a) {
+  this.Np.push(a)
+}
+;
+gvjs_.peek = function() {
+  gvjs_Zk(this);
+  return gvjs_Ae(this.$m)
+}
+;
+gvjs_.Cd = function() {
+  return this.$m.length + this.Np.length
+}
+;
+gvjs_.isEmpty = function() {
+  return 0 === this.$m.length && 0 === this.Np.length
+}
+;
+gvjs_.clear = function() {
+  this.$m = [];
+  this.Np = []
+}
+;
+gvjs_.contains = function(a) {
+  return gvjs_He(this.$m, a) || gvjs_He(this.Np, a)
+}
+;
+gvjs_.remove = function(a) {
+  var b = this.$m;
+  var c = gvjs_haa(b, a);
+  0 <= c ? (gvjs_Je(b, c),
+    b = !0) : b = !1;
+  return b || gvjs_Ie(this.Np, a)
+}
+;
+gvjs_.ob = function() {
+  for (var a = [], b = this.$m.length - 1; 0 <= b; --b)
+    a.push(this.$m[b]);
+  var c = this.Np.length;
+  for (b = 0; b < c; ++b)
+    a.push(this.Np[b]);
+  return a
+}
+;
+function gvjs__k(a, b) {
+  this.Psa = 100;
+  this.cma = a;
+  this.Hva = b;
+  this.SR = 0;
+  this.pc = null
+}
+gvjs__k.prototype.get = function() {
+  if (0 < this.SR) {
+    this.SR--;
+    var a = this.pc;
+    this.pc = a.next;
+    a.next = null
+  } else
+    a = this.cma();
+  return a
+}
+;
+gvjs__k.prototype.put = function(a) {
+  this.Hva(a);
+  this.SR < this.Psa && (this.SR++,
+    a.next = this.pc,
+    this.pc = a)
+}
+;
+var gvjs_0k;
+function gvjs_jba() {
+  var a = gvjs_p.MessageChannel;
+  "undefined" === typeof a && "undefined" !== typeof window && window.postMessage && window.addEventListener && !gvjs_Uf("Presto") && (a = function() {
+      var e = gvjs_dh(gvjs_Ma);
+      e.style.display = gvjs_f;
+      document.documentElement.appendChild(e);
+      var f = e.contentWindow;
+      e = f.document;
+      e.open();
+      e.close();
+      var g = "callImmediate" + Math.random()
+        , h = "file:" == f.location.protocol ? "*" : f.location.protocol + "//" + f.location.host;
+      e = gvjs_s(function(k) {
+        if (("*" == h || k.origin == h) && k.data == g)
+          this.port1.onmessage()
+      }, this);
+      f.addEventListener("message", e, !1);
+      this.port1 = {};
+      this.port2 = {
+        postMessage: function() {
+          f.postMessage(g, h)
+        }
+      }
+    }
+  );
+  if ("undefined" !== typeof a && !gvjs_Uf("Trident") && !gvjs_Uf("MSIE")) {
+    var b = new a
+      , c = {}
+      , d = c;
+    b.port1.onmessage = function() {
+      if (void 0 !== c.next) {
+        c = c.next;
+        var e = c.e8;
+        c.e8 = null;
+        e()
+      }
+    }
+    ;
+    return function(e) {
+      d.next = {
+        e8: e
+      };
+      d = d.next;
+      b.port2.postMessage(0)
+    }
+  }
+  return function(e) {
+    gvjs_p.setTimeout(e, 0)
+  }
+}
+;function gvjs_1k(a) {
+  gvjs_p.setTimeout(function() {
+    throw a;
+  }, 0)
+}
+;function gvjs_2k() {
+  this.XU = this.IF = null
+}
+gvjs_2k.prototype.add = function(a, b) {
+  var c = gvjs_3k.get();
+  c.set(a, b);
+  this.XU ? this.XU.next = c : this.IF = c;
+  this.XU = c
+}
+;
+gvjs_2k.prototype.remove = function() {
+  var a = null;
+  this.IF && (a = this.IF,
+    this.IF = this.IF.next,
+  this.IF || (this.XU = null),
+    a.next = null);
+  return a
+}
+;
+var gvjs_3k = new gvjs__k(function() {
+    return new gvjs_4k
+  }
+  ,function(a) {
+    return a.reset()
+  }
+);
+function gvjs_4k() {
+  this.next = this.scope = this.Xs = null
+}
+gvjs_4k.prototype.set = function(a, b) {
+  this.Xs = a;
+  this.scope = b;
+  this.next = null
+}
+;
+gvjs_4k.prototype.reset = function() {
+  this.next = this.scope = this.Xs = null
+}
+;
+function gvjs_5k(a, b) {
+  gvjs_6k || gvjs_kba();
+  gvjs_7k || (gvjs_6k(),
+    gvjs_7k = !0);
+  gvjs_8k.add(a, b)
+}
+var gvjs_6k;
+function gvjs_kba() {
+  if (gvjs_p.Promise && gvjs_p.Promise.resolve) {
+    var a = gvjs_p.Promise.resolve(void 0);
+    gvjs_6k = function() {
+      a.then(gvjs_9k)
+    }
+  } else
+    gvjs_6k = function() {
+      var b = gvjs_9k;
+      typeof gvjs_p.setImmediate !== gvjs_d || gvjs_p.Window && gvjs_p.Window.prototype && !gvjs_Uf(gvjs_Ca) && gvjs_p.Window.prototype.setImmediate == gvjs_p.setImmediate ? (gvjs_0k || (gvjs_0k = gvjs_jba()),
+        gvjs_0k(b)) : gvjs_p.setImmediate(b)
+    }
+}
+var gvjs_7k = !1
+  , gvjs_8k = new gvjs_2k;
+function gvjs_9k() {
+  for (var a; a = gvjs_8k.remove(); ) {
+    try {
+      a.Xs.call(a.scope)
+    } catch (b) {
+      gvjs_1k(b)
+    }
+    gvjs_3k.put(a)
+  }
+  gvjs_7k = !1
+}
+;function gvjs_$k(a) {
+  if (!a)
+    return !1;
+  try {
+    return !!a.$goog_Thenable
+  } catch (b) {
+    return !1
+  }
+}
+;function gvjs_al(a) {
+  this.K = 0;
+  this.ik = void 0;
+  this.NB = this.Pu = this.qd = null;
+  this.HP = this.CY = !1;
+  if (a != gvjs_ke)
+    try {
+      var b = this;
+      a.call(void 0, function(c) {
+        gvjs_bl(b, 2, c)
+      }, function(c) {
+        gvjs_bl(b, 3, c)
+      })
+    } catch (c) {
+      gvjs_bl(this, 3, c)
+    }
+}
+function gvjs_cl() {
+  this.next = this.context = this.UD = this.kK = this.child = null;
+  this.ZM = !1
+}
+gvjs_cl.prototype.reset = function() {
+  this.context = this.UD = this.kK = this.child = null;
+  this.ZM = !1
+}
+;
+var gvjs_dl = new gvjs__k(function() {
+    return new gvjs_cl
+  }
+  ,function(a) {
+    a.reset()
+  }
+);
+function gvjs_el(a, b, c) {
+  var d = gvjs_dl.get();
+  d.kK = a;
+  d.UD = b;
+  d.context = c;
+  return d
+}
+function gvjs_fl() {
+  var a, b, c = new gvjs_al(function(d, e) {
+      a = d;
+      b = e
+    }
+  );
+  return new gvjs_lba(c,a,b)
+}
+gvjs_al.prototype.then = function(a, b, c) {
+  return gvjs_gl(this, typeof a === gvjs_d ? a : null, typeof b === gvjs_d ? b : null, c)
+}
+;
+gvjs_al.prototype.$goog_Thenable = !0;
+function gvjs_mba(a, b) {
+  return gvjs_gl(a, null, b, void 0)
+}
+gvjs_al.prototype.cancel = function(a) {
+  if (0 == this.K) {
+    var b = new gvjs_hl(a);
+    gvjs_5k(function() {
+      gvjs_il(this, b)
+    }, this)
+  }
+}
+;
+function gvjs_il(a, b) {
+  if (0 == a.K)
+    if (a.qd) {
+      var c = a.qd;
+      if (c.Pu) {
+        for (var d = 0, e = null, f = null, g = c.Pu; g && (g.ZM || (d++,
+        g.child == a && (e = g),
+          !(e && 1 < d))); g = g.next)
+          e || (f = g);
+        e && (0 == c.K && 1 == d ? gvjs_il(c, b) : (f ? (d = f,
+        d.next == c.NB && (c.NB = d),
+          d.next = d.next.next) : gvjs_jl(c),
+          gvjs_kl(c, e, 3, b)))
+      }
+      a.qd = null
+    } else
+      gvjs_bl(a, 3, b)
+}
+function gvjs_ll(a, b) {
+  a.Pu || 2 != a.K && 3 != a.K || gvjs_ml(a);
+  a.NB ? a.NB.next = b : a.Pu = b;
+  a.NB = b
+}
+function gvjs_gl(a, b, c, d) {
+  var e = gvjs_el(null, null, null);
+  e.child = new gvjs_al(function(f, g) {
+      e.kK = b ? function(h) {
+          try {
+            var k = b.call(d, h);
+            f(k)
+          } catch (l) {
+            g(l)
+          }
+        }
+        : f;
+      e.UD = c ? function(h) {
+          try {
+            var k = c.call(d, h);
+            void 0 === k && h instanceof gvjs_hl ? g(h) : f(k)
+          } catch (l) {
+            g(l)
+          }
+        }
+        : g
+    }
+  );
+  e.child.qd = a;
+  gvjs_ll(a, e);
+  return e.child
+}
+gvjs_al.prototype.Cya = function(a) {
+  this.K = 0;
+  gvjs_bl(this, 2, a)
+}
+;
+gvjs_al.prototype.Dya = function(a) {
+  this.K = 0;
+  gvjs_bl(this, 3, a)
+}
+;
+function gvjs_bl(a, b, c) {
+  if (0 == a.K) {
+    a === c && (b = 3,
+      c = new TypeError("Promise cannot resolve to itself"));
+    a.K = 1;
+    a: {
+      var d = c
+        , e = a.Cya
+        , f = a.Dya;
+      if (d instanceof gvjs_al) {
+        gvjs_ll(d, gvjs_el(e || gvjs_ke, f || null, a));
+        var g = !0
+      } else if (gvjs_$k(d))
+        d.then(e, f, a),
+          g = !0;
+      else {
+        if (gvjs_r(d))
+          try {
+            var h = d.then;
+            if (typeof h === gvjs_d) {
+              gvjs_nba(d, h, e, f, a);
+              g = !0;
+              break a
+            }
+          } catch (k) {
+            f.call(a, k);
+            g = !0;
+            break a
+          }
+        g = !1
+      }
+    }
+    g || (a.ik = c,
+      a.K = b,
+      a.qd = null,
+      gvjs_ml(a),
+    3 != b || c instanceof gvjs_hl || gvjs_oba(a, c))
+  }
+}
+function gvjs_nba(a, b, c, d, e) {
+  function f(k) {
+    h || (h = !0,
+      d.call(e, k))
+  }
+  function g(k) {
+    h || (h = !0,
+      c.call(e, k))
+  }
+  var h = !1;
+  try {
+    b.call(a, g, f)
+  } catch (k) {
+    f(k)
+  }
+}
+function gvjs_ml(a) {
+  a.CY || (a.CY = !0,
+    gvjs_5k(a.Xna, a))
+}
+function gvjs_jl(a) {
+  var b = null;
+  a.Pu && (b = a.Pu,
+    a.Pu = b.next,
+    b.next = null);
+  a.Pu || (a.NB = null);
+  return b
+}
+gvjs_al.prototype.Xna = function() {
+  for (var a; a = gvjs_jl(this); )
+    gvjs_kl(this, a, this.K, this.ik);
+  this.CY = !1
+}
+;
+function gvjs_kl(a, b, c, d) {
+  if (3 == c && b.UD && !b.ZM)
+    for (; a && a.HP; a = a.qd)
+      a.HP = !1;
+  if (b.child)
+    b.child.qd = null,
+      gvjs_nl(b, c, d);
+  else
+    try {
+      b.ZM ? b.kK.call(b.context) : gvjs_nl(b, c, d)
+    } catch (e) {
+      gvjs_ol.call(null, e)
+    }
+  gvjs_dl.put(b)
+}
+function gvjs_nl(a, b, c) {
+  2 == b ? a.kK.call(a.context, c) : a.UD && a.UD.call(a.context, c)
+}
+function gvjs_oba(a, b) {
+  a.HP = !0;
+  gvjs_5k(function() {
+    a.HP && gvjs_ol.call(null, b)
+  })
+}
+var gvjs_ol = gvjs_1k;
+function gvjs_hl(a) {
+  gvjs_ve.call(this, a)
+}
+gvjs_t(gvjs_hl, gvjs_ve);
+gvjs_hl.prototype.name = gvjs_Ab;
+function gvjs_lba(a, b, c) {
+  this.promise = a;
+  this.resolve = b;
+  this.reject = c
+}
+;function gvjs_pl(a, b, c) {
+  if (typeof a === gvjs_d)
+    c && (a = gvjs_s(a, c));
+  else if (a && typeof a.handleEvent == gvjs_d)
+    a = gvjs_s(a.handleEvent, a);
+  else
+    throw Error("Invalid listener argument");
+  return 2147483647 < Number(b) ? -1 : gvjs_p.setTimeout(a, b || 0)
+}
+function gvjs_ql(a) {
+  gvjs_p.clearTimeout(a)
+}
+;/*
+ Portions of this code are from MochiKit, received by
+ The Closure Authors under the MIT license. All other code is Copyright
+ 2005-2009 The Closure Authors. All Rights Reserved.
+*/
+function gvjs_rl(a) {
+  var b = gvjs_pba;
+  this.$e = [];
+  this.zda = b;
+  this.p9 = a || null;
+  this.BI = this.sC = !1;
+  this.ik = void 0;
+  this.o4 = this.Oka = this.iW = !1;
+  this.KU = 0;
+  this.qd = null;
+  this.pW = 0
+}
+gvjs_ = gvjs_rl.prototype;
+gvjs_.cancel = function(a) {
+  if (this.sC)
+    this.ik instanceof gvjs_rl && this.ik.cancel();
+  else {
+    if (this.qd) {
+      var b = this.qd;
+      delete this.qd;
+      a ? b.cancel(a) : (b.pW--,
+      0 >= b.pW && b.cancel())
+    }
+    this.zda ? this.zda.call(this.p9, this) : this.o4 = !0;
+    this.sC || (a = new gvjs_sl(this),
+      this.Wp(),
+      gvjs_tl(this, !1, a))
+  }
+}
+;
+gvjs_.H8 = function(a, b) {
+  this.iW = !1;
+  gvjs_tl(this, a, b)
+}
+;
+function gvjs_tl(a, b, c) {
+  a.sC = !0;
+  a.ik = c;
+  a.BI = !b;
+  gvjs_ul(a)
+}
+gvjs_.Wp = function() {
+  if (this.sC) {
+    if (!this.o4)
+      throw new gvjs_vl(this);
+    this.o4 = !1
+  }
+}
+;
+gvjs_.yN = gvjs_n(21);
+function gvjs_wl(a, b, c, d) {
+  a.$e.push([b, c, d]);
+  a.sC && gvjs_ul(a)
+}
+gvjs_.then = function(a, b, c) {
+  var d, e, f = new gvjs_al(function(g, h) {
+      e = g;
+      d = h
+    }
+  );
+  gvjs_wl(this, e, function(g) {
+    g instanceof gvjs_sl ? f.cancel() : d(g)
+  });
+  return f.then(a, b, c)
+}
+;
+gvjs_rl.prototype.$goog_Thenable = !0;
+gvjs_rl.prototype.Xk = function(a) {
+  return a instanceof Error
+}
+;
+function gvjs_xl(a) {
+  return gvjs_Fe(a.$e, function(b) {
+    return typeof b[1] === gvjs_d
+  })
+}
+function gvjs_ul(a) {
+  if (a.KU && a.sC && gvjs_xl(a)) {
+    var b = a.KU
+      , c = gvjs_yl[b];
+    c && (gvjs_p.clearTimeout(c.ac),
+      delete gvjs_yl[b]);
+    a.KU = 0
+  }
+  a.qd && (a.qd.pW--,
+    delete a.qd);
+  b = a.ik;
+  for (var d = c = !1; a.$e.length && !a.iW; ) {
+    var e = a.$e.shift()
+      , f = e[0]
+      , g = e[1];
+    e = e[2];
+    if (f = a.BI ? g : f)
+      try {
+        var h = f.call(e || a.p9, b);
+        void 0 !== h && (a.BI = a.BI && (h == b || a.Xk(h)),
+          a.ik = b = h);
+        if (gvjs_$k(b) || typeof gvjs_p.Promise === gvjs_d && b instanceof gvjs_p.Promise)
+          d = !0,
+            a.iW = !0
+      } catch (k) {
+        b = k,
+          a.BI = !0,
+        gvjs_xl(a) || (c = !0)
+      }
+  }
+  a.ik = b;
+  d && (h = gvjs_s(a.H8, a, !0),
+    d = gvjs_s(a.H8, a, !1),
+    b instanceof gvjs_rl ? (gvjs_wl(b, h, d),
+      b.Oka = !0) : b.then(h, d));
+  c && (b = new gvjs_zl(b),
+    gvjs_yl[b.ac] = b,
+    a.KU = b.ac)
+}
+function gvjs_vl() {
+  gvjs_ve.call(this)
+}
+gvjs_t(gvjs_vl, gvjs_ve);
+gvjs_vl.prototype.message = "Deferred has already fired";
+gvjs_vl.prototype.name = "AlreadyCalledError";
+function gvjs_sl() {
+  gvjs_ve.call(this)
+}
+gvjs_t(gvjs_sl, gvjs_ve);
+gvjs_sl.prototype.message = "Deferred was canceled";
+gvjs_sl.prototype.name = "CanceledError";
+function gvjs_zl(a) {
+  this.ac = gvjs_p.setTimeout(gvjs_s(this.Vxa, this), 0);
+  this.xy = a
+}
+gvjs_zl.prototype.Vxa = function() {
+  delete gvjs_yl[this.ac];
+  throw this.xy;
+}
+;
+var gvjs_yl = {};
+var gvjs_qba = gvjs_9e("https://maps.googleapis.com/maps/api/js?key=%{key}");
+function gvjs_Al() {
+  this.cache = {};
+  this.yC = new google.maps.Geocoder;
+  this.cache[gvjs_Hi({
+    address: ""
+  })] = {
+    response: [],
+    status: google.maps.GeocoderStatus.ZERO_RESULTS
+  };
+  this.yx = new Set;
+  this.Fw = new Map;
+  this.cE = new gvjs_Yk
+}
+gvjs_Al.prototype.aZ = gvjs_n(22);
+gvjs_Al.prototype.FI = gvjs_n(23);
+gvjs_le(gvjs_Al);
+function gvjs_O(a, b) {
+  this.start = a < b ? a : b;
+  this.end = a < b ? b : a
+}
+gvjs_O.prototype.clone = function() {
+  return new gvjs_O(this.start,this.end)
+}
+;
+gvjs_O.prototype.getLength = function() {
+  return this.end - this.start
+}
+;
+function gvjs_Bl(a, b) {
+  return a.start <= b && a.end >= b
+}
+;function gvjs_Cl() {}
+gvjs_Cl.prototype.Pb = function() {}
+;
+function gvjs_Dl(a) {
+  if (gvjs_r(a) && typeof a.$ === gvjs_d && typeof a.ca === gvjs_d)
+    return a;
+  throw Error("Invalid data table.");
+}
+gvjs_Cl.prototype.Ej = function(a) {
+  return this.Pb(a) ? 2 : 0
+}
+;
+function gvjs_El(a, b, c) {
+  return 0 === c.length || gvjs_Fe(c, function(d) {
+    return null == d || a.Jg(b) === d
+  })
+}
+function gvjs_Fl(a, b, c) {
+  return 0 === c.length || gvjs_Fe(c, function(d) {
+    return a.W(b) === d
+  })
+}
+function gvjs_Gl(a, b, c, d) {
+  var e;
+  if (e = b < a.$())
+    e = a.W(b) === c;
+  if (c = e)
+    d = null == d ? null : d,
+      c = null == d || a.Jg(b) === d;
+  return c
+}
+function gvjs_Hl(a, b, c, d) {
+  d = null == d ? [] : [d];
+  return b < a.$() && gvjs_Fl(a, b, c) && gvjs_El(a, b, d)
+}
+gvjs_Cl.prototype.indexOf = function(a, b) {
+  for (var c = 0; c < a.$(); c++)
+    if (a.W(c) == b)
+      return c;
+  return -1
+}
+;
+function gvjs_Il(a, b, c) {
+  for (var d = 0; d < b.length; ++d) {
+    var e = b[d];
+    if (e >= a.$() || a.W(e) != c[d])
+      return !1
+  }
+  return !0
+}
+function gvjs_Jl(a, b) {
+  return gvjs_Gl(a, b, gvjs_g) ? gvjs_Kl(a, b, function(c) {
+    return 0 <= c
+  }) : !1
+}
+function gvjs_Kl(a, b, c) {
+  for (var d = Math.min(a.ca(), 20), e = 0; e < d; e++) {
+    var f = a.getValue(e, b);
+    if (null != f && !c(f))
+      return !1
+  }
+  return !0
+}
+function gvjs_rba(a) {
+  function b(c) {
+    return gvjs_Bl(new gvjs_O(-180,180), c) && !gvjs_1g(c)
+  }
+  return gvjs_Gl(a, 0, gvjs_g) && gvjs_Gl(a, 1, gvjs_g) ? gvjs_Kl(a, 0, function(c) {
+    return gvjs_Bl(new gvjs_O(-90,90), c) && !gvjs_1g(c)
+  }) && gvjs_Kl(a, 1, b) : !1
+}
+function gvjs_Ll(a) {
+  for (var b = a.Py(0), c = Math.min(a.ca(), 20), d = 0, e = 0; e < c; e++) {
+    var f = a.getValue(e, 1);
+    f && !gvjs_He(b, f) || d++
+  }
+  return .6 < d / c
+}
+;function gvjs_Ml() {}
+gvjs_o(gvjs_Ml, gvjs_Cl);
+gvjs_Ml.prototype.Pb = function(a) {
+  a = gvjs_Dl(a);
+  var b = a.$();
+  if (2 > b)
+    return !1;
+  var c = a.W(0);
+  if (c != gvjs_Lb && c != gvjs_Mb || a.W(1) != gvjs_g)
+    return !1;
+  c = 0;
+  for (var d = 1; d < b; d++) {
+    var e = a.W(d);
+    if (e == gvjs_g)
+      c = 0;
+    else if (e == gvjs_l) {
+      if (c++,
+      2 < c)
+        return !1
+    } else
+      return !1
+  }
+  return !0
+}
+;
+gvjs_Ml.prototype.Ej = function(a) {
+  if (!this.Pb(a))
+    return 0;
+  a = gvjs_Dl(a);
+  var b = 0 < this.indexOf(a, gvjs_l)
+    , c = a.ca()
+    , d = a.bn(0);
+  if (50 < c)
+    a = !0;
+  else {
+    for (var e = Number.MAX_VALUE, f = Number.MIN_VALUE, g = 1; g < c; g++) {
+      var h = Math.abs(a.getValue(d[g - 1], 0) - a.getValue(d[g], 0));
+      e = 0 < h && h < e ? h : e;
+      f = h > f ? h : f
+    }
+    a = 0 != e && 50 < f / e ? !0 : !1
+  }
+  return b && a ? 3 : b || a ? 2 : 1
+}
+;
+function gvjs_Nl(a) {
+  a = a || {};
+  this.h7 = !!a.wB
+}
+gvjs_o(gvjs_Nl, gvjs_Cl);
+gvjs_Nl.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = 0
+    , c = a.$();
+  if (1 > c)
+    return !1;
+  if (!gvjs_Gl(a, 0, gvjs_g) && (b++,
+    this.h7))
+    for (; b < c && gvjs_Gl(a, b, gvjs_l); )
+      b++;
+  for (var d = null; b < c; ) {
+    var e = a.W(b);
+    if (e == gvjs_g)
+      d = {};
+    else if (this.h7 && e == gvjs_l) {
+      if (!d)
+        return !1
+    } else if (e == gvjs_zb) {
+      if (!d || d.Nx)
+        return !1;
+      d.Nx = b
+    } else
+      return !1;
+    b++
+  }
+  return null !== d
+}
+;
+function gvjs_Ol(a) {
+  gvjs_Nl.call(this, a);
+  this.W_ = a && a.Qh || !1
+}
+gvjs_o(gvjs_Ol, gvjs_Nl);
+gvjs_Ol.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  if (!gvjs_Nl.prototype.Pb.call(this, a))
+    return !1;
+  var b = a.$();
+  if (this.W_)
+    for (var c = 1; c < b; c++)
+      if (gvjs_Gl(a, c, gvjs_g) && !gvjs_Jl(a, c))
+        return !1;
+  return !0
+}
+;
+gvjs_Ol.prototype.Ej = function(a) {
+  for (var b = a.$(), c = a.ca(), d = 0, e = !1, f = 0; f < b; f++)
+    gvjs_Gl(a, f, gvjs_g) && (d++,
+    gvjs_Jl(a, f) || (e = !0));
+  return this.Pb(a) ? 1 == c || e || gvjs_Gl(a, 0, gvjs_l) ? 1 : 2 < d && this.W_ ? 3 : 1 != d || this.W_ ? 1 : 2 : 0
+}
+;
+function gvjs_Pl() {}
+gvjs_o(gvjs_Pl, gvjs_Cl);
+gvjs_Pl.prototype.Pb = function(a) {
+  a = gvjs_Dl(a);
+  var b = a.$();
+  return 3 > b || 5 < b || !gvjs_Gl(a, 0, gvjs_l) || !gvjs_Gl(a, 1, gvjs_g) || !gvjs_Gl(a, 2, gvjs_g) || 3 < b && !gvjs_Gl(a, 3, gvjs_l) || 4 < b && !gvjs_Gl(a, 4, gvjs_g) ? !1 : !0
+}
+;
+gvjs_Pl.prototype.Ej = function(a) {
+  a = gvjs_Dl(a);
+  if (this.Pb(a)) {
+    var b = a;
+    if (gvjs_Gl(b, 3, gvjs_l)) {
+      for (var c = {}, d = 0, e = Math.min(b.ca(), 20), f = 0; f < e; f++) {
+        var g = b.getValue(f, 3);
+        c[g] || d++;
+        c[g] = !0
+      }
+      b = 10 > d
+    } else
+      b = !1;
+    a = b ? 3 : gvjs_Gl(a, 3, gvjs_l) ? 1 : 2
+  } else
+    a = 0;
+  return a
+}
+;
+function gvjs_Ql() {}
+gvjs_o(gvjs_Ql, gvjs_Cl);
+gvjs_Ql.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (5 > b || 6 < b || !(gvjs_Gl(a, 0, gvjs_l) && gvjs_Gl(a, 1, gvjs_g) && gvjs_Gl(a, 2, gvjs_g) && gvjs_Gl(a, 3, gvjs_g) && gvjs_Gl(a, 4, gvjs_g)) || 6 == b && !gvjs_Gl(a, 5, gvjs_l))
+    return !1;
+  b = Math.min(a.ca(), 20);
+  for (var c = !0, d = 0; d < b; d++) {
+    var e = a.getValue(d, 1)
+      , f = a.getValue(d, 2)
+      , g = a.getValue(d, 3)
+      , h = a.getValue(d, 4);
+    if (null != e && null != f && null != g && null != h && (c = !1,
+    e != Math.min(e, f, g, h) || h != Math.max(e, f, g, h)))
+      return !1
+  }
+  return !c
+}
+;
+gvjs_Ql.prototype.Ej = function(a) {
+  return this.Pb(a) ? 3 : 0
+}
+;
+function gvjs_Rl(a) {
+  gvjs_Nl.call(this, a)
+}
+gvjs_o(gvjs_Rl, gvjs_Nl);
+gvjs_Rl.prototype.Ej = function(a) {
+  a = gvjs_Dl(a);
+  var b = gvjs_Gl(a, 0, gvjs_g)
+    , c = a.$();
+  b || c--;
+  return this.Pb(a) ? 2 > c ? 1 : 2 : 0
+}
+;
+function gvjs_Sl() {}
+gvjs_o(gvjs_Sl, gvjs_Cl);
+gvjs_Sl.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (1 > b || 2 < b)
+    b = !1;
+  else {
+    var c = !0;
+    2 == b && (c = c && gvjs_Gl(a, 0, gvjs_l));
+    b = c = c && gvjs_Jl(a, b - 1)
+  }
+  if (!b)
+    if (b = a.$(),
+      c = a.ca(),
+    0 == b || 1 != c)
+      b = !1;
+    else {
+      c = !0;
+      for (var d = 0; d < b; d++)
+        if (!gvjs_Gl(a, d, gvjs_g)) {
+          c = !1;
+          break
+        }
+      b = c
+    }
+  return b
+}
+;
+gvjs_Sl.prototype.Ej = function(a) {
+  return this.Pb(a) ? 1 < a.ca() ? 2 : 3 : 0
+}
+;
+function gvjs_Tl() {}
+gvjs_o(gvjs_Tl, gvjs_Cl);
+gvjs_Tl.prototype.Pb = function(a) {
+  var b = a.$();
+  if (1 > b || 2 < b)
+    return !1;
+  var c = gvjs_Gl(a, 0, gvjs_l);
+  2 == b && (c = c && gvjs_Gl(a, 1, gvjs_g));
+  return c
+}
+;
+gvjs_Tl.prototype.Ej = function(a) {
+  return this.Pb(a) ? 1 : 0
+}
+;
+gvjs_Tl.prototype.Ac = function(a, b, c) {
+  try {
+    a = gvjs_Dl(a);
+    b = b || gvjs_ub;
+    var d = 0
+      , e = -1
+      , f = -1
+      , g = -1
+      , h = -1;
+    if (gvjs_Il(a, [d, d + 1], [gvjs_g, gvjs_g])) {
+      var k = gvjs_9c;
+      g = d;
+      h = d + 1;
+      d += 2;
+      if (b === gvjs_yd)
+        throw Error("displayMode must be set to Markers when using lat/long addresses.");
+      b === gvjs_ub && (b = gvjs_bd)
+    } else if (gvjs_Il(a, [d], [gvjs_l])) {
+      switch (b) {
+        case gvjs_ub:
+          k = gvjs_xd;
+          b = gvjs_yd;
+          e = d;
+          break;
+        case gvjs_yd:
+          k = gvjs_xd;
+          e = d;
+          break;
+        case gvjs_bd:
+        case gvjs_m:
+          k = "address";
+          f = d;
+          break;
+        default:
+          throw Error("Unknown displayMode: " + b);
+      }
+      d += 1
+    } else
+      throw Error("Unknown address type.");
+    var l = null;
+    gvjs_Il(a, [d], [gvjs_l]) && gvjs_Pd != a.Bd(d, gvjs_Bd) && (l = d++);
+    var m = null
+      , n = null;
+    gvjs_Il(a, [d], [gvjs_g]) && (m = d++,
+    gvjs_Il(a, [d], [gvjs_g]) && (n = d++));
+    var p = null;
+    gvjs_Il(a, [d], [gvjs_l]) && gvjs_Pd == a.Bd(d, gvjs_Bd) && (p = d++);
+    k != gvjs_xd && null != m && null == n && (n = m);
+    if (a.$() != d)
+      throw Error("Table contains more columns than expected (Expecting " + d + " columns)");
+    return {
+      JV: k,
+      ZX: b,
+      KK: e,
+      fG: f,
+      sD: g,
+      yD: h,
+      FJ: l,
+      Yu: m,
+      XE: n,
+      m5: p
+    }
+  } catch (q) {
+    return c && c.Sc("Incompatible data table: " + q),
+      null
+  }
+}
+;
+function gvjs_Ul(a) {
+  gvjs_Nl.call(this, a)
+}
+gvjs_o(gvjs_Ul, gvjs_Nl);
+gvjs_Ul.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  return gvjs_Nl.prototype.Pb.call(this, a) ? !0 : !1
+}
+;
+gvjs_Ul.prototype.Ej = function(a) {
+  for (var b = a.$(), c = a.ca(), d = 0, e = 0, f = 0; f < b; f++)
+    gvjs_Gl(a, f, gvjs_g) ? d++ : gvjs_Gl(a, f, gvjs_Lb) && e++;
+  return this.Pb(a) ? 10 > c ? 1 : 2 > d && 0 == e ? 3 : 2 : 0
+}
+;
+function gvjs_Vl() {}
+gvjs_o(gvjs_Vl, gvjs_Cl);
+gvjs_Vl.prototype.Pb = function(a) {
+  return gvjs_Wl(a) || gvjs_Xl(a)
+}
+;
+gvjs_Vl.prototype.Ej = function(a) {
+  var b = gvjs_Wl(a);
+  a = gvjs_Xl(a);
+  return b || a ? a ? 1 : 3 : 0
+}
+;
+function gvjs_Wl(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (2 > b || 3 < b)
+    return !1;
+  var c = gvjs_Gl(a, 0, gvjs_g);
+  c = c && gvjs_Gl(a, 1, gvjs_g);
+  3 == b && (c = c && gvjs_Gl(a, 2, gvjs_l));
+  return c && gvjs_rba(a)
+}
+function gvjs_Xl(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  return 1 > b || 2 < b || !gvjs_Gl(a, 0, gvjs_l) || 2 == b && !gvjs_Gl(a, 1, gvjs_l) ? !1 : !0
+}
+;function gvjs_Yl() {}
+gvjs_o(gvjs_Yl, gvjs_Cl);
+gvjs_Yl.prototype.Pb = function(a) {
+  a = gvjs_Dl(a);
+  var b = a.$();
+  if (3 > b || a.W(0) != gvjs_l)
+    return !1;
+  var c = a.W(1);
+  if (c != gvjs_g && c != gvjs_Lb && c != gvjs_l || c == gvjs_l && !gvjs_sba(a) && !gvjs_tba(a) || c == gvjs_g && !gvjs_Kl(a, 1, function(e) {
+    return gvjs_1g(e)
+  }))
+    return !1;
+  for (c = 2; c < b; c++) {
+    var d = a.W(c);
+    if (d != gvjs_g && d != gvjs_l)
+      return !1
+  }
+  return !0
+}
+;
+gvjs_Yl.prototype.Ej = function(a) {
+  try {
+    a = gvjs_Dl(a)
+  } catch (b) {
+    return 0
+  }
+  return this.Pb(a) ? gvjs_Gl(a, 1, gvjs_g) && !gvjs_uba(a) ? 1 : 3 : 0
+}
+;
+function gvjs_uba(a) {
+  return gvjs_Kl(a, 1, function(b) {
+    return 1900 < b && 2100 > b
+  })
+}
+function gvjs_sba(a) {
+  return gvjs_Kl(a, 1, function(b) {
+    return 7 != b.length || isNaN(b.substring(0, 3)) || "W" != b.charAt(4) || isNaN(b.substring(6, 7)) ? !1 : !0
+  })
+}
+function gvjs_tba(a) {
+  return gvjs_Kl(a, 1, function(b) {
+    return 6 != b.length || isNaN(b.substring(0, 3)) || "Q" != b.charAt(4) || isNaN(b.charAt(5)) ? !1 : !0
+  })
+}
+;function gvjs_Zl() {}
+gvjs_o(gvjs_Zl, gvjs_Cl);
+gvjs_Zl.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (2 > b || 3 < b)
+    return !1;
+  var c = gvjs_Gl(a, 0, gvjs_l) && gvjs_Gl(a, 1, gvjs_l);
+  3 == b && (c = c && gvjs_Gl(a, 2, gvjs_l));
+  return c && gvjs_Ll(a)
+}
+;
+gvjs_Zl.prototype.Ej = function(a) {
+  return this.Pb(a) ? 3 : 0
+}
+;
+function gvjs__l() {}
+gvjs_o(gvjs__l, gvjs_Cl);
+gvjs__l.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  return 1 > b || 2 < b ? !1 : gvjs_Gl(a, b - 1, gvjs_g) && gvjs_Jl(a, b - 1)
+}
+;
+gvjs__l.prototype.Ej = function(a) {
+  if (this.Pb(a))
+    if (1 == a.ca())
+      a = 1;
+    else {
+      var b;
+      if (!(b = !gvjs_Gl(a, 0, gvjs_l) || 25 < a.ca())) {
+        for (var c = b = 0; c < a.ca(); c++)
+          b += a.getValue(c, 1);
+        b = !(97 < b && 103 > b || .97 < b && 1.03 > b)
+      }
+      a = b ? 2 : 3
+    }
+  else
+    a = 0;
+  return a
+}
+;
+function gvjs_0l() {}
+gvjs_o(gvjs_0l, gvjs_Cl);
+gvjs_0l.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (0 == b)
+    return !1;
+  for (var c = gvjs_Gl(a, 0, gvjs_l) ? 1 : 0, d = b > c; c < b; c++)
+    if (!gvjs_Gl(a, c, gvjs_g)) {
+      d = !1;
+      break
+    }
+  return d
+}
+;
+function gvjs_1l() {}
+gvjs_o(gvjs_1l, gvjs_Cl);
+gvjs_1l.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  for (var b = !0, c = a.$(), d = 0; d < c; d++)
+    if (!gvjs_Gl(a, d, gvjs_g)) {
+      b = !1;
+      break
+    }
+  return b
+}
+;
+gvjs_1l.prototype.Ej = function(a) {
+  return this.Pb(a) ? 2 > a.$() ? 1 : 2 : 0
+}
+;
+function gvjs_2l() {}
+gvjs_o(gvjs_2l, gvjs_Cl);
+gvjs_2l.prototype.Pb = function() {
+  return !0
+}
+;
+function gvjs_3l(a) {
+  this.m = a || new gvjs_Aj([])
+}
+gvjs_o(gvjs_3l, gvjs_Cl);
+gvjs_3l.prototype.Pb = function(a) {
+  try {
+    this.Ac(a)
+  } catch (b) {
+    return !1
+  }
+  return !0
+}
+;
+gvjs_3l.prototype.Ac = function(a) {
+  a = gvjs_Dl(a);
+  for (var b = [], c = a.$(), d = 0; d < c; ++d) {
+    var e = a.Jg(d);
+    if ("" === e)
+      b.push({
+        index: d,
+        Nf: {}
+      });
+    else {
+      if (1 > b.length)
+        throw Error("At least 1 data column must come before any role columns");
+      gvjs_Ae(b).Nf[e] = d
+    }
+  }
+  c = b.length;
+  if (3 !== c && 4 !== c)
+    throw Error("Invalid data table format: must have 3 or 4 data columns.");
+  d = 4 == c;
+  this.jb(a, b[0].index, gvjs_l);
+  d && this.jb(a, b[1].index, gvjs_l);
+  this.jb(a, b[d ? 2 : 1].index, gvjs_4l);
+  this.jb(a, b[d ? 3 : 2].index, gvjs_4l);
+  return 4 === c ? (a = !gvjs_K(this.m, "timeline.taskMajor", !0),
+    {
+      qw: b[a ? 1 : 0],
+      tt: b[a ? 0 : 1],
+      vL: b[2],
+      WH: b[3]
+    }) : {
+    qw: b[0],
+    tt: null,
+    vL: b[1],
+    WH: b[2]
+  }
+}
+;
+gvjs_3l.prototype.jb = function(a, b, c) {
+  Array.isArray(c) || (c = [c]);
+  if (!gvjs_Hl(a, b, c))
+    throw Error(gvjs_Sa + b + gvjs_ba + c + "'.");
+}
+;
+var gvjs_4l = [gvjs_Lb, gvjs_g, gvjs_Mb];
+function gvjs_5l() {}
+gvjs_o(gvjs_5l, gvjs_Cl);
+gvjs_5l.prototype.Pb = function(a) {
+  gvjs_Dl(a);
+  var b = a.$();
+  if (2 > b || 4 < b)
+    return !1;
+  var c = gvjs_Gl(a, 0, gvjs_l) && gvjs_Gl(a, 1, gvjs_l);
+  2 < b && (c = c && gvjs_Jl(a, 2)) && 3 < b && (c = c && gvjs_Gl(a, 3, gvjs_g));
+  return c && gvjs_Ll(a)
+}
+;
+gvjs_5l.prototype.Ej = function(a) {
+  return this.Pb(a) ? 3 : 0
+}
+;
+function gvjs_6l(a) {
+  this.yl = Array.isArray(a) ? a : gvjs_Xe(gvjs_vba)
+}
+gvjs_6l.prototype.BW = function(a) {
+  var b = [];
+  gvjs_u(this.yl, function(c) {
+    var d = gvjs_wba[c]
+      , e = d && d.format;
+    e && (e = e.Ej(a),
+    0 != e && b.push({
+      type: c,
+      o$: e,
+      ve: d.ve
+    }))
+  });
+  gvjs_xba(b);
+  return gvjs_v(b, function(c) {
+    return c.type
+  })
+}
+;
+function gvjs_xba(a) {
+  gvjs_Se(a, function(b, c) {
+    var d = b.o$ - c.o$;
+    0 == d && (d = b.ve - c.ve);
+    return -d
+  })
+}
+var gvjs_vba = {
+  tza: gvjs_ma,
+  Uha: gvjs_na,
+  zza: gvjs_qa,
+  Kza: gvjs_ra,
+  Mza: gvjs_ua,
+  Uza: gvjs_xa,
+  dia: gvjs_ya,
+  hAa: gvjs_Ga,
+  iAa: gvjs_Ha,
+  Cia: gvjs_La,
+  pAa: gvjs_Oa,
+  qAa: gvjs_Pa,
+  QAa: gvjs_Za,
+  Eia: gvjs_Va,
+  bBa: gvjs_3a,
+  GAa: gvjs_Wa,
+  VAa: gvjs_2a,
+  sja: gvjs_9a,
+  wBa: gvjs_oa,
+  zBa: gvjs_ab,
+  G6: gvjs_db,
+  IBa: gvjs_fb,
+  KBa: gvjs_hb,
+  Rja: gvjs_mb
+}
+  , gvjs_wba = {
+  AnnotatedTimeLine: {
+    format: new gvjs_Ml,
+    ve: 3
+  },
+  AreaChart: {
+    format: new gvjs_Ol({
+      wB: !0
+    }),
+    ve: 2
+  },
+  BarChart: {
+    format: new gvjs_Nl({
+      wB: !0
+    }),
+    ve: 2
+  },
+  BubbleChart: {
+    format: new gvjs_Pl,
+    ve: 2
+  },
+  CandlestickChart: {
+    format: new gvjs_Ql,
+    ve: 2
+  },
+  ColumnChart: {
+    format: new gvjs_Nl({
+      wB: !0
+    }),
+    ve: 2
+  },
+  ComboChart: {
+    format: new gvjs_Rl({
+      wB: !0
+    }),
+    ve: 2
+  },
+  Gauge: {
+    format: new gvjs_Sl,
+    ve: 1
+  },
+  GeoChart: {
+    format: new gvjs_Tl,
+    ve: 3
+  },
+  Histogram: {
+    format: new gvjs_Ul,
+    ve: 3
+  },
+  LineChart: {
+    format: new gvjs_Nl({
+      wB: !0
+    }),
+    ve: 2
+  },
+  ImageRadarChart: {
+    format: new gvjs_0l,
+    ve: 1
+  },
+  ImageSparkLine: {
+    format: new gvjs_1l,
+    ve: 1
+  },
+  Map: {
+    format: new gvjs_Vl,
+    ve: 2
+  },
+  MotionChart: {
+    format: new gvjs_Yl,
+    ve: 3
+  },
+  OrgChart: {
+    format: new gvjs_Zl,
+    ve: 2
+  },
+  PieChart: {
+    format: new gvjs__l,
+    ve: 2
+  },
+  ScatterChart: {
+    format: new gvjs_Nl({
+      wB: !0
+    }),
+    ve: 2
+  },
+  "AreaChart-stacked": {
+    format: new gvjs_Ol({
+      Qh: !0
+    }),
+    ve: 2
+  },
+  SteppedAreaChart: {
+    format: new gvjs_Ol,
+    ve: 2
+  },
+  Table: {
+    format: new gvjs_2l,
+    ve: 0
+  },
+  Timeline: {
+    format: new gvjs_3l,
+    ve: 2
+  },
+  TreeMap: {
+    format: new gvjs_5l,
+    ve: 2
+  },
+  WordTree: {
+    format: new gvjs_Tl,
+    ve: 2
+  }
+};
+gvjs_q("google.visualization.ChartSelection", gvjs_6l, void 0);
+gvjs_6l.prototype.calculateChartTypes = gvjs_6l.prototype.BW;
+var google = google || window.google || {};
+var gvjs_yba = new Set([gvjs_Zb, gvjs__b, gvjs_0b, gvjs_2b, gvjs_3b, gvjs_4b, gvjs_5b, gvjs_6b, gvjs_7b, gvjs_8b, gvjs_9b, gvjs_$b, gvjs_ac, "google.visualization.Circles", gvjs_bc, gvjs_cc, gvjs_dc, gvjs_ec, gvjs_fc, gvjs_gc, gvjs_ic, gvjs_jc, gvjs_kc, gvjs_lc, gvjs_mc, gvjs_nc, gvjs_oc, gvjs_pc, gvjs_qc, gvjs_rc, gvjs_sc, gvjs_tc, gvjs_uc, gvjs_vc, gvjs_wc, gvjs_xc, gvjs_yc, gvjs_zc, gvjs_Ac, gvjs_Bc, gvjs_Cc, gvjs_Ec, gvjs_Fc, gvjs_Gc, gvjs_Hc, gvjs_Ic, gvjs_Jc, gvjs_Lc, gvjs_Mc, gvjs_Nc, gvjs_Oc, gvjs_Pc, gvjs_Qc, gvjs_Rc, gvjs_Sc, gvjs_Tc, gvjs_Uc, gvjs_Vc, gvjs_Wc, gvjs_Xc, gvjs_Yc, gvjs_Zc, gvjs_1c, gvjs_0c]);
+function gvjs_zba(a) {
+  a = String(a);
+  return [gvjs_1b + a, gvjs_Yb + a, a].some(function(b) {
+    return gvjs_yba.has(b)
+  }) ? a : ""
+}
+;var gvjs_7l = {};
+function gvjs_8l(a) {
+  if (gvjs_y && !gvjs_Eg(9))
+    return [0, 0, 0, 0];
+  var b = gvjs_7l.hasOwnProperty(a) ? gvjs_7l[a] : null;
+  if (b)
+    return b;
+  65536 < Object.keys(gvjs_7l).length && (gvjs_7l = {});
+  var c = [0, 0, 0, 0];
+  b = gvjs_9l(a, /\\[0-9A-Fa-f]{6}\s?/g);
+  b = gvjs_9l(b, /\\[0-9A-Fa-f]{1,5}\s/g);
+  b = gvjs_9l(b, /\\./g);
+  b = b.replace(/:not\(([^\)]*)\)/g, "     $1 ");
+  b = b.replace(/{[^]*/gm, "");
+  b = gvjs_$l(b, c, /(\[[^\]]+\])/g, 2);
+  b = gvjs_$l(b, c, /(#[^\#\s\+>~\.\[:]+)/g, 1);
+  b = gvjs_$l(b, c, /(\.[^\s\+>~\.\[:]+)/g, 2);
+  b = gvjs_$l(b, c, /(::[^\s\+>~\.\[:]+|:first-line|:first-letter|:before|:after)/gi, 3);
+  b = gvjs_$l(b, c, /(:[\w-]+\([^\)]*\))/gi, 2);
+  b = gvjs_$l(b, c, /(:[^\s\+>~\.\[:]+)/g, 2);
+  b = b.replace(/[\*\s\+>~]/g, " ");
+  b = b.replace(/[#\.]/g, " ");
+  gvjs_$l(b, c, /([^\s\+>~\.\[:]+)/g, 3);
+  b = c;
+  return gvjs_7l[a] = b
+}
+function gvjs_$l(a, b, c, d) {
+  return a.replace(c, function(e) {
+    b[d] += 1;
+    return Array(e.length + 1).join(" ")
+  })
+}
+function gvjs_9l(a, b) {
+  return a.replace(b, function(c) {
+    return Array(c.length + 1).join("A")
+  })
+}
+;var gvjs_Aba = {
+  rgb: !0,
+  rgba: !0,
+  alpha: !0,
+  rect: !0,
+  image: !0,
+  "linear-gradient": !0,
+  "radial-gradient": !0,
+  "repeating-linear-gradient": !0,
+  "repeating-radial-gradient": !0,
+  "cubic-bezier": !0,
+  matrix: !0,
+  perspective: !0,
+  rotate: !0,
+  rotate3d: !0,
+  rotatex: !0,
+  rotatey: !0,
+  steps: !0,
+  rotatez: !0,
+  scale: !0,
+  scale3d: !0,
+  scalex: !0,
+  scaley: !0,
+  scalez: !0,
+  skew: !0,
+  skewx: !0,
+  skewy: !0,
+  translate: !0,
+  translate3d: !0,
+  translatex: !0,
+  translatey: !0,
+  translatez: !0
+}
+  , gvjs_Bba = /[\n\f\r"'()*<>]/g
+  , gvjs_Cba = {
+    "\n": "%0a",
+    "\f": "%0c",
+    "\r": "%0d",
+    '"': "%22",
+    "'": "%27",
+    "(": "%28",
+    ")": "%29",
+    "*": "%2a",
+    "<": "%3c",
+    ">": "%3e"
+  };
+function gvjs_Dba(a) {
+  return gvjs_Cba[a]
+}
+function gvjs_Eba(a, b, c) {
+  b = gvjs_kf(b);
+  if ("" == b)
+    return null;
+  var d = String(b.substr(0, 4)).toLowerCase();
+  if (0 == ("url(" < d ? -1 : "url(" == d ? 0 : 1)) {
+    if (!b.endsWith(")") || 1 < (b ? b.split("(").length - 1 : 0) || 1 < (b ? b.split(")").length - 1 : 0) || !c)
+      a = null;
+    else {
+      a: for (b = b.substring(4, b.length - 1),
+                d = 0; 2 > d; d++) {
+        var e = "\"'".charAt(d);
+        if (b.charAt(0) == e && b.charAt(b.length - 1) == e) {
+          b = b.substring(1, b.length - 1);
+          break a
+        }
+      }
+      a = c ? (a = c(b, a)) && gvjs_xf(a) != gvjs_ob ? 'url("' + gvjs_xf(a).replace(gvjs_Bba, gvjs_Dba) + '")' : null : null
+    }
+    return a
+  }
+  if (0 < b.indexOf("(")) {
+    if (/"|'/.test(b))
+      return null;
+    for (a = /([\-\w]+)\(/g; c = a.exec(b); )
+      if (!(c[1].toLowerCase()in gvjs_Aba))
+        return null
+  }
+  return b
+}
+;function gvjs_am(a, b) {
+  a = gvjs_p[a];
+  return a && a.prototype ? (b = Object.getOwnPropertyDescriptor(a.prototype, b)) && b.get || null : null
+}
+function gvjs_bm(a, b) {
+  return (a = gvjs_p[a]) && a.prototype && a.prototype[b] || null
+}
+var gvjs_Fba = gvjs_am(gvjs_Da, gvjs_tb) || gvjs_am("Node", gvjs_tb)
+  , gvjs_cm = gvjs_bm(gvjs_Da, gvjs_2c)
+  , gvjs_dm = gvjs_bm(gvjs_Da, gvjs_Vb)
+  , gvjs_Gba = gvjs_bm(gvjs_Da, gvjs_Fd)
+  , gvjs_Hba = gvjs_bm(gvjs_Da, gvjs_Ad)
+  , gvjs_Iba = gvjs_bm(gvjs_Da, gvjs_Wb)
+  , gvjs_Jba = gvjs_bm(gvjs_Da, "matches") || gvjs_bm(gvjs_Da, gvjs_nd)
+  , gvjs_Kba = gvjs_am("Node", gvjs_od)
+  , gvjs_Lba = gvjs_am("Node", gvjs_pd)
+  , gvjs_Mba = gvjs_am("Node", "parentNode")
+  , gvjs_Nba = gvjs_am("HTMLElement", gvjs_Jd) || gvjs_am(gvjs_Da, gvjs_Jd)
+  , gvjs_Oba = gvjs_am("HTMLStyleElement", "sheet")
+  , gvjs_Pba = gvjs_bm(gvjs_sa, gvjs_Xb)
+  , gvjs_Qba = gvjs_bm(gvjs_sa, "setProperty");
+function gvjs_em(a, b, c, d) {
+  if (a)
+    return a.apply(b);
+  a = b[c];
+  if (!d(a))
+    throw Error(gvjs_va);
+  return a
+}
+function gvjs_fm(a, b, c, d) {
+  if (a)
+    return a.apply(b, d);
+  if (gvjs_y && 10 > document.documentMode) {
+    if (!b[c].call)
+      throw Error("IE Clobbering detected");
+  } else if (typeof b[c] != gvjs_d)
+    throw Error(gvjs_va);
+  return b[c].apply(b, d)
+}
+function gvjs_gm(a) {
+  return gvjs_em(gvjs_Fba, a, gvjs_tb, function(b) {
+    return b instanceof NamedNodeMap
+  })
+}
+function gvjs_hm(a, b, c) {
+  try {
+    gvjs_fm(gvjs_Gba, a, gvjs_Fd, [b, c])
+  } catch (d) {
+    if (-1 == d.message.indexOf("A security problem occurred"))
+      throw d;
+  }
+}
+function gvjs_Rba(a) {
+  return gvjs_em(gvjs_Nba, a, gvjs_Jd, function(b) {
+    return b instanceof CSSStyleDeclaration
+  })
+}
+function gvjs_Sba(a) {
+  return gvjs_em(gvjs_Oba, a, "sheet", function(b) {
+    return b instanceof CSSStyleSheet
+  })
+}
+function gvjs_im(a) {
+  return gvjs_em(gvjs_Kba, a, gvjs_od, function(b) {
+    return typeof b == gvjs_l
+  })
+}
+function gvjs_jm(a) {
+  return gvjs_em(gvjs_Lba, a, gvjs_pd, function(b) {
+    return typeof b == gvjs_g
+  })
+}
+function gvjs_km(a) {
+  return gvjs_em(gvjs_Mba, a, "parentNode", function(b) {
+    return !(b && typeof b.name == gvjs_l && b.name && "parentnode" == b.name.toLowerCase())
+  })
+}
+function gvjs_lm(a, b) {
+  return gvjs_fm(gvjs_Pba, a, a.getPropertyValue ? gvjs_Xb : gvjs_Vb, [b]) || ""
+}
+function gvjs_mm(a, b, c) {
+  gvjs_fm(gvjs_Qba, a, a.setProperty ? "setProperty" : gvjs_Fd, [b, c])
+}
+;var gvjs_Tba = gvjs_y && 10 > document.documentMode ? null : /\s*([^\s'",]+[^'",]*(('([^'\r\n\f\\]|\\[^])*')|("([^"\r\n\f\\]|\\[^])*")|[^'",])*)/g
+  , gvjs_Uba = {
+    "-webkit-border-horizontal-spacing": !0,
+    "-webkit-border-vertical-spacing": !0
+  };
+function gvjs_Vba(a, b, c) {
+  var d = [];
+  gvjs_nm(gvjs_Le(a.cssRules)).forEach(function(e) {
+    if (b && !/[a-zA-Z][\w-:\.]*/.test(b))
+      throw Error("Invalid container id");
+    if (!(b && gvjs_y && 10 == document.documentMode && /\\['"]/.test(e.selectorText))) {
+      var f = b ? e.selectorText.replace(gvjs_Tba, "#" + b + " $1") : e.selectorText;
+      d.push(gvjs_Nf(f, gvjs_om(e.style, c)))
+    }
+  });
+  return gvjs_Of(d)
+}
+function gvjs_nm(a) {
+  return a.filter(function(b) {
+    return b instanceof CSSStyleRule || b.type == CSSRule.STYLE_RULE
+  })
+}
+function gvjs_Wba(a, b, c) {
+  a = gvjs_pm("<style>" + a + "</style>");
+  return null == a || null == a.sheet ? gvjs_Qf : gvjs_Vba(a.sheet, void 0 != b ? b : null, c)
+}
+function gvjs_pm(a) {
+  if (gvjs_y && !gvjs_Eg(10) || typeof gvjs_p.DOMParser != gvjs_d)
+    return null;
+  a = gvjs_3f("<html><head></head><body>" + a + "</body></html>", null);
+  return (new DOMParser).parseFromString(gvjs_1f(a), "text/html").body.children[0]
+}
+function gvjs_om(a, b) {
+  if (!a)
+    return gvjs_Gf;
+  var c = document.createElement(gvjs_Ob).style;
+  gvjs_qm(a).forEach(function(d) {
+    var e = gvjs_tg && d in gvjs_Uba ? d : d.replace(/^-(?:apple|css|epub|khtml|moz|mso?|o|rim|wap|webkit|xv)-(?=[a-z])/i, "");
+    gvjs_hf(e, "--") || gvjs_hf(e, "var") || (d = gvjs_lm(a, d),
+      d = gvjs_Eba(e, d, b),
+    null != d && gvjs_mm(c, e, d))
+  });
+  return new gvjs_Df(c.cssText || "",gvjs_Ef)
+}
+function gvjs_Xba(a) {
+  var b = Array.from(gvjs_fm(gvjs_Iba, a, gvjs_Wb, [gvjs_7a]))
+    , c = gvjs_jaa(b, function(e) {
+    return gvjs_Le(gvjs_Sba(e).cssRules)
+  });
+  c = gvjs_nm(c);
+  c.sort(function(e, f) {
+    e = gvjs_8l(e.selectorText);
+    a: {
+      f = gvjs_8l(f.selectorText);
+      for (var g = gvjs_Re, h = Math.min(e.length, f.length), k = 0; k < h; k++) {
+        var l = g(e[k], f[k]);
+        if (0 != l) {
+          e = l;
+          break a
+        }
+      }
+      e = gvjs_Re(e.length, f.length)
+    }
+    return -e
+  });
+  a = document.createTreeWalker(a, NodeFilter.SHOW_ELEMENT, null, !1);
+  for (var d; d = a.nextNode(); )
+    c.forEach(function(e) {
+      gvjs_fm(gvjs_Jba, d, d.matches ? "matches" : gvjs_nd, [e.selectorText]) && e.style && gvjs_Yba(d, e.style)
+    });
+  b.forEach(gvjs_kh)
+}
+function gvjs_Yba(a, b) {
+  var c = gvjs_qm(a.style);
+  gvjs_qm(b).forEach(function(d) {
+    if (!(0 <= c.indexOf(d))) {
+      var e = gvjs_lm(b, d);
+      gvjs_mm(a.style, d, e)
+    }
+  })
+}
+function gvjs_qm(a) {
+  gvjs_ne(a) ? a = gvjs_Le(a) : (a = gvjs_Ye(a),
+    gvjs_Ie(a, "cssText"));
+  return a
+}
+;var gvjs_Zba = {
+  "* ARIA-CHECKED": !0,
+  "* ARIA-COLCOUNT": !0,
+  "* ARIA-COLINDEX": !0,
+  "* ARIA-CONTROLS": !0,
+  "* ARIA-DESCRIBEDBY": !0,
+  "* ARIA-DISABLED": !0,
+  "* ARIA-EXPANDED": !0,
+  "* ARIA-GOOG-EDITABLE": !0,
+  "* ARIA-HASPOPUP": !0,
+  "* ARIA-HIDDEN": !0,
+  "* ARIA-LABEL": !0,
+  "* ARIA-LABELLEDBY": !0,
+  "* ARIA-MULTILINE": !0,
+  "* ARIA-MULTISELECTABLE": !0,
+  "* ARIA-ORIENTATION": !0,
+  "* ARIA-PLACEHOLDER": !0,
+  "* ARIA-READONLY": !0,
+  "* ARIA-REQUIRED": !0,
+  "* ARIA-ROLEDESCRIPTION": !0,
+  "* ARIA-ROWCOUNT": !0,
+  "* ARIA-ROWINDEX": !0,
+  "* ARIA-SELECTED": !0,
+  "* ABBR": !0,
+  "* ACCEPT": !0,
+  "* ACCESSKEY": !0,
+  "* ALIGN": !0,
+  "* ALT": !0,
+  "* AUTOCOMPLETE": !0,
+  "* AXIS": !0,
+  "* BGCOLOR": !0,
+  "* BORDER": !0,
+  "* CELLPADDING": !0,
+  "* CELLSPACING": !0,
+  "* CHAROFF": !0,
+  "* CHAR": !0,
+  "* CHECKED": !0,
+  "* CLEAR": !0,
+  "* COLOR": !0,
+  "* COLSPAN": !0,
+  "* COLS": !0,
+  "* COMPACT": !0,
+  "* COORDS": !0,
+  "* DATETIME": !0,
+  "* DIR": !0,
+  "* DISABLED": !0,
+  "* ENCTYPE": !0,
+  "* FACE": !0,
+  "* FRAME": !0,
+  "* HEIGHT": !0,
+  "* HREFLANG": !0,
+  "* HSPACE": !0,
+  "* ISMAP": !0,
+  "* LABEL": !0,
+  "* LANG": !0,
+  "* MAX": !0,
+  "* MAXLENGTH": !0,
+  "* METHOD": !0,
+  "* MULTIPLE": !0,
+  "* NOHREF": !0,
+  "* NOSHADE": !0,
+  "* NOWRAP": !0,
+  "* OPEN": !0,
+  "* READONLY": !0,
+  "* REQUIRED": !0,
+  "* REL": !0,
+  "* REV": !0,
+  "* ROLE": !0,
+  "* ROWSPAN": !0,
+  "* ROWS": !0,
+  "* RULES": !0,
+  "* SCOPE": !0,
+  "* SELECTED": !0,
+  "* SHAPE": !0,
+  "* SIZE": !0,
+  "* SPAN": !0,
+  "* START": !0,
+  "* SUMMARY": !0,
+  "* TABINDEX": !0,
+  "* TITLE": !0,
+  "* TYPE": !0,
+  "* VALIGN": !0,
+  "* VALUE": !0,
+  "* VSPACE": !0,
+  "* WIDTH": !0
+}
+  , gvjs__ba = {
+    "* USEMAP": !0,
+    "* ACTION": !0,
+    "* CITE": !0,
+    "* HREF": !0,
+    "* LONGDESC": !0,
+    "* SRC": !0,
+    "LINK HREF": !0,
+    "* FOR": !0,
+    "* HEADERS": !0,
+    "* NAME": !0,
+    "A TARGET": !0,
+    "* CLASS": !0,
+    "* ID": !0,
+    "* STYLE": !0
+  };
+var gvjs_0ba = "undefined" != typeof WeakMap && -1 != WeakMap.toString().indexOf("[native code]")
+  , gvjs_1ba = 0;
+function gvjs_rm() {
+  this.ad = [];
+  this.mc = [];
+  this.aC = "data-elementweakmap-index-" + gvjs_1ba++
+}
+gvjs_rm.prototype.set = function(a, b) {
+  if (gvjs_fm(gvjs_cm, a, gvjs_2c, [this.aC])) {
+    var c = parseInt(gvjs_fm(gvjs_dm, a, gvjs_Vb, [this.aC]) || null, 10);
+    this.mc[c] = b
+  } else
+    c = this.mc.push(b) - 1,
+      gvjs_hm(a, this.aC, c.toString()),
+      this.ad.push(a);
+  return this
+}
+;
+gvjs_rm.prototype.get = function(a) {
+  if (gvjs_fm(gvjs_cm, a, gvjs_2c, [this.aC]))
+    return a = parseInt(gvjs_fm(gvjs_dm, a, gvjs_Vb, [this.aC]) || null, 10),
+      this.mc[a]
+}
+;
+gvjs_rm.prototype.clear = function() {
+  this.ad.forEach(function(a) {
+    gvjs_fm(gvjs_Hba, a, gvjs_Ad, [this.aC])
+  }, this);
+  this.ad = [];
+  this.mc = []
+}
+;
+var gvjs_sm = !gvjs_y || gvjs_Fg(10)
+  , gvjs_2ba = !gvjs_y || null == document.documentMode;
+function gvjs_tm() {}
+gvjs_tm.prototype.Qd = function(a) {
+  if ("TEMPLATE" == gvjs_im(a).toUpperCase())
+    return null;
+  var b = gvjs_im(a).toUpperCase();
+  if (b in this.EL)
+    b = null;
+  else if (this.gF[b])
+    b = document.createElement(b);
+  else {
+    var c = gvjs_dh(gvjs_6a);
+    this.Z3 && gvjs_hm(c, "data-sanitizer-original-tag", b.toLowerCase());
+    b = c
+  }
+  if (!b)
+    return null;
+  c = b;
+  var d = gvjs_gm(a);
+  if (null != d)
+    for (var e = 0, f; f = d[e]; e++)
+      if (f.specified) {
+        var g = a;
+        var h = f;
+        var k = h.name;
+        if (gvjs_hf(k, gvjs_Kb))
+          h = null;
+        else {
+          var l = gvjs_im(g);
+          h = h.value;
+          var m = {
+            tagName: gvjs_kf(l).toLowerCase(),
+            attributeName: gvjs_kf(k).toLowerCase()
+          }
+            , n = {
+            zX: void 0
+          };
+          m.attributeName == gvjs_Jd && (n.zX = gvjs_Rba(g));
+          g = gvjs_um(l, k);
+          g in this.sG ? (k = this.sG[g],
+            h = k(h, m, n)) : (k = gvjs_um(null, k),
+            k in this.sG ? (k = this.sG[k],
+              h = k(h, m, n)) : h = null)
+        }
+        null !== h && gvjs_hm(c, f.name, h)
+      }
+  return b
+}
+;
+var gvjs_3ba = {
+  APPLET: !0,
+  AUDIO: !0,
+  BASE: !0,
+  BGSOUND: !0,
+  EMBED: !0,
+  FORM: !0,
+  IFRAME: !0,
+  ISINDEX: !0,
+  KEYGEN: !0,
+  LAYER: !0,
+  LINK: !0,
+  META: !0,
+  OBJECT: !0,
+  SCRIPT: !0,
+  SVG: !0,
+  STYLE: !0,
+  TEMPLATE: !0,
+  VIDEO: !0
+};
+var gvjs_4ba = {
+  A: !0,
+  ABBR: !0,
+  ACRONYM: !0,
+  ADDRESS: !0,
+  AREA: !0,
+  ARTICLE: !0,
+  ASIDE: !0,
+  B: !0,
+  BDI: !0,
+  BDO: !0,
+  BIG: !0,
+  BLOCKQUOTE: !0,
+  BR: !0,
+  BUTTON: !0,
+  CAPTION: !0,
+  CENTER: !0,
+  CITE: !0,
+  CODE: !0,
+  COL: !0,
+  COLGROUP: !0,
+  DATA: !0,
+  DATALIST: !0,
+  DD: !0,
+  DEL: !0,
+  DETAILS: !0,
+  DFN: !0,
+  DIALOG: !0,
+  DIR: !0,
+  DIV: !0,
+  DL: !0,
+  DT: !0,
+  EM: !0,
+  FIELDSET: !0,
+  FIGCAPTION: !0,
+  FIGURE: !0,
+  FONT: !0,
+  FOOTER: !0,
+  FORM: !0,
+  H1: !0,
+  H2: !0,
+  H3: !0,
+  H4: !0,
+  H5: !0,
+  H6: !0,
+  HEADER: !0,
+  HGROUP: !0,
+  HR: !0,
+  I: !0,
+  IMG: !0,
+  INPUT: !0,
+  INS: !0,
+  KBD: !0,
+  LABEL: !0,
+  LEGEND: !0,
+  LI: !0,
+  MAIN: !0,
+  MAP: !0,
+  MARK: !0,
+  MENU: !0,
+  METER: !0,
+  NAV: !0,
+  NOSCRIPT: !0,
+  OL: !0,
+  OPTGROUP: !0,
+  OPTION: !0,
+  OUTPUT: !0,
+  P: !0,
+  PRE: !0,
+  PROGRESS: !0,
+  Q: !0,
+  S: !0,
+  SAMP: !0,
+  SECTION: !0,
+  SELECT: !0,
+  SMALL: !0,
+  SOURCE: !0,
+  SPAN: !0,
+  STRIKE: !0,
+  STRONG: !0,
+  STYLE: !0,
+  SUB: !0,
+  SUMMARY: !0,
+  SUP: !0,
+  TABLE: !0,
+  TBODY: !0,
+  TD: !0,
+  TEXTAREA: !0,
+  TFOOT: !0,
+  TH: !0,
+  THEAD: !0,
+  TIME: !0,
+  TR: !0,
+  TT: !0,
+  U: !0,
+  UL: !0,
+  VAR: !0,
+  WBR: !0
+};
+var gvjs_5ba = {
+  "ANNOTATION-XML": !0,
+  "COLOR-PROFILE": !0,
+  "FONT-FACE": !0,
+  "FONT-FACE-SRC": !0,
+  "FONT-FACE-URI": !0,
+  "FONT-FACE-FORMAT": !0,
+  "FONT-FACE-NAME": !0,
+  "MISSING-GLYPH": !0
+};
+function gvjs_vm(a) {
+  a = a || new gvjs_wm;
+  gvjs_6ba(a);
+  this.sG = gvjs_x(a.ao);
+  this.EL = gvjs_x(a.EL);
+  this.gF = gvjs_x(a.gF);
+  this.Z3 = a.Z3;
+  a.b9.forEach(function(b) {
+    if (!gvjs_hf(b, "data-"))
+      throw new gvjs_xe('Only "data-" attributes allowed, got: %s.',[b]);
+    if (gvjs_hf(b, gvjs_Kb))
+      throw new gvjs_xe('Attributes with "%s" prefix are not allowed, got: %s.',[gvjs_Kb, b]);
+    this.sG["* " + b.toUpperCase()] = gvjs_xm
+  }, this);
+  a.V8.forEach(function(b) {
+    b = b.toUpperCase();
+    if (!gvjs_sf(b, "-") || gvjs_5ba[b])
+      throw new gvjs_xe("Only valid custom element tag names allowed, got: %s.",[b]);
+    this.gF[b] = !0
+  }, this);
+  this.RD = a.RD;
+  this.yL = a.yL;
+  this.fO = null;
+  this.D_ = a.D_
+}
+gvjs_t(gvjs_vm, gvjs_tm);
+function gvjs_ym(a) {
+  return function(b, c) {
+    b = gvjs_kf(b);
+    return (c = a(b, c)) && gvjs_xf(c) != gvjs_ob ? gvjs_xf(c) : null
+  }
+}
+function gvjs_wm() {
+  this.ao = {};
+  gvjs_u([gvjs_Zba, gvjs__ba], function(a) {
+    gvjs_Ye(a).forEach(function(b) {
+      this.ao[b] = gvjs_xm
+    }, this)
+  }, this);
+  this.bs = {};
+  this.b9 = [];
+  this.V8 = [];
+  this.EL = gvjs_x(gvjs_3ba);
+  this.gF = gvjs_x(gvjs_4ba);
+  this.Z3 = !1;
+  this.hha = gvjs_Bf;
+  this.afa = this.AU = this.n1 = this.RD = gvjs_ye;
+  this.yL = null;
+  this.lea = this.D_ = !1
+}
+function gvjs_7ba() {
+  var a = gvjs_zm();
+  gvjs_Me(a.b9, ["data-safe-link"]);
+  return a
+}
+function gvjs_zm() {
+  var a = new gvjs_wm;
+  a.afa = gvjs_8ba;
+  return a
+}
+function gvjs_Am(a) {
+  a.hha = gvjs_Bf;
+  return a
+}
+function gvjs_9ba(a, b) {
+  return function(c, d, e, f) {
+    c = a(c, d, e, f);
+    return null == c ? null : b(c, d, e, f)
+  }
+}
+function gvjs_Bm(a, b, c, d) {
+  a[c] && !b[c] && (a[c] = gvjs_9ba(a[c], d))
+}
+gvjs_wm.prototype.cd = function() {
+  return new gvjs_vm(this)
+}
+;
+function gvjs_6ba(a) {
+  if (a.lea)
+    throw Error("HtmlSanitizer.Builder.build() can only be used once.");
+  gvjs_Bm(a.ao, a.bs, "* USEMAP", gvjs_$ba);
+  var b = gvjs_ym(a.hha);
+  ["* ACTION", "* CITE", "* HREF"].forEach(function(d) {
+    gvjs_Bm(this.ao, this.bs, d, b)
+  }, a);
+  var c = gvjs_ym(a.RD);
+  ["* LONGDESC", "* SRC", "LINK HREF"].forEach(function(d) {
+    gvjs_Bm(this.ao, this.bs, d, c)
+  }, a);
+  ["* FOR", "* HEADERS", "* NAME"].forEach(function(d) {
+    gvjs_Bm(this.ao, this.bs, d, gvjs_re(gvjs_aca, this.n1))
+  }, a);
+  gvjs_Bm(a.ao, a.bs, "A TARGET", gvjs_re(gvjs_bca, ["_blank", "_self"]));
+  gvjs_Bm(a.ao, a.bs, "* CLASS", gvjs_re(gvjs_cca, a.AU));
+  gvjs_Bm(a.ao, a.bs, "* ID", gvjs_re(gvjs_dca, a.AU));
+  gvjs_Bm(a.ao, a.bs, "* STYLE", gvjs_re(a.afa, c));
+  a.lea = !0
+}
+function gvjs_um(a, b) {
+  a || (a = "*");
+  return (a + " " + b).toUpperCase()
+}
+function gvjs_8ba(a, b, c, d) {
+  if (!d.zX)
+    return null;
+  b = gvjs_Ff(gvjs_om(d.zX, function(e, f) {
+    c.lma = f;
+    e = a(e, c);
+    return null == e ? null : gvjs_zf(e)
+  }));
+  return "" == b ? null : b
+}
+function gvjs_xm(a) {
+  return gvjs_kf(a)
+}
+function gvjs_bca(a, b) {
+  b = gvjs_kf(b);
+  return gvjs_He(a, b.toLowerCase()) ? b : null
+}
+function gvjs_$ba(a) {
+  return (a = gvjs_kf(a)) && "#" == a.charAt(0) ? a : null
+}
+function gvjs_aca(a, b, c) {
+  b = gvjs_kf(b);
+  return a(b, c)
+}
+function gvjs_cca(a, b, c) {
+  b = b.split(/(?:\s+)/);
+  for (var d = [], e = 0; e < b.length; e++) {
+    var f = a(b[e], c);
+    f && d.push(f)
+  }
+  return 0 == d.length ? null : d.join(" ")
+}
+function gvjs_dca(a, b, c) {
+  b = gvjs_kf(b);
+  return a(b, c)
+}
+gvjs_vm.prototype.sanitize = function(a) {
+  var b = !(gvjs_7a in this.EL) && gvjs_7a in this.gF;
+  this.fO = "*" == this.yL && b ? "sanitizer-" + gvjs_hg() : this.yL;
+  if (gvjs_sm) {
+    b = a;
+    if (gvjs_sm) {
+      a = gvjs_dh(gvjs_6a);
+      this.fO && "*" == this.yL && (a.id = this.fO);
+      this.D_ && (b = gvjs_pm("<div>" + b + gvjs_a),
+        gvjs_Xba(b),
+        b = b.innerHTML);
+      b = gvjs_3f(b, null);
+      var c = document.createElement("template");
+      if (gvjs_2ba && "content"in c)
+        gvjs_cg(c, b),
+          c = c.content;
+      else {
+        var d = document.implementation.createHTMLDocument("x");
+        c = d.body;
+        gvjs_cg(d.body, b)
+      }
+      b = document.createTreeWalker(c, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, null, !1);
+      c = gvjs_0ba ? new WeakMap : new gvjs_rm;
+      for (var e; e = b.nextNode(); ) {
+        c: switch (d = e,
+          gvjs_jm(d)) {
+          case 3:
+            d = this.createTextNode(d);
+            break c;
+          case 1:
+            d = this.Qd(d);
+            break c;
+          default:
+            d = null
+        }
+        if (d) {
+          1 == gvjs_jm(d) && c.set(e, d);
+          e = gvjs_km(e);
+          var f = !1;
+          if (e) {
+            var g = gvjs_jm(e)
+              , h = gvjs_im(e).toLowerCase()
+              , k = gvjs_km(e);
+            11 != g || k ? h == gvjs_yb && k && (g = gvjs_km(k)) && !gvjs_km(g) && (f = !0) : f = !0;
+            g = null;
+            f || !e ? g = a : 1 == gvjs_jm(e) && (g = c.get(e));
+            g.content && (g = g.content);
+            g.appendChild(d)
+          }
+        } else
+          gvjs_hh(e)
+      }
+      c.clear && c.clear()
+    } else
+      a = gvjs_dh(gvjs_6a);
+    0 < gvjs_gm(a).length && (b = gvjs_dh(gvjs_6a),
+      b.appendChild(a),
+      a = b);
+    a = (new XMLSerializer).serializeToString(a);
+    a = a.slice(a.indexOf(">") + 1, a.lastIndexOf("</"))
+  } else
+    a = "";
+  return gvjs_3f(a, null)
+}
+;
+gvjs_vm.prototype.createTextNode = function(a) {
+  var b = a.data;
+  (a = gvjs_km(a)) && gvjs_im(a).toLowerCase() == gvjs_Jd && !(gvjs_7a in this.EL) && gvjs_7a in this.gF && (b = gvjs_Pf(gvjs_Wba(b, this.fO, gvjs_s(function(c, d) {
+    return this.RD(c, {
+      lma: d
+    })
+  }, this))));
+  return document.createTextNode(b)
+}
+;
+function gvjs_Cm() {
+  var a = gvjs_je("google.visualization.ModulePath");
+  if (null != a)
+    return a;
+  a = gvjs_je("google.loader.GoogleApisBase");
+  null == a && (a = "//ajax.googleapis.com/ajax");
+  var b = gvjs_je(gvjs__c);
+  null == b && (b = "current");
+  return "" + a + "/static/modules/gviz/" + b
+}
+function gvjs_Dm() {
+  return gvjs_je("google.visualization.Locale") || "en"
+}
+;var gvjs_Em = gvjs_je("goog.visualization.isSafeMode") || !1
+  , gvjs_Fm = function() {
+    var a = gvjs_7ba()
+      , b = ["icon"];
+    a.V8.push("iron-icon");
+    b && b.forEach(function(c) {
+      c = gvjs_um("iron-icon", c);
+      this.ao[c] = gvjs_xm;
+      this.bs[c] = !0
+    }, a);
+    return a
+  }();
+gvjs_Fm.n1 = function(a) {
+  return a
+}
+;
+gvjs_Fm.AU = function(a) {
+  return a
+}
+;
+gvjs_Fm.RD = function(a, b) {
+  return "img" == b.tagName && "src" == b.attributeName && a.startsWith("data:") ? gvjs_yf(a) || gvjs_Cf : gvjs_Bf(a)
+}
+;
+var gvjs_eca = gvjs_Am(gvjs_Fm).cd();
+function gvjs_Gm(a) {
+  var b = a;
+  gvjs_Em && (b = gvjs_zba(a));
+  a = gvjs_Oh().Vj();
+  b = [gvjs_1b + b, gvjs_Yb + b, "gviz.controls.ui." + b, b];
+  for (var c = 0; c < b.length; c++) {
+    var d = gvjs_je(b[c], a);
+    if (typeof d === gvjs_d)
+      return d
+  }
+  return null
+}
+var gvjs_Hm = [];
+function gvjs_fca(a, b) {
+  function c() {
+    d()
+  }
+  function d() {
+    f("visualization", a, b)
+  }
+  b = null == b ? {} : gvjs_x(b);
+  var e = gvjs_Dm();
+  e && !b.language && (b.language = e);
+  b.debug = b.debug || gvjs_je("google.visualization.isDebug");
+  b.pseudo = b.pseudo || gvjs_je("google.visualization.isPseudo");
+  var f = gvjs_je("google.charts.load") || gvjs_je("google.load");
+  if (!f)
+    throw Error("No loader available.");
+  var g = b.callback || function() {}
+  ;
+  b.callback = function() {
+    g();
+    if (0 < gvjs_Hm.length) {
+      var h = gvjs_Hm.shift();
+      h && h()
+    }
+  }
+  ;
+  0 === gvjs_Hm.length ? d() : gvjs_Hm.push(c)
+}
+;function gvjs_Im(a) {
+  gvjs_Ug(this, a, null)
+}
+gvjs_o(gvjs_Im, gvjs_Sg);
+var gvjs_Jm = {};
+function gvjs_Km() {
+  var a = "undefined" !== typeof window ? window.trustedTypes : void 0;
+  return null !== a && void 0 !== a ? a : null
+}
+var gvjs_Lm;
+function gvjs_gca() {
+  var a, b;
+  void 0 === gvjs_Lm && (gvjs_Lm = null !== (b = null === (a = gvjs_Km()) || void 0 === a ? void 0 : a.createPolicy("google#safe", {
+    createHTML: function(c) {
+      return c
+    },
+    createScript: function(c) {
+      return c
+    },
+    createScriptURL: function(c) {
+      return c
+    }
+  })) && void 0 !== b ? b : null);
+  return gvjs_Lm
+}
+;function gvjs_Mm() {}
+function gvjs_Nm(a, b) {
+  if (b !== gvjs_Jm)
+    throw Error("Bad secret");
+  this.yea = a
+}
+gvjs_o(gvjs_Nm, gvjs_Mm);
+gvjs_Nm.prototype.toString = function() {
+  return this.yea.toString()
+}
+;
+function gvjs_Om(a) {
+  var b, c = null === (b = gvjs_gca()) || void 0 === b ? void 0 : b.createScript(a);
+  return new gvjs_Nm(null !== c && void 0 !== c ? c : a,gvjs_Jm)
+}
+;function gvjs_Pm(a) {
+  if (a instanceof gvjs_Mm) {
+    var b;
+    if (null === (b = gvjs_Km()) || void 0 === b || !b.isScript(a))
+      if (a instanceof gvjs_Nm)
+        a = a.yea;
+      else
+        throw Error("wrong type");
+  } else
+    a = gvjs_bf(a);
+  return a
+}
+;function gvjs_hca() {
+  var a = new gvjs_Im([null, null, null, null, null, '(function(){/*\n\n Copyright The Closure Library Authors.\n SPDX-License-Identifier: Apache-2.0\n*/\nvar d="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},e;if("function"==typeof Object.setPrototypeOf)e=Object.setPrototypeOf;else{var f;a:{var k={a:!0},l={};try{l.__proto__=k;f=l.a;break a}catch(a){}f=!1}e=f?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}var m=e;var n={};function p(){var a="undefined"!==typeof window?window.trustedTypes:void 0;return null!==a&&void 0!==a?a:null}var q;function r(){var a,b;void 0===q&&(q=null!==(b=null===(a=p())||void 0===a?void 0:a.createPolicy("google#safe",{createHTML:function(c){return c},createScript:function(c){return c},createScriptURL:function(c){return c}}))&&void 0!==b?b:null);return q};var t=function(a,b){if(b!==n)throw Error("Bad secret");this.g=a},u=function(){};t.prototype=d(u.prototype);t.prototype.constructor=t;if(m)m(t,u);else for(var v in u)if("prototype"!=v)if(Object.defineProperties){var w=Object.getOwnPropertyDescriptor(u,v);w&&Object.defineProperty(t,v,w)}else t[v]=u[v];t.prototype.toString=function(){return this.g.toString()};function x(a){var b;if(null===(b=p())||void 0===b?0:b.isScriptURL(a))return a;if(a instanceof t)return a.g;throw Error("wrong type");};function y(a){var b,c=null===(b=r())||void 0===b?void 0:b.createScriptURL(a);return new t(null!==c&&void 0!==c?c:a,n)};if(!function(){if(self.origin)return"null"===self.origin;if(""!==location.host)return!1;try{return window.parent.escape(""),!1}catch(a){return!0}}())throw Error("sandboxing error");\nwindow.addEventListener("message",function(a){var b=a.ports[0];a=a.data;var c=a.callbackName.split("."),g=window;"window"===c[0]&&c.unshift();for(var h=0;h<c.length-1;h++)g[c[h]]={},g=g[c[h]];g[c[c.length-1]]=function(z){b.postMessage(JSON.stringify(z))};c=document.createElement("script");a=y(a.url);c.src=x(a);document.body.appendChild(c)},!0);}).call(this);\n']);
+  return a ? (a = gvjs_Xg(a, 6)) ? gvjs_Om(a) : null : null
+}
+;var gvjs_Qm = /^(?:([^:/?#.]+):)?(?:\/\/(?:([^\\/?#]*)@)?([^\\/?#]*?)(?::([0-9]+))?(?=[\\/?#]|$))?([^?#]+)?(?:\?([^#]*))?(?:#([\s\S]*))?$/;
+function gvjs_Rm(a) {
+  return a ? decodeURI(a) : a
+}
+function gvjs_Sm(a, b) {
+  return b.match(gvjs_Qm)[a] || null
+}
+function gvjs_Tm(a) {
+  a = gvjs_Sm(1, a);
+  !a && gvjs_p.self && gvjs_p.self.location && (a = gvjs_p.self.location.protocol,
+    a = a.substr(0, a.length - 1));
+  return a ? a.toLowerCase() : ""
+}
+function gvjs_ica(a, b) {
+  if (a) {
+    a = a.split("&");
+    for (var c = 0; c < a.length; c++) {
+      var d = a[c].indexOf("=")
+        , e = null;
+      if (0 <= d) {
+        var f = a[c].substring(0, d);
+        e = a[c].substring(d + 1)
+      } else
+        f = a[c];
+      b(f, e ? decodeURIComponent(e.replace(/\+/g, " ")) : "")
+    }
+  }
+}
+function gvjs_Um(a, b, c, d) {
+  for (var e = c.length; 0 <= (b = a.indexOf(c, b)) && b < d; ) {
+    var f = a.charCodeAt(b - 1);
+    if (38 == f || 63 == f)
+      if (f = a.charCodeAt(b + e),
+      !f || 61 == f || 38 == f || 35 == f)
+        return b;
+    b += e + 1
+  }
+  return -1
+}
+var gvjs_Vm = /#|$/;
+function gvjs_Wm(a, b) {
+  var c = a.search(gvjs_Vm)
+    , d = gvjs_Um(a, 0, b, c);
+  if (0 > d)
+    return null;
+  var e = a.indexOf("&", d);
+  if (0 > e || e > c)
+    e = c;
+  d += b.length + 1;
+  return decodeURIComponent(a.substr(d, e - d).replace(/\+/g, " "))
+}
+;function gvjs_Xm(a, b) {
+  this.jv = this.dB = this.gp = "";
+  this.Bw = null;
+  this.Fy = this.bl = "";
+  this.kn = this.nsa = !1;
+  if (a instanceof gvjs_Xm) {
+    this.kn = void 0 !== b ? b : a.kn;
+    gvjs_Ym(this, a.gp);
+    var c = a.dB;
+    gvjs_Zm(this);
+    this.dB = c;
+    gvjs__m(this, a.jv);
+    gvjs_0m(this, a.Bw);
+    this.setPath(a.getPath());
+    gvjs_1m(this, a.cg.clone());
+    a = a.Fy;
+    gvjs_Zm(this);
+    this.Fy = a
+  } else
+    a && (c = String(a).match(gvjs_Qm)) ? (this.kn = !!b,
+      gvjs_Ym(this, c[1] || "", !0),
+      a = c[2] || "",
+      gvjs_Zm(this),
+      this.dB = gvjs_2m(a),
+      gvjs__m(this, c[3] || "", !0),
+      gvjs_0m(this, c[4]),
+      this.setPath(c[5] || "", !0),
+      gvjs_1m(this, c[6] || "", !0),
+      a = c[7] || "",
+      gvjs_Zm(this),
+      this.Fy = gvjs_2m(a)) : (this.kn = !!b,
+      this.cg = new gvjs_3m(null,this.kn))
+}
+gvjs_ = gvjs_Xm.prototype;
+gvjs_.toString = function() {
+  var a = []
+    , b = this.gp;
+  b && a.push(gvjs_4m(b, gvjs_5m, !0), ":");
+  var c = this.jv;
+  if (c || "file" == b)
+    a.push("//"),
+    (b = this.dB) && a.push(gvjs_4m(b, gvjs_5m, !0), "@"),
+      a.push(encodeURIComponent(String(c)).replace(/%25([0-9a-fA-F]{2})/g, "%$1")),
+      c = this.Bw,
+    null != c && a.push(":", String(c));
+  if (c = this.getPath())
+    this.jv && "/" != c.charAt(0) && a.push("/"),
+      a.push(gvjs_4m(c, "/" == c.charAt(0) ? gvjs_jca : gvjs_kca, !0));
+  (c = this.cg.toString()) && a.push("?", c);
+  (c = this.Fy) && a.push("#", gvjs_4m(c, gvjs_lca));
+  return a.join("")
+}
+;
+gvjs_.resolve = function(a) {
+  var b = this.clone()
+    , c = !!a.gp;
+  c ? gvjs_Ym(b, a.gp) : c = !!a.dB;
+  if (c) {
+    var d = a.dB;
+    gvjs_Zm(b);
+    b.dB = d
+  } else
+    c = !!a.jv;
+  c ? gvjs__m(b, a.jv) : c = null != a.Bw;
+  d = a.getPath();
+  if (c)
+    gvjs_0m(b, a.Bw);
+  else if (c = !!a.bl) {
+    if ("/" != d.charAt(0))
+      if (this.jv && !this.bl)
+        d = "/" + d;
+      else {
+        var e = b.getPath().lastIndexOf("/");
+        -1 != e && (d = b.getPath().substr(0, e + 1) + d)
+      }
+    e = d;
+    if (".." == e || "." == e)
+      d = "";
+    else if (gvjs_sf(e, "./") || gvjs_sf(e, "/.")) {
+      d = gvjs_hf(e, "/");
+      e = e.split("/");
+      for (var f = [], g = 0; g < e.length; ) {
+        var h = e[g++];
+        "." == h ? d && g == e.length && f.push("") : ".." == h ? ((1 < f.length || 1 == f.length && "" != f[0]) && f.pop(),
+        d && g == e.length && f.push("")) : (f.push(h),
+          d = !0)
+      }
+      d = f.join("/")
+    } else
+      d = e
+  }
+  c ? b.setPath(d) : c = "" !== a.cg.toString();
+  c ? gvjs_1m(b, a.cg.clone()) : c = !!a.Fy;
+  c && (a = a.Fy,
+    gvjs_Zm(b),
+    b.Fy = a);
+  return b
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_Xm(this)
+}
+;
+function gvjs_Ym(a, b, c) {
+  gvjs_Zm(a);
+  a.gp = c ? gvjs_2m(b, !0) : b;
+  a.gp && (a.gp = a.gp.replace(/:$/, ""))
+}
+function gvjs__m(a, b, c) {
+  gvjs_Zm(a);
+  a.jv = c ? gvjs_2m(b, !0) : b
+}
+function gvjs_0m(a, b) {
+  gvjs_Zm(a);
+  if (b) {
+    b = Number(b);
+    if (isNaN(b) || 0 > b)
+      throw Error("Bad port number " + b);
+    a.Bw = b
+  } else
+    a.Bw = null
+}
+gvjs_.getPath = function() {
+  return this.bl
+}
+;
+gvjs_.setPath = function(a, b) {
+  gvjs_Zm(this);
+  this.bl = b ? gvjs_2m(a, !0) : a;
+  return this
+}
+;
+function gvjs_1m(a, b, c) {
+  gvjs_Zm(a);
+  b instanceof gvjs_3m ? (a.cg = b,
+    a.cg.O3(a.kn)) : (c || (b = gvjs_4m(b, gvjs_mca)),
+    a.cg = new gvjs_3m(b,a.kn));
+  return a
+}
+gvjs_.Jn = function(a, b) {
+  return gvjs_1m(this, a, b)
+}
+;
+gvjs_.getQuery = function() {
+  return this.cg.toString()
+}
+;
+gvjs_.Ld = function(a, b) {
+  gvjs_Zm(this);
+  this.cg.set(a, b);
+  return this
+}
+;
+gvjs_.removeParameter = function(a) {
+  gvjs_Zm(this);
+  this.cg.remove(a);
+  return this
+}
+;
+function gvjs_Zm(a) {
+  if (a.nsa)
+    throw Error("Tried to modify a read-only Uri");
+}
+gvjs_.O3 = function(a) {
+  this.kn = a;
+  this.cg && this.cg.O3(a)
+}
+;
+function gvjs_2m(a, b) {
+  return a ? b ? decodeURI(a.replace(/%25/g, "%2525")) : decodeURIComponent(a) : ""
+}
+function gvjs_4m(a, b, c) {
+  return typeof a === gvjs_l ? (a = encodeURI(a).replace(b, gvjs_nca),
+  c && (a = a.replace(/%25([0-9a-fA-F]{2})/g, "%$1")),
+    a) : null
+}
+function gvjs_nca(a) {
+  a = a.charCodeAt(0);
+  return "%" + (a >> 4 & 15).toString(16) + (a & 15).toString(16)
+}
+var gvjs_5m = /[#\/\?@]/g
+  , gvjs_kca = /[#\?:]/g
+  , gvjs_jca = /[#\?]/g
+  , gvjs_mca = /[#\?@]/g
+  , gvjs_lca = /#/g;
+function gvjs_3m(a, b) {
+  this.Vc = this.Hf = null;
+  this.Il = a || null;
+  this.kn = !!b
+}
+function gvjs_6m(a) {
+  a.Hf || (a.Hf = new gvjs_aj,
+    a.Vc = 0,
+  a.Il && gvjs_ica(a.Il, function(b, c) {
+    a.add(decodeURIComponent(b.replace(/\+/g, " ")), c)
+  }))
+}
+function gvjs_oca(a) {
+  var b = gvjs_fj(a);
+  if ("undefined" == typeof b)
+    throw Error("Keys are undefined");
+  var c = new gvjs_3m(null,void 0);
+  a = gvjs_ej(a);
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = a[d];
+    Array.isArray(f) ? c.setValues(e, f) : c.add(e, f)
+  }
+  return c
+}
+gvjs_ = gvjs_3m.prototype;
+gvjs_.Cd = function() {
+  gvjs_6m(this);
+  return this.Vc
+}
+;
+gvjs_.add = function(a, b) {
+  gvjs_6m(this);
+  this.Il = null;
+  a = gvjs_7m(this, a);
+  var c = this.Hf.get(a);
+  c || this.Hf.set(a, c = []);
+  c.push(b);
+  this.Vc += 1;
+  return this
+}
+;
+gvjs_.remove = function(a) {
+  gvjs_6m(this);
+  a = gvjs_7m(this, a);
+  return this.Hf.tf(a) ? (this.Il = null,
+    this.Vc -= this.Hf.get(a).length,
+    this.Hf.remove(a)) : !1
+}
+;
+gvjs_.clear = function() {
+  this.Hf = this.Il = null;
+  this.Vc = 0
+}
+;
+gvjs_.isEmpty = function() {
+  gvjs_6m(this);
+  return 0 == this.Vc
+}
+;
+gvjs_.tf = function(a) {
+  gvjs_6m(this);
+  a = gvjs_7m(this, a);
+  return this.Hf.tf(a)
+}
+;
+gvjs_.XB = function(a) {
+  var b = this.ob();
+  return gvjs_He(b, a)
+}
+;
+gvjs_.forEach = function(a, b) {
+  gvjs_6m(this);
+  this.Hf.forEach(function(c, d) {
+    c.forEach(function(e) {
+      a.call(b, e, d, this)
+    }, this)
+  }, this)
+}
+;
+gvjs_.cj = function() {
+  gvjs_6m(this);
+  for (var a = this.Hf.ob(), b = this.Hf.cj(), c = [], d = 0; d < b.length; d++)
+    for (var e = a[d], f = 0; f < e.length; f++)
+      c.push(b[d]);
+  return c
+}
+;
+gvjs_.ob = function(a) {
+  gvjs_6m(this);
+  var b = [];
+  if (typeof a === gvjs_l)
+    this.tf(a) && (b = b.concat(this.Hf.get(gvjs_7m(this, a))));
+  else {
+    a = this.Hf.ob();
+    for (var c = 0; c < a.length; c++)
+      b = b.concat(a[c])
+  }
+  return b
+}
+;
+gvjs_.set = function(a, b) {
+  gvjs_6m(this);
+  this.Il = null;
+  a = gvjs_7m(this, a);
+  this.tf(a) && (this.Vc -= this.Hf.get(a).length);
+  this.Hf.set(a, [b]);
+  this.Vc += 1;
+  return this
+}
+;
+gvjs_.get = function(a, b) {
+  if (!a)
+    return b;
+  a = this.ob(a);
+  return 0 < a.length ? String(a[0]) : b
+}
+;
+gvjs_.setValues = function(a, b) {
+  this.remove(a);
+  0 < b.length && (this.Il = null,
+    this.Hf.set(gvjs_7m(this, a), gvjs_Le(b)),
+    this.Vc += b.length)
+}
+;
+gvjs_.toString = function() {
+  if (this.Il)
+    return this.Il;
+  if (!this.Hf)
+    return "";
+  for (var a = [], b = this.Hf.cj(), c = 0; c < b.length; c++) {
+    var d = b[c]
+      , e = encodeURIComponent(String(d));
+    d = this.ob(d);
+    for (var f = 0; f < d.length; f++) {
+      var g = e;
+      "" !== d[f] && (g += "=" + encodeURIComponent(String(d[f])));
+      a.push(g)
+    }
+  }
+  return this.Il = a.join("&")
+}
+;
+gvjs_.clone = function() {
+  var a = new gvjs_3m;
+  a.Il = this.Il;
+  this.Hf && (a.Hf = this.Hf.clone(),
+    a.Vc = this.Vc);
+  return a
+}
+;
+function gvjs_7m(a, b) {
+  b = String(b);
+  a.kn && (b = b.toLowerCase());
+  return b
+}
+gvjs_.O3 = function(a) {
+  a && !this.kn && (gvjs_6m(this),
+    this.Il = null,
+    this.Hf.forEach(function(b, c) {
+      var d = c.toLowerCase();
+      c != d && (this.remove(c),
+        this.setValues(d, b))
+    }, this));
+  this.kn = a
+}
+;
+gvjs_.extend = function(a) {
+  for (var b = 0; b < arguments.length; b++)
+    gvjs_gj(arguments[b], function(c, d) {
+      this.add(d, c)
+    }, this)
+}
+;
+function gvjs_8m(a, b) {
+  this.url = a;
+  this.timeout = void 0 === b ? 5E3 : b;
+  this.EW = this.DW = "callback";
+  this.sv = this.YI = null
+}
+gvjs_8m.prototype.fetch = function(a) {
+  var b = this;
+  a = void 0 === a ? {} : a;
+  this.sv = gvjs_fl();
+  var c = new gvjs_Xm(this.url)
+    , d = new Map;
+  this.EW && d.set(this.EW, this.DW);
+  c.cg.extend(gvjs_oca(a), d);
+  gvjs_pca(this).then(function() {
+    gvjs_qca(b, c.toString())
+  }).then(function() {
+    return b.sv.promise
+  }).then(function() {
+    gvjs_9m(b)
+  }, function() {
+    gvjs_9m(b)
+  });
+  0 < this.timeout && (this.g5 = setTimeout(function() {
+    b.sv.reject("Timeout!")
+  }, this.timeout));
+  return this.sv.promise
+}
+;
+function gvjs_qca(a, b) {
+  var c = new MessageChannel;
+  a.YI.contentWindow.postMessage({
+    url: b,
+    callbackName: a.DW
+  }, "*", [c.port2]);
+  c.port1.onmessage = function(d) {
+    var e = {};
+    void 0 !== a.g5 && (clearTimeout(a.g5),
+      a.g5 = void 0);
+    void 0 === d.data && a.sv.reject("Callback called, but no data received");
+    typeof d.data !== gvjs_l && a.sv.reject("Exploitation attempt! Data is not a string!");
+    try {
+      e = JSON.parse(d.data)
+    } catch (f) {
+      a.sv.reject("Invalid Data received: " + f.message)
+    }
+    a.sv.resolve(e)
+  }
+}
+function gvjs_pca(a) {
+  var b = gvjs_fl()
+    , c = gvjs_dh(gvjs_Ma);
+  if (!c.sandbox)
+    throw Error("iframe sandboxes not supported");
+  c.sandbox.value = "allow-scripts";
+  c.style.display = gvjs_f;
+  a.YI = c;
+  a = gvjs_hca();
+  a = gvjs_$f(gvjs_yaa, gvjs_5f(gvjs_yb, {}, gvjs_waa(gvjs_laa(gvjs_Pm(a).toString()))));
+  c.srcdoc = gvjs_1f(a);
+  a = gvjs_gf("data:text/html;charset=UTF-8;base64," + btoa(gvjs_0f(a)));
+  c.src = gvjs_ef(a);
+  c.addEventListener("load", function() {
+    return b.resolve(c)
+  }, !1);
+  c.addEventListener(gvjs_Rb, function(d) {
+    b.reject(d)
+  }, !1);
+  document.documentElement.appendChild(c);
+  return b.promise
+}
+function gvjs_9m(a) {
+  null !== a.YI && (document.documentElement.removeChild(a.YI),
+    a.YI = null)
+}
+;function gvjs_$m(a) {
+  switch (a) {
+    case 200:
+    case 201:
+    case 202:
+    case 204:
+    case 206:
+    case 304:
+    case 1223:
+      return !0;
+    default:
+      return !1
+  }
+}
+;function gvjs_an() {}
+gvjs_an.prototype.T7 = null;
+gvjs_an.prototype.Zc = function() {
+  var a;
+  (a = this.T7) || (a = {},
+  gvjs_bn(this) && (a[0] = !0,
+    a[1] = !0),
+    a = this.T7 = a);
+  return a
+}
+;
+var gvjs_cn;
+function gvjs_dn() {}
+gvjs_t(gvjs_dn, gvjs_an);
+function gvjs_en(a) {
+  return (a = gvjs_bn(a)) ? new ActiveXObject(a) : new XMLHttpRequest
+}
+function gvjs_bn(a) {
+  if (!a.iba && "undefined" == typeof XMLHttpRequest && "undefined" != typeof ActiveXObject) {
+    for (var b = ["MSXML2.XMLHTTP.6.0", "MSXML2.XMLHTTP.3.0", "MSXML2.XMLHTTP", "Microsoft.XMLHTTP"], c = 0; c < b.length; c++) {
+      var d = b[c];
+      try {
+        return new ActiveXObject(d),
+          a.iba = d
+      } catch (e) {}
+    }
+    throw Error("Could not create ActiveXObject. ActiveX might be disabled, or MSXML might not be installed");
+  }
+  return a.iba
+}
+gvjs_cn = new gvjs_dn;
+function gvjs_fn(a) {
+  return gvjs_rca(a).then(function(b) {
+    return b.responseText
+  })
+}
+function gvjs_rca(a) {
+  var b = {}
+    , c = b.gza ? gvjs_en(b.gza) : gvjs_en(gvjs_cn);
+  return gvjs_mba(new gvjs_al(function(d, e) {
+      var f;
+      try {
+        c.open("GET", a, !0)
+      } catch (k) {
+        e(new gvjs_gn("Error opening XHR: " + k.message,a,c))
+      }
+      c.onreadystatechange = function() {
+        if (4 == c.readyState) {
+          gvjs_p.clearTimeout(f);
+          var k;
+          !(k = gvjs_$m(c.status)) && (k = 0 === c.status) && (k = gvjs_Tm(a),
+            k = !("http" == k || "https" == k || "" == k));
+          k ? d(c) : e(new gvjs_hn(c.status,a,c))
+        }
+      }
+      ;
+      c.onerror = function() {
+        e(new gvjs_gn("Network error",a,c))
+      }
+      ;
+      if (b.headers)
+        for (var g in b.headers) {
+          var h = b.headers[g];
+          null != h && c.setRequestHeader(g, h)
+        }
+      b.withCredentials && (c.withCredentials = b.withCredentials);
+      b.responseType && (c.responseType = b.responseType);
+      b.mimeType && c.overrideMimeType(b.mimeType);
+      0 < b.bya && (f = gvjs_p.setTimeout(function() {
+        c.onreadystatechange = gvjs_ke;
+        c.abort();
+        e(new gvjs_in(a,c))
+      }, b.bya));
+      try {
+        c.send(null)
+      } catch (k) {
+        c.onreadystatechange = gvjs_ke,
+          gvjs_p.clearTimeout(f),
+          e(new gvjs_gn("Error sending XHR: " + k.message,a,c))
+      }
+    }
+  ), function(d) {
+    d instanceof gvjs_hl && c.abort();
+    throw d;
+  })
+}
+function gvjs_gn(a, b) {
+  gvjs_ve.call(this, a + ", url=" + b);
+  this.url = b
+}
+gvjs_t(gvjs_gn, gvjs_ve);
+gvjs_gn.prototype.name = "XhrError";
+function gvjs_hn(a, b, c) {
+  gvjs_gn.call(this, "Request Failed, status=" + a, b, c);
+  this.status = a
+}
+gvjs_t(gvjs_hn, gvjs_gn);
+gvjs_hn.prototype.name = "XhrHttpError";
+function gvjs_in(a, b) {
+  gvjs_gn.call(this, gvjs_4a, a, b)
+}
+gvjs_t(gvjs_in, gvjs_gn);
+gvjs_in.prototype.name = "XhrTimeoutError";
+function gvjs_jn(a) {
+  gvjs_H.call(this);
+  this.headers = new gvjs_aj;
+  this.ZU = a || null;
+  this.zu = !1;
+  this.YU = this.Zb = null;
+  this.Az = this.m0 = "";
+  this.lz = this.u_ = this.lQ = this.yY = !1;
+  this.wU = 0;
+  this.vU = null;
+  this.Sea = "";
+  this.Q5 = this.kva = this.e6 = !1;
+  this.v5 = null
+}
+gvjs_t(gvjs_jn, gvjs_H);
+var gvjs_sca = /^https?$/i
+  , gvjs_tca = ["POST", "PUT"]
+  , gvjs_kn = [];
+function gvjs_uca(a, b, c, d, e) {
+  var f = gvjs_vca
+    , g = new gvjs_jn;
+  gvjs_kn.push(g);
+  b && g.o(gvjs_Hb, b);
+  g.vD(gvjs_i, g.Bla);
+  e && (g.e6 = e);
+  g.send(a, c, d, f)
+}
+gvjs_ = gvjs_jn.prototype;
+gvjs_.Bla = function() {
+  this.pa();
+  gvjs_Ie(gvjs_kn, this)
+}
+;
+gvjs_.setTrustToken = function(a) {
+  this.v5 = a
+}
+;
+gvjs_.send = function(a, b, c, d) {
+  if (this.Zb)
+    throw Error("[goog.net.XhrIo] Object is active with another request=" + this.m0 + "; newUri=" + a);
+  b = b ? b.toUpperCase() : "GET";
+  this.m0 = a;
+  this.Az = "";
+  this.yY = !1;
+  this.zu = !0;
+  this.Zb = this.ZU ? gvjs_en(this.ZU) : gvjs_en(gvjs_cn);
+  this.YU = this.ZU ? this.ZU.Zc() : gvjs_cn.Zc();
+  this.Zb.onreadystatechange = gvjs_s(this.Kda, this);
+  this.kva && "onprogress"in this.Zb && (this.Zb.onprogress = gvjs_s(function(f) {
+    this.Jda(f, !0)
+  }, this),
+  this.Zb.upload && (this.Zb.upload.onprogress = gvjs_s(this.Jda, this)));
+  try {
+    this.u_ = !0,
+      this.Zb.open(b, String(a), !0),
+      this.u_ = !1
+  } catch (f) {
+    this.xy(5, f);
+    return
+  }
+  a = c || "";
+  var e = this.headers.clone();
+  d && gvjs_gj(d, function(f, g) {
+    e.set(g, f)
+  });
+  d = e.cj().find(function(f) {
+    return "content-type" == f.toLowerCase()
+  });
+  c = gvjs_p.FormData && a instanceof gvjs_p.FormData;
+  !gvjs_He(gvjs_tca, b) || d || c || e.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+  e.forEach(function(f, g) {
+    this.Zb.setRequestHeader(g, f)
+  }, this);
+  this.Sea && (this.Zb.responseType = this.Sea);
+  gvjs_Yd in this.Zb && this.Zb.withCredentials !== this.e6 && (this.Zb.withCredentials = this.e6);
+  if ("setTrustToken"in this.Zb && this.v5)
+    try {
+      this.Zb.setTrustToken(this.v5)
+    } catch (f) {}
+  try {
+    gvjs_ln(this),
+    0 < this.wU && ((this.Q5 = gvjs_wca(this.Zb)) ? (this.Zb.timeout = this.wU,
+      this.Zb.ontimeout = gvjs_s(this.zg, this)) : this.vU = gvjs_pl(this.zg, this.wU, this)),
+      this.lQ = !0,
+      this.Zb.send(a),
+      this.lQ = !1
+  } catch (f) {
+    this.xy(5, f)
+  }
+}
+;
+function gvjs_wca(a) {
+  return gvjs_y && gvjs_Eg(9) && typeof a.timeout === gvjs_g && void 0 !== a.ontimeout
+}
+gvjs_.zg = function() {
+  "undefined" != typeof gvjs_ie && this.Zb && (this.Az = "Timed out after " + this.wU + "ms, aborting",
+    this.dispatchEvent("timeout"),
+    this.abort(8))
+}
+;
+gvjs_.xy = function(a, b) {
+  this.zu = !1;
+  this.Zb && (this.lz = !0,
+    this.Zb.abort(),
+    this.lz = !1);
+  this.Az = b;
+  gvjs_mn(this);
+  gvjs_nn(this)
+}
+;
+function gvjs_mn(a) {
+  a.yY || (a.yY = !0,
+    a.dispatchEvent(gvjs_Hb),
+    a.dispatchEvent(gvjs_Rb))
+}
+gvjs_.abort = function() {
+  this.Zb && this.zu && (this.zu = !1,
+    this.lz = !0,
+    this.Zb.abort(),
+    this.lz = !1,
+    this.dispatchEvent(gvjs_Hb),
+    this.dispatchEvent("abort"),
+    gvjs_nn(this))
+}
+;
+gvjs_.M = function() {
+  this.Zb && (this.zu && (this.zu = !1,
+    this.lz = !0,
+    this.Zb.abort(),
+    this.lz = !1),
+    gvjs_nn(this, !0));
+  gvjs_jn.G.M.call(this)
+}
+;
+gvjs_.Kda = function() {
+  this.xf || (this.u_ || this.lQ || this.lz ? gvjs_on(this) : this.Aua())
+}
+;
+gvjs_.Aua = function() {
+  gvjs_on(this)
+}
+;
+function gvjs_on(a) {
+  if (a.zu && "undefined" != typeof gvjs_ie && (!a.YU[1] || 4 != gvjs_pn(a) || 2 != a.getStatus()))
+    if (a.lQ && 4 == gvjs_pn(a))
+      gvjs_pl(a.Kda, 0, a);
+    else if (a.dispatchEvent("readystatechange"),
+    4 == gvjs_pn(a)) {
+      a.zu = !1;
+      try {
+        if (gvjs_qn(a))
+          a.dispatchEvent(gvjs_Hb),
+            a.dispatchEvent("success");
+        else {
+          try {
+            var b = 2 < gvjs_pn(a) ? a.Zb.statusText : ""
+          } catch (c) {
+            b = ""
+          }
+          a.Az = b + " [" + a.getStatus() + "]";
+          gvjs_mn(a)
+        }
+      } finally {
+        gvjs_nn(a)
+      }
+    }
+}
+gvjs_.Jda = function(a, b) {
+  this.dispatchEvent(gvjs_rn(a, "progress"));
+  this.dispatchEvent(gvjs_rn(a, b ? "downloadprogress" : "uploadprogress"))
+}
+;
+function gvjs_rn(a, b) {
+  return {
+    type: b,
+    lengthComputable: a.lengthComputable,
+    loaded: a.loaded,
+    total: a.total
+  }
+}
+function gvjs_nn(a, b) {
+  if (a.Zb) {
+    gvjs_ln(a);
+    var c = a.Zb
+      , d = a.YU[0] ? gvjs_ke : null;
+    a.Zb = null;
+    a.YU = null;
+    b || a.dispatchEvent(gvjs_i);
+    try {
+      c.onreadystatechange = d
+    } catch (e) {}
+  }
+}
+function gvjs_ln(a) {
+  a.Zb && a.Q5 && (a.Zb.ontimeout = null);
+  a.vU && (gvjs_ql(a.vU),
+    a.vU = null)
+}
+gvjs_.ak = function() {
+  return !!this.Zb
+}
+;
+function gvjs_qn(a) {
+  var b = a.getStatus(), c;
+  if (!(c = gvjs_$m(b))) {
+    if (b = 0 === b)
+      a = gvjs_Tm(String(a.m0)),
+        b = !gvjs_sca.test(a);
+    c = b
+  }
+  return c
+}
+function gvjs_pn(a) {
+  return a.Zb ? a.Zb.readyState : 0
+}
+gvjs_.getStatus = function() {
+  try {
+    return 2 < gvjs_pn(this) ? this.Zb.status : -1
+  } catch (a) {
+    return -1
+  }
+}
+;
+gvjs_.getResponseHeader = function(a) {
+  if (this.Zb && 4 == gvjs_pn(this))
+    return a = this.Zb.getResponseHeader(a),
+      null === a ? void 0 : a
+}
+;
+gvjs_.getAllResponseHeaders = function() {
+  return this.Zb && 4 == gvjs_pn(this) ? this.Zb.getAllResponseHeaders() || "" : ""
+}
+;
+function gvjs_sn(a) {
+  return typeof a.Az === gvjs_l ? a.Az : String(a.Az)
+}
+;function gvjs_tn() {
+  this.position = null;
+  gvjs_ve.call(this, void 0)
+}
+gvjs_t(gvjs_tn, gvjs_ve);
+gvjs_tn.prototype.name = "ParseError";
+function gvjs_xca(a) {
+  function b() {
+    if (null != l) {
+      var q = l;
+      l = null;
+      return q
+    }
+    if (e >= a.length)
+      return f;
+    q = a.charAt(e++);
+    var r = !1;
+    "\n" == q ? r = !0 : "\r" == q && (e < a.length && "\n" == a.charAt(e) && e++,
+      r = !0);
+    return r ? h : q
+  }
+  function c() {
+    var q = e
+      , r = m;
+    m = !1;
+    var t = b();
+    if (t == k)
+      return g;
+    if (t == f || t == h)
+      return r ? (l = k,
+        "") : g;
+    if ('"' == t) {
+      q = e;
+      r = null;
+      for (t = b(); t != f; t = b())
+        if ('"' == t)
+          if (r = e - 1,
+            t = b(),
+          '"' == t)
+            r = null;
+          else {
+            if ("," == t || t == f || t == h) {
+              t == h && (l = t);
+              "," == t && (m = !0);
+              break
+            }
+            throw new gvjs_tn(a,e - 1,'Unexpected character "' + t + '" after quote mark');
+          }
+      if (null === r)
+        throw new gvjs_tn(a,a.length - 1,"Unexpected end of text after open quote");
+      return a.substring(q, r).replace(/""/g, '"')
+    }
+    for (; ; ) {
+      if (t == f || t == h) {
+        l = t;
+        break
+      }
+      if ("," == t) {
+        m = !0;
+        break
+      }
+      if ('"' == t)
+        throw new gvjs_tn(a,e - 1,"Unexpected quote mark");
+      t = b()
+    }
+    return (t == f ? a.substring(q) : a.substring(q, e - 1)).replace(/[\r\n]+/g, "")
+  }
+  function d() {
+    if (e >= a.length)
+      return f;
+    for (var q = [], r = c(); r != g; r = c())
+      q.push(r);
+    return q
+  }
+  for (var e = 0, f = gvjs_yca, g = gvjs_zca, h = gvjs_Aca, k = gvjs_Bca, l = null, m = !1, n = [], p = d(); p != f; p = d())
+    n.push(p);
+  return n
+}
+var gvjs_Bca = {}
+  , gvjs_yca = {}
+  , gvjs_zca = {}
+  , gvjs_Aca = {};
+function gvjs_Cca(a, b, c) {
+  this.mma = a;
+  this.columns = [];
+  this.WP = null != c ? c : !1;
+  for (a = 0; a < b.length; a++)
+    if (c = b[a],
+      !gvjs_un[c])
+      throw Error("Unsupported type: " + c);
+  this.types = b
+}
+var gvjs_un = {
+  number: function(a) {
+    var b = Number(a);
+    if (isNaN(b))
+      throw Error("Not a number " + a);
+    return b
+  },
+  string: function(a) {
+    return a
+  },
+  "boolean": function(a) {
+    return a.toLowerCase() === gvjs_Rd
+  },
+  date: function(a) {
+    return new Date(a)
+  },
+  datetime: function(a) {
+    return new Date(a)
+  },
+  timeofday: function(a) {
+    return a.split(",")
+  }
+};
+var gvjs_Dca = /\/spreadsheet/
+  , gvjs_vn = /\/(ccc|tq|pub)$/
+  , gvjs_Eca = new RegExp(/^spreadsheets?[0-9]?\.google\.com$/)
+  , gvjs_Fca = new RegExp(/^docs\.google\.com*$/)
+  , gvjs_wn = new RegExp(/^(trix|spreadsheets|docs|webdrive)(-[a-z]+)?\.(corp|sandbox)\.google\.com/)
+  , gvjs_xn = new RegExp(/^(\w*\.){1,2}corp\.google\.com$/)
+  , gvjs_Gca = /\/spreadsheets(\/d\/[^/]+)?/
+  , gvjs_Hca = /\/(edit|gviz\/tq|)$/
+  , gvjs_Ica = new RegExp(/^docs\.google\.com*$/)
+  , gvjs_Jca = new RegExp(/^docs(-qa)?\.(corp|sandbox)\.google\.com*$/)
+  , gvjs_yn = new RegExp(/^(\w*\.){1,2}corp\.google\.com$/)
+  , gvjs_zn = /^\/a\/([\w-]+\.)+\w+/
+  , gvjs_An = /^(\/a\/([\w-]+\.)+\w+)?/
+  , gvjs_Kca = new RegExp(/^[a-z]+\d+:[a-z]+\d+$/i)
+  , gvjs_Lca = new RegExp(/^[a-z]+\d+$/i);
+function gvjs_Bn(a) {
+  var b = gvjs_Rm(gvjs_Sm(3, a)) || ""
+    , c = gvjs_Eca.test(b)
+    , d = gvjs_wn.test(b)
+    , e = gvjs_xn.test(b);
+  b = gvjs_Fca.test(b);
+  var f = gvjs_Rm(gvjs_Sm(5, a)) || ""
+    , g = new RegExp(gvjs_An.source + gvjs_vn.source);
+  f = (a = (new RegExp(gvjs_An.source + gvjs_Dca.source + gvjs_vn.source)).test(f)) || g.test(f);
+  return b && a || (d || e || c) && f
+}
+function gvjs_Cn(a) {
+  var b = gvjs_Rm(gvjs_Sm(3, a)) || ""
+    , c = gvjs_Jca.test(b)
+    , d = gvjs_yn.test(b);
+  b = gvjs_Ica.test(b);
+  a = gvjs_Rm(gvjs_Sm(5, a)) || "";
+  a = (new RegExp(gvjs_An.source + gvjs_Gca.source + gvjs_Hca.source)).test(a);
+  return (b || c || d) && a
+}
+;var gvjs_Dn = {
+  WBa: "xhr",
+  XBa: "xhrpost",
+  kBa: "scriptInjection",
+  Hia: gvjs_ad,
+  YF: gvjs_ub
+}
+  , gvjs_vca = new gvjs_aj({
+    "X-DataSource-Auth": "a"
+  });
+function gvjs_En(a, b) {
+  this.Cga = 30;
+  this.cz = this.d_ = this.query = this.xU = this.Hw = null;
+  this.Eea = !0;
+  this.HK = 0;
+  this.Q2 = !1;
+  this.xJ = this.IK = null;
+  this.Aba = this.ak = !1;
+  this.iO = "";
+  b = b || {};
+  this.Zda = void 0 !== b.csvColumns;
+  this.Cxa = null != b.strictJSON ? !!b.strictJSON : !0;
+  this.Mla = b.csvColumns;
+  this.WP = !!b.csvHasHeader;
+  this.cT = b.sendMethod || gvjs_Dn.YF;
+  this.fza = !!b.xhrWithCredentials;
+  if (!gvjs__e(gvjs_Dn, this.cT))
+    throw Error("Send method not supported: " + this.cT);
+  this.tca = b.makeRequestParams || {};
+  this.yh(a);
+  this.requestId = gvjs_Mca++;
+  gvjs_Nca.push(this)
+}
+gvjs_ = gvjs_En.prototype;
+gvjs_.yh = function(a) {
+  if (gvjs_Cn(a)) {
+    var b = a;
+    a = new gvjs_Xm(b);
+    433 === a.Bw && gvjs_0m(a, null);
+    var c = a.getPath();
+    c = c.replace(/\/edit/, "/gviz/tq");
+    a.setPath(c);
+    c = gvjs_Rm(gvjs_Sm(3, b)) || "";
+    b = null !== (Number(gvjs_Sm(4, b)) || null);
+    b = gvjs_yn.test(c) && b;
+    gvjs_Ym(a, b ? "http" : "https");
+    a = a.toString()
+  } else if (gvjs_Bn(a)) {
+    c = a;
+    a = new gvjs_Xm(c);
+    433 === a.Bw && gvjs_0m(a, null);
+    b = a.getPath();
+    b = b.replace(/\/ccc$/, "/tq");
+    /\/pub$/.test(b) && (b = b.replace(/\/pub$/, "/tq"),
+      a.Ld("pub", "1"));
+    a.setPath(b);
+    b = gvjs_Rm(gvjs_Sm(3, c)) || "";
+    c = null != (Number(gvjs_Sm(4, c)) || null);
+    var d = gvjs_wn.test(b);
+    b = gvjs_xn.test(b) && !d && c;
+    gvjs_Ym(a, b ? "http" : "https");
+    a = a.toString()
+  }
+  c = a;
+  b = gvjs_Bn(c);
+  c = gvjs_Rm(gvjs_Sm(5, c)) || "";
+  c = gvjs_zn.test(c);
+  (b = b && c) || (c = a,
+    b = gvjs_Cn(c),
+    c = gvjs_Rm(gvjs_Sm(5, c)) || "",
+    c = gvjs_zn.test(c),
+    b = b && c);
+  this.Aba = b;
+  this.iO = a
+}
+;
+function gvjs_Fn(a, b) {
+  var c = a.indexOf("#");
+  -1 !== c && (a = a.substring(0, c));
+  var d = a.indexOf("?")
+    , e = [];
+  -1 === d ? c = a : (c = a.substring(0, d),
+    a = a.substring(d + 1),
+    e = a.split("&"));
+  a = [];
+  for (d = 0; d < e.length; d++) {
+    var f = {};
+    f.name = e[d].split("=")[0];
+    f.W1 = e[d];
+    a.push(f)
+  }
+  for (var g in b)
+    if (b.hasOwnProperty(g)) {
+      e = b[g];
+      f = !1;
+      for (d = 0; d < a.length; d++)
+        if (a[d].name === g) {
+          a[d].W1 = g + "=" + encodeURIComponent(e);
+          f = !0;
+          break
+        }
+      f || (d = {},
+        d.name = g,
+        d.W1 = g + "=" + encodeURIComponent(e),
+        a.push(d))
+    }
+  b = c;
+  if (0 < a.length) {
+    b += "?";
+    g = [];
+    for (d = 0; d < a.length; d++)
+      g.push(a[d].W1);
+    b += g.join("&")
+  }
+  return b
+}
+function gvjs_Gn(a) {
+  var b = a.reqId
+    , c = gvjs_Hn[b];
+  if (c)
+    gvjs_Hn[b] = null,
+      c.VC(a);
+  else
+    throw Error("Missing query for request id: " + b);
+}
+function gvjs_In(a, b, c, d) {
+  a.VC({
+    version: "0.6",
+    status: gvjs_Rb,
+    errors: [{
+      reason: b,
+      message: c,
+      detailed_message: d
+    }]
+  })
+}
+gvjs_.IV = function(a) {
+  var b = {};
+  this.query && (b.tq = String(this.query));
+  var c = "reqId:" + String(this.requestId)
+    , d = this.xJ;
+  d && (c += ";sig:" + d);
+  this.d_ && (c += ";type:" + this.d_);
+  b.tqx = c;
+  if (this.cz) {
+    c = [];
+    for (var e in this.cz)
+      this.cz.hasOwnProperty(e) && c.push(e + ":" + this.cz[e]);
+    b.tqh = c.join(";")
+  }
+  a = gvjs_Fn(a, b);
+  this.HK && (a = new gvjs_Xm(a),
+  gvjs_tg && (gvjs_Zm(a),
+    a.Ld("zx", gvjs_hg())),
+    a = a.toString());
+  return a
+}
+;
+gvjs_.nr = function() {
+  var a = this
+    , b = this.IV(this.iO)
+    , c = gvjs_Oh()
+    , d = {};
+  gvjs_Hn[String(this.requestId)] = this;
+  var e = this.cT
+    , f = "GET";
+  "xhrpost" === e && (e = "xhr",
+    f = "POST");
+  e === gvjs_ub && (d = gvjs_Oca(b),
+    e = d.sendMethod,
+    d = d.options);
+  if (e === gvjs_ad)
+    if (gvjs_je("gadgets.io.makeRequest"))
+      gvjs_Pca(this, b, this.tca);
+    else
+      throw Error("gadgets.io.makeRequest is not defined.");
+  else if ("xhr" === e || e === gvjs_ub && gvjs_Qca(c.Vj().location.href, b))
+    c = void 0,
+      e = b,
+    "POST" === f && (b = b.split("?"),
+    1 <= b.length && (e = b[0]),
+    2 <= b.length && (c = b[1])),
+      gvjs_uca(e, function(g) {
+        var h = a.requestId;
+        g = g.target;
+        if (gvjs_qn(g)) {
+          try {
+            var k = g.Zb ? g.Zb.responseText : ""
+          } catch (t) {
+            k = ""
+          }
+          k = gvjs_kf(k);
+          if (a.Zda) {
+            var l = new gvjs_Cca(k,a.Mla,a.WP);
+            g = gvjs_xca(l.mma);
+            k = new gvjs_M;
+            if (g && 0 < g.length) {
+              for (var m = [], n = l.types, p = 0, q = n.length; p < q; p++)
+                m.push({
+                  type: n[p]
+                });
+              if (l.WP)
+                for (n = 0,
+                       p = m.length; n < p; n++)
+                  m[n].label = g[0][n];
+              n = 0;
+              for (p = m.length; n < p; n++)
+                q = m[n],
+                  k.xd(q.type || gvjs_l, q.label);
+              l.columns = m;
+              m = l.columns;
+              n = l = l.WP ? 1 : 0;
+              for (p = g.length; n < p; n++) {
+                k.Kp();
+                q = 0;
+                for (var r = m.length; q < r; q++)
+                  k.Wb(n - l, q, gvjs_un[m[q].type || gvjs_l](g[n][q]))
+              }
+            }
+            g = {};
+            g.table = k.toJSON();
+            g.version = gvjs_Tk(g);
+            g.reqId = h;
+            gvjs_Gn(g)
+          } else
+            k.match(/^({.*})$/) ? gvjs_Gn(gvjs_Li(k)) : gvjs_te(k)
+        } else if (a.Hw)
+          gvjs_In(a, gvjs_Kc, gvjs_sn(g));
+        else
+          throw Error("google.visualization.Query: " + gvjs_sn(g));
+      }, f, c, this.fza || !!d.xhrWithCredentials);
+  else {
+    if (this.Zda)
+      throw Error("CSV files on other domains are not supported. Please use sendMethod: 'xhr' or 'auto' and serve your .csv file from the same domain as this page.");
+    f = gvjs_zh(c, gvjs_yb)[0];
+    d = null === this.xJ;
+    if (this.Aba && d) {
+      d = c.createElement("IMG");
+      gvjs_Rca(this, d, b);
+      c.appendChild(f, d);
+      return
+    }
+    gvjs_Jn(this, b)
+  }
+  this.Q2 && gvjs_Sca(this)
+}
+;
+function gvjs_Rca(a, b, c) {
+  b.onerror = function() {
+    gvjs_Jn(a, c)
+  }
+  ;
+  b.onload = function() {
+    gvjs_Jn(a, c)
+  }
+  ;
+  b.style.display = gvjs_f;
+  var d = c + "&requireauth=1&" + (new Date).getTime();
+  b.src = d
+}
+function gvjs_Oca(a) {
+  var b = {};
+  if (/[?&]alt=gviz(&[^&]*)*$/.test(a))
+    a = gvjs_Dn.Hia;
+  else {
+    var c = (gvjs_Wm(a, "tqrt") || gvjs_Dn.YF).split(":");
+    a = c[0];
+    "xhr" !== a && "xhrpost" !== a || !gvjs_He(c, gvjs_Yd) || (b.xhrWithCredentials = !0);
+    gvjs__e(gvjs_Dn, a) || (a = gvjs_Dn.YF)
+  }
+  return {
+    sendMethod: a,
+    options: b
+  }
+}
+function gvjs_Qca(a, b) {
+  b = (new gvjs_Xm(a)).resolve(new gvjs_Xm(b)).toString();
+  a = a.match(gvjs_Qm);
+  b = b.match(gvjs_Qm);
+  return a[3] == b[3] && a[1] == b[1] && a[4] == b[4]
+}
+function gvjs_Pca(a, b, c) {
+  var d = gvjs_je("gadgets.io");
+  null == c[d.RequestParameters.CONTENT_TYPE] && (c[d.RequestParameters.CONTENT_TYPE] = d.ContentType.TEXT);
+  null == c[d.RequestParameters.AUTHORIZATION] && (c[d.RequestParameters.AUTHORIZATION] = d.AuthorizationType.SIGNED);
+  null == c.OAUTH_ENABLE_PRIVATE_NETWORK && (c.OAUTH_ENABLE_PRIVATE_NETWORK = !0);
+  null == c.OAUTH_ADD_EMAIL && (c.OAUTH_ADD_EMAIL = !0);
+  d.makeRequest(b, function() {
+    return a.sqa
+  }, c);
+  gvjs_Kn(a)
+}
+gvjs_.sqa = function(a) {
+  if (null != a && a.data)
+    gvjs_te(a.data);
+  else {
+    var b = "";
+    a && a.errors && (b = a.errors.join(" "));
+    gvjs_In(this, "make_request_failed", "gadgets.io.makeRequest failed", b)
+  }
+}
+;
+function gvjs_Jn(a, b) {
+  gvjs_Kn(a);
+  a = a.Cxa || gvjs_rg;
+  b.match(/^https?:\/\/spreadsheets.google.com/) && (a = !1);
+  a ? gvjs_Tca(b) : (b = new gvjs_8m(b,0),
+    b.DW = "google.visualization.Query.setResponse",
+    b.EW = "",
+    b.fetch().then(gvjs_Gn))
+}
+function gvjs_Tca(a) {
+  gvjs_fn(a).then(function(b) {
+    try {
+      b = b.replace(/^[\s\S]*google\.visualization\.Query\.setResponse\(/g, ""),
+        b = b.replace(/\);?[\s]*$/g, ""),
+        gvjs_Gn(gvjs_Li(b))
+    } catch (c) {
+      throw Error("Error handling Query strict JSON response: " + c);
+    }
+  }, function(b) {
+    throw Error("Error handling Query: " + b);
+  })
+}
+function gvjs_Ln(a) {
+  a.xU && (clearTimeout(a.xU),
+    a.xU = null)
+}
+function gvjs_Kn(a) {
+  gvjs_Ln(a);
+  a.xU = setTimeout(function() {
+    gvjs_In(a, "timeout", gvjs_4a)
+  }, 1E3 * a.Cga)
+}
+gvjs_.np = function(a) {
+  if (typeof a !== gvjs_g || 0 > a)
+    throw Error("Refresh interval must be a non-negative number");
+  this.HK = a;
+  this.Q2 = !0
+}
+;
+function gvjs_Mn(a) {
+  a.IK && (clearTimeout(a.IK),
+    a.IK = null)
+}
+function gvjs_Sca(a) {
+  gvjs_Mn(a);
+  if (0 !== a.HK && a.Eea && a.ak) {
+    var b = function() {
+      a.nr();
+      a.IK = setTimeout(b, 1E3 * a.HK)
+    };
+    a.IK = setTimeout(b, 1E3 * a.HK);
+    a.Q2 = !1
+  }
+}
+gvjs_.send = function(a) {
+  this.ak = !0;
+  this.Hw = a;
+  this.nr()
+}
+;
+gvjs_.makeRequest = function(a, b) {
+  this.ak = !0;
+  this.Hw = a;
+  this.cT = gvjs_ad;
+  this.tca = b || {};
+  this.nr()
+}
+;
+gvjs_.abort = function() {
+  this.ak = !1;
+  gvjs_Ln(this);
+  gvjs_Mn(this)
+}
+;
+gvjs_.clear = function() {
+  this.abort()
+}
+;
+gvjs_.VC = function(a) {
+  gvjs_Ln(this);
+  a = new gvjs_Sk(a);
+  if (!gvjs_Vk(a)) {
+    this.xJ = a.Xk() ? null : a.m4;
+    var b = this.Hw;
+    b && b.call(b, a)
+  }
+}
+;
+gvjs_.setTimeout = function(a) {
+  if (typeof a !== gvjs_g || isNaN(a) || 0 >= a)
+    throw Error("Timeout must be a positive number");
+  this.Cga = a
+}
+;
+gvjs_.Fwa = function(a) {
+  if (typeof a !== gvjs_zb)
+    throw Error("Refreshable must be a boolean");
+  return this.Eea = a
+}
+;
+gvjs_.Jn = function(a) {
+  if (typeof a !== gvjs_l)
+    throw Error("queryString must be a string");
+  this.query = a
+}
+;
+gvjs_.Cwa = function(a) {
+  this.d_ = a;
+  null != a && this.Bfa(gvjs_Sd, a)
+}
+;
+gvjs_.Bfa = function(a, b) {
+  a = a.replace(/\\/g, "\\\\");
+  b = b.replace(/\\/g, "\\\\");
+  a = a.replace(/:/g, "\\c");
+  b = b.replace(/:/g, "\\c");
+  a = a.replace(/;/g, "\\s");
+  b = b.replace(/;/g, "\\s");
+  this.cz || (this.cz = {});
+  this.cz[a] = b
+}
+;
+var gvjs_Mca = 0
+  , gvjs_Hn = {}
+  , gvjs_Nca = [];
+var gvjs_Nn = {
+  Bar: gvjs_wb,
+  Line: gvjs_e,
+  Scatter: gvjs_Dd,
+  AnnotatedTimeLine: gvjs_qb,
+  AnnotationChart: gvjs_rb,
+  AreaChart: gvjs_Jb,
+  BarChart: gvjs_Jb,
+  BubbleChart: gvjs_Jb,
+  Calendar: "calendar",
+  CandlestickChart: gvjs_Jb,
+  ClusterChart: "clusterchart",
+  ColumnChart: gvjs_Jb,
+  ComboChart: gvjs_Jb,
+  Gantt: "gantt",
+  Gauge: "gauge",
+  GeoChart: gvjs_Ub,
+  GeoMap: "geomap",
+  Histogram: gvjs_Jb,
+  ImageAreaChart: gvjs_6c,
+  ImageBarChart: gvjs_6c,
+  ImageCandlestickChart: gvjs_6c,
+  ImageChart: gvjs_6c,
+  ImageLineChart: gvjs_6c,
+  ImagePieChart: gvjs_6c,
+  ImageSparkLine: gvjs_6c,
+  LineChart: gvjs_Jb,
+  Map: "map",
+  MotionChart: gvjs_fd,
+  OrgChart: gvjs_sd,
+  PieChart: gvjs_Jb,
+  RangeSelector: gvjs_Jb,
+  Sankey: "sankey",
+  ScatterChart: gvjs_Jb,
+  SparklineChart: gvjs_Jb,
+  SteppedAreaChart: gvjs_Jb,
+  Table: gvjs_Ld,
+  Timeline: gvjs_Nd,
+  TreeMap: "treemap",
+  VegaChart: "vegachart",
+  WordTree: gvjs_Zd,
+  StringFilter: gvjs_Ib,
+  DateRangeFilter: gvjs_Ib,
+  NumberRangeFilter: gvjs_Ib,
+  CategoryFilter: gvjs_Ib,
+  ChartRangeFilter: gvjs_Ib,
+  NumberRangeSetter: gvjs_Ib,
+  ColumnSelector: gvjs_Ib,
+  Dashboard: gvjs_Ib
+};
+function gvjs_On(a, b) {
+  var c = a.useFormatFromData;
+  (typeof c !== gvjs_zb || c) && gvjs_jf(gvjs_gg(a.format)) && (b = gvjs_De(b, function(d) {
+    return !gvjs_jf(gvjs_gg(d))
+  }),
+    gvjs_Pe(b),
+  1 == b.length && (b = gvjs_Uca(b[0]),
+    a.format = b))
+}
+function gvjs_Uca(a) {
+  gvjs_jf(gvjs_gg(a)) || (a = a.replace(/\d/g, "0"),
+    a = a.replace(/#{10,}/, gvjs_eg("#", 10)));
+  return a
+}
+;function gvjs_Vca(a) {
+  var b = gvjs_Wca(a)
+    , c = new gvjs_N(a);
+  c.Hn([0, 1, {
+    type: gvjs_g,
+    calc: function(d, e) {
+      d = gvjs_Pn(a, e);
+      return null != d ? b.slope * d.x + b.intercept : null
+    }
+  }]);
+  return c
+}
+function gvjs_Wca(a) {
+  var b = a.ca();
+  for (var c = new gvjs_z, d = 0; d < b; d++) {
+    var e = gvjs_Pn(a, d);
+    null != e && (c.x += e.x,
+      c.y += e.y)
+  }
+  b = new gvjs_z(c.x / b,c.y / b);
+  for (e = d = c = 0; e < a.ca(); e++) {
+    var f = gvjs_Pn(a, e);
+    null != f && (f = new gvjs_z(f.x - b.x,f.y - b.y),
+      c += f.x * f.y,
+      d += f.x * f.x)
+  }
+  a = {};
+  a.slope = c / d || 1;
+  a.intercept = b.y - a.slope * b.x;
+  return a
+}
+function gvjs_Pn(a, b) {
+  var c = a.getValue(b, 0);
+  a = a.getValue(b, 1);
+  return null == c || null == a ? null : new gvjs_z(c,a)
+}
+;function gvjs_Xca(a) {
+  var b = a.mb();
+  if (b) {
+    var c = a.getType();
+    a = a.Zc();
+    a: {
+      var d = a.useFormatFromData;
+      if (typeof d !== gvjs_zb || d) {
+        d = [gvjs_Ud, gvjs_Md, "targetAxes.0", "targetAxes.1", gvjs_Pb];
+        for (var e = 0; e < d.length; e++)
+          if (gvjs_je(d[e] + gvjs_ja, a)) {
+            d = !1;
+            break a
+          }
+        d = !0
+      } else
+        d = !1
+    }
+    if (d)
+      if (c == gvjs_ra)
+        3 > b.$() || (c = b.Co(1),
+          d = a.hAxis || {},
+          gvjs_On(d, [c]),
+          a.hAxis = d,
+          b = b.Co(2),
+          c = a.vAxes || {},
+          d = c[0] || {},
+          gvjs_On(d, [b]),
+          c[0] = d,
+          a.vAxes = c);
+      else if (c != gvjs_La) {
+        d = a.vAxes || [{}, {}];
+        e = a.hAxis || {};
+        for (var f = d[0] || {}, g = d[1] || {}, h = [], k = [], l = b && b.$() || 0, m, n = 0; n < l; n++)
+          if (b.W(n) == gvjs_g) {
+            m = b.Co(n);
+            var p = n;
+            0 == p ? p = null : (p--,
+              p = ((a.series || {})[p] || {}).targetAxisIndex || 0);
+            switch (p) {
+              case 0:
+                h.push(m);
+                break;
+              case 1:
+                k.push(m)
+            }
+          }
+        c == gvjs_qa ? gvjs_On(e, h) : (gvjs_On(f, h),
+          gvjs_On(g, k));
+        0 < l && b.W(0) != gvjs_l && (c = c == gvjs_qa ? f : e,
+          m = b.Co(0),
+          gvjs_On(c, [m]));
+        d[0] = f;
+        d[1] = g;
+        a.vAxes = d;
+        a.hAxis = e
+      }
+  }
+}
+function gvjs_Yca(a) {
+  if (a.getOption(gvjs_pb)) {
+    var b = a.mb();
+    a.getType() == gvjs_9a && 2 == b.$() && (b = gvjs_Vca(b),
+      a.zh(b),
+      a.ba("series.1.lineWidth", 2),
+      a.ba("series.1.pointSize", 0),
+      a.ba("series.1.visibleInLegend", !1));
+    a.ba(gvjs_pb, null)
+  }
+}
+function gvjs_Zca(a) {
+  var b = a.mb()
+    , c = a.Ni;
+  if (Array.isArray(c))
+    for (var d = 0; d < c.length; d++)
+      b = gvjs_Rk(b, c[d]);
+  else
+    null != c && (b = gvjs_Rk(b, c));
+  a.RE(null);
+  a.zh(b)
+}
+function gvjs__ca(a) {
+  var b = a.getType();
+  if ((gvjs_Nn[b] || null) == gvjs_Jb && b != gvjs_9a) {
+    b = a.mb();
+    var c = a.getOption(gvjs_3c);
+    if (null != c) {
+      var d = [{
+        calc: c ? gvjs_Id : "emptyString",
+        sourceColumn: 0,
+        type: gvjs_l
+      }]
+        , e = c ? 1 : 0;
+      for (c = b.$(); e < c; e++)
+        d.push(e);
+      b = new gvjs_N(b);
+      b.Hn(d);
+      a.ba(gvjs_3c, null);
+      a.zh(b)
+    }
+  }
+}
+;function gvjs_Qn(a) {
+  gvjs_F.call(this);
+  this.Fu = null;
+  this.container = gvjs_Qh(a);
+  this.Hg = new gvjs_wi(this,this.container);
+  this.Lh = gvjs_fl()
+}
+gvjs_o(gvjs_Qn, gvjs_F);
+gvjs_ = gvjs_Qn.prototype;
+gvjs_.getContainer = function() {
+  return this.container
+}
+;
+gvjs_.La = gvjs_n(9);
+gvjs_.getHeight = function(a, b) {
+  return a.bD(gvjs_4c) || gvjs_Gh(this.container).height || b || 200
+}
+;
+gvjs_.draw = function(a, b, c) {
+  var d = this;
+  gvjs_Zg(this.Hg, function() {
+    gvjs_Kk(a);
+    if (null == a)
+      throw Error("Undefined or null data");
+    d.Lh && d.Lh.promise.cancel();
+    d.Lh = gvjs_fl();
+    d.Fu && (d.Fu.vQ = !0);
+    d.Fu = new gvjs_Yg(d.Hg);
+    var e = d.Fu.xha.bind(d.Fu);
+    d.Rd(e, a, b, c)
+  })
+}
+;
+gvjs_.ah = gvjs_n(24);
+gvjs_.Jb = function() {
+  this.Fu && (this.Fu.vQ = !0,
+    this.Fu = null);
+  this.Lh && this.Lh.promise && (this.Lh.promise.cancel(),
+    this.Lh = null);
+  this.He()
+}
+;
+gvjs_.He = function() {}
+;
+gvjs_.M = function() {
+  this.Jb();
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_Qn.prototype.clearChart = gvjs_Qn.prototype.Jb;
+var gvjs_0ca = gvjs_D.Sc
+  , gvjs_Rn = gvjs_D.uX;
+function gvjs_Sn(a, b) {
+  gvjs_F.call(this);
+  b = b || {};
+  typeof b === gvjs_l && (b = gvjs_Li(b));
+  this.ma = b.container || null;
+  this.Yx = b.containerId || null;
+  this.HS = null;
+  this.sM = a;
+  this.Ei = b[a + "Name"] || "";
+  this.Kr = null;
+  this.pf = "";
+  a = b[a + "Type"] || null;
+  typeof a === gvjs_d ? (this.rp(""),
+    this.Kr = a) : typeof a === gvjs_l && "" !== a ? (this.rp(a),
+    this.Kr = null) : null == a && (this.rp(a),
+    this.Kr = null);
+  a = b.packages;
+  this.eS = void 0 !== a ? a : null;
+  this.MR = this.visualization = this.zD = null;
+  this.Cba = b.isDefaultVisualization || void 0 === b.isDefaultVisualization;
+  this.VU = null;
+  this.cf = b.dataSourceUrl || null;
+  this.vma = b.dataSourceChecksum || null;
+  this.Z = null;
+  this.zh(b.dataTable);
+  this.m = b.options || {};
+  this.K = b.state || {};
+  this.Dw = b.query || null;
+  this.rS = null;
+  this.Ew = b.refreshInterval || null;
+  this.Ni = b.view || null;
+  this.pba = b.initialView || null;
+  this.yH = null;
+  this.e$ = [gvjs_Zca, gvjs__ca, gvjs_Xca, gvjs_Yca];
+  this.Bea = null
+}
+gvjs_o(gvjs_Sn, gvjs_F);
+gvjs_ = gvjs_Sn.prototype;
+gvjs_.M = function() {
+  this.clear();
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_.clear = function() {
+  gvjs_Tn(this);
+  gvjs_Un(this)
+}
+;
+function gvjs_Tn(a) {
+  a.rS && (a.rS.clear(),
+    a.rS = null)
+}
+gvjs_.clone = function() {
+  var a = this.Bp();
+  a = new this.constructor(a);
+  a.yH = this.yH;
+  return a
+}
+;
+gvjs_.toJSON = function() {
+  var a = gvjs_Vn(this, this.mb());
+  a.container = void 0;
+  a.typeConstructor_ = void 0;
+  return gvjs_Ii(a)
+}
+;
+gvjs_.Bp = function() {
+  return gvjs_Vn(this, this.Bea || this.mb())
+}
+;
+function gvjs_Vn(a, b) {
+  var c = a.eS
+    , d = void 0;
+  b && (b = b.Gr(),
+    d = b.Bp());
+  b = {
+    container: a.ma || void 0,
+    containerId: a.Yx || void 0,
+    dataSourceChecksum: a.vma || void 0,
+    dataSourceUrl: a.cf || void 0,
+    dataTable: d,
+    initialView: a.pba || void 0,
+    options: a.Zc() || void 0,
+    state: a.getState() || void 0,
+    packages: null === c ? void 0 : c,
+    refreshInterval: a.Ew || void 0,
+    query: a.getQuery() || void 0,
+    view: a.Ni || void 0,
+    isDefaultVisualization: a.Bba()
+  };
+  b[a.sM + "Type"] = a.getType() || void 0;
+  b[a.sM + "Name"] = a.getName() || void 0;
+  a.S6(b);
+  return b
+}
+gvjs_.S6 = function() {}
+;
+gvjs_.CZ = function() {
+  return new this.constructor(this.Bp())
+}
+;
+gvjs_.getName = function() {
+  return this.Ei
+}
+;
+gvjs_.rr = function(a) {
+  this.Ei = a
+}
+;
+gvjs_.getType = function() {
+  return this.pf
+}
+;
+gvjs_.rp = function(a) {
+  this.pf = a;
+  this.Kr = null
+}
+;
+gvjs_.zZ = function() {
+  return this.eS
+}
+;
+gvjs_.oL = function(a) {
+  this.eS = a
+}
+;
+gvjs_.HZ = function() {
+  return this.visualization
+}
+;
+gvjs_.Jwa = function(a) {
+  a != this.visualization && (this.MR = a)
+}
+;
+gvjs_.Bba = function() {
+  return this.Cba
+}
+;
+gvjs_.Dfa = function(a) {
+  this.Cba = a
+}
+;
+gvjs_.Owa = function(a) {
+  var b = arguments
+    , c = this;
+  gvjs_Wn(this);
+  var d = [];
+  gvjs_u([gvjs_i, gvjs_k, gvjs_Rb, gvjs_Hd], function(e) {
+    var f = gvjs_oi(a, e, function() {
+      e == gvjs_i && (c.zD = null,
+        c.visualization = a);
+      e != gvjs_i && e != gvjs_Hd || typeof a.getState !== gvjs_d || c.setState(a.getState.call(a));
+      gvjs_I(c, e, b[0])
+    });
+    d.push(f)
+  });
+  this.VU = d
+}
+;
+function gvjs_Un(a) {
+  a.visualization && typeof a.visualization.Jb === gvjs_d && a.visualization.Jb();
+  gvjs_Wn(a);
+  gvjs_E(a.visualization);
+  a.visualization = null
+}
+function gvjs_Wn(a) {
+  Array.isArray(a.VU) && (gvjs_u(a.VU, function(b) {
+    gvjs_ui(b)
+  }),
+    a.VU = null)
+}
+gvjs_.getContainer = function() {
+  var a;
+  if (!(a = this.ma))
+    a: {
+      var b = this.HS;
+      if (null == b) {
+        a = this.Yx;
+        if (null == a) {
+          a = b;
+          break a
+        }
+        b = gvjs_Oh();
+        var c = b.j(a);
+        if (!b.Qo(c))
+          throw Error("The container #" + a + " is not defined.");
+        b = this.HS = c
+      }
+      a = b
+    }
+  return a
+}
+;
+gvjs_.jP = function() {
+  return this.Yx
+}
+;
+gvjs_.yfa = function(a) {
+  this.HS = this.Yx = this.ma = null;
+  typeof a === gvjs_l ? this.Yx = a : this.ma = a
+}
+;
+gvjs_.mT = function(a) {
+  this.HS = this.ma = null;
+  this.Yx = a
+}
+;
+gvjs_.kP = function() {
+  return this.cf
+}
+;
+gvjs_.yh = function(a) {
+  a != this.cf && (gvjs_Tn(this),
+    this.cf = a)
+}
+;
+gvjs_.mb = function() {
+  return this.Z
+}
+;
+gvjs_.zh = function(a) {
+  this.Z = gvjs_Lk(a)
+}
+;
+gvjs_.EP = function() {
+  return this.Ni
+}
+;
+gvjs_.RE = function(a) {
+  this.Ni = a
+}
+;
+gvjs_.nva = function(a) {
+  Array.isArray(this.Ni) ? this.Ni.push(a) : this.Ni = null === this.Ni ? [a] : [this.Ni, a]
+}
+;
+gvjs_.getQuery = function() {
+  return this.Dw
+}
+;
+gvjs_.Jn = function(a) {
+  this.Dw = a;
+  gvjs_Tn(this)
+}
+;
+gvjs_.nr = function(a, b) {
+  b = void 0 === b ? !1 : b;
+  gvjs_Tn(this);
+  var c = this.rS = new gvjs_En(this.cf || "")
+    , d = this.Ew;
+  d && b && c.np(d);
+  (b = this.getQuery()) && c.Jn(b);
+  c.send(a)
+}
+;
+gvjs_.xP = function() {
+  return this.Ew
+}
+;
+gvjs_.np = function(a) {
+  this.Ew = a;
+  gvjs_Tn(this)
+}
+;
+gvjs_.Eoa = function() {
+  return this.yH
+}
+;
+gvjs_.xwa = function(a) {
+  this.yH = a
+}
+;
+gvjs_.getOption = function(a, b) {
+  return gvjs_Xn(this.m, a, b)
+}
+;
+function gvjs_Xn(a, b, c) {
+  a = -1 == b.indexOf(".") ? a[b] : gvjs_je(b, a);
+  return null != a ? a : void 0 !== c ? c : null
+}
+gvjs_.Zc = function() {
+  return this.m
+}
+;
+gvjs_.ba = function(a, b) {
+  if (null == b) {
+    if (b = this.m,
+    null !== gvjs_Xn(b, a)) {
+      var c = a.split(".");
+      1 < c.length && (a = c.pop(),
+        b = gvjs_Xn(b, c.join(".")));
+      delete b[a]
+    }
+  } else
+    gvjs_Yn(this.m, a, b)
+}
+;
+function gvjs_Yn(a, b, c) {
+  b = b.split(".");
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d];
+    d == b.length - 1 ? a[e] = c : (gvjs_r(a[e]) && a[e] !== Object.prototype[e] || (a[e] = {}),
+      a = a[e])
+  }
+}
+gvjs_.setOptions = function(a) {
+  this.m = a || {}
+}
+;
+gvjs_.getState = function() {
+  return this.K
+}
+;
+gvjs_.setState = function(a) {
+  this.K = a || {}
+}
+;
+gvjs_.A9 = function(a) {
+  var b = this.mb();
+  if (b)
+    this.EO(a, b);
+  else if (null != this.cf)
+    b = this.lna.bind(this, a),
+      a = gvjs_Rn(b, this.UZ.bind(this, a)),
+      this.nr(a, !0);
+  else
+    throw Error("Cannot draw chart: no data specified.");
+}
+;
+gvjs_.lna = function(a, b) {
+  if (b.Xk()) {
+    var c = b.sP()
+      , d = b.nZ();
+    a = gvjs_Xk(a, b);
+    gvjs_I(this, gvjs_Rb, {
+      id: a,
+      message: c,
+      detailedMessage: d
+    })
+  } else
+    this.EO(a, b.mb())
+}
+;
+gvjs_.EO = function(a, b) {
+  var c = this.getType()
+    , d = this.Kr || gvjs_Gm(c);
+  if (!d)
+    throw Error("Invalid " + this.sM + " type: " + (c || String(this.Kr) || "unknown"));
+  this.Kr = d;
+  this.MR && (gvjs_Un(this),
+    this.visualization = this.MR,
+    this.MR = null);
+  if (c = this.visualization && this.visualization.constructor == d)
+    c = (c = this.visualization) && typeof c.getContainer === gvjs_d ? c.getContainer() == a : !1;
+  c ? a = this.visualization : (gvjs_Un(this),
+    a = new d(a));
+  this.zD && this.zD != a && typeof this.zD.Jb === gvjs_d && this.zD.Jb();
+  this.zD = a;
+  this.Owa(a);
+  this.Bea = b;
+  d = gvjs_jj(this.Zc());
+  b = new gvjs_Sn(this.sM,{
+    chartType: this.getType(),
+    dataTable: b,
+    options: d,
+    view: this.Ni
+  });
+  for (d = 0; d < this.e$.length; d++)
+    this.e$[d](b);
+  a.draw(b.mb(), b.Zc(), this.getState())
+}
+;
+gvjs_.draw = function(a) {
+  a && this.yfa(a);
+  a = this.getContainer();
+  try {
+    if (!this.Kr && (null == this.pf || "" === this.pf))
+      throw Error("The " + this.sM + " type is not defined.");
+    if (this.Kr)
+      var b = this.Kr;
+    else {
+      var c = this.getType();
+      b = gvjs_Gm(c)
+    }
+    if (b)
+      this.A9(a);
+    else {
+      var d = this.A9.bind(this, a)
+        , e = gvjs_Rn(d, this.UZ.bind(this, a))
+        , f = this.eS;
+      if (null == f) {
+        var g = this.getType();
+        g = g.replace(gvjs_1b, "");
+        g = g.replace(gvjs_Yb, "");
+        f = gvjs_Nn[g] || null;
+        if (null == f)
+          throw Error("Invalid visualization type: " + g);
+      }
+      typeof f === gvjs_l && (f = [f]);
+      b = {
+        packages: f,
+        callback: e
+      };
+      var h = gvjs_je(gvjs__c);
+      null === h && (h = "current");
+      gvjs_fca(h, b)
+    }
+  } catch (k) {
+    this.UZ(a, k)
+  }
+}
+;
+gvjs_.UZ = function(a, b) {
+  b = b && "undefined" != typeof b.message ? b.message : gvjs_Rb;
+  a = gvjs_0ca(a, b);
+  gvjs_I(this, gvjs_Rb, {
+    id: a,
+    message: b
+  })
+}
+;
+gvjs_.setProperty = function(a, b) {
+  a = a.split(".");
+  if (0 < a.length) {
+    var c = a.shift();
+    if (c = gvjs_1ca[c])
+      0 === a.length ? c.set.apply(this, b) : (c = c.get.apply(this),
+        gvjs_Yn(c, a.join("."), b))
+  }
+}
+;
+var gvjs_1ca = {
+  name: {
+    get: gvjs_Sn.prototype.getName,
+    set: gvjs_Sn.prototype.rr
+  },
+  type: {
+    get: gvjs_Sn.prototype.getType,
+    set: gvjs_Sn.prototype.rp
+  },
+  container: {
+    get: gvjs_Sn.prototype.getContainer,
+    set: gvjs_Sn.prototype.yfa
+  },
+  containerId: {
+    get: gvjs_Sn.prototype.jP,
+    set: gvjs_Sn.prototype.mT
+  },
+  options: {
+    get: gvjs_Sn.prototype.Zc,
+    set: gvjs_Sn.prototype.setOptions
+  },
+  state: {
+    get: gvjs_Sn.prototype.getState,
+    set: gvjs_Sn.prototype.setState
+  },
+  dataSourceUrl: {
+    get: gvjs_Sn.prototype.kP,
+    set: gvjs_Sn.prototype.yh
+  },
+  dataTable: {
+    get: gvjs_Sn.prototype.mb,
+    set: gvjs_Sn.prototype.zh
+  },
+  refreshInterval: {
+    get: gvjs_Sn.prototype.xP,
+    set: gvjs_Sn.prototype.np
+  },
+  query: {
+    get: gvjs_Sn.prototype.getQuery,
+    set: gvjs_Sn.prototype.Jn
+  },
+  view: {
+    get: gvjs_Sn.prototype.EP,
+    set: gvjs_Sn.prototype.RE
+  }
+};
+function gvjs_Zn() {
+  this.mh = new gvjs_aj;
+  this.$s = new gvjs_aj;
+  this.Hu = new gvjs_aj
+}
+function gvjs__n(a, b, c) {
+  gvjs_0n(a, b, c) || (a.mh.set(gvjs_1n(b), b),
+    a.mh.set(gvjs_1n(c), c),
+    gvjs_2n(b, c, a.$s),
+    gvjs_2n(c, b, a.Hu))
+}
+gvjs_ = gvjs_Zn.prototype;
+gvjs_.clear = function() {
+  this.mh.clear();
+  this.$s.clear();
+  this.Hu.clear()
+}
+;
+gvjs_.isEmpty = function() {
+  return this.mh.isEmpty()
+}
+;
+gvjs_.DQ = function() {
+  try {
+    return gvjs_2ca(this),
+      !0
+  } catch (a) {
+    return !1
+  }
+}
+;
+gvjs_.Cd = function() {
+  return this.mh.Cd()
+}
+;
+gvjs_.ob = function() {
+  return this.mh.ob()
+}
+;
+gvjs_.contains = function(a) {
+  return this.mh.tf(gvjs_1n(a))
+}
+;
+function gvjs_0n(a, b, c) {
+  b = gvjs_1n(b);
+  return a.$s.tf(b) && a.$s.get(b).has(gvjs_1n(c))
+}
+function gvjs_3n(a, b) {
+  if (!a.contains(b))
+    return null;
+  var c = a.Hu.get(gvjs_1n(b));
+  if (!c)
+    return null;
+  b = [];
+  c = gvjs_8d(c);
+  for (var d = c.next(); !d.done; d = c.next())
+    b.push(a.mh.get(d.value));
+  return b
+}
+gvjs_.getChildren = function(a) {
+  if (!this.contains(a))
+    return null;
+  var b = this.$s.get(gvjs_1n(a));
+  if (!b)
+    return null;
+  a = [];
+  b = gvjs_8d(b);
+  for (var c = b.next(); !c.done; c = b.next())
+    a.push(this.mh.get(c.value));
+  return a
+}
+;
+function gvjs_4n(a) {
+  if (a.mh.isEmpty())
+    return [];
+  var b = [];
+  gvjs_gj(a.$s, function(c, d) {
+    this.Hu.tf(d) || b.push(this.mh.get(d))
+  }, a);
+  if (0 == b.length)
+    throw Error("Invalid state: DAG has not root node(s).");
+  return b
+}
+function gvjs_2ca(a) {
+  for (var b = gvjs_3ca(a.Hu), c = [], d = gvjs_v(gvjs_4n(a), function(l) {
+    return gvjs_1n(l)
+  }, a); 0 < d.length; ) {
+    for (var e = [], f = 0; f < d.length; f++) {
+      var g = d[f];
+      c.push(a.mh.get(g));
+      var h = a.$s.get(g);
+      if (h) {
+        h = gvjs_8d(h);
+        for (var k = h.next(); !k.done; k = h.next())
+          k = k.value,
+            b.get(k).delete(g),
+          0 === b.get(k).size && (b.remove(k),
+            e.push(k))
+      }
+    }
+    d = e
+  }
+  if (c.length != a.mh.Cd())
+    throw Error("cycle detected");
+}
+gvjs_.clone = function() {
+  return this.isEmpty() ? new gvjs_Zn : gvjs_Zn.prototype.WO.apply(this, gvjs_4n(this))
+}
+;
+gvjs_.WO = function(a) {
+  var b = new gvjs_Zn;
+  if (0 == arguments.length)
+    return b;
+  for (var c = 0; c < arguments.length; c++)
+    gvjs_5n(this, arguments[c], b);
+  return b
+}
+;
+function gvjs_5n(a, b, c) {
+  var d = a.getChildren(b);
+  if (d) {
+    d = gvjs_8d(d);
+    for (var e = d.next(); !e.done; e = d.next())
+      e = e.value,
+        gvjs__n(c, b, e),
+        gvjs_5n(a, e, c)
+  }
+}
+function gvjs_1n(a) {
+  var b = typeof a;
+  return b == gvjs_h && a || b == gvjs_d ? "o" + gvjs_pe(a) : b.substr(0, 1) + a
+}
+function gvjs_2n(a, b, c) {
+  var d = c.get(gvjs_1n(a));
+  d || (d = new Set,
+    c.set(gvjs_1n(a), d));
+  d.add(gvjs_1n(b))
+}
+function gvjs_6n(a, b, c) {
+  var d = c.get(gvjs_1n(a));
+  d.delete(gvjs_1n(b));
+  0 === d.size && c.remove(gvjs_1n(a))
+}
+function gvjs_7n(a, b) {
+  return !a.$s.tf(gvjs_1n(b)) && !a.Hu.tf(gvjs_1n(b))
+}
+function gvjs_3ca(a) {
+  var b = new gvjs_aj;
+  gvjs_gj(a, function(c, d) {
+    b.set(d, new Set(c))
+  });
+  return b
+}
+;function gvjs_P(a) {
+  gvjs_Sn.call(this, "control", a)
+}
+gvjs_o(gvjs_P, gvjs_Sn);
+gvjs_ = gvjs_P.prototype;
+gvjs_.Oy = gvjs_Sn.prototype.HZ;
+gvjs_.twa = gvjs_Sn.prototype.rp;
+gvjs_.Doa = gvjs_Sn.prototype.getType;
+gvjs_.swa = gvjs_Sn.prototype.rr;
+gvjs_.Coa = gvjs_Sn.prototype.getName;
+function gvjs_8n(a, b) {
+  return new Set([].concat(gvjs_9d(a)).filter(function(c) {
+    return !b.has(c)
+  }))
+}
+function gvjs_9n(a, b) {
+  return a.size === b.size && [].concat(gvjs_9d(a)).every(function(c) {
+    return b.has(c)
+  })
+}
+function gvjs_$n() {
+  this.pj = new Set;
+  this.dl = new Set;
+  this.nk = new Set
+}
+gvjs_ = gvjs_$n.prototype;
+gvjs_.clear = function() {
+  this.pj = new Set;
+  this.dl = new Set;
+  this.nk = new Set
+}
+;
+gvjs_.clone = function() {
+  var a = new gvjs_$n;
+  a.pj = new Set(this.pj);
+  a.dl = new Set(gvjs_nj(this.dl));
+  a.nk = new Set(gvjs_nj(this.nk));
+  return a
+}
+;
+gvjs_.equals = function(a) {
+  return gvjs_9n(this.pj, a.pj) && gvjs_9n(this.dl, a.dl) && gvjs_9n(this.nk, a.nk)
+}
+;
+function gvjs_ao(a, b) {
+  return gvjs_nj(b === gvjs_Cd ? a.pj : a.dl).map(function(c) {
+    return Number(c)
+  })
+}
+function gvjs_bo(a) {
+  return gvjs_ao(a, gvjs_Cd)
+}
+function gvjs_co(a) {
+  return gvjs_nj(a.nk).map(function(b) {
+    b = b.split(",");
+    return {
+      row: Number(b[0]),
+      column: Number(b[1])
+    }
+  })
+}
+gvjs_.getSelection = function() {
+  var a = gvjs_bo(this)
+    , b = gvjs_ao(this, gvjs_Fb)
+    , c = gvjs_co(this);
+  return [].concat(gvjs_9d(a.map(function(d) {
+    var e = {};
+    return e.row = d,
+      e.column = null,
+      e
+  })), gvjs_9d(b.map(function(d) {
+    var e = {};
+    return e.row = null,
+      e.column = d,
+      e
+  })), gvjs_9d(c.map(function(d) {
+    var e = {};
+    return e.row = d.row,
+      e.column = d.column,
+      e
+  })))
+}
+;
+gvjs_.contains = function(a, b) {
+  return a === gvjs_Cd ? gvjs_do(this, b[0]) : a === gvjs_Fb ? gvjs_eo(this, b[0]) : gvjs_fo(this, b[0], b[1])
+}
+;
+function gvjs_do(a, b) {
+  return a.pj.has(String(b))
+}
+function gvjs_eo(a, b) {
+  return a.dl.has(String(b))
+}
+function gvjs_fo(a, b, c) {
+  return a.nk.has(String(b + "," + c))
+}
+gvjs_.add = function(a, b) {
+  if (this.contains(a, b))
+    return !1;
+  a === gvjs_Cd ? this.pj.add(String(b[0])) : a === gvjs_Fb ? this.dl.add(String(b[0])) : this.nk.add(String(b[0] + "," + b[1]));
+  return !0
+}
+;
+gvjs_.Kp = function(a) {
+  return this.add(gvjs_Cd, [a])
+}
+;
+gvjs_.xd = function(a) {
+  return this.add(gvjs_Fb, [a])
+}
+;
+function gvjs_go(a, b, c) {
+  a.add("cell", [b, c])
+}
+gvjs_.qE = function(a) {
+  if (!gvjs_do(this, a))
+    return !1;
+  this.pj.delete(String(a));
+  return !0
+}
+;
+gvjs_.BS = function(a) {
+  if (!gvjs_eo(this, a))
+    return !1;
+  this.dl.delete(String(a));
+  return !0
+}
+;
+gvjs_.MK = function(a, b) {
+  gvjs_fo(this, a, b) && this.nk.delete(String(a + "," + b))
+}
+;
+gvjs_.setSelection = function(a) {
+  var b = new Set
+    , c = new Set
+    , d = new Set;
+  a || (a = []);
+  for (var e = 0; e < a.length; e++) {
+    var f = a[e];
+    null != f.row && null != f.column ? d.add("" + f.row + "," + f.column) : null != f.row ? b.add(String(f.row)) : null != f.column && c.add(String(f.column))
+  }
+  var g = gvjs_8n(b, this.pj)
+    , h = gvjs_8n(c, this.dl)
+    , k = gvjs_8n(d, this.nk);
+  a = gvjs_8n(this.pj, b);
+  e = gvjs_8n(this.dl, c);
+  f = gvjs_8n(this.nk, d);
+  this.pj = b;
+  this.dl = c;
+  this.nk = d;
+  b = new gvjs_$n;
+  b.pj = g;
+  b.dl = h;
+  b.nk = k;
+  c = new gvjs_$n;
+  c.pj = a;
+  c.dl = e;
+  c.nk = f;
+  return new gvjs_4ca(b,c)
+}
+;
+function gvjs_4ca(a, b) {
+  this.uB = a;
+  this.An = b
+}
+;function gvjs_ho(a) {
+  gvjs_F.call(this);
+  this.ph = new gvjs_Zn;
+  this.Se = new gvjs_$n;
+  this.v3 = {};
+  this.RB = {};
+  this.ZI = null;
+  this.wD = [];
+  this.Sd = new gvjs_wi(this,a);
+  this.Tm = null
+}
+gvjs_t(gvjs_ho, gvjs_F);
+gvjs_ = gvjs_ho.prototype;
+gvjs_.getSelection = function() {
+  return this.Se.getSelection()
+}
+;
+gvjs_.M = function() {
+  this.clear();
+  gvjs_ho.G.M.call(this)
+}
+;
+gvjs_.clear = function() {
+  gvjs_u(this.wD, function(a) {
+    gvjs_ui(a)
+  });
+  this.wD = [];
+  this.Tm = null;
+  this.ph.clear()
+}
+;
+gvjs_.bind = function(a, b) {
+  if (gvjs_io(a) && typeof a.Oy === gvjs_d)
+    if (gvjs_io(b)) {
+      var c = gvjs_pe(a);
+      if (gvjs_pe(b) == c)
+        this.Sd.Sc("Cannot bind a control to itself.");
+      else {
+        c = [];
+        this.ph.contains(a) || c.push(a);
+        this.ph.contains(b) || c.push(b);
+        gvjs__n(this.ph, a, b);
+        if (this.ph.DQ())
+          var d = !0;
+        else
+          this.Sd.Sc("The requested control and participant cannot be bound together, as this would introduce a dependency cycle"),
+            d = !1;
+        if (d)
+          for (a = 0; a < c.length; a++)
+            b = c[a],
+              this.wD.push(gvjs_oi(b, gvjs_Hd, gvjs_s(this.Iqa, this, b))),
+              this.wD.push(gvjs_oi(b, gvjs_i, gvjs_s(this.Gqa, this, b))),
+              this.wD.push(gvjs_oi(b, gvjs_Rb, gvjs_s(this.Fqa, this, b))),
+            b.getChart && this.wD.push(gvjs_oi(b, gvjs_k, gvjs_s(this.Hqa, this, b)));
+        else
+          c = this.ph,
+          gvjs_0n(c, a, b) && (gvjs_6n(a, b, c.$s),
+            gvjs_6n(b, a, c.Hu),
+          gvjs_7n(c, a) && c.mh.remove(gvjs_1n(a)),
+          gvjs_7n(c, b) && c.mh.remove(gvjs_1n(b)))
+      }
+    } else
+      this.Sd.Sc(b + " does not fit either the Control or Visualization specification.");
+  else
+    this.Sd.Sc(a + " does not fit the Control specification.")
+}
+;
+gvjs_.draw = function(a) {
+  if (a && !this.ph.isEmpty()) {
+    this.ZI = gvjs_Lk(a);
+    this.Tm = new gvjs_jo(this);
+    a = gvjs_4n(this.ph);
+    for (var b = 0; b < a.length; b++)
+      a[b].zh(this.ZI);
+    this.Tm.start(a)
+  }
+}
+;
+function gvjs_io(a) {
+  return gvjs_r(a) && typeof a.draw === gvjs_d && typeof a.setDataTable === gvjs_d
+}
+gvjs_.Iqa = function(a) {
+  this.Tm = this.Tm || new gvjs_jo(this);
+  gvjs_ko(this.Tm, a)
+}
+;
+gvjs_.Gqa = function(a) {
+  var b;
+  if (b = gvjs_io(a) && typeof a.Oy === gvjs_d) {
+    b = a.Oy();
+    if (gvjs_r(b))
+      if (typeof b.i7 === gvjs_d)
+        a: {
+          b = this.ph;
+          for (var c = b.WO(a), d = c.ob(), e = 0; e < d.length; e++) {
+            var f = d[e];
+            if (f != a && gvjs_3n(c, f).length != gvjs_3n(b, f).length) {
+              b = !1;
+              break a
+            }
+          }
+          b = !0
+        }
+      else
+        b = typeof b.apply === gvjs_d ? !0 : !1;
+    else
+      b = !1;
+    b = !b
+  }
+  b ? this.Sd.Sc(a + " does not fit the Control specification while handling 'ready' event.") : (this.Tm = this.Tm || new gvjs_jo(this),
+    gvjs_ko(this.Tm, a))
+}
+;
+function gvjs_lo(a, b) {
+  var c = b.row;
+  b = b.column;
+  if (null != c || null != b)
+    null == c ? a.Se.BS(b) : null == b ? a.Se.qE(c) : a.Se.MK(c, b)
+}
+gvjs_.Hqa = function(a) {
+  var b = gvjs_pe(a)
+    , c = a.getChart().getSelection();
+  this.v3[b] || (this.v3[b] = new gvjs_$n);
+  c = gvjs_De(gvjs_v(c, function(e) {
+    for (var f = a.mb(); f !== this.ZI; ) {
+      e = {
+        row: null == e.row ? null : f.getTableRowIndex(e.row),
+        column: null == e.column ? null : f.getTableColumnIndex(e.column)
+      };
+      0 > e.row && (e.row = null);
+      0 > e.column && (e.column = null);
+      if (null == e.row && null == e.column)
+        return null;
+      f = f.mb()
+    }
+    return e
+  }, this), function(e) {
+    return null != e
+  });
+  var d = this.v3[b].setSelection(c);
+  c = d.uB.getSelection();
+  d = d.An.getSelection();
+  gvjs_u(c, function(e) {
+    var f = e.row + "," + e.column;
+    this.RB[f] || (this.RB[f] = new Set);
+    this.RB[f].add(b);
+    f = e.row;
+    e = e.column;
+    if (null != f || null != e)
+      null == f ? this.Se.xd(e) : null == e ? this.Se.Kp(f) : gvjs_go(this.Se, f, e)
+  }, this);
+  gvjs_u(d, function(e) {
+    var f = e.row + "," + e.column;
+    this.RB[f] ? (this.RB[f].delete(b),
+    0 === this.RB[f].size && gvjs_lo(this, e)) : gvjs_lo(this, e)
+  }, this)
+}
+;
+gvjs_.Fqa = function(a) {
+  this.Tm && this.Tm.handleError(a)
+}
+;
+function gvjs_5ca(a, b) {
+  b ? gvjs_I(a, gvjs_i, null) : a.Sd.Sc("One or more participants failed to draw()");
+  a.Tm = null
+}
+function gvjs_6ca(a, b) {
+  if (1 == b.length)
+    return b[0];
+  var c = b[0]
+    , d = gvjs_Oe(b, 1)
+    , e = new Set(gvjs_mo(a, d[0]));
+  for (b = 1; b < d.length && (e = gvjs_oj(e, new Set(gvjs_mo(a, d[b]))),
+  0 !== e.size); b++)
+    ;
+  b = [];
+  for (var f = 0; f < c.ca(); f++)
+    e.has(gvjs_no(a, c, f)) && b.push(f);
+  e = new Set(gvjs_oo(a, d[0]));
+  for (f = 1; f < d.length && (e = gvjs_oj(e, new Set(gvjs_oo(a, d[f]))),
+  0 !== e.size); f++)
+    ;
+  d = [];
+  for (f = 0; f < c.$(); f++)
+    e.has(gvjs_po(a, c, f)) && d.push(f);
+  a = new gvjs_N(c);
+  a.pp(b);
+  a.Hn(d);
+  return a
+}
+function gvjs_mo(a, b) {
+  for (var c = [], d = 0; d < b.ca(); d++) {
+    var e = gvjs_no(a, b, d);
+    null != e && c.push(e)
+  }
+  return c
+}
+function gvjs_no(a, b, c) {
+  for (; b !== a.ZI; )
+    c = b.fj(c),
+      b = b.mb();
+  return c
+}
+function gvjs_oo(a, b) {
+  for (var c = [], d = 0; d < b.$(); d++) {
+    var e = gvjs_po(a, b, d);
+    null != e && c.push(e)
+  }
+  return c
+}
+function gvjs_po(a, b, c) {
+  for (; b !== a.ZI && -1 !== c; )
+    c = b.CP(c),
+      b = b.mb();
+  -1 == c && (c = null);
+  return c
+}
+function gvjs_jo(a) {
+  this.Xp = a;
+  this.ph = a.ph.clone();
+  this.zr = {};
+  a = this.ph.ob();
+  for (var b = 0; b < a.length; b++)
+    this.zr[gvjs_pe(a[b])] = gvjs_i
+}
+gvjs_jo.prototype.start = function(a) {
+  gvjs_jo.prototype.yca.apply(this, a);
+  for (var b = 0; b < a.length; b++)
+    this.Mj(a[b])
+}
+;
+function gvjs_ko(a, b) {
+  if (a.ph.contains(b)) {
+    switch (a.zr[gvjs_pe(b)]) {
+      case "pending":
+        break;
+      case gvjs_Rb:
+        break;
+      case gvjs_Qb:
+        a.zr[gvjs_pe(b)] = gvjs_i;
+        gvjs_qo(a, b);
+        break;
+      case gvjs_i:
+        a.yca(b);
+        gvjs_qo(a, b);
+        break;
+      default:
+        gvjs_pe(b)
+    }
+    gvjs_ro(a)
+  }
+}
+gvjs_jo.prototype.handleError = function(a) {
+  if (this.ph.contains(a)) {
+    switch (this.zr[gvjs_pe(a)]) {
+      case "pending":
+      case gvjs_i:
+      case gvjs_Rb:
+        break;
+      case gvjs_Qb:
+        this.zr[gvjs_pe(a)] = gvjs_Rb;
+        a = this.ph.WO(a).ob();
+        for (var b = 1; b < a.length; b++)
+          this.zr[gvjs_pe(a[b])] = gvjs_Rb;
+        break;
+      default:
+        gvjs_pe(a)
+    }
+    gvjs_ro(this)
+  }
+}
+;
+function gvjs_ro(a) {
+  var b = 0;
+  gvjs_Ve(a.zr, function(c) {
+    if (c == gvjs_Rb)
+      b++;
+    else if (c != gvjs_i)
+      return !1;
+    return !0
+  }, a) && gvjs_5ca(a.Xp, 0 == b)
+}
+gvjs_jo.prototype.yca = function(a) {
+  for (var b = gvjs_Zn.prototype.WO.apply(this.ph, arguments), c = b.ob(), d = 0; d < c.length; d++) {
+    var e = b
+      , f = c[d];
+    if (!e.contains(f) || e.Hu.tf(gvjs_1n(f)))
+      this.zr[gvjs_pe(c[d])] = "pending"
+  }
+}
+;
+gvjs_jo.prototype.Mj = function(a) {
+  this.zr[gvjs_pe(a)] = gvjs_Qb;
+  var b = (0,
+    gvjs_D.uX)(gvjs_s(function() {
+    a.draw()
+  }, this), gvjs_s(this.handleError, this, a));
+  gvjs_pl(b)
+}
+;
+function gvjs_qo(a, b) {
+  var c = a.ph.getChildren(b);
+  if (c) {
+    if ("undefined" === typeof b.Oy)
+      throw Error("Dashboard participant is not a control.");
+    b = b.Oy();
+    b.zfa && b.zfa(c);
+    for (b = 0; b < c.length; b++) {
+      var d = c[b];
+      a: {
+        var e = a;
+        var f = gvjs_3n(e.ph, d);
+        if (f)
+          for (var g = 0; g < f.length; g++)
+            if (e.zr[gvjs_pe(f[g])] != gvjs_i) {
+              e = !1;
+              break a
+            }
+        e = !0
+      }
+      e && (e = gvjs_7ca(a, d),
+        d.zh(e),
+        a.Mj(d))
+    }
+  }
+}
+function gvjs_7ca(a, b) {
+  b = gvjs_v(gvjs_3n(a.ph, b), function(c) {
+    c = c.Oy();
+    if (typeof c.apply === gvjs_d)
+      return c.apply.call(c)
+  });
+  return gvjs_6ca(a.Xp, b)
+}
+;function gvjs_so(a) {
+  gvjs_F.call(this);
+  this.ma = a;
+  this.Xp = new gvjs_ho(this.ma);
+  gvjs_E(this.N2);
+  this.N2 = gvjs_oi(this.Xp, gvjs_i, gvjs_s(this.laa, this, gvjs_i));
+  gvjs_E(this.zY);
+  this.zY = gvjs_oi(this.Xp, gvjs_Rb, gvjs_s(this.laa, this, gvjs_Rb))
+}
+gvjs_t(gvjs_so, gvjs_F);
+gvjs_ = gvjs_so.prototype;
+gvjs_.M = function() {
+  this.clear();
+  gvjs_E(this.N2);
+  gvjs_E(this.zY);
+  gvjs_E(this.Xp);
+  gvjs_so.G.M.call(this)
+}
+;
+gvjs_.clear = function() {
+  gvjs_ui(this.N2);
+  gvjs_ui(this.zY);
+  this.Xp.clear()
+}
+;
+gvjs_.bind = function(a, b) {
+  Array.isArray(a) || (a = [a]);
+  Array.isArray(b) || (b = [b]);
+  for (var c = 0; c < a.length; c++)
+    for (var d = 0; d < b.length; d++)
+      this.Xp.bind(a[c], b[d]);
+  return this
+}
+;
+gvjs_.draw = function(a) {
+  this.Xp.draw(a)
+}
+;
+gvjs_.getContainer = function() {
+  return this.ma
+}
+;
+gvjs_.getSelection = function() {
+  return this.Xp.getSelection()
+}
+;
+gvjs_.laa = function(a, b) {
+  gvjs_I(this, a, b || null)
+}
+;
+function gvjs_to(a, b) {
+  this.Fva = a;
+  this.iO = b
+}
+gvjs_to.prototype.send = function(a) {
+  this.Hw = a;
+  this.nr()
+}
+;
+gvjs_to.prototype.IV = function(a) {
+  var b = {}, c, d = this.xJ;
+  d && (c = "sig:" + d);
+  c && (b.tqx = c,
+    a = gvjs_Fn(a, b));
+  return a
+}
+;
+gvjs_to.prototype.nr = function() {
+  var a = this
+    , b = this.IV(this.iO);
+  this.Fva.call(this, function(c) {
+    a.VC(c)
+  }, b)
+}
+;
+gvjs_to.prototype.VC = function(a) {
+  a = new gvjs_Sk(a);
+  if (!gvjs_Vk(a)) {
+    this.xJ = a.Xk() ? null : a.m4;
+    var b = this.Hw;
+    if (!b)
+      throw Error("Response handler undefined.");
+    b.call(b, a)
+  }
+}
+;
+function gvjs_uo(a, b, c, d) {
+  this.query = a;
+  this.container = d;
+  this.Hg = this.Ta = this.W8 = this.BX = this.OX = null;
+  this.options = c || {};
+  this.visualization = b;
+  d && (this.Hg = this.OX = gvjs_8ca(d));
+  if (!(b && "draw"in b) || typeof b.draw !== gvjs_d)
+    throw Error("Visualization must have a draw method.");
+}
+function gvjs_8ca(a) {
+  return function(b) {
+    (0,
+      gvjs_D.removeAll)(a);
+    var c = b.Xk();
+    c && gvjs_Xk(a, b);
+    return !c
+  }
+}
+gvjs_ = gvjs_uo.prototype;
+gvjs_.setOptions = function(a) {
+  this.options = a || {}
+}
+;
+gvjs_.draw = function() {
+  this.visualization && this.visualization.draw(this.Ta, this.options)
+}
+;
+gvjs_.wwa = function(a) {
+  var b = this.container;
+  this.Hg = a ? a : b ? this.Hg = this.OX : null
+}
+;
+gvjs_.GE = function() {
+  var a = this;
+  if (!this.Hg)
+    throw Error("If no container was supplied, a custom error handler must be supplied instead.");
+  this.query.send(function(b) {
+    var c = a.BX;
+    c && c(b);
+    a.VC(b);
+    (c = a.W8) && c(b)
+  })
+}
+;
+gvjs_.VC = function(a) {
+  var b = this.Hg;
+  b(a) && this.visualization && (this.Ta = a.mb(),
+    this.visualization.draw(this.Ta, this.options))
+}
+;
+gvjs_.oT = function(a) {
+  if (null == a)
+    this.BX = null;
+  else {
+    if (typeof a !== gvjs_d)
+      throw Error(gvjs_Aa);
+    this.BX = a
+  }
+}
+;
+gvjs_.nT = function(a) {
+  if (null != a) {
+    if (typeof a !== gvjs_d)
+      throw Error("Custom post response handler must be a function.");
+    this.W8 = a
+  }
+}
+;
+gvjs_.abort = function() {
+  this.query.abort()
+}
+;
+function gvjs_Q(a) {
+  gvjs_Sn.call(this, gvjs_Bb, a)
+}
+gvjs_o(gvjs_Q, gvjs_Sn);
+gvjs_ = gvjs_Q.prototype;
+gvjs_.zf = gvjs_Sn.prototype.HZ;
+gvjs_.jT = gvjs_Sn.prototype.Jwa;
+gvjs_.cc = gvjs_Sn.prototype.rp;
+gvjs_.Va = gvjs_Sn.prototype.getType;
+gvjs_.C3 = gvjs_Sn.prototype.rr;
+gvjs_.iZ = gvjs_Sn.prototype.getName;
+function gvjs_vo(a) {
+  a = a || {};
+  typeof a === gvjs_l && (a = gvjs_Li(a));
+  return a.dashboardType ? new (gvjs_je(gvjs_hc))(a) : a.controlType ? new gvjs_P(a) : new gvjs_Q(a)
+}
+;function gvjs_wo(a, b) {
+  gvjs_vo(a).draw(b)
+}
+;function gvjs_xo(a) {
+  gvjs_Sn.call(this, "dashboard", a);
+  a = a || {};
+  typeof a === gvjs_l && (a = gvjs_Li(a));
+  this.nN = this.se = null;
+  gvjs_yo(this, a.wrappers, a.bindings);
+  this.rp(a.dashboardType || "Dashboard")
+}
+gvjs_o(gvjs_xo, gvjs_Sn);
+gvjs_ = gvjs_xo.prototype;
+gvjs_.EO = function(a, b) {
+  function c(m) {
+    return f[m]
+  }
+  gvjs_E(this.visualization);
+  a = gvjs_Qh(a);
+  for (var d = new gvjs_so(a), e = this.nN || [], f = this.se, g = e.length, h = 0; h < g; h++) {
+    var k = gvjs_v(e[h].controls, c)
+      , l = gvjs_v(e[h].participants, c);
+    d.bind(k, l)
+  }
+  this.visualization = d;
+  gvjs_Sn.prototype.EO.call(this, a, b)
+}
+;
+gvjs_.S6 = function(a) {
+  a.wrappers = this.se ? gvjs_v(this.se, function(b) {
+    return b.toJSON()
+  }) : void 0;
+  a.bindings = this.nN || void 0
+}
+;
+gvjs_.Kwa = function(a) {
+  gvjs_yo(this, a, null)
+}
+;
+gvjs_.Xoa = function() {
+  return this.se
+}
+;
+gvjs_.qwa = function(a) {
+  gvjs_yo(this, null, a)
+}
+;
+gvjs_.yoa = function() {
+  return this.nN
+}
+;
+function gvjs_yo(a, b, c) {
+  if (null !== b && !Array.isArray(b)) {
+    var d = [];
+    gvjs_w(b, function(e, f) {
+      var g;
+      gvjs_zo(e) || (g = gvjs_vo(e));
+      g.rr(f);
+      d.push(g)
+    });
+    b = d
+  }
+  gvjs_Ao(b) && gvjs_Ao(c) || (a.se = gvjs_v(b, a.A1, a),
+    a.nN = gvjs_v(c, a.Vta, a))
+}
+gvjs_.A1 = function(a) {
+  gvjs_zo(a) || (a = gvjs_vo(a));
+  a.zh(null);
+  a.yh(null);
+  return a
+}
+;
+gvjs_.Vta = function(a) {
+  var b = a.controls
+    , c = a.participants;
+  if (gvjs_Ao(b) || gvjs_Ao(c))
+    throw Error("invalid binding: " + a);
+  b = gvjs_v(b, this.k$, this);
+  c = gvjs_v(c, this.k$, this);
+  return {
+    controls: b,
+    participants: c
+  }
+}
+;
+gvjs_.k$ = function(a) {
+  var b = a
+    , c = /^{.*}$/;
+  if (gvjs_r(a) || typeof a === gvjs_l && c.test(a))
+    return gvjs_zo(b) || (b = gvjs_vo(b)),
+      this.se.push(b),
+    this.se.length - 1;
+  a = gvjs_9ca(this);
+  a = gvjs_jf(gvjs_gg(b)) ? -1 : gvjs_Be(a, b);
+  if (-1 == a)
+    throw Error("Invalid wrapper name: " + b);
+  return a
+}
+;
+function gvjs_zo(a) {
+  return typeof a.toJSON === gvjs_d
+}
+function gvjs_9ca(a) {
+  return (a.se || []).map(function(b) {
+    return b.getName()
+  })
+}
+function gvjs_Ao(a) {
+  return Array.isArray(a) ? 0 == a.length : !0
+}
+gvjs_.Foa = gvjs_Sn.prototype.HZ;
+gvjs_.zwa = gvjs_Sn.prototype.rr;
+gvjs_.Goa = gvjs_Sn.prototype.getName;
+if (gvjs_y && gvjs_y)
+  try {
+    new ActiveXObject("MSXML2.DOMDocument")
+  } catch (a) {}
+;function gvjs_Bo(a) {
+  this.options = a || {}
+}
+gvjs_Bo.prototype.format = function(a, b) {
+  if (a.W(b) === gvjs_g)
+    for (var c = this.options.base || 0, d = 0; d < a.ca(); d++) {
+      var e = a.getValue(d, b);
+      a.setProperty(d, b, gvjs_Db, null != e && e < c ? "google-visualization-formatters-arrow-dr" : null != e && e > c ? "google-visualization-formatters-arrow-ug" : "google-visualization-formatters-arrow-empty")
+    }
+}
+;
+gvjs_Bo.prototype.Jo = function(a) {
+  return a === gvjs_g ? a : null
+}
+;
+function gvjs_Co(a) {
+  this.options = a || {}
+}
+function gvjs_Do(a, b, c) {
+  0 < b && c.push('<span class="google-charts-bar-' + (a || "w") + '" style="width:' + b + 'px;"></span>')
+}
+gvjs_Co.prototype.format = function(a, b) {
+  var c = a.W(b);
+  if (null != this.Jo(c)) {
+    c = this.options;
+    var d = c.min
+      , e = c.max
+      , f = null;
+    if (null == d || null == e)
+      f = a.Sj(b),
+      null == e && (e = f.max),
+      null == d && (d = Math.min(0, f.min));
+    d >= e && (f = f || a.Sj(b),
+      e = f.max,
+      d = f.min);
+    d === e && (0 === d ? e = 1 : 0 < d ? d = 0 : e = 0);
+    f = e - d;
+    var g = c.base || 0;
+    g = Math.max(d, Math.min(e, g));
+    var h = c.width || 100
+      , k = c.showValue;
+    null == k && (k = !0);
+    for (var l = Math.round((g - d) / f * h), m = h - l, n = 0; n < a.ca(); n++) {
+      var p = Number(a.getValue(n, b))
+        , q = [];
+      p = Math.max(d, Math.min(e, p));
+      var r = Math.ceil((p - d) / f * h);
+      q.push('<span class="google-visualization-formatters-bars">');
+      gvjs_Do("s", 1, q);
+      var t = gvjs_Eo(c.colorPositive, "b")
+        , u = gvjs_Eo(c.colorNegative, "r")
+        , v = c.drawZeroLine ? 1 : 0;
+      0 < l ? p < g ? (gvjs_Do("w", r, q),
+        gvjs_Do(u, l - r, q),
+      0 < v && gvjs_Do("z", v, q),
+        gvjs_Do("w", m, q)) : (gvjs_Do("w", l, q),
+      0 < v && gvjs_Do("z", v, q),
+        gvjs_Do(t, r - l, q),
+        gvjs_Do("w", h - r, q)) : (gvjs_Do(t, r, q),
+        gvjs_Do("w", h - r, q));
+      gvjs_Do("s", 1, q);
+      p = a.getProperty(n, b, gvjs_nb);
+      null == p && (p = a.Ha(n, b),
+        a.setProperty(n, b, gvjs_nb, p));
+      k && (q.push("\u00a0"),
+        q.push(p));
+      q.push("</span>\u00a0");
+      a.Nw(n, b, q.join(""))
+    }
+  }
+}
+;
+gvjs_Co.prototype.Jo = function(a) {
+  return a === gvjs_g ? a : null
+}
+;
+function gvjs_Eo(a, b) {
+  a = (a || "").toLowerCase();
+  return gvjs_$ca[a] || b
+}
+var gvjs_$ca = {
+  red: "r",
+  blue: "b",
+  green: "g"
+};
+function gvjs_Fo(a, b, c, d) {
+  null != a && a instanceof Date && (a = a.getTime());
+  null != b && b instanceof Date && (b = b.getTime());
+  null != a && Array.isArray(a) && (a = gvjs_Go(a));
+  null != b && Array.isArray(b) && (b = gvjs_Go(b));
+  this.from = a;
+  this.uk = b;
+  this.color = c;
+  this.Pp = d
+}
+gvjs_Fo.prototype.contains = function(a) {
+  var b = this.from
+    , c = this.uk;
+  if (null == a)
+    return null == b && null == c;
+  a instanceof Date ? a = a.getTime() : Array.isArray(a) && (a = gvjs_Go(a));
+  return (null == b || a >= b) && (null == c || a < c)
+}
+;
+gvjs_Fo.prototype.ee = function() {
+  return this.color
+}
+;
+gvjs_Fo.prototype.getBackgroundColor = function() {
+  return this.Pp
+}
+;
+function gvjs_Ho(a, b, c, d, e) {
+  gvjs_Fo.call(this, a, b, c, "");
+  this.sS = 0;
+  typeof a === gvjs_g && typeof b === gvjs_g && (this.sS = b - a,
+  0 >= this.sS && (this.sS = 1));
+  this.roa = gvjs_vj(gvjs_qj(d).hex);
+  this.hya = gvjs_vj(gvjs_qj(e).hex)
+}
+gvjs_o(gvjs_Ho, gvjs_Fo);
+gvjs_Ho.prototype.getBackgroundColor = function(a) {
+  if (typeof a !== gvjs_g)
+    return "";
+  a = gvjs_xj(this.roa, this.hya, 1 - (a - this.from) / this.sS);
+  return gvjs_wj(a[0], a[1], a[2])
+}
+;
+function gvjs_Io() {
+  this.tS = []
+}
+gvjs_Io.prototype.addRange = function(a, b, c, d) {
+  this.tS.push(new gvjs_Fo(a,b,c,d))
+}
+;
+gvjs_Io.prototype.dka = function(a, b, c, d, e) {
+  this.tS.push(new gvjs_Ho(a,b,c,d,e))
+}
+;
+gvjs_Io.prototype.format = function(a, b) {
+  var c = a.W(b);
+  if (null != this.Jo(c))
+    for (c = 0; c < a.ca(); c++) {
+      for (var d = a.getValue(c, b), e = "", f = 0; f < this.tS.length; f++) {
+        var g = this.tS[f];
+        if ("undefined" !== typeof d && g.contains(d)) {
+          f = g.ee();
+          d = g.getBackgroundColor(d);
+          f && (e += gvjs_Eb + f + ";");
+          d && (e += gvjs_vb + d + ";");
+          break
+        }
+      }
+      a.setProperty(c, b, gvjs_Jd, e)
+    }
+}
+;
+gvjs_Io.prototype.Jo = function(a) {
+  return a !== gvjs_Lb && a !== gvjs_Mb && a !== gvjs_Od && a !== gvjs_g && a !== gvjs_l ? null : a
+}
+;
+function gvjs_Go(a) {
+  return 36E5 * a[0] + 6E4 * a[1] + 1E3 * a[2] + (4 === a.length ? a[3] : 0)
+}
+;function gvjs_Jo(a) {
+  this.pattern = a || ""
+}
+gvjs_Jo.prototype.format = function(a, b, c, d) {
+  var e = b[0];
+  null != c && typeof c === gvjs_g && (e = c);
+  d = d || null;
+  for (c = 0; c < a.ca(); c++) {
+    var f = this.pattern.replace(/{(\d+)}/g, function(g) {
+      return function(h, k, l, m) {
+        return 0 < l && "\\" === m[l - 1] ? h : a.Ha(g, b[Number(k)])
+      }
+    }(c));
+    f = f.replace(/\\(.)/g, "$1");
+    d ? a.setProperty(c, e, d, f) : a.Nw(c, e, f)
+  }
+}
+;
+gvjs_Jo.prototype.Jo = function(a) {
+  return a
+}
+;
+gvjs_q("google.visualization.drawChart", gvjs_wo, void 0);
+gvjs_q("google.visualization.createUrl", function(a, b) {
+  typeof a === gvjs_l && (a = gvjs_Li(a));
+  var c = [], d;
+  for (d in a)
+    if ("options" == d) {
+      var e = a[d], f;
+      for (f in e) {
+        var g = e[f];
+        typeof g !== gvjs_l && (g = gvjs_Ii(g));
+        c.push(f + "=" + encodeURIComponent(String(g)))
+      }
+    } else
+      g = a[d],
+      typeof g !== gvjs_l && (g = typeof g.toJSON === gvjs_d ? g.toJSON() : gvjs_Ii(g)),
+        c.push(d + "=" + encodeURIComponent(String(g)));
+  a = gvjs_Cm() + "/chart.html";
+  a = a.replace(/^https?:/, "");
+  c = (b || a) + "?" + c.join("&");
+  c = c.replace(/'/g, "%27");
+  return c = c.replace(/"/g, "%22")
+}, void 0);
+gvjs_q("google.visualization.createSnippet", function(a) {
+  var b = gvjs_Cm() + "/chart.js";
+  b = b.replace(/^https?:/, "");
+  b = '<script type="text/javascript" src="' + b + '">\n';
+  a = gvjs_vo(a).toJSON();
+  a = a.replace(/</g, gvjs_fa);
+  a = a.replace(/>/g, "&gt;");
+  return b + a + "\n\x3c/script>"
+}, void 0);
+gvjs_q("google.visualization.createWrapper", gvjs_vo, void 0);
+gvjs_q("google.visualization.ChartWrapper", gvjs_Q, void 0);
+gvjs_Q.prototype.clear = gvjs_Q.prototype.clear;
+gvjs_Q.prototype.draw = gvjs_Q.prototype.draw;
+gvjs_Q.prototype.clone = gvjs_Q.prototype.clone;
+gvjs_Q.prototype.toJSON = gvjs_Q.prototype.toJSON;
+gvjs_Q.prototype.getSnapshot = gvjs_Q.prototype.CZ;
+gvjs_Q.prototype.getDataSourceUrl = gvjs_Q.prototype.kP;
+gvjs_Q.prototype.getDataTable = gvjs_Q.prototype.mb;
+gvjs_Q.prototype.getChartName = gvjs_Q.prototype.iZ;
+gvjs_Q.prototype.getChartType = gvjs_Q.prototype.Va;
+gvjs_Q.prototype.getChart = gvjs_Q.prototype.zf;
+gvjs_Q.prototype.getContainerId = gvjs_Q.prototype.jP;
+gvjs_Q.prototype.getPackages = gvjs_Q.prototype.zZ;
+gvjs_Q.prototype.getQuery = gvjs_Q.prototype.getQuery;
+gvjs_Q.prototype.getRefreshInterval = gvjs_Q.prototype.xP;
+gvjs_Q.prototype.getView = gvjs_Q.prototype.EP;
+gvjs_Q.prototype.getOption = gvjs_Q.prototype.getOption;
+gvjs_Q.prototype.getOptions = gvjs_Q.prototype.Zc;
+gvjs_Q.prototype.getState = gvjs_Q.prototype.getState;
+gvjs_Q.prototype.getCustomRequestHandler = gvjs_Q.prototype.Eoa;
+gvjs_Q.prototype.isDefaultVisualization = gvjs_Q.prototype.Bba;
+gvjs_Q.prototype.pushView = gvjs_Q.prototype.nva;
+gvjs_Q.prototype.safeDraw = gvjs_Q.prototype.draw;
+gvjs_Q.prototype.sendQuery = gvjs_Q.prototype.nr;
+gvjs_Q.prototype.setDataSourceUrl = gvjs_Q.prototype.yh;
+gvjs_Q.prototype.setDataTable = gvjs_Q.prototype.zh;
+gvjs_Q.prototype.setChart = gvjs_Q.prototype.jT;
+gvjs_Q.prototype.setChartName = gvjs_Q.prototype.C3;
+gvjs_Q.prototype.setChartType = gvjs_Q.prototype.cc;
+gvjs_Q.prototype.setContainerId = gvjs_Q.prototype.mT;
+gvjs_Q.prototype.setIsDefaultVisualization = gvjs_Q.prototype.Dfa;
+gvjs_Q.prototype.setPackages = gvjs_Q.prototype.oL;
+gvjs_Q.prototype.setQuery = gvjs_Q.prototype.Jn;
+gvjs_Q.prototype.setRefreshInterval = gvjs_Q.prototype.np;
+gvjs_Q.prototype.setView = gvjs_Q.prototype.RE;
+gvjs_Q.prototype.setOption = gvjs_Q.prototype.ba;
+gvjs_Q.prototype.setOptions = gvjs_Q.prototype.setOptions;
+gvjs_Q.prototype.setState = gvjs_Q.prototype.setState;
+gvjs_Q.prototype.setCustomRequestHandler = gvjs_Q.prototype.xwa;
+gvjs_q("google.visualization.ControlWrapper", gvjs_P, void 0);
+gvjs_P.prototype.clear = gvjs_P.prototype.clear;
+gvjs_P.prototype.draw = gvjs_P.prototype.draw;
+gvjs_P.prototype.toJSON = gvjs_P.prototype.toJSON;
+gvjs_P.prototype.getSnapshot = gvjs_P.prototype.CZ;
+gvjs_P.prototype.getDataSourceUrl = gvjs_P.prototype.kP;
+gvjs_P.prototype.getDataTable = gvjs_P.prototype.mb;
+gvjs_P.prototype.getControlName = gvjs_P.prototype.Coa;
+gvjs_P.prototype.getControlType = gvjs_P.prototype.Doa;
+gvjs_P.prototype.getControl = gvjs_P.prototype.Oy;
+gvjs_P.prototype.getContainerId = gvjs_P.prototype.jP;
+gvjs_P.prototype.getPackages = gvjs_P.prototype.zZ;
+gvjs_P.prototype.getQuery = gvjs_P.prototype.getQuery;
+gvjs_P.prototype.getRefreshInterval = gvjs_P.prototype.xP;
+gvjs_P.prototype.getView = gvjs_P.prototype.EP;
+gvjs_P.prototype.getOption = gvjs_P.prototype.getOption;
+gvjs_P.prototype.getOptions = gvjs_P.prototype.Zc;
+gvjs_P.prototype.getState = gvjs_P.prototype.getState;
+gvjs_P.prototype.sendQuery = gvjs_P.prototype.nr;
+gvjs_P.prototype.setDataSourceUrl = gvjs_P.prototype.yh;
+gvjs_P.prototype.setDataTable = gvjs_P.prototype.zh;
+gvjs_P.prototype.setControlName = gvjs_P.prototype.swa;
+gvjs_P.prototype.setControlType = gvjs_P.prototype.twa;
+gvjs_P.prototype.setContainerId = gvjs_P.prototype.mT;
+gvjs_P.prototype.setPackages = gvjs_P.prototype.oL;
+gvjs_P.prototype.setQuery = gvjs_P.prototype.Jn;
+gvjs_P.prototype.setRefreshInterval = gvjs_P.prototype.np;
+gvjs_P.prototype.setView = gvjs_P.prototype.RE;
+gvjs_P.prototype.setOption = gvjs_P.prototype.ba;
+gvjs_P.prototype.setOptions = gvjs_P.prototype.setOptions;
+gvjs_P.prototype.setState = gvjs_P.prototype.setState;
+gvjs_q(gvjs_hc, gvjs_xo, void 0);
+gvjs_xo.prototype.clear = gvjs_xo.prototype.clear;
+gvjs_xo.prototype.draw = gvjs_xo.prototype.draw;
+gvjs_xo.prototype.toJSON = gvjs_xo.prototype.toJSON;
+gvjs_xo.prototype.getBindings = gvjs_xo.prototype.yoa;
+gvjs_xo.prototype.getDataSourceUrl = gvjs_xo.prototype.kP;
+gvjs_xo.prototype.getDataTable = gvjs_xo.prototype.mb;
+gvjs_xo.prototype.getDashboard = gvjs_xo.prototype.Foa;
+gvjs_xo.prototype.getDashboardName = gvjs_xo.prototype.Goa;
+gvjs_xo.prototype.getContainerId = gvjs_xo.prototype.jP;
+gvjs_xo.prototype.getPackages = gvjs_xo.prototype.zZ;
+gvjs_xo.prototype.getQuery = gvjs_xo.prototype.getQuery;
+gvjs_xo.prototype.getRefreshInterval = gvjs_xo.prototype.xP;
+gvjs_xo.prototype.getView = gvjs_xo.prototype.EP;
+gvjs_xo.prototype.getWrappers = gvjs_xo.prototype.Xoa;
+gvjs_xo.prototype.setBindings = gvjs_xo.prototype.qwa;
+gvjs_xo.prototype.setDataSourceUrl = gvjs_xo.prototype.yh;
+gvjs_xo.prototype.setDataTable = gvjs_xo.prototype.zh;
+gvjs_xo.prototype.setDashboardName = gvjs_xo.prototype.zwa;
+gvjs_xo.prototype.setContainerId = gvjs_xo.prototype.mT;
+gvjs_xo.prototype.setPackages = gvjs_xo.prototype.oL;
+gvjs_xo.prototype.setQuery = gvjs_xo.prototype.Jn;
+gvjs_xo.prototype.setRefreshInterval = gvjs_xo.prototype.np;
+gvjs_xo.prototype.setView = gvjs_xo.prototype.RE;
+gvjs_xo.prototype.getSnapshot = gvjs_xo.prototype.CZ;
+gvjs_xo.prototype.setWrappers = gvjs_xo.prototype.Kwa;
+function gvjs_Ko(a) {
+  for (var b = 0, c = 0; c < a.length; c++)
+    b += a[c];
+  return b
+}
+function gvjs_Lo(a) {
+  return a.length
+}
+function gvjs_Mo(a) {
+  return gvjs_Ko(a) / a.length
+}
+;function gvjs_No(a, b, c) {
+  function d(r, t, u, v) {
+    return t(u.getValue(v, r))
+  }
+  c = void 0 === c ? [] : c;
+  for (var e = [], f = [], g = gvjs_8d(b), h = g.next(); !h.done; h = g.next())
+    if (h = h.value,
+    typeof h === gvjs_g)
+      e.push(h);
+    else if (typeof h === gvjs_h) {
+      var k = a.jf(h.column);
+      "modifier"in h && f.push({
+        bla: {
+          calc: gvjs_re(d, k, h.modifier),
+          type: h.type,
+          label: h.label,
+          id: h.id
+        },
+        Jta: e.length
+      });
+      e.push(k)
+    }
+  if (0 < f.length) {
+    g = new gvjs_N(a);
+    h = g.FZ();
+    f = gvjs_8d(f);
+    for (k = f.next(); !k.done; k = f.next()) {
+      k = k.value;
+      var l = h.length;
+      h[l] = k.bla;
+      e[k.Jta] = l
+    }
+    g.Hn(h);
+    a = g
+  }
+  var m = new gvjs_M;
+  f = [];
+  for (g = 0; g < e.length; g++) {
+    l = b[g];
+    var n = e[g];
+    h = a.W(n);
+    k = typeof l === gvjs_h && null != l.label ? l.label : a.Ga(n);
+    l = typeof l === gvjs_h && null != l.id ? l.id : a.Ne(n);
+    m.xd(h, k, l);
+    f.push(h)
+  }
+  g = gvjs_8d(c);
+  for (h = g.next(); !h.done; h = g.next())
+    h = h.value,
+      l = a.jf(h.column),
+      k = h.label || a.Ga(l),
+      l = null != h.id ? h.id : a.Ne(l),
+      m.xd(h.type, k, l);
+  g = e.map(function(r) {
+    return {
+      column: r
+    }
+  });
+  var p = a.bn(g)
+    , q = [];
+  for (g = 0; g < c.length; g++)
+    q.push([]);
+  for (g = {
+    Sr: 0
+  }; g.Sr < p.length; g = {
+    BM: g.BM,
+    Sr: g.Sr,
+    gV: g.gV
+  },
+         g.Sr++) {
+    for (h = 0; h < c.length; h++)
+      q[h].push(a.getValue(p[g.Sr], a.jf(c[h].column)));
+    h = !1;
+    if (g.Sr < p.length - 1)
+      for (h = !0,
+             k = 0; k < e.length; k++)
+        if (l = a.getValue(p[g.Sr], e[k]),
+          n = a.getValue(p[g.Sr + 1], e[k]),
+        0 !== gvjs_vk(f[k], l, n)) {
+          h = !1;
+          break
+        }
+    if (!h)
+      for (g.BM = m.Kp(),
+             gvjs_u(e, function(r) {
+               return function(t, u) {
+                 m.Wa(r.BM, u, a.getValue(p[r.Sr], t))
+               }
+             }(g)),
+             g.gV = b.length,
+             gvjs_u(c, function(r) {
+               return function(t, u) {
+                 t = (0,
+                   t.aggregation)(q[u]);
+                 m.Wa(r.BM, r.gV + u, t)
+               }
+             }(g)),
+             h = 0; h < c.length; h++)
+        q[h] = []
+  }
+  return m
+}
+;function gvjs_Oo(a, b, c) {
+  var d = b.W(c)
+    , e = b.Ne(c)
+    , f = b.Ga(c);
+  d = a.xd(d, f, e);
+  a.lT(d, b.Rj(c))
+}
+;gvjs_q("google.visualization.data.avg", gvjs_Mo, void 0);
+gvjs_q("google.visualization.data.count", gvjs_Lo, void 0);
+gvjs_q("google.visualization.data.group", gvjs_No, void 0);
+gvjs_q("google.visualization.data.join", function(a, b, c, d, e, f) {
+  d = d.map(function(B) {
+    return [a.jf(B[0]), b.jf(B[1])]
+  });
+  e = e.map(a.jf.bind(a));
+  f = f.map(b.jf.bind(b));
+  for (var g = c === gvjs_$c || c === gvjs_Tb, h = c === gvjs_j || c === gvjs_Tb, k = new gvjs_M, l = d.map(function(B) {
+    var D = a.W(B[0])
+      , C = b.W(B[1]);
+    if (D !== C)
+      throw Error("Key types do not match:" + D + gvjs_ha + C);
+    gvjs_Oo(k, a, B[0]);
+    return D
+  }), m = [], n = [], p = gvjs_8d(d), q = p.next(); !q.done; q = p.next()) {
+    var r = q.value;
+    m.push({
+      column: r[0]
+    });
+    n.push({
+      column: r[1]
+    })
+  }
+  m = a.bn(m);
+  n = b.bn(n);
+  p = gvjs_8d(e);
+  for (q = p.next(); !q.done; q = p.next())
+    gvjs_Oo(k, a, q.value);
+  p = gvjs_8d(f);
+  for (q = p.next(); !q.done; q = p.next())
+    gvjs_Oo(k, b, q.value);
+  p = !1;
+  for (var t = r = 0, u = 0; r < m.length || t < n.length; ) {
+    var v = 0
+      , w = [];
+    if (t >= n.length)
+      if (g)
+        w[0] = m[r],
+          v = -1;
+      else
+        break;
+    else if (r >= m.length)
+      if (h)
+        w[1] = n[t],
+          v = 1;
+      else
+        break;
+    else {
+      w[0] = m[r];
+      w[1] = n[t];
+      for (var x = 0; x < d.length && (v = a.getValue(w[0], d[x][0]),
+        q = b.getValue(w[1], d[x][1]),
+        v = gvjs_vk(l[x], v, q),
+      0 === v); x++)
+        ;
+    }
+    if (p && 0 !== v)
+      p = !1,
+        t++;
+    else {
+      if (-1 === v && g || 1 === v && h || 0 === v) {
+        k.Kp();
+        var y = void 0
+          , z = void 0;
+        -1 === v && g || 0 === v && c !== gvjs_j ? (y = a,
+          z = 0) : (y = b,
+          z = 1);
+        x = 0;
+        var A = gvjs_8d(d);
+        for (q = A.next(); !q.done; q = A.next())
+          q = q.value,
+            c === gvjs_Tb ? k.Wa(u, x, y.getValue(w[z], q[z])) : k.Wb(u, x, y.getValue(w[z], q[z]), y.Ha(w[z], q[z]), y.getProperties(w[z], q[z])),
+            x++;
+        if (-1 === v && g || 0 === v)
+          for (y = d.length,
+                 x = 0,
+                 z = gvjs_8d(e),
+                 q = z.next(); !q.done; q = z.next())
+            q = q.value,
+              k.Wb(u, x + y, a.getValue(w[0], q), a.Ha(w[0], q), a.getProperties(w[0], q)),
+              x++;
+        if (1 === v && h || 0 === v)
+          for (y = e.length + d.length,
+                 x = 0,
+                 z = gvjs_8d(f),
+                 q = z.next(); !q.done; q = z.next())
+            q = q.value,
+              k.Wb(u, x + y, b.getValue(w[1], q), b.Ha(w[1], q), b.getProperties(w[1], q)),
+              x++;
+        u++
+      }
+      1 === v ? t++ : r++;
+      0 === v && (p = !0)
+    }
+  }
+  return k
+}, void 0);
+gvjs_q("google.visualization.data.max", function(a) {
+  if (0 === a.length)
+    return null;
+  for (var b = a[0], c = 1; c < a.length; c++) {
+    var d = a[c];
+    null != d && d > b && (b = d)
+  }
+  return b
+}, void 0);
+gvjs_q("google.visualization.data.min", function(a) {
+  if (0 === a.length)
+    return null;
+  for (var b = a[0], c = 1; c < a.length; c++) {
+    var d = a[c];
+    null != d && d < b && (b = d)
+  }
+  return b
+}, void 0);
+gvjs_q("google.visualization.data.month", function(a) {
+  return a.getMonth() + 1
+}, void 0);
+gvjs_q("google.visualization.data.sum", gvjs_Ko, void 0);
+function gvjs_Po(a, b) {
+  gvjs_Ai.call(this);
+  if (a instanceof gvjs_Ai)
+    this.bd = a;
+  else if (null == a)
+    this.bd = new gvjs_M;
+  else {
+    this.data = a;
+    a: {
+      if (b && (a = b ? gvjs_kj(b, this.data) : this.data,
+        Array.isArray(a))) {
+        b = a[0];
+        a = Array.isArray(b) ? gvjs_Mk(a) : typeof b === gvjs_h ? gvjs_Nk(a) : gvjs_dba(a);
+        break a
+      }
+      a = new gvjs_M
+    }
+    this.bd = a
+  }
+}
+gvjs_o(gvjs_Po, gvjs_Ai);
+gvjs_ = gvjs_Po.prototype;
+gvjs_.getData = function() {
+  return this.data
+}
+;
+gvjs_.Py = function(a) {
+  return this.bd.Py(a)
+}
+;
+gvjs_.ca = function() {
+  return this.bd.ca()
+}
+;
+gvjs_.$ = function() {
+  return this.bd.$()
+}
+;
+gvjs_.Do = gvjs_n(18);
+gvjs_.Ne = function(a) {
+  return this.bd.Ne(a)
+}
+;
+gvjs_.Ga = function(a) {
+  return this.bd.Ga(a)
+}
+;
+gvjs_.Co = function(a) {
+  return this.bd.Co(a)
+}
+;
+gvjs_.Jg = function(a) {
+  return this.bd.Jg(a)
+}
+;
+gvjs_.W = function(a) {
+  return this.bd.W(a)
+}
+;
+gvjs_.getValue = function(a, b) {
+  return this.bd.getValue(a, b)
+}
+;
+gvjs_.si = function(a, b) {
+  return this.bd.si(a, b)
+}
+;
+gvjs_.Ha = function(a, b) {
+  return this.bd.Ha(a, b)
+}
+;
+gvjs_.Nw = function(a, b, c) {
+  this.bd.Nw(a, b, c)
+}
+;
+gvjs_.format = function(a, b) {
+  this.bd.format(a, b)
+}
+;
+gvjs_.Sj = function(a) {
+  return this.bd.Sj(a)
+}
+;
+gvjs_.getProperty = function(a, b, c) {
+  return this.bd.getProperty(a, b, c)
+}
+;
+gvjs_.setProperty = function(a, b, c, d) {
+  this.bd.setProperty(a, b, c, d)
+}
+;
+gvjs_.getProperties = function(a, b) {
+  return this.bd.getProperties(a, b)
+}
+;
+gvjs_.Sy = function(a) {
+  return this.bd.Sy(a)
+}
+;
+gvjs_.Cv = function() {
+  return this.bd.Cv()
+}
+;
+gvjs_.Ul = function(a, b) {
+  return this.bd.Ul(a, b)
+}
+;
+gvjs_.zv = function(a) {
+  return this.bd.zv(a)
+}
+;
+gvjs_.Bd = function(a, b) {
+  return this.bd.Bd(a, b)
+}
+;
+gvjs_.Rj = function(a) {
+  return this.bd.Rj(a)
+}
+;
+gvjs_.bn = function(a) {
+  return this.bd.bn(a)
+}
+;
+gvjs_.at = function(a) {
+  return this.bd.at(a)
+}
+;
+gvjs_.fj = function(a) {
+  return this.bd.fj(a)
+}
+;
+gvjs_.Ty = function(a) {
+  return this.bd.Ty(a)
+}
+;
+gvjs_.Uy = function(a) {
+  return this.bd.Uy(a)
+}
+;
+gvjs_.Gr = function() {
+  return this.bd.Gr()
+}
+;
+gvjs_.Bp = function() {
+  return this.bd.Bp()
+}
+;
+gvjs_.toJSON = function() {
+  return this.bd.toJSON()
+}
+;
+gvjs_q(gvjs_Kc, gvjs_En, void 0);
+gvjs_En.prototype.makeRequest = gvjs_En.prototype.makeRequest;
+gvjs_En.prototype.setRefreshInterval = gvjs_En.prototype.np;
+gvjs_En.prototype.setQuery = gvjs_En.prototype.Jn;
+gvjs_En.prototype.send = gvjs_En.prototype.send;
+gvjs_En.prototype.setRefreshable = gvjs_En.prototype.Fwa;
+gvjs_En.prototype.setTimeout = gvjs_En.prototype.setTimeout;
+gvjs_En.prototype.setHandlerType = gvjs_En.prototype.Cwa;
+gvjs_En.prototype.setHandlerParameter = gvjs_En.prototype.Bfa;
+gvjs_En.setResponse = gvjs_Gn;
+gvjs_En.prototype.abort = gvjs_En.prototype.abort;
+gvjs_En.prototype.clear = gvjs_En.prototype.clear;
+gvjs_q("google.visualization.CustomQuery", gvjs_to, void 0);
+gvjs_to.prototype.send = gvjs_to.prototype.send;
+gvjs_q("google.visualization.QueryResponse", gvjs_Sk, void 0);
+gvjs_Sk.prototype.getDataTable = gvjs_Sk.prototype.mb;
+gvjs_Sk.prototype.isError = gvjs_Sk.prototype.Xk;
+gvjs_Sk.prototype.hasWarning = gvjs_Sk.prototype.j_;
+gvjs_Sk.prototype.getReasons = gvjs_Sk.prototype.Q$;
+gvjs_Sk.prototype.getMessage = gvjs_Sk.prototype.sP;
+gvjs_Sk.prototype.getDetailedMessage = gvjs_Sk.prototype.nZ;
+gvjs_Sk.addErrorFromQueryResponse = gvjs_Xk;
+gvjs_q("google.visualization.Data", gvjs_Po, void 0);
+gvjs_Po.prototype.getColumnId = gvjs_Po.prototype.Ne;
+gvjs_Po.prototype.getColumnIndex = gvjs_Po.prototype.jf;
+gvjs_Po.prototype.getColumnLabel = gvjs_Po.prototype.Ga;
+gvjs_Po.prototype.getColumnPattern = gvjs_Po.prototype.Co;
+gvjs_Po.prototype.getColumnProperty = gvjs_Po.prototype.Bd;
+gvjs_Po.prototype.getColumnProperty = gvjs_Po.prototype.Bd;
+gvjs_Po.prototype.getColumnProperties = gvjs_Po.prototype.Rj;
+gvjs_Po.prototype.getColumnRange = gvjs_Po.prototype.Sj;
+gvjs_Po.prototype.getColumnRole = gvjs_Po.prototype.Jg;
+gvjs_Po.prototype.getColumnType = gvjs_Po.prototype.W;
+gvjs_Po.prototype.getDistinctValues = gvjs_Po.prototype.Py;
+gvjs_Po.prototype.getFilteredRows = gvjs_Po.prototype.at;
+gvjs_Po.prototype.getFormattedValue = gvjs_Po.prototype.Ha;
+gvjs_Po.prototype.getNumberOfColumns = gvjs_Po.prototype.$;
+gvjs_Po.prototype.getNumberOfRows = gvjs_Po.prototype.ca;
+gvjs_Po.prototype.getProperties = gvjs_Po.prototype.getProperties;
+gvjs_Po.prototype.getProperty = gvjs_Po.prototype.getProperty;
+gvjs_Po.prototype.getRowProperty = gvjs_Po.prototype.Ul;
+gvjs_Po.prototype.getRowProperties = gvjs_Po.prototype.zv;
+gvjs_Po.prototype.getSortedRows = gvjs_Po.prototype.bn;
+gvjs_Po.prototype.getUnderlyingTableColumnIndex = gvjs_Po.prototype.Ty;
+gvjs_Po.prototype.getTableRowIndex = gvjs_Po.prototype.fj;
+gvjs_Po.prototype.getUnderlyingTableRowIndex = gvjs_Po.prototype.Uy;
+gvjs_Po.prototype.getTableProperty = gvjs_Po.prototype.Sy;
+gvjs_Po.prototype.getTableProperties = gvjs_Po.prototype.Cv;
+gvjs_Po.prototype.getValue = gvjs_Po.prototype.getValue;
+gvjs_Po.prototype.toDataTable = gvjs_Po.prototype.Gr;
+gvjs_Po.prototype.toJSON = gvjs_Po.prototype.toJSON;
+gvjs_q("google.visualization.DataTable", gvjs_M, void 0);
+gvjs_M.prototype.addColumn = gvjs_M.prototype.xd;
+gvjs_M.prototype.addRow = gvjs_M.prototype.Kp;
+gvjs_M.prototype.addRows = gvjs_M.prototype.Yn;
+gvjs_M.prototype.clone = gvjs_M.prototype.clone;
+gvjs_M.prototype.getColumnId = gvjs_M.prototype.Ne;
+gvjs_M.prototype.getColumnIndex = gvjs_M.prototype.jf;
+gvjs_M.prototype.getColumnLabel = gvjs_M.prototype.Ga;
+gvjs_M.prototype.getColumnPattern = gvjs_M.prototype.Co;
+gvjs_M.prototype.getColumnProperty = gvjs_M.prototype.Bd;
+gvjs_M.prototype.getColumnProperties = gvjs_M.prototype.Rj;
+gvjs_M.prototype.getColumnRange = gvjs_M.prototype.Sj;
+gvjs_M.prototype.getColumnRole = gvjs_M.prototype.Jg;
+gvjs_M.prototype.getColumnType = gvjs_M.prototype.W;
+gvjs_M.prototype.getDistinctValues = gvjs_M.prototype.Py;
+gvjs_M.prototype.getFilteredRows = gvjs_M.prototype.at;
+gvjs_M.prototype.getFormattedValue = gvjs_M.prototype.Ha;
+gvjs_M.prototype.getNumberOfColumns = gvjs_M.prototype.$;
+gvjs_M.prototype.getNumberOfRows = gvjs_M.prototype.ca;
+gvjs_M.prototype.getProperties = gvjs_M.prototype.getProperties;
+gvjs_M.prototype.getProperty = gvjs_M.prototype.getProperty;
+gvjs_M.prototype.getRowProperty = gvjs_M.prototype.Ul;
+gvjs_M.prototype.getRowProperties = gvjs_M.prototype.zv;
+gvjs_M.prototype.getSortedRows = gvjs_M.prototype.bn;
+gvjs_M.prototype.getTableProperty = gvjs_M.prototype.Sy;
+gvjs_M.prototype.getTableProperties = gvjs_M.prototype.Cv;
+gvjs_M.prototype.getUnderlyingTableColumnIndex = gvjs_M.prototype.Ty;
+gvjs_M.prototype.getUnderlyingTableRowIndex = gvjs_M.prototype.Uy;
+gvjs_M.prototype.getValue = gvjs_M.prototype.getValue;
+gvjs_M.prototype.insertColumn = gvjs_M.prototype.uba;
+gvjs_M.prototype.insertRows = gvjs_M.prototype.G_;
+gvjs_M.prototype.removeColumn = gvjs_M.prototype.BS;
+gvjs_M.prototype.removeColumns = gvjs_M.prototype.Hea;
+gvjs_M.prototype.removeRow = gvjs_M.prototype.qE;
+gvjs_M.prototype.removeRows = gvjs_M.prototype.Iea;
+gvjs_M.prototype.setCell = gvjs_M.prototype.Wb;
+gvjs_M.prototype.setColumnLabel = gvjs_M.prototype.xfa;
+gvjs_M.prototype.setColumnProperties = gvjs_M.prototype.lT;
+gvjs_M.prototype.setColumnProperty = gvjs_M.prototype.rA;
+gvjs_M.prototype.setFormattedValue = gvjs_M.prototype.Nw;
+gvjs_M.prototype.setProperties = gvjs_M.prototype.sr;
+gvjs_M.prototype.setProperty = gvjs_M.prototype.setProperty;
+gvjs_M.prototype.setRowProperties = gvjs_M.prototype.Gwa;
+gvjs_M.prototype.setRowProperty = gvjs_M.prototype.Gfa;
+gvjs_M.prototype.setTableProperties = gvjs_M.prototype.Hwa;
+gvjs_M.prototype.setTableProperty = gvjs_M.prototype.Iwa;
+gvjs_M.prototype.setValue = gvjs_M.prototype.Wa;
+gvjs_M.prototype.sort = gvjs_M.prototype.sort;
+gvjs_M.prototype.toJSON = gvjs_M.prototype.toJSON;
+gvjs_q("google.visualization.arrayToDataTable", gvjs_Mk, void 0);
+gvjs_q("google.visualization.DataView", gvjs_N, void 0);
+gvjs_N.fromJSON = gvjs_Rk;
+gvjs_N.prototype.getColumnId = gvjs_N.prototype.Ne;
+gvjs_N.prototype.getColumnIndex = gvjs_N.prototype.jf;
+gvjs_N.prototype.getColumnLabel = gvjs_N.prototype.Ga;
+gvjs_N.prototype.getColumnPattern = gvjs_N.prototype.Co;
+gvjs_N.prototype.getColumnProperty = gvjs_N.prototype.Bd;
+gvjs_N.prototype.getColumnProperty = gvjs_N.prototype.Bd;
+gvjs_N.prototype.getColumnProperties = gvjs_N.prototype.Rj;
+gvjs_N.prototype.getColumnRange = gvjs_N.prototype.Sj;
+gvjs_N.prototype.getColumnRole = gvjs_N.prototype.Jg;
+gvjs_N.prototype.getColumnType = gvjs_N.prototype.W;
+gvjs_N.prototype.getDistinctValues = gvjs_N.prototype.Py;
+gvjs_N.prototype.getFilteredRows = gvjs_N.prototype.at;
+gvjs_N.prototype.getFormattedValue = gvjs_N.prototype.Ha;
+gvjs_N.prototype.getNumberOfColumns = gvjs_N.prototype.$;
+gvjs_N.prototype.getNumberOfRows = gvjs_N.prototype.ca;
+gvjs_N.prototype.getProperties = gvjs_N.prototype.getProperties;
+gvjs_N.prototype.getProperty = gvjs_N.prototype.getProperty;
+gvjs_N.prototype.getRowProperty = gvjs_N.prototype.Ul;
+gvjs_N.prototype.getRowProperties = gvjs_N.prototype.zv;
+gvjs_N.prototype.getSortedRows = gvjs_N.prototype.bn;
+gvjs_N.prototype.getTableColumnIndex = gvjs_N.prototype.CP;
+gvjs_N.prototype.getUnderlyingTableColumnIndex = gvjs_N.prototype.Ty;
+gvjs_N.prototype.getTableRowIndex = gvjs_N.prototype.fj;
+gvjs_N.prototype.getUnderlyingTableRowIndex = gvjs_N.prototype.Uy;
+gvjs_N.prototype.getTableProperty = gvjs_N.prototype.Sy;
+gvjs_N.prototype.getTableProperties = gvjs_N.prototype.Cv;
+gvjs_N.prototype.getValue = gvjs_N.prototype.getValue;
+gvjs_N.prototype.getViewColumnIndex = gvjs_N.prototype.S$;
+gvjs_N.prototype.getViewColumns = gvjs_N.prototype.FZ;
+gvjs_N.prototype.getViewRowIndex = gvjs_N.prototype.GZ;
+gvjs_N.prototype.getViewRows = gvjs_N.prototype.T$;
+gvjs_N.prototype.hideColumns = gvjs_N.prototype.ora;
+gvjs_N.prototype.hideRows = gvjs_N.prototype.qra;
+gvjs_N.prototype.setColumns = gvjs_N.prototype.Hn;
+gvjs_N.prototype.setRows = gvjs_N.prototype.pp;
+gvjs_N.prototype.toDataTable = gvjs_N.prototype.Gr;
+gvjs_N.prototype.toJSON = gvjs_N.prototype.toJSON;
+gvjs_q("google.visualization.errors", gvjs_D, void 0);
+gvjs_D.addError = gvjs_D.Sc;
+gvjs_D.removeAll = gvjs_D.removeAll;
+gvjs_D.removeError = gvjs_D.yva;
+gvjs_D.getContainer = gvjs_D.getContainer;
+gvjs_D.createProtectedCallback = gvjs_D.uX;
+gvjs_D.addErrorFromQueryResponse = gvjs_Xk;
+gvjs_q("google.visualization.events.addListener", gvjs_oi, void 0);
+gvjs_q("google.visualization.events.addOneTimeListener", gvjs_si, void 0);
+gvjs_q("google.visualization.events.trigger", gvjs_I, void 0);
+gvjs_q("google.visualization.events.removeListener", gvjs_ui, void 0);
+gvjs_q("google.visualization.events.removeAllListeners", gvjs_vi, void 0);
+gvjs_q("google.visualization.QueryWrapper", gvjs_uo, void 0);
+gvjs_uo.prototype.setOptions = gvjs_uo.prototype.setOptions;
+gvjs_uo.prototype.draw = gvjs_uo.prototype.draw;
+gvjs_uo.prototype.setCustomErrorHandler = gvjs_uo.prototype.wwa;
+gvjs_uo.prototype.sendAndDraw = gvjs_uo.prototype.GE;
+gvjs_uo.prototype.setCustomPostResponseHandler = gvjs_uo.prototype.nT;
+gvjs_uo.prototype.setCustomResponseHandler = gvjs_uo.prototype.oT;
+gvjs_uo.prototype.abort = gvjs_uo.prototype.abort;
+gvjs_q("google.visualization.datautils.arrayToDataTable", gvjs_Mk, void 0);
+gvjs_q("google.visualization.datautils.compareValues", gvjs_vk, void 0);
+gvjs_q("google.visualization.dataTableToCsv", function(a) {
+  for (var b = "", c = 0; c < a.ca(); c++) {
+    for (var d = 0; d < a.$(); d++) {
+      0 < d && (b += ",");
+      var e = a.Ha(c, d);
+      e = e.replace(/"/g, '""');
+      var f = -1 !== e.indexOf(",")
+        , g = -1 !== e.indexOf("\n")
+        , h = -1 !== e.indexOf('"');
+      if (f || g || h)
+        e = '"' + e + '"';
+      b += e
+    }
+    b += "\n"
+  }
+  return b
+}, void 0);
+gvjs_q(gvjs_Dc, gvjs_gk, void 0);
+gvjs_gk.prototype.format = gvjs_gk.prototype.format;
+gvjs_gk.prototype.formatValue = gvjs_gk.prototype.Ob;
+gvjs_q("google.visualization.NumberFormat.useNativeCharactersIfAvailable", function(a) {
+  gvjs_lk = a
+}, void 0);
+gvjs_q("google.visualization.NumberFormat.DECIMAL_SEP", gvjs_hk, void 0);
+gvjs_q("google.visualization.NumberFormat.GROUP_SEP", gvjs_ik, void 0);
+gvjs_q("google.visualization.NumberFormat.DECIMAL_PATTERN", gvjs_mk, void 0);
+gvjs_q("google.visualization.ColorFormat", gvjs_Io, void 0);
+gvjs_Io.prototype.format = gvjs_Io.prototype.format;
+gvjs_Io.prototype.addRange = gvjs_Io.prototype.addRange;
+gvjs_Io.prototype.addGradientRange = gvjs_Io.prototype.dka;
+gvjs_q("google.visualization.BarFormat", gvjs_Co, void 0);
+gvjs_Co.prototype.format = gvjs_Co.prototype.format;
+gvjs_q("google.visualization.ArrowFormat", gvjs_Bo, void 0);
+gvjs_Bo.prototype.format = gvjs_Bo.prototype.format;
+gvjs_q("google.visualization.PatternFormat", gvjs_Jo, void 0);
+gvjs_Jo.prototype.format = gvjs_Jo.prototype.format;
+gvjs_q("google.visualization.DateFormat", gvjs_Tj, void 0);
+gvjs_Tj.prototype.format = gvjs_Tj.prototype.format;
+gvjs_Tj.prototype.formatValue = gvjs_Tj.prototype.Ob;
+gvjs_q(gvjs_Dc, gvjs_gk, void 0);
+gvjs_gk.prototype.format = gvjs_gk.prototype.format;
+gvjs_q("google.visualization.TableColorFormat", gvjs_Io, void 0);
+gvjs_q("google.visualization.TableBarFormat", gvjs_Co, void 0);
+gvjs_Co.prototype.format = gvjs_Co.prototype.format;
+gvjs_q("google.visualization.TableArrowFormat", gvjs_Bo, void 0);
+gvjs_Bo.prototype.format = gvjs_Bo.prototype.format;
+gvjs_q("google.visualization.TablePatternFormat", gvjs_Jo, void 0);
+gvjs_Jo.prototype.format = gvjs_Jo.prototype.format;
+gvjs_q("google.visualization.TableDateFormat", gvjs_Tj, void 0);

--- a/cypress/fixtures/charts/jsapi_compiled_flashui_module
+++ b/cypress/fixtures/charts/jsapi_compiled_flashui_module
@@ -1,0 +1,488 @@
+/*
+ SWFObject v2.2 <http://code.google.com/p/swfobject/>
+ is released under the MIT License <http://www.opensource.org/licenses/mit-license.php>
+*/
+var gvjs_yQ = "SWFObjectExprInst"
+  , gvjs_zQ = "Shockwave Flash"
+  , gvjs_AQ = "application/x-shockwave-flash"
+  , gvjs_BQ = "https://www.gstatic.com/charts/%{package}/%{version}/%{subdir}/%{filename}"
+  , gvjs_CQ = "onreadystatechange";
+function gvjs_DQ(a) {
+  return gvjs_Vy(a.format, a.Ch, a.params || {})
+}
+var gvjs_EQ = function() {
+  function a() {
+    if (!H) {
+      try {
+        var E = x.getElementsByTagName(gvjs_yb)[0].appendChild(x.createElement(gvjs_0w));
+        E.parentNode.removeChild(E)
+      } catch (L) {
+        return
+      }
+      H = !0;
+      E = A.length;
+      for (var F = 0; F < E; F++)
+        A[F]()
+    }
+  }
+  function b(E) {
+    H ? E() : A[A.length] = E
+  }
+  function c(E) {
+    if ("undefined" != typeof w.addEventListener)
+      w.addEventListener("load", E, !1);
+    else if ("undefined" != typeof x.addEventListener)
+      x.addEventListener("load", E, !1);
+    else if ("undefined" != typeof w.attachEvent)
+      q(w, "onload", E);
+    else if (typeof w.onload == gvjs_d) {
+      var F = w.onload;
+      w.onload = function() {
+        F(null);
+        E()
+      }
+    } else
+      w.onload = E
+  }
+  function d() {
+    var E = x.getElementsByTagName(gvjs_yb)[0]
+      , F = x.createElement(gvjs_h);
+    F.setAttribute(gvjs_Sd, gvjs_AQ);
+    var L = E.appendChild(F);
+    if (L) {
+      var N = 0;
+      (function() {
+          function P() {
+            if ("undefined" != typeof L.GetVariable) {
+              var S = L.GetVariable("$version");
+              S && (S = S.split(" ")[1].split(","),
+                K.kE = [parseInt(S[0], 10), parseInt(S[1], 10), parseInt(S[2], 10)])
+            } else if (10 > N) {
+              N++;
+              setTimeout(P, 10);
+              return
+            }
+            E.removeChild(F);
+            L = null;
+            e()
+          }
+          return P
+        }
+      )()()
+    } else
+      e()
+  }
+  function e() {
+    var E = B.length;
+    if (0 < E)
+      for (var F = 0; F < E; F++) {
+        var L = B[F].id
+          , N = B[F].ela
+          , P = {
+          dF: !1,
+          id: L
+        };
+        if (0 < K.kE[0]) {
+          var S = p(L);
+          if (S)
+            if (!r(B[F].Ixa) || K.tu && 312 > K.tu)
+              if (B[F].d$ && g()) {
+                P = {};
+                P.data = B[F].d$;
+                P.width = S.getAttribute(gvjs_Xd) || "0";
+                P.height = S.getAttribute(gvjs_4c) || "0";
+                S.getAttribute(gvjs_Cb) && (P.uEa = S.getAttribute(gvjs_Cb));
+                S.getAttribute("align") && (P.align = S.getAttribute("align"));
+                var U = {};
+                S = S.getElementsByTagName("param");
+                for (var fa = S.length, V = 0; V < fa; V++)
+                  "movie" != S[V].getAttribute(gvjs_Zv).toLowerCase() && (U[S[V].getAttribute(gvjs_Zv)] = S[V].getAttribute(gvjs_Vd));
+                h(P, U, L, N)
+              } else
+                k(S),
+                N && N(P);
+            else
+              u(L, !0),
+              N && (P.dF = !0,
+                P.ref = f(L),
+                N(P))
+        } else
+          u(L, !0),
+          N && ((L = f(L)) && "undefined" != typeof L.SetVariable && (P.dF = !0,
+            P.ref = L),
+            N(P))
+      }
+  }
+  function f(E) {
+    var F = null;
+    (E = p(E)) && E.nodeName == gvjs_0a && ("undefined" != typeof E.SetVariable ? F = E : (E = E.getElementsByTagName(gvjs_h)[0]) && (F = E));
+    return F
+  }
+  function g() {
+    return !Q && r("6.0.65") && (K.Un || K.oca) && !(K.tu && 312 > K.tu)
+  }
+  function h(E, F, L, N) {
+    Q = !0;
+    I = N || null;
+    M = {
+      dF: !1,
+      id: L
+    };
+    var P = p(L);
+    if (P) {
+      P.nodeName == gvjs_0a ? (G = l(P),
+        J = null) : (G = P,
+        J = L);
+      E.id = gvjs_yQ;
+      if ("undefined" == typeof E.width || !/%$/.test(E.width) && 310 > parseInt(E.width, 10))
+        E.width = "310";
+      if ("undefined" == typeof E.height || !/%$/.test(E.height) && 137 > parseInt(E.height, 10))
+        E.height = "137";
+      x.title = x.title.slice(0, 47) + " - Flash Player Installation";
+      N = K.jn && K.Un ? "ActiveX" : "PlugIn";
+      N = "MMredirectURL=" + w.location.toString().replace(/&/g, "%26") + "&MMplayerType=" + N + "&MMdoctitle=" + x.title;
+      F.flashVars = "undefined" != typeof F.flashVars ? F.flashVars + ("&" + N) : N;
+      K.jn && K.Un && 4 != P.readyState && (N = x.createElement(gvjs_Ob),
+        L += "SWFObjectNew",
+        N.setAttribute(gvjs_5c, L),
+        P.parentNode.insertBefore(N, P),
+        P.style.display = gvjs_f,
+        function() {
+          function S() {
+            4 == P.readyState ? P.parentNode.removeChild(P) : setTimeout(S, 10)
+          }
+          return S
+        }()());
+      m(E, F, L)
+    }
+  }
+  function k(E) {
+    if (K.jn && K.Un && 4 != E.readyState) {
+      var F = x.createElement(gvjs_Ob);
+      E.parentNode.insertBefore(F, E);
+      F.parentNode.replaceChild(l(E), F);
+      E.style.display = gvjs_f;
+      (function() {
+          function L() {
+            4 == E.readyState ? E.parentNode.removeChild(E) : setTimeout(L, 10)
+          }
+          return L
+        }
+      )()()
+    } else
+      E.parentNode.replaceChild(l(E), E)
+  }
+  function l(E) {
+    var F = x.createElement(gvjs_Ob);
+    if (K.Un && K.jn)
+      F.innerHTML = E.innerHTML;
+    else if (E = E.getElementsByTagName(gvjs_h)[0])
+      if (E = E.childNodes)
+        for (var L = E.length, N = 0; N < L; N++)
+          1 == E[N].nodeType && "PARAM" == E[N].nodeName || 8 == E[N].nodeType || F.appendChild(E[N].cloneNode(!0));
+    return F
+  }
+  function m(E, F, L) {
+    var N = p(L);
+    if (K.tu && 312 > K.tu)
+      return fa;
+    if (N)
+      if ("undefined" == typeof E.id && (E.id = L),
+      K.jn && K.Un) {
+        var P = "";
+        for (S in E)
+          E[S] != Object.prototype[S] && (S.toLowerCase() == gvjs_$t ? F.movie = E[S] : "styleclass" == S.toLowerCase() ? P += gvjs_dr + E[S] + '"' : "classid" != S.toLowerCase() && (P += " " + S + '="' + E[S] + '"'));
+        var S = "";
+        for (var U in F)
+          F[U] != Object.prototype[U] && (S += '<param name="' + U + gvjs_jr + F[U] + '" />');
+        N.outerHTML = '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"' + P + ">" + S + "</object>";
+        D[D.length] = E.id;
+        var fa = p(E.id)
+      } else {
+        U = x.createElement(gvjs_h);
+        U.setAttribute(gvjs_Sd, gvjs_AQ);
+        for (var V in E)
+          E[V] != Object.prototype[V] && ("styleclass" == V.toLowerCase() ? U.setAttribute(gvjs_Cb, E[V]) : "classid" != V.toLowerCase() && U.setAttribute(V, E[V]));
+        for (P in F)
+          F[P] != Object.prototype[P] && "movie" != P.toLowerCase() && (E = U,
+            S = P,
+            V = F[P],
+            L = x.createElement("param"),
+            L.setAttribute(gvjs_Zv, S),
+            L.setAttribute(gvjs_Vd, V),
+            E.appendChild(L));
+        N.parentNode.replaceChild(U, N);
+        fa = U
+      }
+    return fa
+  }
+  function n(E) {
+    var F = p(E);
+    F && F.nodeName == gvjs_0a && (K.jn && K.Un ? (F.style.display = gvjs_f,
+      function() {
+        function L() {
+          if (4 == F.readyState) {
+            var N = p(E);
+            if (N) {
+              for (var P in N)
+                typeof N[P] == gvjs_d && (N[P] = null);
+              N.parentNode.removeChild(N)
+            }
+          } else
+            setTimeout(L, 10)
+        }
+        return L
+      }()()) : F.parentNode.removeChild(F))
+  }
+  function p(E) {
+    var F = null;
+    try {
+      F = x.getElementById(E)
+    } catch (L) {}
+    return F
+  }
+  function q(E, F, L) {
+    E.attachEvent(F, L);
+    C[C.length] = [E, F, L]
+  }
+  function r(E) {
+    var F = K.kE;
+    E = E.split(".");
+    E[0] = parseInt(E[0], 10);
+    E[1] = parseInt(E[1], 10) || 0;
+    E[2] = parseInt(E[2], 10) || 0;
+    return F[0] > E[0] || F[0] == E[0] && F[1] > E[1] || F[0] == E[0] && F[1] == E[1] && F[2] >= E[2] ? !0 : !1
+  }
+  function t(E, F, L, N) {
+    if (!K.jn || !K.oca) {
+      var P = x.getElementsByTagName("head")[0];
+      P && (L = L && typeof L == gvjs_l ? L : gvjs_Fw,
+      N && (T = R = null),
+      R && T == L || (N = x.createElement(gvjs_Jd),
+        N.setAttribute(gvjs_Sd, "text/css"),
+        N.setAttribute("media", L),
+        R = P.appendChild(N),
+      K.jn && K.Un && "undefined" != typeof x.styleSheets && 0 < x.styleSheets.length && (R = x.styleSheets[x.styleSheets.length - 1]),
+        T = L),
+        K.jn && K.Un ? R && typeof R.addRule == gvjs_h && R.addRule(E, F) : R && "undefined" != typeof x.createTextNode && R.appendChild(x.createTextNode(E + " {" + F + "}")))
+    }
+  }
+  function u(E, F) {
+    O && (F = F ? gvjs_Mx : gvjs_0u,
+      H && p(E) ? p(E).style.visibility = F : t("#" + E, "visibility:" + F, null, null))
+  }
+  function v(E) {
+    return null != /[\\"<>\.;]/.exec(E) && "undefined" != typeof encodeURIComponent ? encodeURIComponent(E) : E
+  }
+  var w = window, x = document, y = navigator, z = !1, A = [function() {
+    z ? d() : e()
+  }
+  ], B = [], D = [], C = [], G, J, I, M, H = !1, Q = !1, R, T, O = !0, K = function() {
+    var E = "undefined" != typeof x.getElementById && "undefined" != typeof x.getElementsByTagName && "undefined" != typeof x.createElement
+      , F = y.userAgent.toLowerCase()
+      , L = y.platform.toLowerCase()
+      , N = L ? /win/.test(L) : /win/.test(F);
+    L = L ? /mac/.test(L) : /mac/.test(F);
+    F = /webkit/.test(F) ? parseFloat(F.replace(/^.*webkit\/(\d+(\.\d+)?).*$/, "$1")) : !1;
+    var P = !+"\v1"
+      , S = [0, 0, 0]
+      , U = null;
+    if ("undefined" != typeof y.plugins && typeof y.plugins[gvjs_zQ] == gvjs_h)
+      !(U = y.plugins[gvjs_zQ].description) || "undefined" != typeof y.mimeTypes && y.mimeTypes[gvjs_AQ] && !y.mimeTypes[gvjs_AQ].enabledPlugin || (z = !0,
+        P = !1,
+        U = U.replace(/^.*\s+(\S+\s+\S+$)/, "$1"),
+        S[0] = parseInt(U.replace(/^(.*)\..*$/, "$1"), 10),
+        S[1] = parseInt(U.replace(/^.*\.(.*)\s.*$/, "$1"), 10),
+        S[2] = /[a-zA-Z]/.test(U) ? parseInt(U.replace(/^.*[a-zA-Z]+(.*)$/, "$1"), 10) : 0);
+    else if ("undefined" != typeof w.ActiveXObject)
+      try {
+        if (U = (new ActiveXObject("ShockwaveFlash.ShockwaveFlash")).GetVariable("$version"))
+          P = !0,
+            U = U.split(" ")[1].split(","),
+            S = [parseInt(U[0], 10), parseInt(U[1], 10), parseInt(U[2], 10)]
+      } catch (fa) {}
+    return {
+      mx: E,
+      kE: S,
+      tu: F,
+      jn: P,
+      Un: N,
+      oca: L
+    }
+  }();
+  (function() {
+      K.mx && (("undefined" != typeof x.readyState && x.readyState == gvjs_Hb || "undefined" == typeof x.readyState && (x.getElementsByTagName(gvjs_yb)[0] || x.body)) && a(),
+      H || ("undefined" != typeof x.addEventListener && x.addEventListener("DOMContentLoaded", a, !1),
+      K.jn && K.Un && (x.attachEvent(gvjs_CQ, function() {
+        function E() {
+          x.readyState == gvjs_Hb && (x.detachEvent(gvjs_CQ, E),
+            a())
+        }
+        return E
+      }()),
+      w == top && function() {
+        function E() {
+          if (!H) {
+            try {
+              x.documentElement.doScroll(gvjs_$c)
+            } catch (F) {
+              setTimeout(E, 0);
+              return
+            }
+            a()
+          }
+        }
+        return E
+      }()()),
+      K.tu && function() {
+        function E() {
+          H || (/loaded|complete/.test(x.readyState) ? a() : setTimeout(E, 0))
+        }
+        return E
+      }()(),
+        c(a)))
+    }
+  )();
+  (function() {
+      K.jn && K.Un && window.attachEvent("onunload", function() {
+        for (var E = C.length, F = 0; F < E; F++)
+          C[F][0].detachEvent(C[F][1], C[F][2]);
+        E = D.length;
+        for (F = 0; F < E; F++)
+          n(D[F]);
+        for (var L in K)
+          K[L] = null;
+        K = null;
+        for (var N in gvjs_EQ)
+          gvjs_EQ[N] = null;
+        gvjs_EQ = null
+      })
+    }
+  )();
+  return {
+    lEa: function(E, F, L, N) {
+      if (K.mx && E && F) {
+        var P = {};
+        P.id = E;
+        P.Ixa = F;
+        P.d$ = L;
+        P.ela = N;
+        B[B.length] = P;
+        u(E, !1)
+      } else
+        N && N({
+          dF: !1,
+          id: E
+        })
+    },
+    EDa: function(E) {
+      if (K.mx)
+        return f(E)
+    },
+    J9: function(E, F, L, N, P, S, U, fa, V, pa) {
+      var W = {
+        dF: !1,
+        id: F
+      };
+      K.mx && !(K.tu && 312 > K.tu) && E && F && L && N && P ? (u(F, !1),
+        b(function() {
+          L += "";
+          N += "";
+          var ja = {};
+          if (V && typeof V === gvjs_h)
+            for (var ia in V)
+              ja[ia] = V[ia];
+          ja.data = E;
+          ja.width = L;
+          ja.height = N;
+          ia = {};
+          if (fa && typeof fa === gvjs_h)
+            for (var Da in fa)
+              ia[Da] = fa[Da];
+          if (U && typeof U === gvjs_h)
+            for (var Ea in U)
+              ia.flashVars = "undefined" != typeof ia.flashVars ? ia.flashVars + ("&" + Ea + "=" + U[Ea]) : Ea + "=" + U[Ea];
+          if (r(P))
+            Da = m(ja, ia, F),
+            ja.id == F && u(F, !0),
+              W.dF = !0,
+              W.ref = Da;
+          else {
+            if (S && g()) {
+              ja.data = S;
+              h(ja, ia, F, pa);
+              return
+            }
+            u(F, !0)
+          }
+          pa && pa(W)
+        })) : pa && pa(W)
+    },
+    vEa: function() {
+      O = !1
+    },
+    DEa: K,
+    DDa: function() {
+      return {
+        ZDa: K.kE[0],
+        cEa: K.kE[1],
+        release: K.kE[2]
+      }
+    },
+    MDa: r,
+    ACa: function(E, F, L) {
+      if (K.mx)
+        return m(E, F, L)
+    },
+    sEa: function(E, F, L, N) {
+      K.mx && g() && h(E, F, L, N)
+    },
+    nEa: function(E) {
+      K.mx && n(E)
+    },
+    zCa: function(E, F, L, N) {
+      K.mx && t(E, F, L, N)
+    },
+    bCa: b,
+    cCa: c,
+    FDa: function(E) {
+      var F = x.location.search || x.location.hash;
+      if (F) {
+        /\?/.test(F) && (F = F.split("?")[1]);
+        if (null == E)
+          return v(F);
+        F = F.split("&");
+        for (var L = 0; L < F.length; L++)
+          if (F[L].substring(0, F[L].indexOf("=")) == E)
+            return v(F[L].substring(F[L].indexOf("=") + 1))
+      }
+      return ""
+    },
+    JCa: function() {
+      if (Q) {
+        var E = p(gvjs_yQ);
+        E && G && (E.parentNode.replaceChild(G, E),
+        J && (u(J, !0),
+        K.jn && K.Un && (G.style.display = gvjs_xb)),
+        I && I(M));
+        Q = !1
+      }
+    }
+  }
+}();
+var gvjs_Bia = {
+  base: gvjs_9e("https://www.gstatic.com/charts/%{package}/%{version}/"),
+  flash: gvjs_9e("https://www.gstatic.com/charts/%{package}/%{version}/%{filename}"),
+  flash_subdir: gvjs_9e(gvjs_BQ),
+  map: gvjs_9e(gvjs_BQ)
+};
+function gvjs_FQ(a, b, c) {
+  return {
+    format: gvjs_Bia[a],
+    Ch: {
+      "package": b,
+      version: c
+    }
+  }
+}
+;

--- a/cypress/fixtures/charts/jsapi_compiled_gauge_module
+++ b/cypress/fixtures/charts/jsapi_compiled_gauge_module
@@ -1,0 +1,512 @@
+var gvjs_bT = "border: 0; padding: 0; margin: 0;";
+gvjs_bI.prototype.OE = gvjs_V(67, function(a) {
+  this.ticks = a
+});
+gvjs_1I.prototype.OE = gvjs_V(66, function(a) {
+  gvjs_bI.prototype.OE.call(this, a);
+  var b = 0;
+  gvjs_u(this.ticks, function(c) {
+    c = this.Xq(c);
+    b = Math.max(b, gvjs_pA(c / this.dfa))
+  }, this);
+  this.h9 = b
+});
+function gvjs_cT(a, b, c, d, e) {
+  gvjs_H.call(this);
+  this.ma = a;
+  this.ga = b;
+  this.Pa = c;
+  this.Fga = new gvjs_ly({
+    bb: gvjs_ft,
+    fontSize: d,
+    color: gvjs_nr,
+    opacity: 1,
+    Lb: "",
+    bold: !1,
+    Nc: !1,
+    Ue: !1
+  });
+  this.Yya = new gvjs_ly({
+    bb: gvjs_ft,
+    fontSize: d,
+    color: gvjs_rt,
+    opacity: 1,
+    Lb: "",
+    bold: !1,
+    Nc: !1,
+    Ue: !1
+  });
+  this.Wxa = new gvjs_ly({
+    bb: gvjs_ft,
+    fontSize: 0,
+    color: gvjs_nr,
+    opacity: 1,
+    Lb: "",
+    bold: !1,
+    Nc: !1,
+    Ue: !1
+  });
+  this.tva = e;
+  this.Um = this.ab = this.F = null;
+  this.K2 = []
+}
+gvjs_o(gvjs_cT, gvjs_H);
+gvjs_ = gvjs_cT.prototype;
+gvjs_.lf = function() {
+  return this.Xa
+}
+;
+gvjs_.Ow = function(a) {
+  this.Xa = a
+}
+;
+gvjs_.kf = function() {
+  return this.Cb
+}
+;
+gvjs_.bu = function(a) {
+  this.Cb = a
+}
+;
+gvjs_.Wa = function(a, b, c) {
+  this.$d = a;
+  this.RY = b;
+  this.ku();
+  a = gvjs_dT(this, a);
+  null != this.ZJ && c ? (this.Tf = new gvjs_1E([this.ZJ],[a],c.duration,c.easing),
+    gvjs_G(this.Tf, ["begin", "animate", gvjs_R], this.fua, !1, this),
+    gvjs_G(this.Tf, gvjs_R, this.eua, !1, this),
+    this.Tf.play(!1)) : (this.ZJ = a,
+    gvjs_eT(this))
+}
+;
+gvjs_.OE = function(a, b) {
+  this.sca = Math.max(1, a);
+  this.PD = Math.max(1, b)
+}
+;
+gvjs_.P3 = function(a) {
+  this.Iz = a
+}
+;
+function gvjs_fT(a, b, c, d) {
+  a.K2.push({
+    hf: b,
+    ol: c,
+    color: d
+  })
+}
+gvjs_.setAnimation = function() {}
+;
+gvjs_.clear = function() {
+  this.ku();
+  gvjs_E(this.ab);
+  this.ab = null;
+  gvjs_li(this)
+}
+;
+gvjs_.draw = function(a, b) {
+  var c = new gvjs_A(this.ga,this.Pa);
+  null == this.ab ? this.ab = new gvjs_3B(this.ma,c,a,b) : this.ab.update(c, a);
+  this.ab.rl(gvjs_s(this.no, this), a)
+}
+;
+gvjs_.no = function() {
+  var a = this.ab.Oa()
+    , b = a.Lm(this.ga, this.Pa);
+  a.ic(b, gvjs_3t, gvjs_Lz);
+  this.F = a;
+  var c = this.Um = a.Sa(!1);
+  a.appendChild(b, c);
+  b = Math.round(.45 * Math.min(this.ga, this.Pa));
+  var d = this.ga / 2
+    , e = this.Pa / 2;
+  a.Ke(d - .5, e - .5, b, gvjs_gT, c);
+  b -= gvjs_gT.strokeWidth;
+  b = Math.round(.9 * b);
+  a.Ke(d - .5, e - .5, b, gvjs_hT, c);
+  b -= 2 * gvjs_hT.strokeWidth;
+  var f = .75 * b;
+  for (var g = 0; g < this.K2.length; g++) {
+    var h = this.K2[g]
+      , k = gvjs_iT(this, gvjs_dT(this, h.hf))
+      , l = gvjs_iT(this, gvjs_dT(this, h.ol))
+      , m = new gvjs_SA
+      , n = d + gvjs_8y(k, b)
+      , p = e + gvjs_9y(k, b);
+    m.move(n, p);
+    m.Sf(d, e, b, b, k + 90, l + 90, !0);
+    n = d + gvjs_8y(l, f);
+    p = e + gvjs_9y(l, f);
+    m.va(n, p);
+    m.Sf(d, e, f, f, l + 90, k + 90, !1);
+    m.close();
+    a.Ia(m, new gvjs_3({
+      fill: h.color
+    }), c)
+  }
+  if (this.QL || this.i5)
+    this.QL && (f = e - Math.round(.35 * b),
+      a.Zi(this.QL, 0, f, this.ga, f, gvjs_0, gvjs_0, this.Fga, c)),
+    this.i5 && (f = e + Math.round(.35 * b),
+      a.Zi(this.i5, 0, f, this.ga, f, gvjs_0, gvjs_0, this.Fga, c));
+  h = this.PD;
+  k = .8 * b;
+  l = .9 * b;
+  n = this.sca * h;
+  p = (this.Cb - this.Xa) / n;
+  var q = new gvjs_SA
+    , r = new gvjs_SA
+    , t = this.Wxa
+    , u = Math.round(.14 * b);
+  t.fontSize = u;
+  for (g = 0; g <= n; g++) {
+    var v = gvjs_iT(this, gvjs_dT(this, g * p + this.Xa))
+      , w = 0 == g % h
+      , x = w ? k : l;
+    m = w ? q : r;
+    var y = d + gvjs_8y(v, x);
+    f = e + gvjs_9y(v, x);
+    m.move(y, f);
+    y = d + gvjs_8y(v, b);
+    f = e + gvjs_9y(v, b);
+    m.va(y, f);
+    w && this.Iz && (m = this.Iz[Math.floor(g / h)]) && (y = d + gvjs_8y(v, x - u / 2),
+      f = e + gvjs_9y(v, x - u / 2),
+      x = gvjs_0,
+      280 < v || 90 > v ? (x = gvjs_R,
+        v = 0) : 90 <= v && 260 > v ? (x = gvjs_2,
+        v = y,
+        y = this.ga) : (w = Math.min(y, this.ga - y),
+        v = y - w,
+        y += w,
+        f += Math.round(u / 4)),
+      a.Zi(m, v, f, y, f, x, gvjs_0, t, c))
+  }
+  a.Ia(r, gvjs_7ia, c);
+  a.Ia(q, gvjs_8ia, c);
+  this.ku();
+  this.kda = b;
+  gvjs_eT(this);
+  this.tva()
+}
+;
+gvjs_.fua = function(a) {
+  this.ZJ = a.x;
+  gvjs_eT(this)
+}
+;
+gvjs_.eua = function() {
+  this.ku()
+}
+;
+gvjs_.ku = function() {
+  this.Tf && (gvjs_li(this.Tf),
+    this.Tf.stop(!1),
+    gvjs_E(this.Tf),
+    this.Tf = null)
+}
+;
+function gvjs_dT(a, b) {
+  a = (b - a.Xa) / (a.Cb - a.Xa);
+  a = Math.max(a, -.02);
+  return a = Math.min(a, 1.02)
+}
+function gvjs_iT(a, b) {
+  return a.f7 * b + gvjs_5y((360 - a.f7) / 2 + 90)
+}
+function gvjs_eT(a) {
+  if (a.F) {
+    var b = a.kda
+      , c = a.F
+      , d = a.ga / 2
+      , e = a.Pa / 2
+      , f = gvjs_iT(a, a.ZJ)
+      , g = Math.round(.95 * b)
+      , h = Math.round(.3 * b)
+      , k = gvjs_8y(f, g);
+    g = gvjs_9y(f, g);
+    var l = gvjs_8y(f, h);
+    h = gvjs_9y(f, h);
+    f = gvjs_5y(f + 90);
+    var m = .07 * b
+      , n = gvjs_8y(f, m);
+    m = gvjs_9y(f, m);
+    f = new gvjs_SA;
+    f.move(d + k, e + g);
+    f.Jp(d + n, e + m, d - l + n / 2, e - h + m / 2, d - l, e - h);
+    f.Jp(d - l - n / 2, e - h - m / 2, d - n, e - m, d + k, e + g);
+    k = Math.round(.15 * b);
+    (g = a.jda) ? c.qc(g) : g = a.jda = c.Sa();
+    a.RY && (b = e + Math.round(.75 * b),
+      c.Zi(a.RY, 0, b, a.ga, b, gvjs_0, gvjs_0, a.Yya, g));
+    c.Ia(f, gvjs_9ia, g);
+    c.Ke(d - .5, e - .5, k, gvjs_$ia, g);
+    c.appendChild(a.Um, g)
+  }
+}
+var gvjs_gT = new gvjs_3({
+  fill: gvjs_zr,
+  stroke: gvjs_nr,
+  strokeWidth: 1
+})
+  , gvjs_hT = new gvjs_3({
+  fill: "#f7f7f7",
+  stroke: gvjs_Ar,
+  strokeWidth: 2
+})
+  , gvjs_7ia = new gvjs_3({
+  stroke: gvjs_pr,
+  strokeWidth: 1
+})
+  , gvjs_8ia = new gvjs_3({
+  stroke: gvjs_nr,
+  strokeWidth: 2
+})
+  , gvjs_9ia = new gvjs_3({
+  fill: "#dc3912",
+  fillOpacity: .7,
+  stroke: "#c63310",
+  strokeWidth: 1
+})
+  , gvjs_$ia = new gvjs_3({
+  fill: "#4684ee",
+  stroke: gvjs_pr,
+  strokeWidth: 1
+});
+gvjs_ = gvjs_cT.prototype;
+gvjs_.Xa = NaN;
+gvjs_.Cb = NaN;
+gvjs_.sca = NaN;
+gvjs_.PD = NaN;
+gvjs_.$d = 0;
+gvjs_.RY = null;
+gvjs_.QL = null;
+gvjs_.i5 = null;
+gvjs_.f7 = 270;
+gvjs_.kda = 0;
+gvjs_.jda = null;
+gvjs_.ZJ = null;
+gvjs_.Iz = null;
+gvjs_.Tf = null;
+function gvjs_jT(a, b, c, d) {
+  this.ma = a;
+  this.ga = b;
+  this.Pa = c;
+  this.$O = d;
+  this.Ky = [];
+  this.mc = [];
+  this.Iz = [];
+  this.SY = [];
+  this.Kq = [];
+  this.Xa = 0;
+  this.Cb = 100;
+  this.g7 = this.P2 = this.yS = this.xS = this.k6 = this.dV = this.cV = this.KZ = this.GP = this.FP = null;
+  this.vr = !0;
+  this.I1 = 0
+}
+gvjs_ = gvjs_jT.prototype;
+gvjs_.Ow = function(a) {
+  this.Xa != a && (this.Xa = a,
+    this.vr = !0)
+}
+;
+gvjs_.lf = function() {
+  return this.Xa
+}
+;
+gvjs_.bu = function(a) {
+  this.Cb != a && (this.Cb = a,
+    this.vr = !0)
+}
+;
+gvjs_.kf = function() {
+  return this.Cb
+}
+;
+gvjs_.setAnimation = function(a) {
+  this.g7 = a
+}
+;
+gvjs_.setValues = function(a, b, c) {
+  this.vr = this.vr || this.mc.length != a.length || this.Kq.length != c.length || !gvjs_Jy(this.Kq, c);
+  this.mc = a;
+  this.SY = b;
+  this.Kq = c
+}
+;
+gvjs_.P3 = function(a) {
+  1 == a.length && (a = ["", a[0], ""]);
+  gvjs_Jy(this.Iz, a) || (this.Iz = a,
+    this.vr = !0)
+}
+;
+function gvjs_kT(a, b, c) {
+  return Math.min(Math.floor(a.ga / c), Math.floor(a.Pa / b))
+}
+gvjs_.draw = function(a) {
+  if (this.vr)
+    gvjs_aja(this, a);
+  else
+    for (a = 0; a < this.mc.length; a++) {
+      var b = this.Ky[a];
+      b.QL = this.Kq[a];
+      b.Wa(this.mc[a], this.SY[a], this.g7)
+    }
+}
+;
+function gvjs_aja(a, b) {
+  a.clear();
+  var c = a.mc.length
+    , d = 1
+    , e = 1;
+  if (1 < c) {
+    var f = Math.floor(Math.sqrt(a.ga * a.Pa / c));
+    e = Math.floor(a.ga / f);
+    for (d = Math.floor(a.Pa / f); !(c <= Math.floor(a.ga / f) * Math.floor(a.Pa / f)); ) {
+      var g = gvjs_kT(a, d, e + 1)
+        , h = gvjs_kT(a, d + 1, e);
+      g >= h && (f = g,
+        e++);
+      h >= g && (f = h,
+        d++)
+    }
+  }
+  f = gvjs_kT(a, d, e);
+  f -= 0;
+  h = gvjs_Oh();
+  h.qc(a.ma);
+  a.Ky = [];
+  if (0 != c) {
+    var k = h.J(gvjs_ss, {
+      style: gvjs_bT,
+      cellpadding: 0,
+      cellspacing: 0,
+      align: gvjs_0
+    })
+      , l = h.J(gvjs_ts, null);
+    h.appendChild(k, l);
+    g = [];
+    for (var m = 0, n = 0; n < d; n++) {
+      var p = h.J(gvjs_vs, {
+        style: gvjs_bT
+      });
+      h.appendChild(l, p);
+      for (var q = 0; q < e; q++) {
+        var r = h.J(gvjs_us, {
+          style: "border: 0; padding: 0; margin: 0; width: " + f + "px;"
+        });
+        g[m++] = r;
+        h.appendChild(p, r)
+      }
+    }
+    h.appendChild(a.ma, k);
+    d = Math.round(.1 * f);
+    a.I1 = 0;
+    a.vr = !0;
+    for (e = 0; e < c; e++)
+      h = a.Ky[e] = new gvjs_cT(g[e],f,f,d,gvjs_s(function() {
+        this.I1++;
+        this.I1 == this.Ky.length && (this.vr = !1)
+      }, a)),
+        h.Ow(a.Xa),
+        h.bu(a.Cb),
+        h.QL = a.Kq[e],
+        k = a.Iz,
+        l = k.length,
+        h.OE(1 < l ? l - 1 : 4, a.PD),
+      0 < l && h.P3(k),
+        h.Wa(a.mc[e], a.SY[e], null),
+      null != a.FP && null != a.GP && gvjs_fT(h, a.FP, a.GP, a.KZ),
+      null != a.cV && null != a.dV && gvjs_fT(h, a.cV, a.dV, a.k6),
+      null != a.xS && null != a.yS && gvjs_fT(h, a.xS, a.yS, a.P2),
+        h.draw(b, a.$O)
+  }
+}
+gvjs_.clear = function() {
+  for (var a = 0; a < this.Ky.length; ++a)
+    this.Ky[a].clear();
+  this.Ky = []
+}
+;
+gvjs_.PD = 2;
+function gvjs_lT(a) {
+  gvjs_Qn.call(this, a)
+}
+gvjs_o(gvjs_lT, gvjs_Qn);
+gvjs_ = gvjs_lT.prototype;
+gvjs_.Rd = function(a, b, c) {
+  var d = new gvjs_Aj([c || {}]);
+  c = this.container;
+  var e = this.La(d)
+    , f = this.getHeight(d)
+    , g = gvjs_K(d, gvjs_Eu);
+  if (e != this.ga || f != this.Pa || g != this.$O)
+    this.xL && this.xL.clear(),
+      this.xL = new gvjs_jT(c,e,f,g),
+      this.ga = e,
+      this.Pa = f,
+      this.$O = g;
+  c = this.xL;
+  e = gvjs_L(d, gvjs_Ov, 0);
+  c.Ow(e);
+  e = gvjs_L(d, gvjs_Gv, 100);
+  c.bu(e);
+  e = d.fa("majorTicks", [String(c.lf()), "", "", "", String(c.kf())]);
+  c.P3(e);
+  e = gvjs_L(d, "minorTicks", 2);
+  c.PD != e && (c.PD = e,
+    c.vr = !0);
+  e = d.Aa("greenFrom");
+  f = d.Aa("greenTo");
+  g = d.Aa("yellowFrom");
+  var h = d.Aa("yellowTo")
+    , k = d.Aa("redFrom")
+    , l = d.Aa("redTo")
+    , m = gvjs_oy(d, "greenColor", gvjs_lr)
+    , n = gvjs_oy(d, "yellowColor", gvjs_wr)
+    , p = gvjs_oy(d, "redColor", gvjs_vr);
+  if (c.FP != e || c.GP != f || c.KZ != m || c.cV != g || c.dV != h || c.k6 != n || c.xS != k || c.yS != l || c.P2 != p)
+    c.FP = e,
+      c.GP = f,
+      c.KZ = m,
+      c.cV = g,
+      c.dV = h,
+      c.k6 = n,
+      c.xS = k,
+      c.yS = l,
+      c.P2 = p,
+      c.vr = !0;
+  d = gvjs_5K(d, 400, gvjs_cv);
+  c.setAnimation(d);
+  d = [];
+  e = [];
+  f = [];
+  if (2 == b.$() && b.W(0) == gvjs_l && b.W(1) == gvjs_g)
+    for (g = 0; g < b.ca(); g++)
+      null != b.getValue(g, 0) && null != b.getValue(g, 1) && (f.push(b.getValue(g, 0)),
+        d.push(b.getValue(g, 1)),
+        e.push(b.Ha(g, 1)));
+  else
+    for (h = 0; h < b.$(); h++)
+      if (b.W(h) == gvjs_g)
+        for (g = 0; g < b.ca(); g++)
+          null != b.getValue(g, h) && (d.push(b.getValue(g, h)),
+            e.push(b.Ha(g, h)),
+            f.push(b.Ga(h)));
+  c.setValues(d, e, f);
+  c.draw(a);
+  gvjs_I(this, gvjs_i, null)
+}
+;
+gvjs_.He = function() {
+  this.xL && this.xL.clear()
+}
+;
+gvjs_.ga = 0;
+gvjs_.Pa = 0;
+gvjs_.$O = !0;
+gvjs_q(gvjs_mc, gvjs_lT, void 0);
+gvjs_lT.prototype.draw = gvjs_lT.prototype.draw;
+gvjs_lT.prototype.clearChart = gvjs_lT.prototype.Jb;
+gvjs_lT.prototype.getContainer = gvjs_lT.prototype.getContainer;

--- a/cypress/fixtures/charts/jsapi_compiled_geo_module
+++ b/cypress/fixtures/charts/jsapi_compiled_geo_module
@@ -1,0 +1,308 @@
+var gvjs_mT = "COUNTRIES"
+  , gvjs_nT = "Data has no columns."
+  , gvjs_oT = "Geocoding failed for all data points"
+  , gvjs_pT = "The columns type does not match the supported data format. See documentation for supported formats."
+  , gvjs_qT = "countries"
+  , gvjs_rT = "datalessRegionColor"
+  , gvjs_sT = "defaultColor"
+  , gvjs_tT = "enableScrollWheel"
+  , gvjs_uT = "hybrid"
+  , gvjs_vT = "mapType"
+  , gvjs_wT = "provinces"
+  , gvjs_xT = "region"
+  , gvjs_yT = "resolution"
+  , gvjs_zT = "showLine"
+  , gvjs_AT = "useLargeControl"
+  , gvjs_BT = "useMapTypeControl"
+  , gvjs_CT = "world";
+function gvjs_DT(a, b, c) {
+  if (gvjs_r(b) && (b = gvjs_0e(b),
+    b.bounds)) {
+    var d = b.bounds;
+    b.bounds = new google.maps.LatLngBounds(new google.maps.LatLng(d.lo.lat,d.lo.lng),new google.maps.LatLng(d.hi.lat,d.hi.lng))
+  }
+  a.yC.geocode(b, c)
+}
+function gvjs_ET(a, b, c) {
+  var d = gvjs_Hi(b)
+    , e = a.Fw.get(d);
+  null != e && gvjs_u(e, function(f) {
+    f.MG || f.finish(b, c)
+  });
+  a.yx.delete(d);
+  a.Fw.delete(d)
+}
+gvjs_Al.prototype.FI = gvjs_V(23, function(a, b, c) {
+  var d = 0;
+  if (c === google.maps.GeocoderStatus.OVER_QUERY_LIMIT)
+    d = 520;
+  else if (c === google.maps.GeocoderStatus.OK) {
+    var e = gvjs_Hi(a);
+    if (!b || !c)
+      throw Error("There must be a response and status here.");
+    b = {
+      response: b,
+      status: c
+    };
+    this.cache[e] = b;
+    gvjs_ET(this, a, b)
+  } else
+    gvjs_ET(this, a, {
+      response: null,
+      status: c
+    });
+  gvjs_pl(this.aZ.bind(this), d, this)
+});
+gvjs_Al.prototype.aZ = gvjs_V(22, function() {
+  if (0 !== this.cE.Cd() || 0 !== this.yx.size) {
+    var a = 0 < this.yx.size ? gvjs_Gi(this.yx.values().next().value) : this.cE.peek()
+      , b = gvjs_Hi(a);
+    if (b in this.cache) {
+      this.Fw.get(b);
+      var c = this.cache[b];
+      gvjs_Ux(this.cE);
+      this.FI(a, c.response, c.status);
+      this.Fw.delete(b)
+    } else
+      0 === this.yx.size && 0 < this.cE.Cd() ? (gvjs_Ux(this.cE),
+        c = this.Fw.get(b),
+        gvjs_Ge(c, function(d) {
+          return d.MG
+        }) ? this.FI(a, null, null) : (this.yx.add(b),
+          gvjs_DT(this, a, this.FI.bind(this, a)))) : 0 < this.yx.size && gvjs_DT(this, a, this.FI.bind(this, a))
+  }
+});
+gvjs_rl.prototype.yN = gvjs_V(21, function(a) {
+  this.Wp();
+  gvjs_tl(this, !0, a)
+});
+function gvjs_bja(a, b) {
+  gvjs_u(b.St, function(c) {
+    var d = gvjs_Hi(c);
+    d in a.cache ? b.finish(c, a.cache[d]) : (a.Fw.has(d) || (a.cE.enqueue(c),
+      a.Fw.set(d, [])),
+      a.Fw.get(d).push(b))
+  });
+  a.aZ()
+}
+function gvjs_cja(a) {
+  var b = gvjs_8f(gvjs_Ed, a.ownerDocument && a.ownerDocument.defaultView);
+  b && a.setAttribute(gvjs_qd, b)
+}
+function gvjs_dja(a) {
+  var b = (a || document).getElementsByTagName("HEAD");
+  return b && 0 !== b.length ? b[0] : a.documentElement
+}
+function gvjs_FT(a, b, c) {
+  null != c && gvjs_p.clearTimeout(c);
+  a.onload = gvjs_ke;
+  a.onerror = gvjs_ke;
+  a.onreadystatechange = gvjs_ke;
+  b && window.setTimeout(function() {
+    gvjs_kh(a)
+  }, 0)
+}
+function gvjs_pba() {
+  if (this && this.jfa) {
+    var a = this.jfa;
+    a && "SCRIPT" == a.tagName && gvjs_FT(a, !0, this.zg)
+  }
+}
+function gvjs_GT(a, b) {
+  var c = "Jsloader error (code #" + a + ")";
+  b && (c += ": " + b);
+  gvjs_ve.call(this, c);
+  this.code = a
+}
+gvjs_t(gvjs_GT, gvjs_ve);
+function gvjs_eja(a) {
+  var b = {
+    timeout: 3E4,
+    attributes: {
+      async: !1,
+      defer: !1
+    }
+  }
+    , c = b.document || document
+    , d = gvjs_ef(a)
+    , e = (new gvjs_4g(c)).createElement("SCRIPT")
+    , f = {
+    jfa: e,
+    zg: void 0
+  }
+    , g = new gvjs_rl(f)
+    , h = null
+    , k = null != b.timeout ? b.timeout : 5E3;
+  0 < k && (h = window.setTimeout(function() {
+    gvjs_FT(e, !0);
+    var l = new gvjs_GT(1,"Timeout reached for loading script " + d);
+    g.Wp();
+    gvjs_tl(g, !1, l)
+  }, k),
+    f.zg = h);
+  e.onload = e.onreadystatechange = function() {
+    e.readyState && "loaded" != e.readyState && e.readyState != gvjs_Hb || (gvjs_FT(e, b.tCa || !1, h),
+      g.yN(null))
+  }
+  ;
+  e.onerror = function() {
+    gvjs_FT(e, !0, h);
+    var l = new gvjs_GT(0,"Error while loading script " + d);
+    g.Wp();
+    gvjs_tl(g, !1, l)
+  }
+  ;
+  f = b.attributes || {};
+  gvjs_2e(f, {
+    type: "text/javascript",
+    charset: "UTF-8"
+  });
+  gvjs_8g(e, f);
+  e.src = gvjs_ff(a);
+  gvjs_cja(e);
+  gvjs_dja(c).appendChild(e);
+  return g
+}
+function gvjs_fja(a) {
+  var b = b || {};
+  a = gvjs_Vy(gvjs_qba, a, b);
+  var c = gvjs_eja(a);
+  return new Promise(function(d) {
+      gvjs_wl(c, d, null, void 0)
+    }
+  )
+}
+var gvjs_HT = [];
+function gvjs_IT() {
+  return !!gvjs_je("google.maps.DirectionsService")
+}
+function gvjs_JT(a, b) {
+  function c() {
+    if (gvjs_IT()) {
+      var d = gvjs_HT;
+      gvjs_HT = [];
+      gvjs_u(d, function(e) {
+        e()
+      })
+    } else
+      throw Error("Error: cannot load Maps API.");
+  }
+  gvjs_IT() ? a() : (gvjs_HT.push(a),
+  1 === gvjs_HT.length && (b = b || gvjs_je("google.visualization.mapsApiKey"),
+    "" === b ? a({
+      Sma: !0
+    }) : gvjs_fja({
+      key: typeof b === gvjs_l ? b : ""
+    }).then(c)))
+}
+function gvjs_KT(a, b, c) {
+  this.yN = b;
+  this.TK = 0;
+  this.MG = !1;
+  this.St = a || [];
+  this.IS = new Map;
+  this.Mka = c || this.St.length
+}
+gvjs_KT.prototype.cancel = function() {
+  this.MG = !0
+}
+;
+gvjs_KT.prototype.finish = function(a, b) {
+  a = gvjs_Hi(a);
+  this.IS.has(a) || this.IS.set(a, b);
+  b = [];
+  if (!this.MG) {
+    a = this.St.length;
+    for (var c = this.TK; c < a; c++) {
+      var d = gvjs_Hi(this.St[c]);
+      if (!this.IS.has(d))
+        break;
+      d = this.IS.get(d);
+      null != d && (d = d.response);
+      b.push(d)
+    }
+    b.length < this.Mka && this.TK + b.length < a || (this.TK += b.length,
+      this.yN(b),
+    this.TK >= this.St.length && this.cancel())
+  }
+}
+;
+function gvjs_LT() {
+  this.St = [];
+  this.yC = null
+}
+gvjs_LT.prototype.add = function(a) {
+  this.St.push(a)
+}
+;
+gvjs_LT.prototype.create = function(a, b, c, d) {
+  var e = this;
+  null != this.yC ? (d = new gvjs_KT(a,b,c),
+    this.add(d),
+    gvjs_bja(this.yC, d)) : gvjs_JT(function(f) {
+    f = void 0 === f ? {} : f;
+    f && f.Sma || (null == e.yC && (e.yC = gvjs_Al.Lc()),
+      e.create(a, b, c))
+  }, d)
+}
+;
+gvjs_LT.prototype.cancel = function() {
+  gvjs_u(this.St, function(a) {
+    a.cancel()
+  });
+  this.St = []
+}
+;
+var gvjs_MT = {}
+  , gvjs_NT = "https://www.gstatic.com/charts/regioncoder/0/";
+function gvjs_OT(a) {
+  this.Pma = a
+}
+function gvjs_PT(a) {
+  gvjs_QT = a;
+  gvjs_NT = "https://www.gstatic.com/charts/regioncoder/" + a + "/"
+}
+function gvjs_RT(a, b) {
+  a = gvjs_kf(a.toLowerCase());
+  a = encodeURIComponent(String(a));
+  var c = gvjs_MT[a];
+  null == c ? (c = [b],
+    gvjs_MT[a] = c,
+    gvjs_gja(a, function(d) {
+      gvjs_ST(a, d)
+    }, function() {
+      gvjs_ST(a, null)
+    })) : Array.isArray(c) ? gvjs_Gy(c, b) : gvjs_pl(gvjs_re(b, c), 0)
+}
+function gvjs_gja(a, b, c) {
+  gvjs_fn(gvjs_NT + "/geocodes/" + (a + ".js")).then(function(d) {
+    d = d.replace(/^[\s\S]*var results\s*=\s*/g, "");
+    d = d.replace(/;\s*gviz\.util\.RegionCoder\.dictionaryReady[\s\S]*$/g, "");
+    d = JSON.parse(d);
+    b && b(d);
+    return d
+  }, function(d) {
+    c && c(d)
+  })
+}
+function gvjs_ST(a, b) {
+  var c = gvjs_MT[a];
+  if (b) {
+    if (b = new gvjs_OT(b),
+      Array.isArray(c))
+      for (gvjs_MT[a] = b,
+             a = 0; a < c.length; a++)
+        c[a](b)
+  } else if (Array.isArray(c))
+    for (gvjs_MT[a] = null,
+           a = 0; a < c.length; a++)
+      c[a](null)
+}
+function gvjs_TT(a, b) {
+  b = gvjs_kf(b.toLowerCase());
+  return a.Pma[b]
+}
+gvjs_OT.dictionaryReady = gvjs_ST;
+var gvjs_QT = "0";
+gvjs_PT(gvjs_QT);
+gvjs_q("gviz.util.RegionCoder.dictionaryReady", gvjs_ST, void 0);

--- a/cypress/fixtures/charts/jsapi_compiled_geochart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_geochart_module
@@ -1,0 +1,2266 @@
+var gvjs_iZ = 'Failed geocoding "'
+  , gvjs_jZ = "Requested map does not exist."
+  , gvjs_kZ = "The visualization is not ready yet."
+  , gvjs_lZ = "bottom_left"
+  , gvjs_mZ = "feature"
+  , gvjs_nZ = "featureClick"
+  , gvjs_oZ = "featureHover"
+  , gvjs_pZ = "featureMove"
+  , gvjs_qZ = "google.visualization.GeoChart.mapExists"
+  , gvjs_rZ = "google.visualization.GeoChart.setMapsSource"
+  , gvjs_sZ = "kavrayskiy-vii"
+  , gvjs_tZ = "magnifyingGlassBorder"
+  , gvjs_uZ = "magnifyingGlassTriangle"
+  , gvjs_vZ = "marker"
+  , gvjs_wZ = "markerClick"
+  , gvjs_xZ = "markerHover"
+  , gvjs_yZ = "mercator"
+  , gvjs_zZ = "natural"
+  , gvjs_AZ = "top_left";
+gvjs_dJ.prototype.xW = gvjs_V(68, function() {
+  var a = this
+    , b = gvjs_v(this.lines, function(c) {
+    var d = a.anchor ? a.anchor : {
+      x: 0,
+      y: 0
+    }
+      , e = gvjs_VA(c.x + d.x, c.length, a.ld);
+    c = gvjs_VA(c.y + d.y, a.ja.fontSize, a.Pc);
+    return e.start == e.end || c.start == c.end ? null : new gvjs_B(c.start,e.end,c.end,e.start)
+  });
+  b = gvjs_De(b, function(c) {
+    return null != c
+  });
+  return gvjs_$B(b)
+});
+gvjs_XA.prototype.cw = gvjs_V(36, function() {
+  return !1
+});
+gvjs_TB.prototype.cw = gvjs_V(35, function() {
+  return !0
+});
+function gvjs_BZ(a) {
+  return Math.min(a.width, a.height)
+}
+var gvjs_mla = {
+  gBa: gvjs_yd,
+  HAa: gvjs_bd,
+  TEXT: gvjs_m,
+  YF: gvjs_ub
+}
+  , gvjs_nla = {
+  IM: gvjs_S,
+  MM: gvjs_U
+}
+  , gvjs_ola = ["AD", "AE", "AF", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CF", "CG", "CH", "CI", "CL", "CM", "CN", "CO", "CR", "CS", "CU", "CV", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ER", "ES", "ET", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IR", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KZ", "LA", "LB", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MD", "ME", "MG", "MH", "MK", "ML", "MM", "MN", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PT", "PW", "PY", "QA", "RO", "RS", "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI", "SK", "SL", "SM", "SN", "SO", "SR", "ST", "SV", "SY", "SZ", gvjs_us, "TG", "TH", "TJ", "TL", "TM", "TN", "TO", gvjs_vs, "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "YE", "YU", "ZA", "ZM", "ZW"]
+  , gvjs_pla = ["ad", "ae", "af", "ag", "al", "am", "ao", "ar", "as", "at", "au", "ax", "az", "ba", "bb", "bd", "be", "bf", "bg", "bh", "bi", "bj", "bm", "bn", "bo", "bq", "br", "bs", "bt", "bw", "by", "bz", "ca", "cd", "cf", "cg", "ch", "ci", "cl", "cm", "co", "cr", "cu", "cv", "cw", "cy", "cz", "de", "dj", "dk", "dm", "do", "dz", "ec", "ee", "eg", "eh", "er", "es", "et", "fi", "fj", "fm", "fo", "fr", "ga", "gb", "gd", "ge", "gf", "gg", "gh", "gl", "gm", "gn", "gp", "gq", "gr", "gt", "gw", "gy", "hk", "hn", "hr", "ht", "hu", gvjs_5c, "ie", "il", gvjs_Fp, "iq", "ir", "is", "it", "je", "jm", "jo", "jp", "ke", "kg", "kh", "ki", "km", "kn", "kp", "kw", "ky", "kz", "la", "lb", "lc", "li", "lk", "lr", "ls", "lt", "lu", "lv", "ly", "ma", "md", "me", "mf", "mg", "mh", "mk", "ml", "mm", "mn", "mp", "mq", "mr", "ms", "mu", "mv", "mw", "mx", "my", "mz", "na", "nc", "ne", "ng", "ni", "nl", "no", "np", "nr", "nu", "nz", "om", "pa", "pe", "pf", "pg", "ph", "pk", "pl", "pm", "pr", "ps", "pt", "pw", "py", "qa", "re", "ro", "rs", "ru", "rw", "sa", "sb", "sc", "sd", "se", "sh", "si", "sj", "sk", "sl", "sm", "sn", "so", "sr", "ss", "st", "sv", "sx", "sy", "sz", "tc", "td", "tg", "th", "tj", "tk", "tl", "tm", "tn", "to", "tr", "tt", "tv", "tw", "tz", "ua", "ug", "us", "uy", "uz", "vc", "ve", "vg", "vi", "vn", "vu", "wf", "ws", "xk", "ye", "yt", "za", "zm", "zw"];
+function gvjs_qla(a) {
+  var b = gvjs_ola;
+  "1" === gvjs_QT && (b = gvjs_pla,
+    a = a.toLowerCase());
+  return 0 <= gvjs_Iy(b, a)
+}
+;function gvjs_CZ(a) {
+  this.selection = new gvjs_$n;
+  this.iw = this.Nj = this.iI = this.ff = null;
+  if (null != a) {
+    this.selection.setSelection(a.selection);
+    var b = new gvjs_Aj([a]);
+    this.ff = b.cb("focusedFeature");
+    this.iI = b.cb("focusedMarker");
+    if (null != b.pb("elaborated")) {
+      a = b.Aa("elaborated.rowId");
+      var c = b.Dq("elaborated.isDisputed")
+        , d = b.Aa("elaborated.origin.x");
+      b = b.Aa("elaborated.origin.y");
+      null != a && null != d && null != b && null != c && (this.Nj = {
+        oj: a,
+        gJ: c,
+        origin: {
+          x: d,
+          y: b
+        }
+      })
+    }
+  }
+}
+gvjs_CZ.prototype.clone = function() {
+  var a = new gvjs_CZ;
+  a.selection = this.selection.clone();
+  a.ff = gvjs_0e(this.ff);
+  a.Nj = gvjs_0e(this.Nj);
+  a.iw = gvjs_0e(this.iw);
+  return a
+}
+;
+gvjs_CZ.prototype.equals = function(a) {
+  return gvjs_Bi(this) == gvjs_Bi(a)
+}
+;
+var gvjs_DZ = {
+  Wza: "continents",
+  DBa: "subcontinents",
+  Xza: gvjs_qT,
+  eBa: gvjs_wT,
+  NAa: "metros"
+};
+function gvjs_EZ(a) {
+  this.m = a || {}
+}
+gvjs_EZ.prototype.project = function() {
+  return []
+}
+;
+gvjs_EZ.prototype.bZ = function() {
+  return 1.618
+}
+;
+gvjs_EZ.prototype.set = function(a, b) {
+  this.m[a] = b
+}
+;
+gvjs_EZ.prototype.Zc = function() {
+  return gvjs_0e(this.m)
+}
+;
+function gvjs_FZ(a) {
+  var b = 0
+    , c = 0;
+  if (a.boundingBox) {
+    var d = a.boundingBox.lo;
+    c = a.boundingBox.hi;
+    b = (c[0] - d[0]) / 2 + d[0];
+    c = (c[1] - d[1]) / 2 + d[1]
+  }
+  d = [29.5, 45.5];
+  b = {
+    parallels: d,
+    origin: {
+      lat: b,
+      lng: c
+    }
+  };
+  c = b.origin;
+  a.origin && Object.assign(c, a.origin);
+  Object.assign(b, a);
+  b.origin = c;
+  b.parallels && 0 !== b.parallels.length ? 2 > b.parallels.length && (b.parallels[1] = Math.abs(b.parallels[0] - d[0]) > Math.abs(b.parallels[0] - d[1]) ? d[0] : d[1]) : b.parallels = d;
+  this.m = a || {};
+  this.V1 = b.origin.lat / (180 / Math.PI);
+  this.$R = b.origin.lng / (180 / Math.PI);
+  this.bp = gvjs_v(b.parallels, function(e) {
+    return e / (180 / Math.PI)
+  })
+}
+gvjs_o(gvjs_FZ, gvjs_EZ);
+gvjs_FZ.prototype.project = function(a) {
+  var b = this;
+  return gvjs_v(arguments, function(c) {
+    var d = c[0] / (180 / Math.PI)
+      , e = .5 * (Math.sin(b.bp[0]) + Math.sin(b.bp[1]));
+    c = e * (c[1] / (180 / Math.PI) - b.$R);
+    var f = Math.cos(b.bp[0]);
+    f = f * f + 2 * e * Math.sin(b.bp[0]);
+    d = Math.sqrt(f - 2 * e * Math.sin(d)) / e;
+    return {
+      x: 180 / Math.PI * Math.sin(c) * d,
+      y: 180 / Math.PI * (Math.sqrt(f - 2 * e * Math.sin(b.V1)) / e - d * Math.cos(c))
+    }
+  })
+}
+;
+function gvjs_GZ(a) {
+  this.m = a || {}
+}
+gvjs_o(gvjs_GZ, gvjs_EZ);
+gvjs_GZ.prototype.bZ = function() {
+  return 2.2
+}
+;
+gvjs_GZ.prototype.project = function(a) {
+  return gvjs_v(arguments, function(b) {
+    var c = b[0] / (180 / Math.PI);
+    return {
+      x: b[1] / (180 / Math.PI) * 3 / (2 * Math.PI) * Math.sqrt(Math.PI * Math.PI / 3 - c * c) * (180 / Math.PI),
+      y: c
+    }
+  })
+}
+;
+function gvjs_HZ(a) {
+  var b = 0
+    , c = 0;
+  if (a.boundingBox) {
+    var d = a.boundingBox.lo;
+    c = a.boundingBox.hi;
+    b = (c[0] - d[0]) / 2 + d[0];
+    c = (c[1] - d[1]) / 2 + d[1]
+  }
+  d = [20, 50];
+  b = {
+    parallels: d,
+    origin: {
+      lat: b,
+      lng: c
+    }
+  };
+  c = b.origin;
+  a.origin && Object.assign(c, a.origin);
+  Object.assign(b, a);
+  b.origin = c;
+  b.parallels && 0 !== b.parallels.length ? 2 > b.parallels.length && (b.parallels[1] = Math.abs(b.parallels[0] - d[0]) > Math.abs(b.parallels[0] - d[1]) ? d[0] : d[1]) : b.parallels = d;
+  this.m = a || {};
+  this.V1 = b.origin.lat / (180 / Math.PI);
+  this.$R = b.origin.lng / (180 / Math.PI);
+  this.bp = gvjs_v(b.parallels, function(e) {
+    return e / (180 / Math.PI)
+  })
+}
+gvjs_o(gvjs_HZ, gvjs_EZ);
+gvjs_HZ.prototype.project = function(a) {
+  var b = this;
+  return gvjs_v(arguments, function(c) {
+    var d = c[1] / (180 / Math.PI)
+      , e = Math.log(1 / Math.cos(b.bp[1]) * Math.cos(b.bp[0])) / Math.log(1 / Math.tan(.25 * Math.PI + .5 * b.bp[0]) * Math.tan(.25 * Math.PI + .5 * b.bp[1]))
+      , f = Math.cos(b.bp[0]) * Math.pow(Math.tan(.25 * Math.PI + .5 * b.bp[0]), e) / e;
+    c = f * Math.pow(1 / Math.tan(.25 * Math.PI + c[0] / (180 / Math.PI) * .5), e);
+    return {
+      x: 180 / Math.PI * Math.sin(e * (d - b.$R)) * c,
+      y: f * Math.pow(1 / Math.tan(.25 * Math.PI + .5 * b.V1), e) - 180 / Math.PI * Math.cos(e * (d - b.$R)) * c
+    }
+  })
+}
+;
+function gvjs_IZ(a) {
+  return 180 / Math.PI * (Math.atan(Math.exp(a / (180 / Math.PI))) - Math.PI / 4) * 2
+}
+function gvjs_JZ() {
+  this.Ir = {}
+}
+gvjs_JZ.prototype.track = function(a) {
+  var b = this;
+  gvjs_u(arguments, function(c) {
+    for (var d in c)
+      if (c.hasOwnProperty(d)) {
+        d in b.Ir || (b.Ir[d] = {
+          min: Infinity,
+          max: -Infinity
+        });
+        if (!b.Ir[d].min || c[d] < b.Ir[d].min)
+          b.Ir[d].min = c[d];
+        if (!b.Ir[d].max || c[d] > b.Ir[d].max)
+          b.Ir[d].max = c[d]
+      }
+  })
+}
+;
+gvjs_JZ.prototype.getBounds = function(a) {
+  return {
+    min: this.Ir[a].min,
+    max: this.Ir[a].max
+  }
+}
+;
+function gvjs_KZ(a) {
+  this.m = a || {}
+}
+gvjs_o(gvjs_KZ, gvjs_EZ);
+gvjs_KZ.prototype.project = function(a) {
+  return gvjs_v(arguments, function(b) {
+    return {
+      x: b[1],
+      y: 180 / Math.PI * Math.log(Math.tan(b[0] / 180 * .5 * Math.PI + Math.PI / 4))
+    }
+  })
+}
+;
+var gvjs_rla = {
+  sza: "albers",
+  yAa: gvjs_sZ,
+  BAa: "lambert",
+  MAa: gvjs_yZ
+}
+  , gvjs_LZ = {};
+gvjs_LZ.mercator = gvjs_KZ;
+gvjs_LZ[gvjs_sZ] = gvjs_GZ;
+gvjs_LZ.albers = gvjs_FZ;
+gvjs_LZ.lambert = gvjs_HZ;
+var gvjs_sla = {
+  NONE: gvjs_f,
+  TOP_LEFT: gvjs_AZ,
+  TOP_RIGHT: "top_right",
+  BOTTOM_LEFT: gvjs_lZ,
+  BOTTOM_RIGHT: "bottom_right"
+}
+  , gvjs_tla = {
+  NONE: gvjs_f,
+  fBa: gvjs_xT,
+  Gza: "bounds",
+  HM: gvjs_ut
+};
+function gvjs_ula(a) {
+  return gvjs_my(a, "projection", {
+    name: gvjs_yZ
+  }, function(b) {
+    b = typeof b === gvjs_l ? b : (gvjs_lj(b) || {}).name;
+    b = gvjs_Hj(b, gvjs_rla);
+    if (!b)
+      throw Error('The projection you specified, "' + b + '", is not valid.');
+    return {
+      name: b
+    }
+  })
+}
+var gvjs_MZ = {
+  region: gvjs_CT,
+  resolution: gvjs_qT,
+  domain: "COM",
+  displayMode: gvjs_ub,
+  showGeocodeWarnings: !1,
+  backgroundColor: {
+    fill: gvjs_Ox,
+    stroke: "#666",
+    strokeWidth: 0
+  },
+  datalessRegionColor: "F5F5F5",
+  defaultColor: "267114",
+  markerOpacity: 1,
+  selectionMode: gvjs_Ww,
+  fontName: gvjs_2r,
+  geocodingContext: gvjs_xT,
+  tooltip: {
+    isHtml: !1,
+    textStyle: {
+      fontName: gvjs_2r,
+      fontSize: 13,
+      color: gvjs_rt
+    },
+    trigger: gvjs_xu,
+    showDisputedText: !1,
+    showTitle: !0
+  },
+  colorAxis: {
+    minValue: null,
+    maxValue: null,
+    values: null
+  },
+  sizeAxis: {
+    minValue: null,
+    maxValue: null,
+    minSize: 3,
+    maxSize: 12
+  },
+  legend: {
+    position: gvjs_lZ,
+    orientation: gvjs_S,
+    textStyle: {
+      color: gvjs_rt,
+      auraColor: gvjs_Ox
+    }
+  },
+  marker: {
+    style: {
+      stroke: {
+        color: gvjs_yr,
+        width: 1
+      }
+    }
+  },
+  projection: gvjs_yZ,
+  keepAspectRatio: !0,
+  magnifyingGlass: {
+    enable: !0,
+    zoomFactor: 5
+  }
+};
+function gvjs_NZ(a) {
+  gvjs_F.call(this);
+  this.Sd = a;
+  this.aF = null;
+  this.Tfa = !0;
+  this.nI = null;
+  this.er = new gvjs_LT;
+  this.isa = /^([a-zA-Z][a-zA-Z]|[a-zA-Z][a-zA-Z]\-[a-zA-Z0-9](|[a-zA-Z0-9](|[a-zA-Z0-9]))|\d\d\d)$/;
+  this.psa = /^\d\d\d$/
+}
+gvjs_o(gvjs_NZ, gvjs_F);
+gvjs_ = gvjs_NZ.prototype;
+gvjs_.U3 = function(a) {
+  this.aF = a;
+  null != this.Ysa && this.Ysa(a)
+}
+;
+function gvjs_vla(a, b, c, d, e, f) {
+  a.Tfa = e;
+  if (0 === b.ca())
+    gvjs_pl(function() {
+      f([], [], !0)
+    });
+  else
+    switch (c.JV) {
+      case gvjs_9c:
+        a.qX(b, c, f);
+        break;
+      case gvjs_xd:
+        gvjs_wla(a, b, c, d, f);
+        break;
+      case "address":
+        a.pX(b, c, d, f)
+    }
+}
+gvjs_.qX = function(a, b, c) {
+  for (var d = [], e = 0; e < a.ca(); e++) {
+    var f = a.getValue(e, b.sD)
+      , g = a.getValue(e, b.yD);
+    d[e] = null == f || null == g ? null : {
+      lat: gvjs_gg(f),
+      lng: gvjs_gg(g)
+    }
+  }
+  gvjs_pl(function() {
+    c([], d, !0)
+  })
+}
+;
+function gvjs_wla(a, b, c, d, e) {
+  for (var f = [], g = 0; g < b.ca(); g++)
+    f.push(b.getValue(g, c.KK));
+  "metros" == d.resolution || "continents" == d.resolution || "subcontinents" == d.resolution ? a.oX(d, f, e) : a.rX(d, f, e)
+}
+gvjs_.oX = function(a, b, c) {
+  a = gvjs_hf(a.region, "US") && "metros" == a.resolution;
+  for (var d = [], e = 0; e < b.length; e++) {
+    var f = gvjs_gg(b[e]);
+    a && this.psa.test(f) && (f = "US-" + f);
+    d.push(f.toUpperCase())
+  }
+  gvjs_pl(function() {
+    c(d, [], !0)
+  })
+}
+;
+gvjs_.rX = function(a, b, c) {
+  var d = this
+    , e = a.region;
+  var f = a.resolution == gvjs_wT && gvjs_qla(e) ? e : "countries_en";
+  if (a.resolution == gvjs_wT && "US" == e)
+    for (a = 0; a < b.length; ++a) {
+      var g = b[a];
+      2 == g.length && (b[a] = "US-" + g)
+    }
+  gvjs_RT(f, function(h) {
+    h = d.WW(b, h);
+    for (var k = [], l = 0; l < b.length; l++)
+      if (null == h[l]) {
+        var m = b[l];
+        k.push({
+          address: m,
+          Fea: l,
+          Aca: null
+        });
+        h[l] = m
+      }
+    0 == k.length ? c(h, [], !0) : (c(h, [], !1),
+      gvjs_OZ(d, k, e, c, h))
+  })
+}
+;
+gvjs_.WW = function(a, b) {
+  for (var c = [], d = 0; d < a.length; ++d) {
+    var e = gvjs_kf(gvjs_gg(a[d])).toLowerCase()
+      , f = b && gvjs_TT(b, e);
+    e = f ? f : this.isa.test(e) ? e.toUpperCase() : null;
+    c.push(e)
+  }
+  return c
+}
+;
+function gvjs_PZ(a, b) {
+  a.Tfa && a.Sd && gvjs_8x(a.Sd, b)
+}
+gvjs_.pX = function(a, b, c, d) {
+  var e = [];
+  c = c.region;
+  2 == c.length && (c = c.toUpperCase(),
+    c = c.replace(/GB/, "UK"),
+    c = c.replace(/RU/, "SU"),
+    c = c.replace(/TP/, "TL"));
+  for (var f = 0; f < a.ca(); f++) {
+    var g = gvjs_gg(a.getValue(f, b.fG));
+    gvjs_QZ(this, c) && (g += " " + c);
+    e.push({
+      address: g,
+      Aca: f,
+      Fea: null
+    })
+  }
+  gvjs_OZ(this, e, c, d, [])
+}
+;
+function gvjs_QZ(a, b) {
+  return b == gvjs_CT || gvjs_Yy(b) ? !1 : a.nI === gvjs_xT || a.nI === gvjs_ut
+}
+function gvjs_xla(a) {
+  var b = Infinity
+    , c = Infinity
+    , d = -Infinity
+    , e = -Infinity;
+  if (null != a.aF && 0 !== a.aF.views.length)
+    return gvjs_u(a.aF.views, function(f) {
+      f = f.Ju;
+      b = Math.min(b, f.kh[0]);
+      c = Math.min(b, f.kh[1]);
+      d = Math.max(d, f.xi[0]);
+      e = Math.max(d, f.xi[1])
+    }),
+      {
+        lo: {
+          lat: b,
+          lng: c
+        },
+        hi: {
+          lat: d,
+          lng: e
+        }
+      }
+}
+function gvjs_OZ(a, b, c, d, e) {
+  for (var f = [], g = [], h = 0; h < b.length; h++) {
+    var k = {
+      address: b[h].address
+    };
+    gvjs_QZ(a, c) && (k.region = c);
+    "bounds" !== a.nI && a.nI !== gvjs_ut || (k.bounds = gvjs_xla(a));
+    g.push(k)
+  }
+  var l = gvjs_Le(b);
+  a.er.create(g, function(m) {
+    return a.XZ(l, d, e, f, m)
+  }, 1)
+}
+gvjs_.XZ = function(a, b, c, d, e) {
+  for (var f = e.length, g = 0; g < f; g++) {
+    var h = a[g]
+      , k = h.address
+      , l = h.Fea;
+    h = h.Aca;
+    if (e[g] && e[g][0]) {
+      var m = e[g][0];
+      null != l && (c[l] = gvjs_yla(m),
+      c[l] || (gvjs_PZ(this, gvjs_iZ + k + '"'),
+        c[l] = k));
+      null != h && (d[h] = {
+        lat: m.geometry.location.lat(),
+        lng: m.geometry.location.lng()
+      })
+    } else
+      null != l && (c[l] = null),
+      null != h && (d[h] = null),
+        gvjs_PZ(this, gvjs_iZ + k + '"')
+  }
+  gvjs_Ne(a, 0, f);
+  (a = 0 == a.length) && gvjs_Ge(c, function(n) {
+    return null === n
+  }) && gvjs_Ge(d, function(n) {
+    return null === n
+  }) && gvjs_PZ(this, gvjs_oT);
+  b(c, d, a)
+}
+;
+function gvjs_yla(a) {
+  var b = gvjs_Yx(a.address_components, function(c) {
+    return 0 <= gvjs_Be(c.types, "country")
+  });
+  if (!b)
+    return null;
+  b = b.short_name;
+  "US" == b && (a = gvjs_Yx(a.address_components, function(c) {
+    return 0 <= gvjs_Be(c.types, "administrative_area_level_1")
+  })) && (b = "US-" + a.short_name);
+  return b
+}
+gvjs_.M = function() {
+  this.er.cancel();
+  gvjs_F.prototype.M.call(this)
+}
+;
+function gvjs_RZ(a, b, c) {
+  gvjs_F.call(this);
+  var d = this;
+  this.F = b;
+  this.me = function(e, f) {
+    return d.F.me(e, f)
+  }
+  ;
+  this.Hi = a;
+  this.VA = [];
+  this.gb = c;
+  this.Fd = {};
+  this.nc = new gvjs_H;
+  this.v0 = this.jw = this.Xu = this.Xv = this.Vs = this.mw = this.pD = null
+}
+gvjs_o(gvjs_RZ, gvjs_F);
+gvjs_RZ.prototype.o = function(a, b) {
+  gvjs_G(this.nc, a, b)
+}
+;
+function gvjs_SZ(a, b) {
+  var c = a.F;
+  c.clear();
+  var d = c.Lm(b.width, b.height);
+  a.Fd = {};
+  var e = c.Sa();
+  gvjs_TZ(a, e, b, new gvjs_5(0,0,b.width,b.height), !1);
+  var f = c.Sa()
+    , g = a.F
+    , h = g.Sa();
+  a.Vs = g.Sa();
+  for (var k = 0; k < b.views.length; ++k)
+    gvjs_UZ(a, h, b, b.views[k], !1),
+      gvjs_VZ(a, b, b.views[k]);
+  a.mw = g.Sa();
+  gvjs_WZ(a, a.mw, b.FD, !1, b.Hj);
+  g.appendChild(f, h);
+  a.Vs && g.appendChild(f, a.Vs);
+  g.appendChild(f, a.mw);
+  g = b.$sa;
+  f = c.ZG(f, a.cw() ? new gvjs_5(g.left,g.top,g.width - 1,g.height - 1) : g);
+  a.Xu = c.Sa();
+  gvjs_XZ(a, b);
+  a.jw = c.Sa();
+  gvjs_YZ(a, b);
+  a.Xv = c.Sa();
+  gvjs_ZZ(a, b);
+  c.appendChild(d, e);
+  c.appendChild(e, f);
+  c.appendChild(e, a.Xu);
+  c.appendChild(e, a.jw);
+  c.appendChild(e, a.Xv);
+  a.pD = b;
+  gvjs_zla(a, d)
+}
+function gvjs__Z(a, b, c) {
+  c = void 0 === c ? !1 : c;
+  a.Xv && a.F.qc(a.Xv);
+  gvjs_ZZ(a, b);
+  if (c || !gvjs_Uz(a.pD.NC, b.NC))
+    for (a.Vs && a.F.qc(a.Vs),
+           c = 0; c < b.views.length; ++c)
+      gvjs_VZ(a, b, b.views[c]);
+  gvjs_Ala(a, b);
+  a.Xu && a.F.qc(a.Xu);
+  gvjs_XZ(a, b);
+  a.v0 != (b.HJ ? b.HJ.Xo : null) && a.jw && (a.F.qc(a.jw),
+    gvjs_YZ(a, b));
+  a.pD = b
+}
+function gvjs_VZ(a, b, c) {
+  var d = a.F.Sa();
+  c = gvjs_De(c.features, function(f) {
+    return gvjs_He(b.NC, f.id)
+  });
+  for (var e = 0; e < c.length; ++e)
+    gvjs_Bla(a, d, b, c[e]);
+  a.F.appendChild(a.Vs, d)
+}
+function gvjs_0Z(a, b) {
+  var c = a.F;
+  gvjs_u(gvjs_lh(a.mw.j()), function(d) {
+    gvjs_u(gvjs_lh(d), function(e) {
+      c.Re(e)
+    }, this)
+  }, a);
+  gvjs_WZ(a, a.mw, b.FD, !1, b.Hj)
+}
+function gvjs_Bla(a, b, c, d) {
+  a.cw() || (c = c.qC[d.id].Rb,
+    gvjs_1Z(a, b, d, !1, !1, [gvjs_2Z, gvjs_Cla, c.fill]),
+  0 != d.Rm.length && (gvjs_1Z(a, b, d, !0, !1, [c.Rm]),
+    gvjs_1Z(a, b, d, !1, !1, [c.border])))
+}
+function gvjs_YZ(a, b) {
+  var c = b.HJ;
+  if (c) {
+    var d = a.jw
+      , e = a.F
+      , f = c.view.XD
+      , g = f.left + f.width / 2
+      , h = f.top + f.height / 2
+      , k = f.width / 2
+      , l = f.height / 2
+      , m = c.Bca.x
+      , n = c.Bca.y
+      , p = new gvjs_3({
+      fill: "808080",
+      fillOpacity: .25
+    })
+      , q = new gvjs_SA;
+    q.move(m, n);
+    q.va(m, n + (h > n ? l : -l));
+    q.va(m + (g > m ? k : -k), n);
+    q.close();
+    m = e.Ia(q, p, d);
+    gvjs_3Z(a, m, gvjs_uZ, !0);
+    m = new gvjs_3({
+      fill: gvjs_Ox
+    });
+    m = e.Gl(g, h, k, l, m, d);
+    gvjs_3Z(a, m, gvjs_tZ, !0);
+    m = new gvjs_3({
+      stroke: "bfbfbf",
+      strokeWidth: 1.5
+    });
+    m = e.Gl(g, h, k, l, m, d);
+    gvjs_3Z(a, m, gvjs_tZ, !0);
+    m = e.Sa();
+    f = e.ZG(m, new gvjs_5(f.left + 3.5,f.top + 3.5,f.width - 7,f.height - 7), !0);
+    e.appendChild(d, f);
+    f = new gvjs_3({
+      stroke: "cccccc",
+      strokeWidth: 1.5
+    });
+    d = e.Gl(g, h, k - 3.5, l - 3.5, f, d);
+    gvjs_3Z(a, d, gvjs_tZ, !0);
+    d = c.view;
+    gvjs_TZ(a, m, b, d.XD, !0);
+    gvjs_UZ(a, m, b, d, !0);
+    gvjs_WZ(a, m, c.FD, !0, b.Hj);
+    a.v0 = c.Xo
+  } else
+    a.v0 = null
+}
+function gvjs_ZZ(a, b) {
+  0 < a.VA.length && (gvjs_u(a.VA, function(c) {
+    this.F.Re(c)
+  }, a),
+    a.VA = []);
+  a.VA = 0 < b.qu.length ? gvjs_v(b.qu, function(c) {
+    return c.html ? gvjs_IG(c, this.Hi.getContainer()) : gvjs_JG(c, this.F, this.Xv).j()
+  }, a) : []
+}
+function gvjs_4Z(a, b) {
+  gvjs_w(b.qC, function(c, d) {
+    c = c.Rb;
+    gvjs_5Z(this, d, gvjs_mZ, c.fill);
+    gvjs_5Z(this, d, "disputed", c.Rm);
+    gvjs_5Z(this, d, "border", c.border)
+  }, a)
+}
+function gvjs_5Z(a, b, c, d) {
+  b = [c, b].join(".");
+  b = a.Fd[b];
+  if (null != b)
+    for (c = 0; c < b.length; ++c)
+      a.F.rj(b[c], d)
+}
+function gvjs_zla(a, b) {
+  function c(e) {
+    var f = gvjs_Dla(a, e.target);
+    if (f && f.QO) {
+      var g = gvjs_Ela(e.type, f.type)
+        , h = f.elementType;
+      f = gvjs_x(f.data);
+      e.type == gvjs_kd ? f.Ro = !1 : e.type == gvjs_ld && (f.Ro = !0);
+      f.xb = gvjs_qB(e);
+      a.nc.dispatchEvent({
+        type: g,
+        elementType: h,
+        data: f
+      })
+    }
+  }
+  var d = a.F;
+  d.ic(b, gvjs_jd, c);
+  d.ic(b, gvjs_kd, c);
+  d.ic(b, gvjs_ld, c);
+  d.ic(b, gvjs_Wt, c)
+}
+function gvjs_Ela(a, b) {
+  switch (b) {
+    case gvjs_mZ:
+      switch (a) {
+        case gvjs_Wt:
+          return gvjs_nZ;
+        case gvjs_jd:
+          return gvjs_pZ;
+        case gvjs_kd:
+        case gvjs_ld:
+          return gvjs_oZ
+      }
+    case gvjs_vZ:
+      switch (a) {
+        case gvjs_Wt:
+          return gvjs_wZ;
+        case gvjs_jd:
+          return "markerMove";
+        case gvjs_kd:
+        case gvjs_ld:
+          return gvjs_xZ
+      }
+  }
+  return null
+}
+function gvjs_3Z(a, b, c, d) {
+  gvjs_6Z(a, b, ["F", c, "1", d ? "1" : "0", "", "0"])
+}
+function gvjs_6Z(a, b, c) {
+  c = c.join("#");
+  a.F.kp(b, c)
+}
+function gvjs_Dla(a, b) {
+  a = a.F.xv(b);
+  if (!a || a == gvjs_Bs)
+    return null;
+  a = a.split("#");
+  b = a[1];
+  var c = "1" == a[2] ? !0 : !1
+    , d = "1" == a[3] ? !0 : !1;
+  switch (a[0]) {
+    case "F":
+      return {
+        type: gvjs_mZ,
+        elementType: b,
+        QO: c,
+        data: {
+          iJ: d,
+          featureId: a[4] ? a[4] : null,
+          gJ: "1" == a[5] ? !0 : !1
+        }
+      };
+    case "M":
+      return {
+        type: gvjs_vZ,
+        elementType: b,
+        QO: c,
+        data: {
+          iJ: d,
+          Xo: a[4],
+          oj: gvjs_jg(a[5]),
+          hD: "1" == a[6] ? !0 : !1
+        }
+      };
+    default:
+      return null
+  }
+}
+function gvjs_TZ(a, b, c, d, e) {
+  b = a.F.yb(d.left, d.top, d.width, d.height, c.xG, b);
+  gvjs_3Z(a, b, "ocean", e)
+}
+function gvjs_UZ(a, b, c, d, e) {
+  for (var f = a.F.Sa(), g = 0; g < d.features.length; ++g) {
+    var h = a
+      , k = d.features[g]
+      , l = e
+      , m = c.qC[k.id].Rb;
+    gvjs_1Z(h, f, k, !1, l, [m.fill], gvjs_mZ);
+    0 != k.Rm.length && (gvjs_1Z(h, f, k, !0, l, [m.Rm], "disputed"),
+      gvjs_1Z(h, f, k, !1, l, [m.border], "border"))
+  }
+  a.F.appendChild(b, f)
+}
+function gvjs_1Z(a, b, c, d, e, f, g) {
+  var h = d ? c.Rm : c.polygons
+    , k = c.id;
+  (g = null != g ? [g, k].join(".") : null) && (a.Fd[g] = a.Fd[g] || []);
+  for (k = 0; k < h.length; ++k) {
+    var l = h[k]
+      , m = new gvjs_SA;
+    gvjs_7Z(m, l.pL, gvjs_zZ);
+    for (var n = 0; n < l.SI.length; n++)
+      gvjs_7Z(m, l.SI[n], "reverse");
+    l = m;
+    if (0 < l.vc.length)
+      for (m = 0; m < f.length; ++m)
+        if (n = a.F.Ia(l, f[m], b))
+          gvjs_6Z(a, n, ["F", gvjs_mZ, c.QO ? "1" : "0", e ? "1" : "0", c.id, d ? "1" : "0"]),
+          g && a.Fd[g].push(n)
+  }
+}
+function gvjs_7Z(a, b, c) {
+  b = b.points;
+  var d = b.length;
+  if (!(1 >= d)) {
+    var e = c == gvjs_zZ ? 0 : d - 1;
+    d = c == gvjs_zZ ? d : -1;
+    c = c == gvjs_zZ ? 1 : -1;
+    for (var f = e; f != d; f += c) {
+      var g = b[f][0]
+        , h = b[f][1];
+      f == e ? a.move(g, h) : a.va(g, h)
+    }
+    a.close()
+  }
+}
+function gvjs_WZ(a, b, c, d, e) {
+  var f = a.F;
+  c = gvjs_Le(c);
+  gvjs_Qe(c, function(m, n) {
+    return n.size - m.size
+  });
+  for (var g = 0; g < c.length; ++g) {
+    var h = c[g]
+      , k = f.Sa();
+    gvjs_6Z(a, k, ["M", gvjs_vZ, "1", d ? "1" : "0", h.Xo, h.oj, h.hD ? "1" : "0"]);
+    f.appendChild(b, k);
+    if (a.gb.ZX === gvjs_m) {
+      var l = new gvjs_ly({
+        bb: e,
+        fontSize: h.size,
+        color: h.brush.fill,
+        opacity: h.brush.fillOpacity,
+        Lb: "",
+        bold: !1,
+        Ue: !1,
+        Nc: !1
+      });
+      f.ce(h.label, h.x, h.y, 20, gvjs_0, gvjs_0, l, k)
+    } else
+      f.Ke(h.x, h.y, h.size, h.brush, k);
+    h = [gvjs_vZ, h.Xo].join(".");
+    a.Fd[h] = k.j()
+  }
+}
+function gvjs_Ala(a, b) {
+  var c = a.F
+    , d = a.pD.OC;
+  gvjs_u(d, function(e) {
+    if (!gvjs_He(b.OC, e)) {
+      e = [gvjs_vZ, e].join(".");
+      e = gvjs_lh(this.Fd[e]);
+      for (var f = 1; f < e.length; ++f)
+        c.Re(e[f])
+    }
+  }, a);
+  gvjs_u(b.OC, function(e) {
+    if (!gvjs_He(d, e)) {
+      e = [gvjs_vZ, e].join(".");
+      e = this.Fd[e];
+      var f = gvjs_mh(e).cloneNode(!0);
+      c.rj(f, gvjs_2Z);
+      e.appendChild(f)
+    }
+  }, a)
+}
+function gvjs_XZ(a, b) {
+  if (b.Vi) {
+    b = b.Vi;
+    var c = a.F;
+    a = a.Xu;
+    gvjs_EG(b.XW, c, a);
+    gvjs_FG(b.G0, c, a);
+    gvjs_GG(b.V4, c, a)
+  }
+}
+gvjs_RZ.prototype.M = function() {
+  gvjs_li(this.nc);
+  0 < this.VA.length && (gvjs_u(this.VA, function(a) {
+    this.F.Re(a)
+  }, this),
+    this.VA = []);
+  this.F.clear();
+  gvjs_E(this.pD);
+  this.pD = null;
+  this.mw && this.F.Re(this.mw.j());
+  this.mw = null;
+  this.Vs && this.F.Re(this.Vs.j());
+  this.Vs = null;
+  this.Xv && this.F.Re(this.Xv.j());
+  this.Xv = null;
+  this.Xu && this.F.Re(this.Xu.j());
+  this.Xu = null;
+  this.jw && this.F.Re(this.jw.j());
+  this.jw = null;
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_RZ.prototype.cw = function() {
+  return this.F.cw()
+}
+;
+var gvjs_2Z = new gvjs_3({
+  strokeWidth: "3",
+  stroke: gvjs_rt,
+  strokeOpacity: "0.2"
+})
+  , gvjs_Cla = new gvjs_3({
+  strokeWidth: "1",
+  stroke: gvjs_rt,
+  strokeOpacity: "0.1"
+});
+function gvjs_8Z(a, b) {
+  var c = new gvjs_B(-5,-5,-5,-5);
+  this.af = b.clone().expand(c);
+  a = 2 * gvjs_BZ(a) / 5;
+  this.W$ = new gvjs_A(a,a)
+}
+function gvjs_Fla(a, b) {
+  var c = a.af;
+  a = a.W$;
+  var d = b.x;
+  d + a.width > c.right && (d = b.x - a.width);
+  var e = b.y - a.height;
+  e < c.top && (e = b.y);
+  return new gvjs_5(d,e,a.width,a.height)
+}
+gvjs_8Z.prototype.xW = function(a, b, c) {
+  var d = b.D0
+    , e = b.XD.Tb();
+  b = parseFloat(a.lat);
+  a = parseFloat(a.lng);
+  a < d.kh[1] ? a += 360 : a > d.xi[1] && (a -= 360);
+  c = gvjs_BZ(this.W$) / 2 / c / (e.height / (d.xi[0] - d.kh[0]));
+  return {
+    xi: [b + c, a + c],
+    kh: [b - c, a - c]
+  }
+}
+;
+function gvjs_Gla(a, b) {
+  var c = gvjs_Yx(a.FD, function(d) {
+    return d.oj == b
+  });
+  if (!c)
+    return !1;
+  a = a.view.XD;
+  c = gvjs_cz(new gvjs_z(c.x,c.y), new gvjs_z(a.left + a.width / 2,a.top + a.height / 2));
+  a = gvjs_BZ(a.Tb()) / 2;
+  return c < .9 * a
+}
+;function gvjs_9Z(a, b, c, d) {
+  this.kg = !a.cw() && gvjs_K(b, "magnifyingGlass.enable");
+  this.K = c;
+  this.zb = d;
+  this.SB = this.mK = null
+}
+gvjs_9Z.prototype.handleEvent = function(a, b) {
+  if (!this.kg)
+    return !1;
+  if (gvjs_Hla(this, a) || this.YZ(a, b))
+    return !0;
+  b = a.elementType == gvjs_mZ;
+  return a.data.iJ && b ? !0 : !1
+}
+;
+gvjs_9Z.prototype.YZ = function(a, b) {
+  var c = this;
+  if (a.type != gvjs_xZ)
+    return !1;
+  if (a.data.Ro) {
+    if (!a.data.hD)
+      return !1;
+    if (b && gvjs_Gla(b, a.data.oj))
+      return !0;
+    gvjs_$Z(this);
+    this.mK = setTimeout(function() {
+      c.mK = null;
+      c.K.iw = {
+        Xo: a.data.Xo,
+        oj: a.data.oj
+      };
+      gvjs_LK(c.zb, 0)
+    }, 300);
+    return !0
+  }
+  gvjs_$Z(this);
+  return !1
+}
+;
+function gvjs_Hla(a, b) {
+  if (!a.K.iw)
+    return !1;
+  switch (b.type) {
+    case gvjs_wZ:
+    case gvjs_nZ:
+      return b.data.iJ ? a = !1 : (gvjs_a_(a),
+        a = !0),
+        a;
+    case gvjs_xZ:
+    case gvjs_oZ:
+      if (b.data.Ro) {
+        var c = b.elementType == gvjs_vZ
+          , d = b.elementType == gvjs_uZ;
+        b.data.iJ && !d ? gvjs_b_(a) : c && (b.data.hD ? gvjs_b_(a) : gvjs_a_(a))
+      } else
+        null === a.SB && (c = b.elementType == gvjs_vZ,
+        (b.data.iJ || c) && gvjs_c_(a));
+      return !1;
+    case gvjs_pZ:
+      return b.elementType == gvjs_uZ ? (gvjs_c_(a),
+        a = !0) : a = !1,
+        a;
+    default:
+      return !1
+  }
+}
+function gvjs_c_(a) {
+  gvjs_b_(a);
+  a.SB = setTimeout(function() {
+    a.SB = null;
+    gvjs_a_(a)
+  }, 500)
+}
+function gvjs_a_(a) {
+  a.K.iw = null;
+  gvjs_LK(a.zb, 0)
+}
+function gvjs_$Z(a) {
+  var b = gvjs_Oh().Vj();
+  null !== a.mK && (b.clearTimeout(a.mK),
+    a.mK = null)
+}
+function gvjs_b_(a) {
+  var b = gvjs_Oh().Vj();
+  null !== a.SB && (b.clearTimeout(a.SB),
+    a.SB = null)
+}
+;function gvjs_d_(a) {
+  this.m = a || {}
+}
+gvjs_o(gvjs_d_, gvjs_EZ);
+gvjs_d_.prototype.bZ = function() {
+  return 1
+}
+;
+gvjs_d_.prototype.project = function(a) {
+  return gvjs_v(arguments, function(b) {
+    return {
+      x: b[1],
+      y: b[0]
+    }
+  })
+}
+;
+function gvjs_Ila(a, b, c, d, e, f) {
+  this.m = a;
+  var g = gvjs_ula(a);
+  this.I2 = new gvjs_LZ[g.name](g);
+  this.ga = b;
+  this.Pa = c;
+  var h = gvjs_fy(gvjs_qy(a, gvjs_ht));
+  g = b - h;
+  h = c - h;
+  this.ms = new gvjs_5(Math.round((b - g) / 2),Math.round((c - h) / 2),g,h);
+  g = this.ms;
+  if (a.Dq("keepAspectRatio")) {
+    h = g.width;
+    var k = g.height
+      , l = this.I2.bZ()
+      , m = Math.min(h, Math.round(k * l));
+    l = Math.min(k, Math.round(h / l));
+    g = new gvjs_5(Math.round((h - m) / 2) + g.left,Math.round((k - l) / 2) + g.top,m,l)
+  } else
+    g = g.clone();
+  this.lw = g;
+  this.Zd = d;
+  this.Z = e;
+  this.gb = f;
+  this.n9 = gvjs_Oj(a, gvjs_zp, Math.round(Math.pow(2 * (this.ms.width + this.ms.height), 1 / 3)));
+  this.bta = gvjs_oy(a, ["marker.style.stroke.color", "marker.style.stroke"], gvjs_yr);
+  this.cta = gvjs_Oj(a, "marker.style.stroke.width", 1);
+  this.PX = gvjs_J(a, gvjs_yp);
+  this.rs = gvjs_e_(this);
+  this.tL = gvjs_f_(this);
+  d = a.fa(gvjs_rv);
+  this.kra = gvjs_me(d) == gvjs_h;
+  this.XQ = gvjs_J(a, gvjs_uv, gvjs_lZ, gvjs_sla);
+  this.fca = gvjs_ny(a, "legend.bar.length", 1 / 3);
+  this.VQ = gvjs_J(a, "legend.orientation", gvjs_S, gvjs_nla);
+  this.ica = gvjs_ry(a, gvjs_vv, {
+    bb: this.PX,
+    fontSize: this.n9
+  });
+  this.G1 = a.cb("legend.numberFormat");
+  this.yma = gvjs_oy(a, gvjs_rT, "");
+  this.sO = gvjs_oy(a, gvjs_sT, "");
+  this.w8 = gvjs_Jla(this);
+  this.qxa = gvjs_Kla(this);
+  d = gvjs_ry(a, gvjs_px);
+  e = gvjs_ry(a, gvjs_px, {
+    bold: !0
+  });
+  this.tF = gvjs_J(a, gvjs_qx, gvjs_xu, gvjs_mC);
+  this.wz = this.tF != gvjs_f;
+  this.pu = {
+    Hd: d,
+    bold: e
+  };
+  d = gvjs_K(a, "tooltip.showDisputedText");
+  this.qya = gvjs_K(a, "tooltip.showTitle");
+  this.oya = d ? "%s's administration (under dispute)" : "%s";
+  this.Q_ = gvjs_K(a, gvjs_nx);
+  this.Dma = 10;
+  this.R2 = this.Nq = this.FF = null;
+  this.O7 = gvjs_yr;
+  this.BK = null;
+  this.ata = gvjs_ny(a, "markerOpacity");
+  this.Xsa = new gvjs_8Z(this.lw.Tb(),new gvjs_B(0,b,c,0))
+}
+function gvjs_Lla(a, b) {
+  for (var c = 0, d = a.FF.length; c < d; c++)
+    for (var e = a.FF[c].NX.features, f = 0, g = e.length; f < g; f++) {
+      var h = e[f];
+      if (h.id == b)
+        return h
+    }
+  return null
+}
+function gvjs_Mla(a, b) {
+  var c = gvjs_g_(a, a.yma)
+    , d = {};
+  gvjs_u(b.views, function(e) {
+    gvjs_u(e.features, function(f) {
+      d[f.id] = {
+        Rb: c
+      }
+    }, this)
+  }, a);
+  return d
+}
+function gvjs_h_(a, b) {
+  for (var c = new gvjs_JZ, d = 1; 10 > d; d++) {
+    var e = (a.xi[1] - a.kh[1]) / 10 * d + a.kh[1]
+      , f = (a.xi[0] - a.kh[0]) / 10 * d + a.kh[0];
+    e = b.project([f, a.kh[1]], [f, a.xi[1]], [a.kh[0], e], [a.xi[0], e]);
+    c.track.apply(c, e)
+  }
+  a = c.getBounds("x");
+  c = c.getBounds("y");
+  return {
+    xi: [c.max, a.max],
+    kh: [c.min, a.min]
+  }
+}
+function gvjs_Nla(a, b, c) {
+  var d = new gvjs_5(b.hza * a.lw.width + a.lw.left,b.pza * a.lw.height + a.lw.top,b.scale * a.lw.width,b.scale * a.lw.height)
+    , e = a.BK[c]
+    , f = gvjs_h_(b.Ju, e);
+  return {
+    id: String(c),
+    Ju: f,
+    D0: b.Ju,
+    XD: d,
+    features: gvjs_v(b.features, function(g) {
+      return gvjs_i_(a, f, d, e, g)
+    })
+  }
+}
+function gvjs_i_(a, b, c, d, e) {
+  for (a = gvjs_Ola(a, gvjs_Rz(gvjs_Oz(e.polygons), gvjs_Oz(e.Rm))); a[1] > b.xi[1]; )
+    a[1] -= 360;
+  for (; a[1] < b.kh[1]; )
+    a[1] += 360;
+  return {
+    id: e.id,
+    center: gvjs_j_(b, c, d, a),
+    polygons: gvjs_v(e.polygons, function(f) {
+      return gvjs_k_(b, c, d, f)
+    }),
+    Rm: gvjs_v(e.Rm, function(f) {
+      return gvjs_k_(b, c, d, f)
+    }),
+    QO: "__DISPUTED__All" != e.id
+  }
+}
+function gvjs_Ola(a, b) {
+  var c = 0
+    , d = 0
+    , e = 0;
+  gvjs_Pz(b, function(f) {
+    gvjs_u(f.pL, function(g) {
+      c += g[0];
+      d += gvjs_3y(g[1], 360);
+      e++
+    }, this)
+  }, a);
+  return [c / e, d / e]
+}
+function gvjs_k_(a, b, c, d) {
+  return {
+    pL: gvjs_l_(a, b, c, d.pL),
+    SI: gvjs_v(d.SI, function(e) {
+      return gvjs_l_(a, b, c, e)
+    })
+  }
+}
+function gvjs_l_(a, b, c, d) {
+  return {
+    points: gvjs_v(d, function(e) {
+      return gvjs_j_(a, b, c, e)
+    })
+  }
+}
+function gvjs_j_(a, b, c, d) {
+  var e = a.kh;
+  a = a.xi;
+  var f = b.width
+    , g = b.height
+    , h = b.left;
+  b = b.top;
+  c = c.project(d)[0];
+  return [h + f * (c.x - e[1]) / (a[1] - e[1]), b + g * (1 - (c.y - e[0]) / (a[0] - e[0]))]
+}
+function gvjs_Pla(a, b) {
+  var c = [];
+  a.Nq = [];
+  for (var d = gvjs_v(a.FF, function(l) {
+    return l.NX
+  }), e = 0; e < b.length; ++e) {
+    var f = b[e]
+      , g = {
+      location: f,
+      SX: {}
+    };
+    if (null != f) {
+      f = gvjs_m_(a, e, f, d);
+      gvjs_Me(c, f);
+      for (var h = 0; h < f.length; h++) {
+        var k = f[h];
+        g.SX[k.Xo] = k
+      }
+    }
+    a.Nq.push(g)
+  }
+  gvjs_Qla(c);
+  return c
+}
+function gvjs_Qla(a) {
+  for (var b = 0; b < a.length; b++) {
+    for (var c = a[b], d = new gvjs_z(c.x,c.y), e = 0, f = 0; f < a.length; f++)
+      if (b != f) {
+        var g = a[f]
+          , h = gvjs_cz(d, new gvjs_z(g.x,g.y));
+        h < c.size + g.size && (e += c.size + g.size - h)
+      }
+    c.hD = e > c.size
+  }
+}
+function gvjs_m_(a, b, c, d) {
+  var e = a.qxa(b)
+    , f = a.w8(b);
+  if (null == f)
+    return [];
+  f = new gvjs_3({
+    stroke: a.bta,
+    strokeWidth: a.cta,
+    fill: f,
+    fillOpacity: a.ata
+  });
+  var g = parseFloat(c.lat)
+    , h = [];
+  c = parseFloat(c.lng);
+  c = [c, c + 360, c - 360];
+  for (var k = 0; k < d.length; ++k) {
+    var l = d[k]
+      , m = a.BK[k]
+      , n = l.D0;
+    if (!(g < n.kh[0] || g > n.xi[0])) {
+      for (var p = 0; p < c.length; ++p) {
+        var q = c[p];
+        if (!(q < n.kh[1] || q > n.xi[1])) {
+          q = gvjs_j_(l.Ju, l.XD, m, [g, q]);
+          var r = String(b + "-" + l.id + "-" + p)
+            , t = gvjs_vZ;
+          if (null != a.gb.FJ && 0 <= a.gb.FJ)
+            t = a.Z.Ha(b, a.gb.FJ);
+          else if (null != a.gb.fG && 0 <= a.gb.fG)
+            t = a.Z.Ha(b, a.gb.fG);
+          else if (null != a.gb.KK && 0 <= a.gb.KK)
+            t = a.Z.Ha(b, a.gb.KK);
+          else if (null != a.gb.sD && null != a.gb.yD && 0 <= a.gb.sD && 0 <= a.gb.yD) {
+            t = a.Z.getValue(b, a.gb.sD);
+            var u = a.Z.getValue(b, a.gb.yD);
+            t = gvjs_n_(t, "S", "N") + " " + gvjs_n_(u, "W", "E")
+          }
+          h.push({
+            Xo: r,
+            label: t,
+            oj: b,
+            x: q[0],
+            y: q[1],
+            size: e,
+            brush: f,
+            hD: !1
+          })
+        }
+      }
+      if (0 < h.length)
+        break
+    }
+  }
+  return h
+}
+function gvjs_Rla(a, b, c) {
+  var d = a.Nq
+    , e = d[c]
+    , f = e.SX[b];
+  if (!f.hD)
+    return null;
+  var g = Number(b.split("-")[1])
+    , h = a.FF[g]
+    , k = a.BK[g]
+    , l = gvjs_L(a.m, "magnifyingGlass.zoomFactor")
+    , m = a.Xsa
+    , n = m.xW(e.location, h.NX, l);
+  e = new gvjs_z(f.x,f.y);
+  var p = gvjs_Fla(m, e);
+  k = gvjs_h_(n, k);
+  var q = new gvjs_d_;
+  c = {
+    id: g + "-" + c + "-mag",
+    Ju: k,
+    D0: n,
+    XD: p,
+    features: gvjs_v(h.features, function(r) {
+      return gvjs_i_(a, n, p, q, r)
+    })
+  };
+  g = [];
+  for (h = 0; h < d.length; h++)
+    k = d[h].location,
+    null != k && gvjs_Me(g, gvjs_m_(a, h, k, [c]));
+  return {
+    Xo: b,
+    Bca: e,
+    view: c,
+    FD: g
+  }
+}
+function gvjs_o_(a, b) {
+  if (!a.kra || null == a.rs || !a.rs.pl)
+    return null;
+  var c = a.ica.fontSize
+    , d = a.ms.width
+    , e = a.ms.height
+    , f = {
+    top: 0,
+    left: 0,
+    width: a.VQ == gvjs_S ? d * a.fca : e * a.fca,
+    height: 1.5 * c,
+    orientation: a.VQ,
+    ja: a.ica,
+    zca: gvjs_rt,
+    numberFormat: a.G1
+  };
+  f.top = a.XQ === gvjs_AZ || "top_right" === a.XQ ? 3 * c : a.VQ === gvjs_U ? e - c - f.width : e - c - f.height;
+  f.left = a.XQ === gvjs_AZ || a.XQ === gvjs_lZ ? .5 * c : a.VQ == gvjs_U ? d - c - f.height : d - c - f.width;
+  f.left += a.ms.left;
+  f.top += a.ms.top;
+  return gvjs_0H(a.rs, f, b, a.Zd)
+}
+function gvjs_p_(a, b) {
+  for (var c = null, d = 0; d < a.Z.ca(); ++d) {
+    var e = a.Z.getValue(d, b);
+    c = gvjs_8B(c, e)
+  }
+  return c
+}
+function gvjs_Jla(a) {
+  var b = a.gb.Yu;
+  return null != b ? function(c) {
+      c = a.Z.getValue(c, b);
+      return null != c ? gvjs_XH(a.rs, c) : a.sO
+    }
+    : function() {
+      return a.sO
+    }
+}
+function gvjs_Kla(a) {
+  var b = a.gb.XE;
+  return null != b ? function(c) {
+      c = a.Z.getValue(c, b);
+      return gvjs_MI(a.tL, c)
+    }
+    : function() {
+      return a.Dma
+    }
+}
+function gvjs_e_(a) {
+  var b = a.gb.Yu;
+  if (null == b)
+    return null;
+  b = gvjs_p_(a, b);
+  return gvjs__H(a.m, b)
+}
+function gvjs_f_(a) {
+  var b = a.gb.XE;
+  b = null != b ? gvjs_p_(a, b) : null;
+  return gvjs_NI(a.m, b)
+}
+function gvjs_Sla(a, b) {
+  var c = {
+    NC: [],
+    OC: []
+  };
+  null != b.ff && (c.NC = [b.ff]);
+  null != b.iI && (c.OC = [b.iI]);
+  c.qu = [];
+  var d = a.wz && (a.tF === gvjs_ut || a.tF === gvjs_Jw);
+  gvjs_u(gvjs_bo(b.selection), function(h) {
+    var k = gvjs_q_(this, h, !1)
+      , l = this.Zd
+      , m = this.pu.Hd.fontSize
+      , n = new gvjs_B(0,this.ga - 1,this.Pa - 1,0)
+      , p = this.Nq[h];
+    h = (h = this.R2[h]) && gvjs_Lla(this, h);
+    var q = null
+      , r = null;
+    h ? (c.NC.push(h.id),
+    d && (q = r = new gvjs_z(h.center[0],h.center[1]),
+      c.qu.push(gvjs_kG(k, l, !1, r, n, q, void 0, this.Q_)))) : p && gvjs_w(p.SX, function(t, u) {
+      c.OC.push(u);
+      d && c.qu.push(gvjs_kG(k, l, !1, new gvjs_z(t.x - m,t.y - m), n, new gvjs_z(t.x,t.y), void 0, this.Q_))
+    }, this)
+  }, a);
+  if (null != b.Nj) {
+    if (a.wz && (a.tF === gvjs_ut || a.tF === gvjs_xu)) {
+      var e = gvjs_q_(a, b.Nj.oj, b.Nj.gJ)
+        , f = a.pu.Hd.fontSize
+        , g = new gvjs_z(b.Nj.origin.x,b.Nj.origin.y);
+      c.qu.push(gvjs_kG(e, a.Zd, !1, new gvjs_z(g.x - f,g.y - f), new gvjs_B(0,a.ga - 1,a.Pa - 1,0), g, void 0, a.Q_))
+    }
+    null != a.gb.Yu && (e = {
+      value: a.Z.getValue(b.Nj.oj, a.gb.Yu)
+    },
+      c.Vi = gvjs_o_(a, [e]))
+  }
+  null != b.iw && (c.HJ = gvjs_Rla(a, b.iw.Xo, b.iw.oj));
+  return c
+}
+function gvjs_n_(a, b, c) {
+  b = 0 <= a ? c : b;
+  a = Math.abs(a);
+  c = Math.floor(a);
+  a = 60 * (a - c);
+  var d = Math.floor(a);
+  return c + "\u00b0" + d + "'" + Math.round(60 * (a - d)) + '"' + b
+}
+function gvjs_q_(a, b, c) {
+  var d = a.gb
+    , e = a.Z
+    , f = {
+    entries: []
+  };
+  if (null != d.FJ)
+    var g = e.Ha(b, d.FJ);
+  else
+    switch (d.JV) {
+      case gvjs_9c:
+        c = e.getValue(b, d.sD);
+        g = e.getValue(b, d.yD);
+        g = gvjs_n_(c, "S", "N") + " " + gvjs_n_(g, "W", "E");
+        break;
+      case gvjs_xd:
+        g = e.Ha(b, d.KK);
+        c && (g = gvjs_NB(a.oya, g));
+        break;
+      case "address":
+        g = e.Ha(b, d.fG);
+        break;
+      default:
+        g = ""
+    }
+  a.qya && (c = gvjs_hG(g, a.pu.bold),
+    f.entries.push(c));
+  c = null != d.m5 ? e.getStringValue(b, d.m5) : null;
+  if (null != c)
+    if (d = d.m5,
+    e.Bd(d, gvjs_av) || e.getProperty(b, d, gvjs_av))
+      f.entries.push(gvjs_hG(c, a.pu.Hd, void 0, void 0, void 0, void 0, void 0, !0));
+    else
+      for (b = c.split("\n"),
+             e = 0; e < b.length; e++)
+        d = gvjs_hG(b[e], a.pu.Hd),
+          f.entries.push(d);
+  else
+    null != d.Yu && (c = e.Ga(d.Yu),
+      g = e.Ha(b, d.Yu),
+      c = gvjs_hG(g, a.pu.bold, c, a.pu.Hd),
+      f.entries.push(c)),
+    null != d.XE && d.XE != d.Yu && (c = e.Ga(d.XE),
+      b = e.Ha(b, d.XE),
+      a = gvjs_hG(b, a.pu.bold, c, a.pu.Hd),
+      f.entries.push(a));
+  return f
+}
+function gvjs_g_(a, b) {
+  var c = b === gvjs_f ? [255, 255, 255] : gvjs_vj(b);
+  c = gvjs_uj(gvjs_1z(c, .1));
+  return {
+    fill: new gvjs_3({
+      stroke: c,
+      fill: b
+    }),
+    Rm: new gvjs_3({
+      stroke: gvjs_f,
+      pattern: new gvjs_$x(gvjs_rw,b,b == a.O7 ? gvjs_Br : a.O7)
+    }),
+    border: new gvjs_3({
+      stroke: c
+    })
+  }
+}
+;function gvjs_r_(a, b, c, d, e, f, g, h, k) {
+  gvjs_F.call(this);
+  var l = this;
+  this.cm = a;
+  this.m = b;
+  this.ga = c;
+  this.Pa = d;
+  this.gb = f;
+  this.K = g;
+  this.Vm = null;
+  this.O2 = !1;
+  this.uva = h;
+  this.Xm = k;
+  this.L4 = !1;
+  this.VX = null;
+  this.X6 = !1;
+  this.zb = new gvjs_KK(function() {
+      return l.Qt()
+    }
+  );
+  this.CD = new gvjs_9F(3);
+  this.uO = [!1, !1, !1];
+  this.BD = new gvjs_Ila(this.m,this.ga,this.Pa,this.cm.me,e,this.gb);
+  this.pca = new gvjs_9Z(a,b,g,this.zb);
+  this.Q9 = gvjs_K(b, "enableRegionInteractivity", f.ZX == gvjs_yd);
+  this.M9 = gvjs_K(b, "enableMarkerInteractivity", f.ZX == gvjs_bd);
+  this.S2()
+}
+gvjs_o(gvjs_r_, gvjs_F);
+gvjs_ = gvjs_r_.prototype;
+gvjs_.U3 = function(a, b) {
+  var c = this.BD
+    , d = c.m;
+  c.FF = [];
+  c.BK = [];
+  for (var e = [], f = 0, g = a.views.length; f < g; f++) {
+    var h = a.views[f]
+      , k = c.I2.Zc();
+    k.boundingBox = {
+      lo: h.Ju.kh,
+      hi: h.Ju.xi
+    };
+    k = new c.I2.constructor(k);
+    c.BK.push(k);
+    k = gvjs_Nla(c, h, f);
+    e.push(k);
+    c.FF.push({
+      features: h.features,
+      NX: k
+    })
+  }
+  a = {
+    width: c.ga,
+    height: c.Pa,
+    $sa: c.lw,
+    FE: gvjs_J(d, gvjs_Kw, gvjs_Ww, gvjs_lC),
+    CEa: c.tF,
+    xG: gvjs_qy(d, gvjs_ht),
+    baa: d.mz(gvjs_Qu),
+    title: {
+      text: gvjs_J(d, gvjs_fx),
+      ja: gvjs_ry(d, gvjs_ix, {
+        bb: c.PX,
+        fontSize: c.n9
+      }),
+      lines: [],
+      align: gvjs_2,
+      tooltip: ""
+    },
+    views: e,
+    qC: gvjs_Mla(c, a),
+    NC: [],
+    OC: [],
+    FD: [],
+    Vi: null,
+    HJ: null,
+    Hj: c.PX
+  };
+  this.nL(0, a);
+  this.L4 = !0;
+  this.Xm("mapLoaded", b);
+  null != this.VX ? this.VX() : this.Qt()
+}
+;
+function gvjs_Tla(a, b, c, d, e, f) {
+  function g() {
+    a.X6 = d;
+    if (null != e) {
+      a.Vm = null;
+      var h = a.BD;
+      h.Z = e;
+      h.rs = gvjs_e_(h);
+      h.tL = gvjs_f_(h)
+    }
+    null != f && (a.K = f,
+      a.pca.K = f);
+    h = a.BD;
+    h.R2 = [];
+    for (var k = {}, l = 0; l < h.Z.ca(); ++l) {
+      var m = b[l];
+      h.R2.push(m);
+      if (null != m) {
+        var n = h.w8(l);
+        null != n && (k[m] = {
+          oj: l,
+          Rb: gvjs_g_(h, n)
+        })
+      }
+    }
+    h = {
+      qC: k,
+      FD: gvjs_Pla(h, c),
+      Vi: gvjs_o_(h, [])
+    };
+    a.nL(1, h);
+    a.Qt()
+  }
+  a.O2 = !1;
+  a.L4 ? g() : a.VX = g
+}
+gvjs_.setSelection = function(a) {
+  this.K.selection.setSelection(a);
+  gvjs_LK(this.zb, 1)
+}
+;
+gvjs_.getSelection = function() {
+  return this.K.selection.getSelection()
+}
+;
+gvjs_.Qt = function() {
+  if (this.L4) {
+    if (null == this.Vm || !this.Vm.equals(this.K)) {
+      var a = gvjs_Sla(this.BD, this.K);
+      this.nL(2, a)
+    }
+    a = this.CD.compact();
+    if (this.uO[0])
+      gvjs_SZ(this.cm, a);
+    else if (this.uO[1]) {
+      var b = this.cm;
+      gvjs_4Z(b, a);
+      gvjs_0Z(b, a);
+      gvjs__Z(b, a, !0)
+    } else
+      gvjs__Z(this.cm, a);
+    this.uO = [!1, !1, !1];
+    this.Vm = this.K.clone();
+    !this.O2 && this.X6 && (this.uva(),
+      this.O2 = !0)
+  }
+}
+;
+function gvjs_s_(a, b) {
+  null != a.K.Nj && b.data.xb && (a.K.Nj.origin = {
+    x: b.data.xb.x,
+    y: b.data.xb.y
+  },
+    gvjs_LK(a.zb, 3))
+}
+gvjs_.et = function(a, b) {
+  a = this.CD.compact().FE == gvjs_Ww;
+  null != b ? (gvjs_ty(this.K.selection, b, a),
+    this.Xm(gvjs_k, {})) : (b = 0 < this.K.selection.getSelection().length,
+    this.K.selection.clear(),
+  b && this.Xm(gvjs_k, {}));
+  this.zb && gvjs_LK(this.zb, 50)
+}
+;
+function gvjs_t_(a, b) {
+  var c = a.CD.compact();
+  return a.pca.handleEvent(b, c ? c.HJ : null)
+}
+gvjs_.S2 = function() {
+  var a = this;
+  this.cm.o(gvjs_nZ, function(b) {
+    if (!gvjs_t_(a, b) && a.Q9) {
+      var c = b.data.featureId;
+      null !== c && a.Xm("regionClick", {
+        region: c
+      });
+      c = gvjs_u_(a, c);
+      a.et(b, c)
+    }
+  });
+  this.cm.o(gvjs_oZ, function(b) {
+    if (!gvjs_t_(a, b) && a.Q9) {
+      var c = b.data.featureId;
+      null !== c && (b.data.Ro ? (a.K.ff = c,
+        c = gvjs_u_(a, c),
+        a.K.Nj = null != c ? {
+          oj: c,
+          gJ: b.data.gJ,
+          origin: {
+            x: b.data.xb.x,
+            y: b.data.xb.y
+          }
+        } : null) : (a.K.ff = null,
+        a.K.Nj = null),
+        gvjs_LK(a.zb, 50))
+    }
+  });
+  this.cm.o(gvjs_pZ, function(b) {
+    gvjs_t_(a, b) || gvjs_s_(a, b)
+  });
+  this.cm.o(gvjs_wZ, function(b) {
+    gvjs_t_(a, b) || a.M9 && a.et(b, b.data.oj)
+  });
+  this.cm.o(gvjs_xZ, function(b) {
+    !gvjs_t_(a, b) && a.M9 && (b.data.Ro ? (a.K.iI = b.data.Xo,
+      a.K.Nj = {
+        oj: b.data.oj,
+        gJ: !1,
+        origin: {
+          x: b.data.xb.x,
+          y: b.data.xb.y
+        }
+      }) : (a.K.iI = null,
+      a.K.Nj = null),
+      gvjs_LK(a.zb, 50))
+  });
+  this.cm.o("markerMove", function(b) {
+    gvjs_s_(a, b)
+  })
+}
+;
+function gvjs_u_(a, b) {
+  if (null === b)
+    return null;
+  a = a.CD.compact();
+  return a.qC[b] ? a.qC[b].oj : null
+}
+gvjs_.nL = function(a, b) {
+  gvjs_$F(this.CD, a, b);
+  this.uO[a] = !0
+}
+;
+gvjs_.M = function() {
+  gvjs_E(this.zb);
+  this.zb = null;
+  gvjs_E(this.cm);
+  this.cm = null;
+  gvjs_E(this.BD);
+  this.BD = null;
+  gvjs_F.prototype.M.call(this)
+}
+;
+var gvjs_v_ = {}
+  , gvjs_w_ = {}
+  , gvjs_x_ = null
+  , gvjs_y_ = null;
+function gvjs_Ula(a, b, c) {
+  "" !== a && (gvjs_y_ = a = a.replace(/\/$/, ""));
+  gvjs_z_("info", "mapList", function(d) {
+    gvjs_A_ = d;
+    b()
+  }, c)
+}
+function gvjs_Vla(a) {
+  gvjs_y_ = "https://www.gstatic.com/charts/geochart/" + a
+}
+gvjs_Vla("10");
+function gvjs_z_(a, b, c, d) {
+  gvjs_fn(gvjs_y_ + "/" + a + "/" + (b + ".js")).then(function(e) {
+    e = e.replace(/^[\s\S]*google_visualization_geochart_[^=]*\s*=\s*/g, "");
+    e = e.replace(/;[\s]*$/g, "");
+    e = JSON.parse(e);
+    c && c(e);
+    return e
+  }, function(e) {
+    d && d(e)
+  })
+}
+function gvjs_Wla(a, b) {
+  if (null == b)
+    throw Error("Callback is null or undefined");
+  var c = gvjs_Xla(a)
+    , d = gvjs_Yla(a);
+  if (void 0 !== gvjs_w_[d])
+    setTimeout(function() {
+      return b(gvjs_w_[d])
+    }, 0);
+  else if (void 0 !== gvjs_v_[d])
+    gvjs_v_[d].push(b);
+  else {
+    gvjs_v_[d] = [b];
+    var e = function(f) {
+      for (; gvjs_v_[d] && 0 < gvjs_v_[d].length; )
+        gvjs_v_[d].shift()(f)
+    };
+    gvjs_z_("mapfiles", c, function(f) {
+      f = {
+        views: gvjs_v(f.views, gvjs_Zla)
+      };
+      gvjs_w_[d] = f;
+      e(f)
+    }, function() {
+      e(null)
+    })
+  }
+}
+function gvjs__la(a) {
+  var b = null[gvjs_y_];
+  null != b ? a(b) : gvjs_z_("info", "boundingBoxes", function(c) {
+    b = gvjs_v(c, gvjs_0la);
+    a(b)
+  }, function() {
+    a(null)
+  })
+}
+function gvjs_Xla(a) {
+  var b = "";
+  "COM" != a.domain && (b = a.domain + "_");
+  return "" + b + a.region + "_" + gvjs_1la(a.resolution)
+}
+function gvjs_Yla(a) {
+  a = gvjs_Xla(a);
+  return gvjs_y_ + ":" + a
+}
+function gvjs_1la(a) {
+  null == gvjs_x_ && (gvjs_x_ = {
+    continents: "REGIONS",
+    subcontinents: "SUBREGIONS",
+    countries: gvjs_mT,
+    provinces: "PROVINCES",
+    metros: "METROS"
+  });
+  return gvjs_x_[a]
+}
+var gvjs_A_ = null;
+function gvjs_2la(a) {
+  if (!gvjs_A_)
+    return !1;
+  var b = a.domain
+    , c = a.region;
+  a = gvjs_1la(a.resolution);
+  if (b = gvjs_A_[b])
+    if (b = b[a])
+      return 0 <= gvjs_Iy(b, c);
+  return !1
+}
+function gvjs_Zla(a) {
+  for (var b = gvjs_v(a.features, gvjs_3la), c = {}, d = [], e = 0; e < b.length; e++) {
+    var f = b[e]
+      , g = f.id;
+    gvjs_hf(g, "__DISPUTED__") ? c[g] = f : d.push(f)
+  }
+  for (b = 0; b < d.length; b++)
+    e = d[b],
+      f = c["__DISPUTED__" + e.id],
+      e.Rm = f ? f.polygons : [];
+  if (c = c.__DISPUTED__All)
+    c.Rm = c.polygons,
+      d.push(c);
+  return {
+    features: d,
+    Ju: gvjs_4la(a.boundingBox),
+    hza: a.xoffset,
+    pza: a.yoffset,
+    scale: a.scale
+  }
+}
+function gvjs_3la(a) {
+  return {
+    id: a.id,
+    polygons: gvjs_v(a.polygons, gvjs_5la),
+    Rm: []
+  }
+}
+function gvjs_5la(a) {
+  return gvjs_ne(a) ? {
+    pL: gvjs_B_(a),
+    SI: []
+  } : {
+    pL: gvjs_B_(a.shell),
+    SI: gvjs_v(a.holes, gvjs_B_)
+  }
+}
+function gvjs_B_(a) {
+  return gvjs_v(a, function(b) {
+    return [gvjs_IZ(b[0]), parseFloat(b[1])]
+  })
+}
+function gvjs_4la(a) {
+  return {
+    xi: [gvjs_IZ(a.hi[0]), parseFloat(a.hi[1])],
+    kh: [gvjs_IZ(a.lo[0]), parseFloat(a.lo[1])]
+  }
+}
+function gvjs_0la(a) {
+  return {
+    region: a.region,
+    resolution: a.resolution,
+    domain: a.domain,
+    Uka: gvjs_v(a.boundingBoxes, gvjs_4la)
+  }
+}
+;function gvjs_C_(a, b, c, d) {
+  var e = gvjs_J(c, gvjs_xT);
+  if (e != gvjs_ub)
+    d(gvjs_D_(e, c));
+  else if (b.JV != gvjs_9c)
+    d(gvjs_D_(gvjs_CT, c));
+  else {
+    var f = c.cb(gvjs_yT, gvjs_DZ)
+      , g = c.cb(gvjs_mu)
+      , h = [];
+    for (e = 0; e < a.ca(); ++e)
+      h.push({
+        lat: a.getValue(e, b.sD),
+        lng: a.getValue(e, b.yD)
+      });
+    gvjs__la(function(k) {
+      if (k) {
+        a: {
+          for (var l = 0; l < k.length; ++l) {
+            var m = k[l];
+            if (null == f || m.resolution == f)
+              if (null == g || m.domain == g) {
+                for (var n = !0, p = 0; p < h.length; ++p) {
+                  for (var q = h[p], r = !1, t = m.Uka, u = 0; u < t.length; ++u)
+                    if (gvjs_6la(q, t[u])) {
+                      r = !0;
+                      break
+                    }
+                  if (!r) {
+                    n = !1;
+                    break
+                  }
+                }
+                if (n) {
+                  k = {
+                    region: m.region,
+                    resolution: m.resolution,
+                    domain: m.domain
+                  };
+                  break a
+                }
+              }
+          }
+          k = null
+        }
+        null != k ? d(k) : d(gvjs_D_(gvjs_CT, c))
+      } else
+        d(null)
+    })
+  }
+}
+function gvjs_D_(a, b) {
+  var c = gvjs_J(b, gvjs_yT, gvjs_qT, gvjs_DZ);
+  b = gvjs_J(b, gvjs_mu);
+  a = {
+    region: a,
+    resolution: c,
+    domain: b
+  };
+  return gvjs_2la(a) || "COM" != a.domain && (a.domain = "COM",
+    gvjs_2la(a)) ? a : null
+}
+function gvjs_6la(a, b) {
+  return a.lat > b.kh[0] && a.lat < b.xi[0] && gvjs_Fe([-360, 0, 360], function(c) {
+    return a.lng + c > b.kh[1] && a.lng + c < b.xi[1]
+  })
+}
+;var gvjs_7la = gvjs_D.removeAll;
+function gvjs_E_(a) {
+  gvjs_Qn.call(this, a);
+  this.Ak = this.ab = null;
+  this.Hz = new gvjs_NZ(this.Hg);
+  this.f0 = "";
+  this.eb = this.Bk = null
+}
+gvjs_o(gvjs_E_, gvjs_Qn);
+function gvjs_8la(a) {
+  null == a && (a = {});
+  a = new gvjs_Aj([a, gvjs_MZ]);
+  var b = gvjs_J(a, gvjs_xT);
+  return null != gvjs_D_(b, a)
+}
+function gvjs_F_(a, b, c) {
+  a = a || "";
+  var d = gvjs_G_ && a === gvjs_H_;
+  gvjs_H_ = a;
+  b ? d ? b() : gvjs_Ula(a, function() {
+    gvjs_G_ = !0;
+    b()
+  }, c) : gvjs_G_ = !1
+}
+gvjs_ = gvjs_E_.prototype;
+gvjs_.Rd = function(a, b, c, d) {
+  var e = this;
+  c = void 0 === c ? {} : c;
+  gvjs_7la(this.container);
+  this.Bk = a;
+  gvjs_E(this.Hz);
+  this.Hz = new gvjs_NZ(this.Hg);
+  c = gvjs_Li(gvjs_Ii(c));
+  a = [c];
+  var f = c.theme || [];
+  Array.isArray(f) || (f = [f]);
+  for (var g = 0; g < f.length; ++g) {
+    var h = void 0;
+    if (typeof f[g] === gvjs_l)
+      h = gvjs_4F(f[g]);
+    else if (gvjs_r(f[g]))
+      h = f[g];
+    else
+      throw Error("Theme should be a theme name or an options object.");
+    a.push(h)
+  }
+  a.push(gvjs_MZ);
+  var k = gvjs_7K()
+    , l = [];
+  gvjs_u(a, function(t) {
+    l.push.apply(l, gvjs_Vz(t, k))
+  });
+  var m = new gvjs_Aj(a)
+    , n = new gvjs_CZ(d);
+  this.eb = this.Bv(this.container, m);
+  d = gvjs_J(m, "displayMode", gvjs_ub, gvjs_mla);
+  var p = (new gvjs_Tl).Ac(b, d, this.Hg);
+  if (null != p) {
+    var q = gvjs_Bi({
+      options: c,
+      format: p,
+      size: this.eb
+    })
+      , r = this.Bk(function(t) {
+      if (null == t)
+        throw Error(gvjs_jZ);
+      gvjs_9la(this, b, p, m, q, n, t)
+    }, this);
+    c = gvjs_H_;
+    c = gvjs_J(m, "mapsSource", c);
+    "" === c && (d = gvjs_J(m, "geochartVersion", "10"),
+      gvjs_Vla(d));
+    d = gvjs_J(m, "regioncoderVersion", "0");
+    gvjs_PT(d);
+    gvjs_F_(c, function() {
+      l.length && e.Lh ? (e.Lh.promise.then(function() {
+        gvjs_C_(b, p, m, r)
+      }, null, e),
+        gvjs_sy(e, function() {
+          gvjs_C_(b, p, m, r)
+        }),
+        new gvjs_6K(l,e.Lh)) : gvjs_C_(b, p, m, r)
+    })
+  }
+}
+;
+gvjs_.ah = function() {
+  if (!this.Ak)
+    throw Error("Must draw chart before calling getImageURI.");
+  var a = gvjs_3g(this.container).createElement(gvjs_Ob)
+    , b = gvjs_1B(a, this.eb)
+    , c = new gvjs_MB(a)
+    , d = new gvjs_rB(a,b);
+  b = this.Ak;
+  c = new gvjs_RZ(c,d,b.cm.gb);
+  b = b.CD.compact();
+  gvjs_SZ(c, b);
+  gvjs_4Z(c, b);
+  gvjs_0Z(c, b);
+  gvjs__Z(c, b, !0);
+  gvjs__Z(c, b);
+  return a.childNodes[0].toDataURL(gvjs_bv)
+}
+;
+gvjs_.Bv = function(a, b) {
+  a = this.La(b, -1);
+  b = this.getHeight(b, -1);
+  -1 == a && -1 == b ? (a = 556,
+    b = 347) : -1 == a ? a = Math.round(556 * b / 347) : -1 == b && (b = Math.round(347 * a / 556));
+  return new gvjs_A(a,b)
+}
+;
+function gvjs_9la(a, b, c, d, e, f, g) {
+  var h = gvjs_K(d, "showGeocodeWarnings");
+  if (a.f0 == e)
+    gvjs_$la(a, !1, d, b, c, g, h, f, e);
+  else {
+    if (null != a.ab)
+      a.ab.update(a.eb, a.Bk);
+    else {
+      var k = gvjs_K(d, gvjs_Eu);
+      a.ab = new gvjs_3B(a.container,a.eb,a.Bk,k)
+    }
+    a.ab.rl(function() {
+      var l = a.ab.Oa()
+        , m = a.ab.yq();
+      gvjs_ama(a, b, c, d, e, f, g, h, m, l)
+    }, a.Bk)
+  }
+}
+function gvjs_ama(a, b, c, d, e, f, g, h, k, l) {
+  k = new gvjs_RZ(k,l,c);
+  null != a.Ak && gvjs_E(a.Ak);
+  l = a.eb;
+  gvjs_E(a.Ak);
+  a.Ak = new gvjs_r_(k,d,l.width,l.height,b,c,f,function() {
+      gvjs_I(a, gvjs_i, {})
+    }
+    ,function(m, n) {
+      gvjs_I(a, m, n)
+    }
+  );
+  gvjs_$la(a, !0, d, b, c, g, h, f, e)
+}
+function gvjs_$la(a, b, c, d, e, f, g, h, k) {
+  function l() {
+    gvjs_vla(a.Hz, d, e, f, g, n)
+  }
+  c = gvjs_J(c, "geocodingContext", gvjs_xT, gvjs_tla);
+  var m = "bounds" === c || c === gvjs_ut
+    , n = a.Bk(function(p, q, r) {
+    gvjs_Tla(a.Ak, p, q, r, d, h)
+  });
+  a.Hz.nI = c;
+  b && (a.Hz.aF = null,
+    gvjs_Wla(f, a.Bk(function(p) {
+      null != p ? (a.Ak.U3(p, f),
+      m && (a.Hz.U3(p),
+        l()),
+        a.f0 = k) : a.Hg.Sc(gvjs_jZ)
+    })));
+  m || (a.Hz.aF = null,
+    l())
+}
+gvjs_.setSelection = function(a) {
+  null != this.Ak ? this.Ak.setSelection(a) : this.Hg.Sc(gvjs_kZ)
+}
+;
+gvjs_.getSelection = function() {
+  if (null != this.Ak)
+    return this.Ak.getSelection();
+  this.Hg.Sc(gvjs_kZ);
+  return []
+}
+;
+gvjs_.He = function() {
+  this.f0 = "";
+  gvjs_E(this.Ak);
+  this.Ak = null;
+  gvjs_E(this.ab);
+  this.ab = null
+}
+;
+var gvjs_H_ = ""
+  , gvjs_G_ = !1;
+gvjs_q(gvjs_nc, gvjs_E_, void 0);
+gvjs_E_.prototype.draw = gvjs_E_.prototype.draw;
+gvjs_E_.prototype.getImageURI = gvjs_E_.prototype.ah;
+gvjs_E_.prototype.setSelection = gvjs_E_.prototype.setSelection;
+gvjs_E_.prototype.getSelection = gvjs_E_.prototype.getSelection;
+gvjs_E_.prototype.clearChart = gvjs_E_.prototype.Jb;
+gvjs_q(gvjs_qZ, gvjs_8la, void 0);
+gvjs_q(gvjs_rZ, gvjs_F_, void 0);
+gvjs_q(gvjs_nc, gvjs_E_, void 0);
+gvjs_E_.prototype.draw = gvjs_E_.prototype.draw;
+gvjs_E_.prototype.getImageURI = gvjs_E_.prototype.ah;
+gvjs_E_.prototype.setSelection = gvjs_E_.prototype.setSelection;
+gvjs_E_.prototype.getSelection = gvjs_E_.prototype.getSelection;
+gvjs_E_.prototype.clearChart = gvjs_E_.prototype.Jb;
+gvjs_q(gvjs_qZ, gvjs_8la, void 0);
+gvjs_q(gvjs_rZ, gvjs_F_, void 0);

--- a/cypress/fixtures/charts/jsapi_compiled_graphics_module
+++ b/cypress/fixtures/charts/jsapi_compiled_graphics_module
@@ -1,0 +1,1182 @@
+var gvjs_Qo = " 0 0 1 "
+  , gvjs_Ro = "0%"
+  , gvjs_So = "100%"
+  , gvjs_To = "BUTTON"
+  , gvjs_Uo = "SELECT"
+  , gvjs_Vo = "TEXTAREA"
+  , gvjs_Wo = "background"
+  , gvjs_Xo = "baseline"
+  , gvjs_Yo = "blur"
+  , gvjs_Zo = "chartArea.bottom"
+  , gvjs__o = "chartArea.height"
+  , gvjs_0o = "chartArea.left"
+  , gvjs_1o = "chartArea.right"
+  , gvjs_2o = "chartArea.top"
+  , gvjs_3o = "chartArea.width"
+  , gvjs_4o = "circle"
+  , gvjs_5o = "clip-path"
+  , gvjs_6o = "corners.bottomleft.rx"
+  , gvjs_7o = "corners.bottomleft.ry"
+  , gvjs_8o = "corners.bottomright.rx"
+  , gvjs_9o = "corners.bottomright.ry"
+  , gvjs_$o = "corners.rx"
+  , gvjs_ap = "corners.ry"
+  , gvjs_bp = "corners.topleft.rx"
+  , gvjs_cp = "corners.topleft.ry"
+  , gvjs_dp = "corners.topright.rx"
+  , gvjs_ep = "corners.topright.ry"
+  , gvjs_fp = "datatable"
+  , gvjs_gp = "datum"
+  , gvjs_hp = "defs"
+  , gvjs_ip = "discrete"
+  , gvjs_jp = "ellipse"
+  , gvjs_R = "end"
+  , gvjs_kp = "feComponentTransfer"
+  , gvjs_lp = "feGaussianBlur"
+  , gvjs_mp = "feMergeNode"
+  , gvjs_np = "fill"
+  , gvjs_op = "fill-opacity"
+  , gvjs_pp = "fill.color"
+  , gvjs_qp = "fill.opacity"
+  , gvjs_rp = "fillColor"
+  , gvjs_sp = "fillOpacity"
+  , gvjs_tp = "filter"
+  , gvjs_up = "finishAnimation"
+  , gvjs_vp = "font.family"
+  , gvjs_wp = "font.size"
+  , gvjs_xp = "fontFamily"
+  , gvjs_yp = "fontName"
+  , gvjs_zp = "fontSize"
+  , gvjs_Ap = "getcontext"
+  , gvjs_Bp = "gradient"
+  , gvjs_Cp = "group"
+  , gvjs_Dp = "halign"
+  , gvjs_S = "horizontal"
+  , gvjs_Ep = "http://www.w3.org/2000/svg"
+  , gvjs_Fp = "in"
+  , gvjs_Gp = "italic"
+  , gvjs_Hp = "linear"
+  , gvjs_Ip = "linearGradient"
+  , gvjs_Jp = "offset"
+  , gvjs_Kp = "opacity"
+  , gvjs_Lp = "path"
+  , gvjs_Mp = "playAnimation"
+  , gvjs_Np = "point"
+  , gvjs_Op = "pointShape"
+  , gvjs_T = "px"
+  , gvjs_Pp = "rabl-use-parent"
+  , gvjs_Qp = "rect"
+  , gvjs_Rp = "redraw"
+  , gvjs_Sp = "rotate"
+  , gvjs_Tp = "rotate("
+  , gvjs_Up = "rtl"
+  , gvjs_Vp = "shadow.opacity"
+  , gvjs_Wp = "shadow.radius"
+  , gvjs_Xp = "shadow.xoffset"
+  , gvjs_Yp = "shadow.yoffset"
+  , gvjs_Zp = "slice"
+  , gvjs__p = "stop"
+  , gvjs_0p = "stroke"
+  , gvjs_1p = "stroke-opacity"
+  , gvjs_2p = "stroke-width"
+  , gvjs_3p = "stroke.color"
+  , gvjs_4p = "stroke.opacity"
+  , gvjs_5p = "stroke.width"
+  , gvjs_6p = "strokeColor"
+  , gvjs_7p = "strokeOpacity"
+  , gvjs_8p = "strokeWidth"
+  , gvjs_9p = "svg"
+  , gvjs_$p = "text-anchor"
+  , gvjs_aq = "transform"
+  , gvjs_bq = "underline"
+  , gvjs_cq = 'unknown property on ellipse "'
+  , gvjs_dq = "url(#"
+  , gvjs_eq = "valign"
+  , gvjs_U = "vertical";
+function gvjs_V(a, b) {
+  return gvjs_2d[a] = b
+}
+gvjs_B.prototype.La = gvjs_V(10, function() {
+  return this.right - this.left
+});
+gvjs_Qn.prototype.La = gvjs_V(9, function(a, b) {
+  return a.bD(gvjs_Xd) || gvjs_Gh(this.container).width || b || 400
+});
+function gvjs_fq(a, b, c) {
+  gvjs_Ne(a, c, 0, b)
+}
+function gvjs_gq(a, b, c) {
+  b = gvjs_iaa(b, function(d, e) {
+    var f = {};
+    return f[e] = d,
+      f
+  }, c);
+  gvjs_mj(a, b)
+}
+function gvjs_hq(a, b, c) {
+  if (a.lN) {
+    var d = {};
+    gvjs_gq(d, a.lN[0].split("."), c);
+    c = d
+  }
+  for (var e = d = 0; e < b; e++)
+    e === a.AJ.length && a.AJ.push(0),
+      d += a.AJ[e];
+  a.AJ[b]++;
+  gvjs_fq(a.Gd, c, d)
+}
+function gvjs_iq(a, b) {
+  for (var c = gvjs_8d(Object.keys(b)), d = c.next(); !d.done; d = c.next()) {
+    d = d.value;
+    var e = b[d];
+    null != e && e instanceof Object && !Array.isArray(e) ? (a[d] = a[d] || {},
+      gvjs_iq(a[d], e)) : null != e && (a[d] = e)
+  }
+}
+function gvjs_jq(a) {
+  var b = void 0 === b ? {} : b;
+  gvjs_Ce(a.Gd, function(c) {
+    gvjs_iq(b, c)
+  });
+  return b
+}
+function gvjs_kq(a, b, c) {
+  return gvjs_Fj(a, gvjs_Lj, 0, b, c)
+}
+function gvjs_lq(a) {
+  var b = arguments.length;
+  if (1 == b && Array.isArray(arguments[0]))
+    return gvjs_lq.apply(null, arguments[0]);
+  for (var c = {}, d = 0; d < b; d++)
+    c[arguments[d]] = !0;
+  return c
+}
+var gvjs_ada = /<[^>]*>|&[^;]+;/g
+  , gvjs_bda = /[A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff]/
+  , gvjs_cda = /^[^A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff]*[\u0591-\u06ef\u06fa-\u08ff\u200f\ud802-\ud803\ud83a-\ud83b\ufb1d-\ufdff\ufe70-\ufefc]/
+  , gvjs_dda = /^http:\/\/.*/
+  , gvjs_eda = /\s+/
+  , gvjs_fda = /[\d\u06f0-\u06f9]/;
+function gvjs_mq(a, b) {
+  var c = 0
+    , d = 0
+    , e = !1;
+  a = (b ? a.replace(gvjs_ada, "") : a).split(gvjs_eda);
+  for (b = 0; b < a.length; b++) {
+    var f = a[b];
+    gvjs_cda.test(f) ? (c++,
+      d++) : gvjs_dda.test(f) ? e = !0 : gvjs_bda.test(f) ? d++ : gvjs_fda.test(f) && (e = !0)
+  }
+  return 0 == d ? e ? 1 : 0 : .4 < c / d ? -1 : 1
+}
+;/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+var gvjs_gda = function() {
+  if (gvjs_vg) {
+    var a = /Windows NT ([0-9.]+)/;
+    return (a = a.exec(gvjs_Rf)) ? a[1] : "0"
+  }
+  return gvjs_ug ? (a = /1[0|1][_.][0-9_.]+/,
+    (a = a.exec(gvjs_Rf)) ? a[0].replace(/_/g, ".") : "10") : gvjs_Eaa ? (a = /Android\s+([^\);]+)(\)|;)/,
+    (a = a.exec(gvjs_Rf)) ? a[1] : "") : gvjs_Faa || gvjs_Gaa || gvjs_Haa ? (a = /(?:iPhone|CPU)\s+OS\s+(\S+)/,
+    (a = a.exec(gvjs_Rf)) ? a[1].replace(/_/g, ".") : "") : ""
+}();
+function gvjs_nq(a) {
+  return (a = a.exec(gvjs_Rf)) ? a[1] : ""
+}
+var gvjs_oq = function() {
+  if (gvjs_Laa)
+    return gvjs_nq(/Firefox\/([0-9.]+)/);
+  if (gvjs_y || gvjs_rg || gvjs_qg)
+    return gvjs_Dg;
+  if (gvjs_Kg)
+    return gvjs_mg() ? gvjs_nq(/CriOS\/([0-9.]+)/) : gvjs_nq(/Chrome\/([0-9.]+)/);
+  if (gvjs_Lg && !gvjs_mg())
+    return gvjs_nq(/Version\/([0-9.]+)/);
+  if (gvjs_Ig || gvjs_Jg) {
+    var a = /Version\/(\S+).*Mobile\/(\S+)/.exec(gvjs_Rf);
+    if (a)
+      return a[1] + "." + a[2]
+  } else if (gvjs_Maa)
+    return (a = gvjs_nq(/Android\s+([0-9.]+)/)) ? a : gvjs_nq(/Version\/([0-9.]+)/);
+  return ""
+}();
+var gvjs_pq = {};
+function gvjs_qq() {
+  throw Error("Do not instantiate directly");
+}
+gvjs_qq.prototype.TN = null;
+gvjs_qq.prototype.getContent = function() {
+  return this.content
+}
+;
+gvjs_qq.prototype.toString = function() {
+  return this.content
+}
+;
+function gvjs_rq() {
+  gvjs_qq.call(this)
+}
+gvjs_t(gvjs_rq, gvjs_qq);
+gvjs_rq.prototype.eq = gvjs_pq;
+gvjs_y && gvjs_Eg(8);
+var gvjs_W = function(a) {
+  function b(c) {
+    this.content = c
+  }
+  b.prototype = a.prototype;
+  return function(c, d) {
+    c = new b(String(c));
+    void 0 !== d && (c.TN = d);
+    return c
+  }
+}(gvjs_rq)
+  , gvjs_sq = function(a) {
+  function b(c) {
+    this.content = c
+  }
+  b.prototype = a.prototype;
+  return function(c, d) {
+    c = String(c);
+    if (!c)
+      return "";
+    c = new b(c);
+    void 0 !== d && (c.TN = d);
+    return c
+  }
+}(gvjs_rq);
+var gvjs_tq = {
+  s: function(a, b, c) {
+    return isNaN(c) || "" == c || a.length >= Number(c) ? a : a = -1 < b.indexOf("-", 0) ? a + gvjs_eg(" ", Number(c) - a.length) : gvjs_eg(" ", Number(c) - a.length) + a
+  },
+  f: function(a, b, c, d, e) {
+    d = a.toString();
+    isNaN(e) || "" == e || (d = parseFloat(a).toFixed(e));
+    var f = 0 > Number(a) ? "-" : 0 <= b.indexOf("+") ? "+" : 0 <= b.indexOf(" ") ? " " : "";
+    0 <= Number(a) && (d = f + d);
+    if (isNaN(c) || d.length >= Number(c))
+      return d;
+    d = isNaN(e) ? Math.abs(Number(a)).toString() : Math.abs(Number(a)).toFixed(e);
+    a = Number(c) - d.length - f.length;
+    0 <= b.indexOf("-", 0) ? d = f + d + gvjs_eg(" ", a) : (b = 0 <= b.indexOf("0", 0) ? "0" : " ",
+      d = f + gvjs_eg(b, a) + d);
+    return d
+  },
+  d: function(a, b, c, d, e, f, g, h) {
+    return gvjs_tq.f(parseInt(a, 10), b, c, d, 0, f, g, h)
+  }
+};
+gvjs_tq.i = gvjs_tq.d;
+gvjs_tq.u = gvjs_tq.d;
+gvjs_lq(["A", "AREA", gvjs_To, "HEAD", gvjs_Na, "LINK", "MENU", "META", "OPTGROUP", "OPTION", "PROGRESS", gvjs_7a, gvjs_Uo, gvjs_5a, gvjs_Vo, "TITLE", "TRACK"]);
+function gvjs_uq() {}
+gvjs_uq.prototype.o = function(a, b) {
+  gvjs_vq(this, a);
+  this.cI[a].push(b);
+  return this
+}
+;
+gvjs_uq.prototype.Ab = function(a, b) {
+  gvjs_vq(this, a);
+  a = this.cI[a];
+  for (var c = null, d = 0, e = a.length; d < e; d++)
+    if (a[d] === b) {
+      c = d;
+      break
+    }
+  return null != c ? (a.splice(c, 1),
+    !0) : !1
+}
+;
+gvjs_uq.prototype.fireEvent = function(a, b) {
+  gvjs_vq(this, a);
+  a = this.cI[a];
+  for (var c = [], d = 0, e = a.length; d < e; d++)
+    c.push(a[d]);
+  for (d = 0; d < e; d++)
+    c[d].apply(this, b);
+  return 0 < e
+}
+;
+function gvjs_vq(a, b) {
+  if (!a.cI.hasOwnProperty(b))
+    throw 'event type "' + b + '" unknown.';
+}
+;function gvjs_wq(a) {
+  this.cI = {
+    add: [],
+    click: [],
+    getcontext: [],
+    mousemove: [],
+    mouseenter: [],
+    mouseleave: [],
+    box: [],
+    redraw: [],
+    remove: [],
+    playAnimation: [],
+    finishAnimation: []
+  };
+  this.Sb = this.ra = null;
+  this.md = {};
+  this.Zn = [];
+  this.lS = [];
+  if (null != a)
+    for (var b in a)
+      this.setStyle(b, a[b]);
+  this.f6 = null
+}
+gvjs_t(gvjs_wq, gvjs_uq);
+gvjs_ = gvjs_wq.prototype;
+gvjs_.data = function(a) {
+  return void 0 !== a ? (this.ra = a,
+    this) : this.ra
+}
+;
+gvjs_.setData = function(a) {
+  this.ra = a;
+  return this
+}
+;
+gvjs_.setStyle = function(a, b) {
+  b instanceof Object && null != b && (b = b.toString());
+  if (this.md[a] === b)
+    return !1;
+  this.md[a] = b;
+  this.eo = null;
+  return !0
+}
+;
+gvjs_.getStyle = function(a) {
+  return this.md[a]
+}
+;
+function gvjs_xq(a) {
+  null == a.f6 && (a.f6 = new gvjs_Aj([a.md],void 0,!0));
+  return a.f6
+}
+gvjs_.style = function(a, b) {
+  return void 0 !== b ? (this.setStyle(a, b) && this.fireEvent(gvjs_Rp, [this, a]),
+    this) : this.getStyle(a)
+}
+;
+gvjs_.styles = function(a) {
+  for (var b in a)
+    a.hasOwnProperty(b) && this.style(b, a[b]);
+  return this
+}
+;
+gvjs_.getContext = function() {
+  this.Sb || this.fireEvent(gvjs_Ap, [this]);
+  return this.Sb
+}
+;
+gvjs_.Qj = gvjs_n(25);
+gvjs_.Ou = gvjs_n(27);
+gvjs_.kEa = function() {
+  for (var a = this; 0 < this.Zn.length; ) {
+    var b = this.Zn.shift();
+    a.lS.push(b);
+    b.o(gvjs_up, function(c, d) {
+      c = a.lS.indexOf(d);
+      if (0 > c)
+        throw "Animation not found.";
+      a.lS.splice(c, 1);
+      0 === a.lS.length && a.fireEvent(gvjs_up, [a])
+    });
+    if (!this.fireEvent(gvjs_Mp, [this, b]))
+      throw "Cannot play animations for shape not in a scene.";
+  }
+  return this
+}
+;
+var gvjs_hda = gvjs_p.requestAnimationFrame || gvjs_p.mozRequestAnimationFrame || gvjs_p.webkitRequestAnimationFrame || gvjs_p.msRequestAnimationFrame || function(a) {
+    return gvjs_p.setTimeout(function() {
+      return a.call(this, Date.now())
+    }, 1E3 / 60)
+  }
+;
+function gvjs_yq(a) {
+  for (var b = 0, c = arguments.length; b < c; b++)
+    if (null != arguments[b])
+      return arguments[b]
+}
+function gvjs_zq(a, b, c, d) {
+  gvjs_Aq(a, b, c, d);
+  gvjs_Bq(a, b, c, d);
+  gvjs_Cq(a, b, c, d);
+  gvjs_Dq(a, b, c, d);
+  gvjs_Eq(a, b, c, d);
+  gvjs_Fq(a, b, c, d);
+  gvjs_Gq(a, b, c, d);
+  var e = gvjs_xq(c)
+    , f = gvjs_L(e, "clip.width")
+    , g = gvjs_L(e, "clip.height");
+  if (f && g) {
+    var h = gvjs_L(e, "clip.x", 0);
+    e = gvjs_L(e, "clip.y", 0);
+    var k = ["clip", h, e, f, g].join()
+      , l = c.yr;
+    if (c = a.g3(k, l))
+      n = c.getAttribute(gvjs_5c);
+    else {
+      var m = gvjs_Ph();
+      c = m.createElementNS(gvjs_Ep, "clipPath");
+      var n = a.yZ();
+      c.setAttribute(gvjs_5c, n);
+      m = m.createElementNS(gvjs_Ep, gvjs_Qp);
+      m.setAttribute("x", h);
+      m.setAttribute("y", e);
+      m.setAttribute(gvjs_Xd, f);
+      m.setAttribute(gvjs_4c, g);
+      c.appendChild(m);
+      a.N4(k, c, l);
+      for (a = d; a.nodeName !== gvjs_9p; )
+        a = a.parentNode;
+      a = a.querySelector(gvjs_hp) || a;
+      a.insertBefore(c, a.firstChild)
+    }
+    b.setAttribute(gvjs_5o, gvjs_dq + n + ")")
+  } else
+    b.hasAttribute(gvjs_5o) && b.removeAttribute(gvjs_5o)
+}
+function gvjs_Bq(a, b, c, d) {
+  gvjs_Hq(a, b, c, d, !1);
+  a = gvjs_yq(c.style(gvjs_pp), c.style(gvjs_rp), c.style(gvjs_np));
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_np, a) : null === a && b.removeAttribute(gvjs_np)
+}
+function gvjs_Cq(a, b, c) {
+  a = gvjs_yq(c.style(gvjs_qp), c.style(gvjs_sp), c.style(gvjs_op));
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_op, a) : null === a && b.removeAttribute(gvjs_op)
+}
+function gvjs_Dq(a, b, c, d) {
+  gvjs_Hq(a, b, c, d, !0);
+  a = gvjs_yq(c.style(gvjs_3p), c.style(gvjs_6p), c.style(gvjs_0p));
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_0p, a) : null === a && b.removeAttribute(gvjs_0p)
+}
+function gvjs_Eq(a, b, c) {
+  a = gvjs_yq(c.style(gvjs_4p), c.style(gvjs_7p), c.style(gvjs_1p));
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_1p, a) : null === a && b.removeAttribute(gvjs_1p)
+}
+function gvjs_Fq(a, b, c) {
+  a = gvjs_yq(c.style(gvjs_5p), c.style(gvjs_8p), c.style(gvjs_2p));
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_2p, a) : null === a && b.removeAttribute(gvjs_2p)
+}
+function gvjs_Aq(a, b, c) {
+  a = c.style(gvjs_Kp);
+  typeof a === gvjs_l || typeof a === gvjs_g ? b.setAttribute(gvjs_Kp, a) : null === a && b.removeAttribute(gvjs_Kp)
+}
+function gvjs_Hq(a, b, c, d, e) {
+  var f = gvjs_xq(c)
+    , g = e ? gvjs_0p : gvjs_np
+    , h = f.kt(g + ".gradient.from")
+    , k = f.kt(g + ".gradient.to");
+  e = b.getAttribute(g);
+  if (h && k) {
+    var l = gvjs_kq(f, g + ".gradient.x1", gvjs_Ro)
+      , m = gvjs_kq(f, g + ".gradient.y1", gvjs_Ro)
+      , n = gvjs_kq(f, g + ".gradient.x2", gvjs_So)
+      , p = gvjs_kq(f, g + ".gradient.y2", gvjs_Ro);
+    f = [gvjs_Bp, h, k, l, m, n, p].join();
+    var q = c.yr;
+    if (c = a.g3(f, q))
+      g = c.getAttribute(gvjs_5c);
+    else {
+      var r = gvjs_Ph();
+      c = r.createElementNS(gvjs_Ep, gvjs_Ip);
+      g = a.yZ();
+      c.setAttribute(gvjs_5c, g);
+      c.setAttribute("x1", l);
+      c.setAttribute("y1", m);
+      c.setAttribute("x2", n);
+      c.setAttribute("y2", p);
+      l = r.createElementNS(gvjs_Ep, gvjs__p);
+      l.setAttribute("stop-color", h);
+      l.setAttribute(gvjs_Jp, gvjs_Ro);
+      h = r.createElementNS(gvjs_Ep, gvjs__p);
+      h.setAttribute("stop-color", k);
+      h.setAttribute(gvjs_Jp, gvjs_So);
+      c.appendChild(l);
+      c.appendChild(h);
+      a.N4(f, c, q);
+      for (a = d; a.nodeName !== gvjs_9p; )
+        a = a.parentNode;
+      a = a.querySelector(gvjs_hp) || a;
+      a.insertBefore(c, a.firstChild)
+    }
+    a = gvjs_dq + g + ")";
+    e !== a && b.setAttribute(gvjs_np, a)
+  } else
+    e && e.substr(0, 5) === gvjs_dq && b.removeAttribute(g)
+}
+function gvjs_Gq(a, b, c, d) {
+  var e = gvjs_xq(c)
+    , f = gvjs_kq(e, gvjs_Wp, 0)
+    , g = gvjs_kq(e, gvjs_Vp, 0);
+  if (f || g) {
+    var h = e.kt("shadow.xOffset") || e.kt("shadow.x-offset") || e.kt(gvjs_Xp) || 0
+      , k = e.kt("shadow.yOffset") || e.kt("shadow.y-offset") || e.kt(gvjs_Yp) || 0;
+    e = [gvjs_Yo, f, g, h, k].join();
+    var l = c.yr
+      , m = a.g3(e, l);
+    if (m)
+      c = m.getAttribute(gvjs_5c);
+    else {
+      var n = gvjs_Ph();
+      m = n.createElementNS(gvjs_Ep, gvjs_tp);
+      m.setAttribute("x", "-100%");
+      m.setAttribute("y", "-100%");
+      m.setAttribute(gvjs_Xd, "300%");
+      m.setAttribute(gvjs_4c, "300%");
+      c = a.yZ();
+      m.setAttribute(gvjs_5c, c);
+      var p = n.createElementNS(gvjs_Ep, gvjs_lp);
+      p.setAttribute(gvjs_Fp, "SourceAlpha");
+      p.setAttribute("stdDeviation", f);
+      f = n.createElementNS(gvjs_Ep, "feOffset");
+      f.setAttribute("dx", h);
+      f.setAttribute("dy", k);
+      if (null != g) {
+        var q = n.createElementNS(gvjs_Ep, gvjs_kp);
+        var r = n.createElementNS(gvjs_Ep, "feFuncA");
+        r.setAttribute(gvjs_Sd, gvjs_Hp);
+        r.setAttribute("slope", g)
+      }
+      g = n.createElementNS(gvjs_Ep, "feMerge");
+      h = n.createElementNS(gvjs_Ep, gvjs_mp);
+      n = n.createElementNS(gvjs_Ep, gvjs_mp);
+      n.setAttribute(gvjs_Fp, "SourceGraphic");
+      m.appendChild(p);
+      m.appendChild(f);
+      null != r && (q.appendChild(r),
+        m.appendChild(q));
+      g.appendChild(h);
+      g.appendChild(n);
+      m.appendChild(g);
+      a.N4(e, m, l);
+      for (a = d; a.nodeName !== gvjs_9p; )
+        a = a.parentNode;
+      a = a.querySelector(gvjs_hp) || a;
+      a.insertBefore(m, a.firstChild)
+    }
+    a = b.getAttribute(gvjs_tp);
+    d = gvjs_dq + c + ")";
+    a !== d && b.setAttribute(gvjs_tp, d)
+  } else
+    b.hasAttribute(gvjs_tp) && b.removeAttribute(gvjs_tp)
+}
+var gvjs_ida = {
+  "fill.color": gvjs_Bq,
+  fillColor: gvjs_Bq,
+  fill: gvjs_Bq,
+  "fill.gradient.from": gvjs_Bq,
+  "fill.gradient.to": gvjs_Bq,
+  "fill.gradient.x1": gvjs_Bq,
+  "fill.gradient.y1": gvjs_Bq,
+  "fill.gradient.x2": gvjs_Bq,
+  "fill.gradient.y2": gvjs_Bq,
+  "fill.opacity": gvjs_Cq,
+  fillOpacity: gvjs_Cq,
+  "fill-opacity": gvjs_Cq,
+  height: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), gvjs_4c);
+    b.setAttribute(gvjs_4c, a)
+  },
+  opacity: gvjs_Aq,
+  "shadow.radius": gvjs_Gq,
+  "shadow.opacity": gvjs_Gq,
+  "shadow.xOffset": gvjs_Gq,
+  "shadow.x-offset": gvjs_Gq,
+  "shadow.xoffset": gvjs_Gq,
+  "shadow.yOffset": gvjs_Gq,
+  "shadow.y-offset": gvjs_Gq,
+  "shadow.yoffset": gvjs_Gq,
+  "stroke.color": gvjs_Dq,
+  strokeColor: gvjs_Dq,
+  stroke: gvjs_Dq,
+  "stroke.gradient.from": gvjs_Dq,
+  "stroke.gradient.to": gvjs_Dq,
+  "stroke.gradient.x1": gvjs_Dq,
+  "stroke.gradient.y1": gvjs_Dq,
+  "stroke.gradient.x2": gvjs_Dq,
+  "stroke.gradient.y2": gvjs_Dq,
+  "stroke.opacity": gvjs_Eq,
+  strokeOpacity: gvjs_Eq,
+  "stroke-opacity": gvjs_Eq,
+  "stroke.width": gvjs_Fq,
+  strokeWidth: gvjs_Fq,
+  "stroke-width": gvjs_Fq,
+  width: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), gvjs_Xd);
+    b.setAttribute(gvjs_Xd, a)
+  },
+  x: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "x");
+    b.setAttribute("x", a)
+  },
+  y: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "y");
+    b.setAttribute("y", a)
+  }
+};
+function gvjs_Iq(a, b, c, d, e, f) {
+  f = f || {};
+  return (c = f[c] || gvjs_ida[c]) ? (c(a, b, d, e),
+    !0) : !1
+}
+;var gvjs_Jq = {
+  applyX: function(a, b, c) {
+    a = gvjs_xq(c).Aa("x");
+    null != a && b.setAttribute("cx", a)
+  },
+  applyY: function(a, b, c) {
+    a = gvjs_xq(c).Aa("y");
+    null != a && b.setAttribute("cy", a)
+  },
+  j7: function(a, b, c) {
+    a = gvjs_xq(c).Aa("r");
+    null != a && b.setAttribute("r", a)
+  }
+};
+gvjs_Jq.DK = {
+  r: gvjs_Jq.j7,
+  x: gvjs_Jq.applyX,
+  y: gvjs_Jq.applyY
+};
+gvjs_Jq.draw = function(a, b, c, d) {
+  var e = gvjs_Ph();
+  d = d || e.createElementNS(gvjs_Ep, gvjs_4o);
+  gvjs_Jq.applyX(a, d, b);
+  gvjs_Jq.applyY(a, d, b);
+  gvjs_Jq.j7(a, d, b);
+  gvjs_zq(a, d, b, c);
+  c && d.parentNode !== c && c.appendChild(d);
+  return d
+}
+;
+gvjs_Jq.Lf = function(a, b, c, d, e) {
+  if (!gvjs_Iq(a, e, c, b, d, gvjs_Jq.DK))
+    throw 'unknown property on circle "' + c + '".';
+}
+;
+var gvjs_Kq = {};
+function gvjs_Lq(a, b, c) {
+  a = gvjs_L(gvjs_xq(c), "x");
+  b.setAttribute("cx", a)
+}
+function gvjs_Mq(a, b, c) {
+  a = gvjs_L(gvjs_xq(c), "y");
+  b.setAttribute("cy", a)
+}
+function gvjs_Nq(a, b, c) {
+  a = gvjs_L(gvjs_xq(c), "rx");
+  b.setAttribute("rx", a)
+}
+function gvjs_Oq(a, b, c) {
+  a = gvjs_L(gvjs_xq(c), "ry");
+  b.setAttribute("ry", a)
+}
+var gvjs_Pq = {
+  x: gvjs_Lq,
+  y: gvjs_Mq,
+  rx: gvjs_Nq,
+  ry: gvjs_Oq
+};
+gvjs_Kq.kCa = gvjs_Nq;
+gvjs_Kq.lCa = gvjs_Oq;
+gvjs_Kq.applyX = gvjs_Lq;
+gvjs_Kq.applyY = gvjs_Mq;
+gvjs_Kq.draw = function(a, b, c, d) {
+  var e = gvjs_Ph();
+  d = d || e.createElementNS(gvjs_Ep, gvjs_jp);
+  gvjs_Lq(a, d, b);
+  gvjs_Mq(a, d, b);
+  gvjs_Nq(a, d, b);
+  gvjs_Oq(a, d, b);
+  gvjs_zq(a, d, b, c);
+  c && d.parentNode !== c && c.appendChild(d);
+  return d
+}
+;
+gvjs_Kq.DK = gvjs_Pq;
+gvjs_Kq.Lf = function(a, b, c, d, e) {
+  if (!gvjs_Iq(a, e, c, b, d, gvjs_Pq))
+    throw gvjs_cq + c + '".';
+}
+;
+var gvjs_Qq = {
+  k7: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "x1");
+    b.setAttribute("x1", a)
+  },
+  m7: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "y1");
+    b.setAttribute("y1", a)
+  },
+  l7: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "x2");
+    b.setAttribute("x2", a)
+  },
+  n7: function(a, b, c) {
+    a = gvjs_L(gvjs_xq(c), "y2");
+    b.setAttribute("y2", a)
+  }
+};
+gvjs_Qq.DK = {
+  x1: gvjs_Qq.k7,
+  x2: gvjs_Qq.l7,
+  y1: gvjs_Qq.m7,
+  y2: gvjs_Qq.n7
+};
+gvjs_Qq.draw = function(a, b, c, d) {
+  var e = gvjs_Ph();
+  d = d || e.createElementNS(gvjs_Ep, gvjs_e);
+  gvjs_Qq.k7(a, d, b);
+  gvjs_Qq.l7(a, d, b);
+  gvjs_Qq.m7(a, d, b);
+  gvjs_Qq.n7(a, d, b);
+  gvjs_zq(a, d, b, c);
+  c && d.parentNode !== c && c.appendChild(d);
+  return d
+}
+;
+gvjs_Qq.Lf = function(a, b, c, d, e) {
+  if (!gvjs_Iq(a, e, c, b, d, gvjs_Qq.DK))
+    throw gvjs_cq + c + '".';
+}
+;
+function gvjs_Rq(a) {
+  a %= 360;
+  return 0 > 360 * a ? a + 360 : a
+}
+;function gvjs_Sq(a, b, c, d) {
+  var e = gvjs_Ph();
+  e = d || e.createElementNS(gvjs_Ep, gvjs_Lp);
+  d || e.setAttribute("d", gvjs_Tq(c));
+  gvjs_zq(a, e, c, b);
+  return e
+}
+function gvjs_Tq(a) {
+  a = a.$u;
+  for (var b = [], c = 0, d = a.length; c < d; c++) {
+    var e = a[c];
+    if ("GVIZARC" === e[0]) {
+      var f = e
+        , g = Number(f[1])
+        , h = Number(f[2]);
+      e = Number(f[3]);
+      var k = Number(f[4])
+        , l = gvjs_Rq(Number(f[5]))
+        , m = gvjs_Rq(Number(f[6]));
+      f = !!Number(f[7]);
+      270 === l && 0 === m ? e = "A " + e + " " + k + gvjs_Qo + (e + g) + " " + h : 180 === l && 270 === m ? e = "A " + e + " " + k + gvjs_Qo + g + " " + (h - k) : 0 === l && 90 === m ? e = "A " + e + " " + k + gvjs_Qo + g + " " + (h + k) : 90 === l && 180 === m ? e = "A " + e + " " + k + gvjs_Qo + (g - e) + " " + h : (g += Math.cos(m / 180 * Math.PI) * e,
+        h += Math.sin(m / 180 * Math.PI) * k,
+        l = f ? m - l : l - m,
+      0 > l && (l += 360),
+        e = "A " + e + " " + k + " 0 " + Number(180 < l) + " " + Number(f) + " " + g + " " + h)
+    } else
+      e = e.join(" ");
+    b.push(e)
+  }
+  return b.join(" ")
+}
+;function gvjs_Uq(a) {
+  gvjs_wq.call(this, a);
+  this.eo = {
+    x1: null,
+    y1: null,
+    x2: null,
+    y2: null,
+    width: 0,
+    height: 0
+  };
+  this.$u = []
+}
+gvjs_o(gvjs_Uq, gvjs_wq);
+gvjs_ = gvjs_Uq.prototype;
+gvjs_.Rk = gvjs_n(32);
+gvjs_.Ou = gvjs_n(26);
+gvjs_.clear = function() {
+  this.eo = {
+    x1: null,
+    y1: null,
+    x2: null,
+    y2: null,
+    width: 0,
+    height: 0
+  };
+  this.$u = []
+}
+;
+gvjs_.move = function(a, b) {
+  this.$u.push(["M", a, b]);
+  return this
+}
+;
+gvjs_.line = function(a, b) {
+  this.$u.push(["L", a, b]);
+  return this
+}
+;
+gvjs_.arc = function(a, b, c, d, e, f, g) {
+  e = gvjs_Rq(e);
+  f = gvjs_Rq(f);
+  this.$u.push(["GVIZARC", a, b, c, d, e, f, Number(g)]);
+  return this
+}
+;
+gvjs_.curve = function(a, b, c, d, e, f) {
+  this.$u.push(["C", a, b, c, d, e, f]);
+  return this
+}
+;
+gvjs_.close = function() {
+  this.$u.push(["Z"]);
+  return this
+}
+;
+function gvjs_Vq(a) {
+  var b = gvjs_xq(a);
+  a = b.Aa(gvjs_bp) || 0;
+  var c = b.Aa(gvjs_cp) || 0
+    , d = b.Aa(gvjs_dp) || 0
+    , e = b.Aa(gvjs_ep) || 0
+    , f = b.Aa(gvjs_6o) || 0
+    , g = b.Aa(gvjs_7o) || 0
+    , h = b.Aa(gvjs_8o) || 0;
+  b = b.Aa(gvjs_9o) || 0;
+  return !!(a || c || d || e || f || g || h || b)
+}
+function gvjs_Wq(a) {
+  var b = gvjs_xq(a)
+    , c = gvjs_L(b, gvjs_$o, 0)
+    , d = gvjs_L(b, gvjs_ap, 0)
+    , e = gvjs_L(b, gvjs_bp, c)
+    , f = gvjs_L(b, gvjs_cp, d)
+    , g = gvjs_L(b, gvjs_dp, c)
+    , h = gvjs_L(b, gvjs_ep, d)
+    , k = gvjs_L(b, gvjs_6o, c)
+    , l = gvjs_L(b, gvjs_7o, d);
+  c = gvjs_L(b, gvjs_8o, c);
+  d = gvjs_L(b, gvjs_9o, d);
+  var m = gvjs_L(b, gvjs_Xd)
+    , n = gvjs_L(b, gvjs_4c)
+    , p = gvjs_L(b, "x");
+  b = gvjs_L(b, "y");
+  p = 0 <= m ? p : p + m;
+  b = 0 <= n ? b : b + n;
+  m = Math.abs(m);
+  n = Math.abs(n);
+  if (e + g > m) {
+    var q = m / (e + g);
+    e *= q;
+    f *= q;
+    g *= q;
+    h *= q
+  }
+  k + c > m && (q = m / (k + c),
+    k *= q,
+    l *= q,
+    c *= q,
+    d *= q);
+  f + l > n && (q = n / (f + l),
+    e *= q,
+    f *= q,
+    k *= q,
+    l *= q);
+  h + d > n && (q = n / (h + d),
+    g *= q,
+    h *= q,
+    c *= q,
+    d *= q);
+  return (new gvjs_Uq(a.md)).move(p + m - g, b).arc(p + m - g, b + h, g, h, 270, 0, !0).line(p + m, b + n - d).arc(p + m - c, b + n - d, c, d, 0, 90, !0).line(p + k, b + n).arc(p + k, b + n - l, k, l, 90, 180, !0).line(p, b + f).arc(p + e, b + f, e, f, 180, 270, !0).close()
+}
+;var gvjs_Xq = {
+  draw: function(a, b, c, d) {
+    var e = b.style(gvjs_$o)
+      , f = b.style(gvjs_ap)
+      , g = gvjs_xq(b)
+      , h = gvjs_L(g, gvjs_Xd)
+      , k = gvjs_L(g, gvjs_4c)
+      , l = gvjs_L(g, "x");
+    g = gvjs_L(g, "y");
+    l = 0 <= h ? l : l + h;
+    g = 0 <= k ? g : g + k;
+    h = Math.abs(h);
+    k = Math.abs(k);
+    if (typeof e === gvjs_g && typeof f === gvjs_g || !gvjs_Vq(b)) {
+      var m = gvjs_Ph();
+      d = d || m.createElementNS(gvjs_Ep, gvjs_Qp);
+      d.setAttribute("x", l);
+      d.setAttribute("y", g);
+      d.setAttribute(gvjs_Xd, h);
+      d.setAttribute(gvjs_4c, k);
+      null != e && typeof e === gvjs_g && d.setAttribute("rx", e);
+      null != f && typeof f === gvjs_g && d.setAttribute("ry", f);
+      gvjs_zq(a, d, b, c)
+    } else
+      b = gvjs_Wq(b),
+        d = gvjs_Sq(a, c, b, d);
+    c && d.parentNode !== c && c.appendChild(d);
+    return d
+  },
+  Lf: function(a, b, c, d, e) {
+    if (!gvjs_Iq(a, e, c, b, d))
+      switch (c) {
+        case gvjs_$o:
+        case gvjs_ap:
+        case gvjs_bp:
+        case gvjs_cp:
+        case gvjs_dp:
+        case gvjs_ep:
+        case gvjs_6o:
+        case gvjs_7o:
+        case gvjs_8o:
+        case gvjs_9o:
+          var f = gvjs_Vq(b)
+            , g = e.tagName.toLowerCase();
+          if (g === gvjs_Lp && !f || g === gvjs_Qp && f)
+            return gvjs_Xq.draw(a, b, d);
+          g === gvjs_Lp ? (a = gvjs_Wq(b),
+            a = gvjs_Tq(a),
+            e.setAttribute("d", a)) : c === gvjs_$o ? e.setAttribute("rx", gvjs_L(gvjs_xq(b), gvjs_$o)) : c === gvjs_ap && e.setAttribute("ry", gvjs_L(gvjs_xq(b), gvjs_ap));
+          break;
+        default:
+          throw 'unknown property on rect "' + c + '".';
+      }
+  }
+};
+var gvjs_Yq = {};
+function gvjs_Zq(a, b, c) {
+  a = c.style(gvjs_vp) || c.style(gvjs_xp) || c.style(gvjs_yp);
+  b.style.fontFamily = typeof a === gvjs_l ? a : ""
+}
+function gvjs__q(a, b, c) {
+  a = c.style(gvjs_wp) || c.style(gvjs_zp);
+  b.style.fontSize = typeof a === gvjs_g ? a + gvjs_T : typeof a === gvjs_l ? a : ""
+}
+function gvjs_0q(a, b, c) {
+  a = c.style("font.weight") || c.style("fontWeight");
+  b.style.fontWeight = typeof a === gvjs_l || typeof a === gvjs_g ? String(a) : ""
+}
+function gvjs_1q(a, b, c) {
+  !0 === c.style(gvjs_Gp) ? b.style.fontStyle = gvjs_Gp : b.style.fontStyle = ""
+}
+function gvjs_2q(a, b, c) {
+  !0 === c.style(gvjs_bq) ? b.style.textDecoration = gvjs_bq : b.style.textDecoration = ""
+}
+var gvjs_3q = {
+  "font.family": gvjs_Zq,
+  fontFamily: gvjs_Zq,
+  fontName: gvjs_Zq,
+  "font.size": gvjs__q,
+  fontSize: gvjs__q,
+  "font.weight": gvjs_0q,
+  fontWeight: gvjs_0q,
+  italic: gvjs_1q,
+  underline: gvjs_2q
+};
+function gvjs_4q(a, b, c, d, e, f, g, h) {
+  var k = gvjs_Ph();
+  f = f || gvjs_m;
+  e = !e || f && e.tagName !== f ? k.createElementNS(gvjs_Ep, f) : e;
+  e.textContent = c;
+  c = gvjs_xq(d);
+  e.setAttribute("x", null == g ? gvjs_kq(c, "x") : g);
+  e.setAttribute("y", null == h ? gvjs_kq(c, "y") : h);
+  e.setAttribute(gvjs_Jd, "cursor:default;-webkit-user-select:none;-moz-osx-font-smoothing:grayscale;");
+  e.style.webkitFontSmoothing = "antialiased";
+  gvjs_zq(a, e, d, b);
+  gvjs_1q(a, e, d);
+  gvjs_2q(a, e, d);
+  gvjs_Zq(a, e, d);
+  gvjs__q(a, e, d);
+  gvjs_0q(a, e, d);
+  return e
+}
+function gvjs_5q(a, b, c, d) {
+  var e = b.style("lineSpacing") || b.style("line-spacing") || 0
+    , f = gvjs_xq(b)
+    , g = gvjs_J(f, gvjs_m, "")
+    , h = -1 == gvjs_mq(g, void 0) && gvjs_y;
+  typeof g === gvjs_l && (g = g.split("\n"));
+  var k = gvjs_L(f, "y", 0)
+    , l = !0;
+  1 === g.length && (g = g[0],
+    l = !1);
+  a = gvjs_4q(a, c, l ? "" : g, b, d, null, gvjs_L(f, "x", 0), k);
+  c && a.parentNode !== c && c.appendChild(a);
+  c = [];
+  if (l)
+    for (b = gvjs_Ph(),
+           d = 0,
+           k = g.length; d < k; d++) {
+      var m = b.createElementNS(gvjs_Ep, "tspan");
+      m.textContent = g[d];
+      m.setAttribute(gvjs_Pp, !0);
+      m.setAttribute("x", gvjs_kq(f, "x"));
+      m.setAttribute("y", gvjs_kq(f, "y"));
+      var n = a.getBBox().height;
+      0 < d && (n += e);
+      m.setAttribute("dy", n + gvjs_T);
+      a.appendChild(m);
+      c.push(m)
+    }
+  h && (a.setAttribute("dir", gvjs_Up),
+    a.setAttribute(gvjs_$p, gvjs_R));
+  return {
+    group: a,
+    lines: l ? c : [a]
+  }
+}
+function gvjs_6q(a, b, c, d) {
+  c = gvjs_5q(a, b, c, d);
+  a = c.lines;
+  c = c.group;
+  d = Math.max(0, Math.min(1, b.style(gvjs_Dp) || 0));
+  if (isNaN(d) || !isFinite(d))
+    d = 0;
+  var e = b.style(gvjs_eq);
+  if (typeof e === gvjs_g) {
+    if (e = Math.max(0, Math.min(1, e)),
+    isNaN(e) || !isFinite(e))
+      e = 0
+  } else
+    e = gvjs_Xo;
+  var f = c.getBBox()
+    , g = b.style("y") - f.y;
+  var h = "tspan" === a[a.length - 1].tagName.toLowerCase() ? a[a.length - 1].getBoundingClientRect().top - c.getBoundingClientRect().top : a[a.length - 1].getBBox().y - f.y;
+  var k = b.style("y");
+  if (null == k)
+    return c;
+  if (typeof e === gvjs_g)
+    k = k + g - f.height * e;
+  else if (e === gvjs_Xo)
+    k = k + g - h;
+  else
+    throw "Unrecognized valign value: " + e;
+  c.setAttribute("y", k);
+  e = 0;
+  for (f = a.length; e < f; e++)
+    g = a[e],
+      g.setAttribute("dx", -g.getComputedTextLength() * d + gvjs_T),
+      g.setAttribute("y", k);
+  a = b.style(gvjs_Sp);
+  null != a && 0 != a && c.setAttribute(gvjs_aq, gvjs_Tp + a + " " + b.style("x") + " " + b.style("y") + ")");
+  return c
+}
+gvjs_Yq.gCa = gvjs_Zq;
+gvjs_Yq.hCa = gvjs__q;
+gvjs_Yq.iCa = gvjs_0q;
+gvjs_Yq.jCa = gvjs_1q;
+gvjs_Yq.mCa = gvjs_2q;
+gvjs_Yq.BCa = gvjs_4q;
+gvjs_Yq.draw = gvjs_6q;
+gvjs_Yq.ICa = gvjs_5q;
+gvjs_Yq.DK = gvjs_3q;
+gvjs_Yq.Lf = function(a, b, c, d, e) {
+  var f = "x" === c || "y" === c;
+  if (f || !gvjs_Iq(a, e, c, b, d, gvjs_3q))
+    if (c === gvjs_m || c === gvjs_Dp || c === gvjs_eq || f) {
+      for (; e && e.firstChild; )
+        e.removeChild(e.firstChild);
+      a = gvjs_6q(a, b, d, e);
+      if (e !== a)
+        throw "error redrawing text";
+    } else
+      throw 'error redrawing text element with changed property "' + c + '".';
+}
+;
+var gvjs_7q = {
+  draw: function(a, b, c, d) {
+    var e = gvjs_Ph();
+    d = d || e.createElementNS(gvjs_Ep, "g");
+    gvjs_zq(a, d, b, c);
+    c && d.parentNode !== c && c.appendChild(d);
+    return d
+  },
+  Lf: function(a, b, c, d) {
+    a = gvjs_7q.draw(a, b, c, d);
+    d !== a && b.getContext().fireEvent("add", [b, a, !1])
+  }
+};
+var gvjs_jda = {
+  Circle: gvjs_Jq,
+  Ellipse: gvjs_Kq,
+  Line: gvjs_Qq,
+  Path: {
+    draw: function(a, b, c, d) {
+      a = gvjs_Sq(a, c, b, d);
+      c && a.parentNode !== c && c.appendChild(a);
+      return a
+    },
+    Lf: function(a, b, c, d, e) {
+      if (!gvjs_Iq(a, e, c, b, d))
+        throw gvjs_cq + c + '".';
+    }
+  },
+  Rect: gvjs_Xq,
+  Text: gvjs_Yq,
+  Group: gvjs_7q
+};
+/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+
+*/
+/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+*/
+function gvjs_8q(a) {
+  gvjs_F.call(this);
+  this.Y9 = a
+}
+gvjs_o(gvjs_8q, gvjs_F);
+gvjs_8q.prototype.Is = gvjs_n(33);
+gvjs_8q.prototype.dispatchEvent = function(a, b) {
+  gvjs_I(this.Y9, a, void 0 === b ? null : b)
+}
+;
+gvjs_8q.prototype.M = function() {
+  this.Y9 = null;
+  gvjs_F.prototype.M.call(this)
+}
+;
+function gvjs_9q(a, b, c, d, e) {
+  if (null == a || null == b)
+    null == c && (c = e),
+      c = Math.max(0, d - c),
+      null == a && null == b ? a = b = c / 2 : null == a ? a = Math.max(0, c - b) : b = Math.max(0, c - a);
+  c = Math.max(0, Math.round(d - (a + b)));
+  a = Math.round(a);
+  d = Math.min(d, a + c);
+  return {
+    before: a,
+    after: d,
+    size: d - a
+  }
+}
+function gvjs_$q(a, b, c) {
+  var d = a / 1.618
+    , e = a - b * (1.618 - 1)
+    , f = b / 1.618
+    , g = b - a * (1.618 - 1);
+  a = gvjs_9q(c.left, c.right, c.width, a, Math.round(d > e ? d : (d + 2 * e) / 3));
+  b = gvjs_9q(c.top, c.bottom, c.height, b, Math.round(f > g ? f : (f + 2 * g) / 3));
+  return {
+    left: a.before,
+    right: a.after,
+    width: a.size,
+    top: b.before,
+    bottom: b.after,
+    height: b.size
+  }
+}
+;

--- a/cypress/fixtures/charts/jsapi_compiled_imagechart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_imagechart_module
@@ -1,0 +1,1078 @@
+var gvjs_UT = "#00000000"
+  , gvjs_VT = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-."
+  , gvjs_WT = "__ImageChartId__"
+  , gvjs_XT = "error: cannot draw chart"
+  , gvjs_YT = "google-visualization-sparkline-default"
+  , gvjs_ZT = "google-visualization-sparkline-selected";
+function gvjs__T(a) {
+  if (a instanceof gvjs_Zf)
+    return a;
+  a = gvjs_2f(a);
+  var b = gvjs_0f(a).replace(/(\r\n|\r|\n)/g, gvjs_la);
+  return gvjs_3f(b, a.getDirection())
+}
+gvjs_fD.prototype.V3 = gvjs_V(7, function(a) {
+  gvjs_jD(this, gvjs__T(a))
+});
+function gvjs_0T(a, b, c, d) {
+  if (null != a)
+    for (a = a.firstChild; a; ) {
+      if (b(a) && (c.push(a),
+        d) || gvjs_0T(a, b, c, d))
+        return !0;
+      a = a.nextSibling
+    }
+  return !1
+}
+function gvjs_1T(a) {
+  return Array.prototype.join.call(arguments, "")
+}
+function gvjs_hja(a, b) {
+  var c = [];
+  return gvjs_0T(a, b, c, !0) ? c[0] : void 0
+}
+function gvjs_2T(a) {
+  var b = gvjs_ija
+    , c = a && a.colors;
+  return c && 0 < c.length ? c : (a = (null === a || void 0 === a ? void 0 : a.color) || null) ? [a] : b
+}
+;/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+function gvjs_3T(a, b, c, d, e) {
+  gvjs_MC.call(this, d);
+  this.Ee = new gvjs_Xm(e || "//chart.googleapis.com/chart");
+  this.OO = "";
+  this.jy = [];
+  this.E3 = [];
+  this.wT = [];
+  this.Qr = [];
+  this.Hsa = [];
+  this.Pva = [];
+  this.YJ = [];
+  this.l1 = {};
+  this.Eta = {};
+  this.IR = {};
+  this.Fta = {};
+  this.rp(a);
+  this.wg(b, c);
+  this.Xa = gvjs_4T(this) ? 0 : Infinity
+}
+gvjs_t(gvjs_3T, gvjs_MC);
+gvjs_ = gvjs_3T.prototype;
+gvjs_.gha = 2048;
+gvjs_.apa = 0;
+gvjs_.bpa = 0;
+gvjs_.Cb = -Infinity;
+gvjs_.Pn = null;
+gvjs_.fya = 13.5;
+gvjs_.j5 = "333333";
+gvjs_.E1 = null;
+gvjs_.J = function() {
+  var a = this.Tb();
+  this.H = this.wa().J("IMG", {
+    src: gvjs_5T(this),
+    "class": "aAAaGVIZSENTINELaAAa-serverchart-image",
+    width: a[0],
+    height: a[1]
+  })
+}
+;
+gvjs_.vf = function(a) {
+  var b = gvjs_5T(this).toString();
+  if (!(b instanceof gvjs_vf)) {
+    var c = /^data:image\//i.test(b);
+    b = gvjs_Wy(b, c)
+  }
+  a.src = gvjs_xf(b);
+  this.H = a
+}
+;
+gvjs_.setUri = function(a) {
+  this.Ee = a
+}
+;
+function gvjs_5T(a) {
+  if ("" != a.OO)
+    var b = gvjs_6T(a, a.OO);
+  else
+    (b = gvjs_6T(a, "e")) || (b = gvjs_6T(a, "s"));
+  b || a.dispatchEvent(new gvjs_7T(a.Ee.toString()));
+  return a.Ee
+}
+function gvjs_jja(a, b) {
+  var c = [];
+  b.forEach(function(d) {
+    d.area = d.area || "bg";
+    d.effect = d.effect || "s";
+    c.push([d.area, d.effect, d.color].join())
+  });
+  c = c.join("|");
+  a.Ld("chf", c)
+}
+gvjs_.rp = function(a) {
+  this.Ee.Ld("cht", a)
+}
+;
+gvjs_.getType = function() {
+  return this.Ee.cg.get("cht")
+}
+;
+gvjs_.wg = function(a, b) {
+  a = [a || 300, b || 150].join("x");
+  this.Ee.Ld("chs", a)
+}
+;
+gvjs_.Tb = function() {
+  return this.Ee.cg.get("chs").split("x")
+}
+;
+gvjs_.yT = function(a) {
+  this.Xa = a
+}
+;
+gvjs_.xT = function(a) {
+  this.Cb = a
+}
+;
+function gvjs_8T(a) {
+  a = a.getType();
+  return "br" == a || "bhg" == a || "bhs" == a || "bvg" == a || "bvs" == a
+}
+function gvjs_4T(a) {
+  a = a.getType();
+  return "p" == a || "p3" == a || "pc" == a
+}
+function gvjs_9T(a) {
+  a = a.getType();
+  return "br" == a || "bhg" == a || "bhs" == a
+}
+gvjs_.isMap = function() {
+  var a = this.getType();
+  return "t" == a || "tuss" == a || "twoc" == a
+}
+;
+function gvjs_$T(a) {
+  a = a.getType();
+  return "br" == a || "bhs" == a || "bvs" == a
+}
+gvjs_.Ld = function(a, b) {
+  this.Ee.Ld(a, b)
+}
+;
+gvjs_.removeParameter = function(a) {
+  this.Ee.removeParameter(a)
+}
+;
+gvjs_.setTitle = function(a) {
+  this.Pn = a;
+  this.Ee.Ld("chtt", this.Pn.replace(/\n/g, "|"))
+}
+;
+gvjs_.setTitleColor = function(a) {
+  this.j5 = a;
+  this.Ee.Ld("chts", this.j5 + "," + this.fya)
+}
+;
+gvjs_.getTitleColor = function() {
+  return this.j5
+}
+;
+function gvjs_aU(a, b) {
+  a.YJ.push(b);
+  a.Ee.Ld("chxt", a.YJ.join(","));
+  return a.YJ.length - 1
+}
+function gvjs_bU(a, b, c) {
+  a.l1[b] = c;
+  b = gvjs_cU(a, a.l1, ":|", "|");
+  a.Ee.Ld("chxl", b)
+}
+function gvjs_dU(a, b, c, d) {
+  var e = Infinity;
+  for (var f = 0, g = b.length; f < g; ++f) {
+    var h = b[f];
+    null != h && h < e && (e = h)
+  }
+  e < a.Xa && (a.Xa = e);
+  e = -Infinity;
+  f = 0;
+  for (g = b.length; f < g; ++f)
+    h = b[f],
+    null != h && h > e && (e = h);
+  e > a.Cb && (a.Cb = e);
+  if (void 0 !== d) {
+    if (a.wT.length < a.jy.length)
+      throw Error("Cannot start adding legends text after first element.");
+    a.wT.push(d);
+    a.Ee.Ld("chdl", a.wT.join("|"))
+  }
+  a.jy.push(b);
+  a.E3.push(c);
+  a.Ee.Ld("chco", a.E3.join(","))
+}
+gvjs_.getData = function(a) {
+  return void 0 !== a ? this.jy[a] : this.jy
+}
+;
+function gvjs_6T(a, b) {
+  for (var c = [], d = 0, e = a.jy.length; d < e; ++d) {
+    var f = c
+      , g = d;
+    var h = a;
+    for (var k = a.jy[d], l = a.Xa, m = a.Cb, n = b, p = [], q = 0, r = k.length; q < r; ++q) {
+      var t = k[q];
+      var u = "e" == n;
+      if (null === t || void 0 === t || isNaN(t) || t < l || t > m)
+        t = u ? "__" : "_";
+      else if ("t" == n)
+        t = String(t);
+      else {
+        var v = .5;
+        m > l && (v = (t - l) / (m - l));
+        t = u ? gvjs_VT.charAt(Math.floor(v * gvjs_eU / 64)) + gvjs_VT.charAt(Math.floor(v * gvjs_eU % 64)) : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".charAt(Math.round(61 * v))
+      }
+      p.push(t)
+    }
+    h = p.join("t" == h.OO ? "," : "");
+    f[g] = h
+  }
+  c = c.join("t" == b ? "|" : ",");
+  b = null == a.E1 ? gvjs_1T(b, ":", c) : gvjs_1T(b, a.E1, ":", c);
+  a.Ee.Ld("chd", b);
+  return a.Ee.toString().length < a.gha
+}
+function gvjs_cU(a, b, c, d) {
+  var e = []
+    , f = 0;
+  for (a = a.YJ.length; f < a; ++f)
+    b[f] && e.push(f + c + b[f].join(d));
+  return e.join("|")
+}
+var gvjs_eU = Math.pow(64, 2) - 1;
+gvjs_3T.prototype.M = function() {
+  gvjs_3T.G.M.call(this);
+  delete this.Qr;
+  delete this.Hsa;
+  delete this.Pva;
+  delete this.apa;
+  delete this.bpa;
+  delete this.E3;
+  delete this.wT;
+  delete this.jy;
+  this.Ee = null;
+  delete this.Xa;
+  delete this.Cb;
+  this.Pn = null;
+  delete this.YJ;
+  delete this.l1;
+  delete this.Eta;
+  delete this.IR;
+  delete this.Fta
+}
+;
+function gvjs_7T(a) {
+  gvjs_1h.call(this, "uritoolong");
+  this.uri = a
+}
+gvjs_t(gvjs_7T, gvjs_1h);
+function gvjs_fU(a, b) {
+  gvjs_Qn.call(this, b);
+  this.k8 = a;
+  this.Sd = new gvjs_wi(this,this.container)
+}
+gvjs_o(gvjs_fU, gvjs_Qn);
+gvjs_ = gvjs_fU.prototype;
+gvjs_.Sc = function(a) {
+  this.Sd.Sc(a)
+}
+;
+gvjs_.oP = function(a, b, c, d) {
+  return b && (b = b.width,
+  typeof b === gvjs_l && gvjs_Yy(b) && (b = Number(b)),
+  typeof b === gvjs_g && 30 <= b && (!d || b <= d)) || a && (b = a.clientWidth,
+  30 <= b && (!d || b <= d)) ? b : c || 400
+}
+;
+gvjs_.qI = function(a, b, c, d, e) {
+  return b && (b = b.height,
+  typeof b === gvjs_l && gvjs_Yy(b) && (b = Number(b)),
+  typeof b === gvjs_g && b >= (e || 30) && (!d || b <= d)) || a && (b = a.clientHeight,
+  b >= (e || 30) && (!d || b <= d)) ? b : c || 200
+}
+;
+function gvjs_gU(a) {
+  return 0 < a.$() && a.W(0) == gvjs_l ? 1 : 0
+}
+function gvjs_hU(a, b) {
+  gvjs_G(b, "load", a.gx.bind(a));
+  gvjs_G(b, gvjs_Rb, a.Sc.bind(a, gvjs_XT))
+}
+gvjs_.gx = function() {
+  gvjs_I(this, gvjs_i, null)
+}
+;
+gvjs_.xya = function(a) {
+  gvjs_I(this, "on" + a.type, a)
+}
+;
+function gvjs_kja(a) {
+  return gvjs_hja(a.container, function(b) {
+    return b.tagName ? "map" === String(b.tagName).toLowerCase() : !1
+  })
+}
+function gvjs_iU(a) {
+  return "r" == a || "rs" == a
+}
+function gvjs_lja(a, b, c, d) {
+  for (var e = Math.floor(1E5 * Math.random()); c.j(gvjs_WT + e); )
+    e++;
+  e = gvjs_WT + e;
+  var f = c.J(gvjs_ls, {
+    id: e,
+    name: e
+  });
+  c.appendChild(a.container, f);
+  b.useMap = "#" + e;
+  (new gvjs_8m(d)).fetch({
+    chof: "json"
+  }).then(function(g) {
+    if (g.chartshape) {
+      var h = gvjs_kja(a);
+      if (null == h)
+        a.Sc("Cannot create events map");
+      else
+        for (var k = g.chartshape.length - 1; 0 <= k; k--) {
+          var l = c.createElement(gvjs_at);
+          l.coords = g.chartshape[k].coords;
+          l.shape = g.chartshape[k].type;
+          for (var m = gvjs_jU.length, n = 0; n < m; n++) {
+            var p = new gvjs_1h(gvjs_jU[n],l);
+            p.type = gvjs_jU[n];
+            p.region = g.chartshape[k].name;
+            gvjs_G(l, gvjs_jU[n], a.xya.bind(a, p), !0)
+          }
+          h.appendChild(l)
+        }
+    }
+  })
+}
+gvjs_.Rd = function(a, b, c) {
+  a = c || {};
+  if (b && this.container && this.k8)
+    if (c = this.IG(b, a)) {
+      b = gvjs_5T(c);
+      if (!b || !b.gp) {
+        var d = (new gvjs_Xm(gvjs_Ph().location.href)).gp;
+        "http" != d && "https" != d && gvjs_Ym(b, "http")
+      }
+      if (b.toString().length > c.gha) {
+        c = b.cg.get("chs");
+        c = c.split("x");
+        a = gvjs_Oh().createElement(gvjs_Ma);
+        a.width = c[0];
+        a.height = c[1];
+        a.frameBorder = "0";
+        a.scrolling = "no";
+        a.marginHeight = "0";
+        a.marginWidth = "0";
+        this.container.appendChild(a);
+        c = a.contentDocument;
+        c || (c = a.contentWindow.document);
+        c.open();
+        c.close();
+        d = c;
+        var e = d.getElementsByTagName(gvjs_yb)[0];
+        c = d.createElement("form");
+        e.appendChild(c);
+        e = b.cg.cj();
+        e = gvjs_8d(e);
+        for (var f = e.next(); !f.done; f = e.next()) {
+          f = f.value;
+          var g = b.cg.get(f)
+            , h = d.createElement(gvjs_fv);
+          h.type = gvjs_0u;
+          h.name = f;
+          h.value = g;
+          c.appendChild(h)
+        }
+        gvjs_1m(b, null);
+        b = b.toString();
+        b = b instanceof gvjs_vf ? b : gvjs_Wy(b);
+        c.action = gvjs_xf(b);
+        c.method = "POST";
+        gvjs_hU(this, a);
+        c.submit()
+      } else
+        c.R(this.container),
+          d = c.j(),
+          gvjs_hU(this, d),
+        a.enableEvents && (a = c.wa(),
+          gvjs_lja(this, d, a, b))
+    } else
+      this.Sc(gvjs_XT)
+}
+;
+gvjs_.IG = function(a, b) {
+  var c;
+  b = b || {};
+  var d = this.k8, e, f = !0;
+  switch (d) {
+    case 2:
+      var g = "lc";
+      break;
+    case 1:
+      f = b.showAxisLines;
+      null == f && (f = !0);
+      g = f ? "lc" : "ls";
+      break;
+    case 3:
+      g = b.is3D ? "p3" : "p";
+      break;
+    case 4:
+      var h = b.isVertical;
+      g = b.isStacked;
+      null == g && (g = !0);
+      g = g ? h ? "bvs" : "bhs" : h ? "bvg" : "bhg";
+      break;
+    case 5:
+      g = b.cht;
+      break;
+    default:
+      return null
+  }
+  gvjs_hh(this.container);
+  var k = b;
+  var l = "lr" == g || "lc" == g || "ls" == g;
+  var m = this.container;
+  h = (c = k && k.isInternal) ? void 0 : 1E3;
+  var n = c ? void 0 : 1E3;
+  if ("t" == g || "tuss" == g || "twoc" == g)
+    h = 440,
+      n = 220;
+  h = this.oP(m, k, 0, h);
+  k = l ? this.qI(m, k, 0, n, 15) : this.qI(m, k, 0, n);
+  c || (c = h * k,
+  3E5 < c && (c = Math.sqrt(c / 3E5),
+    h /= c,
+    k /= c));
+  c = Math.floor(h);
+  l = Math.floor(k);
+  h = new gvjs_3T(g,c,l);
+  b.addPadding && (c = k = .19 * c,
+    l = m = .19 * l,
+    c = [c, k, l, m].join(),
+    h.Ee.Ld("chma", c));
+  if (c = !(b && b.isInternal))
+    k = h.Tb(),
+      c = parseInt(k[0], 10),
+      k = parseInt(k[1], 10),
+      c = !(1E3 < c || 1E3 < k ? 0 : 3E5 >= c * k);
+  if (c)
+    throw Error("Assertion failed: invalid size.");
+  (c = b.title) && h.setTitle(c);
+  k = b.singleColumnDisplay;
+  var p = a.$();
+  l = a.ca();
+  var q = 0 < p && a.W(0) != gvjs_g;
+  m = 0;
+  for (var r = q ? 1 : 0; r < p; ) {
+    if (a.W(r) == gvjs_g) {
+      if (null == k || r == k)
+        break;
+      m++
+    }
+    r++
+  }
+  if (null != k || 3 == d)
+    var t = 1;
+  c = 0;
+  n = !1;
+  for (e = r; e < p; e++)
+    if (a.W(e) == gvjs_g) {
+      if (t && c == t)
+        break;
+      null == k && a.Ga(e) && !gvjs_4T(h) && "s" != g && "lxy" != g && (n = !0);
+      c++
+    }
+  var u = b.min
+    , v = b.max;
+  if (gvjs_4T(h))
+    u = 0,
+      v = null;
+  else if (gvjs_8T(h)) {
+    if (!u || gvjs_$T(h) && 1 < c)
+      u = 0;
+    if (gvjs_$T(h) && 1 < c)
+      for (p = 0; p < l; p++) {
+        var w = 0;
+        e = r;
+        for (t = 0; t < c; e++)
+          a.W(e) == gvjs_g && (w += a.getValue(p, e),
+            t++);
+        if (!v || w > v)
+          v = w
+      }
+  }
+  (u || 0 === u) && h.yT(u);
+  (v || 0 === v) && h.xT(v);
+  t = b.showCategoryLabels;
+  null == t && (t = f);
+  if (q && t) {
+    t = [];
+    for (p = 0; p < l; p++)
+      t.push(a.Ha(p, 0) || "");
+    if (gvjs_4T(h))
+      b.legend != gvjs_f && h.Ld("chdl", t.join("|")),
+      b.labels == gvjs_Zv && (h.Qr = t,
+        h.Ee.Ld("chl", h.Qr.join("|")));
+    else if (gvjs_9T(h))
+      t.reverse(),
+        gvjs_aU(h, "y"),
+        gvjs_bU(h, 0, t);
+    else if ((e = gvjs_8T(h)) || (e = h.getType(),
+      e = "lr" == e || "lc" == e || "ls" == e || "lxy" == e),
+    e || gvjs_iU(g))
+      gvjs_aU(h, "x"),
+        gvjs_bU(h, 0, t)
+  }
+  t = "r";
+  switch (b.legend) {
+    case gvjs_$c:
+      t = "l";
+      break;
+    case gvjs_vx:
+      t = "t";
+      break;
+    case gvjs_vt:
+      t = "b";
+      break;
+    case gvjs_f:
+      n = !1
+  }
+  h.Ee.Ld("chdlp", t);
+  e = r;
+  for (t = 0; t < c; e++)
+    if (a.W(e) == gvjs_g) {
+      r = [];
+      q = n ? a.Ga(e) || "" : void 0;
+      for (p = 0; p < l; p++)
+        r.push(a.getValue(p, e));
+      p = gvjs_kU(null != k ? m : t, b);
+      gvjs_dU(h, r, p, q);
+      gvjs_4T(h) && b.labels == gvjs_Vd && (h.Qr = r,
+        h.Ee.Ld("chl", h.Qr.join("|")));
+      t++
+    }
+  if (gvjs_8T(h) || gvjs_iU(g) || "gom" == g || "lr" == g || "lc" == g || "ls" == g)
+    t = b.showValueLabels,
+    null == t && (t = f),
+    t && (f = "y",
+    gvjs_9T(h) && (f = "x"),
+      t = b.valueLabelsInterval,
+    null == t && gvjs_iU(g) && null == b.chds && (t = (h.Cb - h.Xa) / 4),
+      gvjs_lU(h, f, {
+        interval: t
+      }));
+  gvjs_8T(h) && h.Ee.Ld("chbh", "a");
+  g = b.firstHiddenColumn;
+  null != g && (g -= gvjs_gU(a),
+    h.E1 = g);
+  if (2 == d || b.fill) {
+    d = c;
+    g = b;
+    f = [];
+    t = null == g.firstHiddenColumn ? d : g.firstHiddenColumn;
+    for (c = 0; c < t; c++)
+      k = gvjs_kU(c, g),
+        k = ["b", k, c, c + 1 == t ? d : c + 1, 0],
+        f.push(k.join(","));
+    d = f.join("|");
+    h.Ee.Ld("chm", d);
+    d = [];
+    g = h.Xa;
+    d.push(g);
+    d.push(g);
+    gvjs_dU(h, d, "00000000", void 0)
+  }
+  this.ip(h, a, b);
+  this.setBackgroundColor(h, b);
+  return h
+}
+;
+gvjs_.setBackgroundColor = function(a, b) {
+  b = b.backgroundColor;
+  null != b && (b = b.replace("#", ""),
+    gvjs_jja(a, [{
+      area: "bg",
+      color: b
+    }]))
+}
+;
+function gvjs_mja(a, b) {
+  if (gvjs_iU(a))
+    return b.$() - gvjs_gU(b);
+  switch (a) {
+    case "p":
+    case "pc":
+    case "s":
+      return b.ca();
+    case "v":
+      return 3;
+    case "br":
+    case "bhg":
+    case "bhs":
+    case "bvg":
+    case "bvs":
+    case "lc":
+      return b.$() - gvjs_gU(b);
+    case "lxy":
+      return (b.$() - gvjs_gU(b)) / 2;
+    default:
+      return null
+  }
+}
+gvjs_.ip = function(a, b, c) {
+  if ("lc" != a.getType()) {
+    var d = c.singleColumnDisplay;
+    if (null == d) {
+      c = gvjs_2T(c);
+      b = gvjs_mja(a.getType(), b);
+      b = null === b ? c.length : b;
+      d = [];
+      for (var e = 0; e < b; e++)
+        d[e] = c[e % c.length];
+      c = d = d.join(",").replace(/#/g, "");
+      gvjs_5T(a).Ld("chco", c)
+    } else
+      c = gvjs_kU(d, c),
+        gvjs_5T(a).Ld("chco", c)
+  }
+}
+;
+function gvjs_lU(a, b, c) {
+  c = c || {};
+  b = gvjs_aU(a, b);
+  var d = null != c.min ? c.min : a.Xa
+    , e = null != c.max ? c.max : a.Cb;
+  isFinite(d) && isFinite(e) ? d == e ? gvjs_bU(a, b, ["", d, ""]) : (c = c.interval,
+    a.IR[b] = [d, e],
+  void 0 !== c && a.IR[b].push(c),
+    c = gvjs_cU(a, a.IR, ",", ","),
+    a.Ee.Ld("chxr", c)) : (d = isFinite(d) ? d : "",
+    e = isFinite(e) ? e : "",
+    gvjs_bU(a, b, [d, e]))
+}
+function gvjs_kU(a, b) {
+  var c = b.singleColumnDisplay;
+  null != c && (a = c);
+  c = (c = b.chco) && typeof c == gvjs_l && -1 == c.indexOf("|") ? c.split(",") : gvjs_2T(b);
+  a = c[a % c.length];
+  "#" == a.charAt(0) && (a = a.substring(1));
+  return a
+}
+var gvjs_ija = ["#3399CC", "#80C65A", "#FF0000", "#FFCC33", "#BBCCED", "#3399CC", "#990066", gvjs_wr]
+  , gvjs_jU = [gvjs_Wt, gvjs_ld, gvjs_kd];
+function gvjs_mU(a) {
+  gvjs_fU.call(this, 5, a);
+  this.Q8 = null
+}
+gvjs_o(gvjs_mU, gvjs_fU);
+gvjs_mU.prototype.ip = function(a, b, c) {
+  null == c.colors && "s" == a.getType() ? a.removeParameter("chco") : gvjs_fU.prototype.ip.call(this, a, b, c)
+}
+;
+gvjs_mU.prototype.IG = function(a, b) {
+  if (!a || !this.getContainer())
+    return null;
+  var c = b;
+  c = c ? gvjs_x(c) : {};
+  b = c.cht;
+  null == b && (b = "lc",
+    c.cht = b);
+  var d = c.chs;
+  null != d && (d = d.split("x"),
+    c.width = parseInt(d[0], 10),
+    c.height = parseInt(d[1], 10));
+  "gom" == b && (null == c.min && (c.min = 0),
+  null == c.max && (c.max = 100));
+  b = c;
+  c = gvjs_fU.prototype.IG.call(this, a, b);
+  d = b;
+  for (var e in d)
+    if (!gvjs_nja[e]) {
+      var f = d[e];
+      if (null != f) {
+        var g = e;
+        gvjs_5T(c).Ld(g, f)
+      }
+    }
+  e = b;
+  b = c.getType();
+  d = null == e.chxt;
+  if (gvjs_iU(b))
+    d && 0 == gvjs_gU(a) && (b = gvjs_aU(c, "x"),
+      gvjs_bU(c, b, "0 45 90 135 180 225 270 315".split(" ")));
+  else
+    switch (b) {
+      case "t":
+        b = a.$();
+        (d = 2 == b) || this.Sc("The DataTable has an unexpected number of columns.  Expected: 2, actual: " + b);
+        if (d && gvjs_nU(this, a, 0, gvjs_l) && gvjs_nU(this, a, 1, gvjs_g)) {
+          b = "";
+          for (d = 0; d < a.ca(); d++)
+            b += a.getValue(d, 0);
+          gvjs_5T(c).Ld("chld", b)
+        }
+        break;
+      case "s":
+      case "lxy":
+        if (d) {
+          g = e.chds;
+          g = typeof g === gvjs_l ? g.split(",") : [];
+          b = g[0];
+          d = g[1];
+          f = g[2];
+          g = g[3];
+          f = void 0 !== f ? f : b;
+          g = void 0 !== g ? g : d;
+          var h = e.valueLabelsInterval;
+          gvjs_lU(c, "x", {
+            min: b,
+            max: d,
+            interval: h
+          });
+          gvjs_lU(c, "y", {
+            min: f,
+            max: g,
+            interval: h
+          })
+        }
+    }
+  (b = null != e.chds) || (b = e.chm,
+    b = typeof b === gvjs_l && "N" == b.charAt(0));
+  b && (c.OO = "t");
+  b = e.annotationColumns;
+  if (null != b && 0 !== b.length) {
+    d = gvjs_gU(a);
+    e = [];
+    for (f = 0; f < b.length; f++) {
+      g = b[f];
+      h = g.column;
+      var k = g.positionColumn || d;
+      k -= d;
+      var l = g.color;
+      l = l || "000000";
+      "#" == l.charAt(0) && (l = l.substring(1));
+      var m = {
+        low: -1,
+        medium: 0,
+        high: 1
+      }[g.priority] || 0
+        , n = "t";
+      "flag" == g.type && (n = "f");
+      for (var p = 0; p < a.ca(); p++) {
+        var q = a.getValue(p, h);
+        if (null != q) {
+          var r = [];
+          r.push(n + q);
+          r.push(l);
+          r.push(k);
+          r.push(p);
+          r.push(g.size);
+          r.push(m);
+          r = r.join(",");
+          e.push(r)
+        }
+      }
+    }
+    a = c.Ee.cg.get("chm");
+    null != a && 0 < a.length && e.push(a);
+    0 < e.length && (a = e.join("|"),
+      c.Ee.Ld("chm", a))
+  }
+  this.Q8 = (a = gvjs_5T(c)) ? a.toString() : null;
+  return c
+}
+;
+gvjs_mU.prototype.Ooa = function() {
+  return this.Q8
+}
+;
+function gvjs_nU(a, b, c, d) {
+  b = b.W(c);
+  (c = d == b) || a.Sc("The DataTable column has an unexpected type.  Expected: " + d + ", actual: " + b);
+  return c
+}
+var gvjs_nja = {
+  annotationColumns: !0,
+  backgroundColor: !0,
+  color: !0,
+  colors: !0,
+  enableEvents: !0,
+  fill: !0,
+  firstHiddenColumn: !0,
+  height: !0,
+  labels: !0,
+  legend: !0,
+  max: !0,
+  min: !0,
+  showCategoryLabels: !0,
+  showValueLabels: !0,
+  singleColumnDisplay: !0,
+  title: !0,
+  width: !0,
+  valueLabelsInterval: !0,
+  chd: !0,
+  chs: !0
+};
+function gvjs_oU(a) {
+  gvjs_fU.call(this, 2, a)
+}
+gvjs_o(gvjs_oU, gvjs_fU);
+function gvjs_pU(a) {
+  gvjs_fU.call(this, 4, a)
+}
+gvjs_o(gvjs_pU, gvjs_fU);
+function gvjs_qU(a) {
+  gvjs_mU.call(this, a)
+}
+gvjs_o(gvjs_qU, gvjs_mU);
+gvjs_qU.prototype.IG = function(a, b) {
+  b = b ? gvjs_x(b) : {};
+  a = a.Gr();
+  a.G_(0, [["", 0, 0, 0, 0]]);
+  a.Yn([["", 0, 0, 0, 0]]);
+  b.cht = "lc";
+  b.color = gvjs_UT;
+  b.colors = [gvjs_UT];
+  b.legend = gvjs_f;
+  var c = b.monochrome ? "000000" : ""
+    , d = "1:" + (a.ca() - 2)
+    , e = b.candlestickWidth;
+  e = typeof e === gvjs_g ? String(e) : "20";
+  b.chm = ["F", c, "0", d, e].join();
+  return gvjs_mU.prototype.IG.call(this, a, b)
+}
+;
+function gvjs_rU(a) {
+  gvjs_fU.call(this, 1, a)
+}
+gvjs_o(gvjs_rU, gvjs_fU);
+function gvjs_sU(a) {
+  gvjs_fU.call(this, 3, a)
+}
+gvjs_o(gvjs_sU, gvjs_fU);
+function gvjs_tU(a, b) {
+  gvjs_Qn.call(this, a);
+  this.Se = new gvjs_$n;
+  this.xr = [];
+  this.bm = [];
+  this.ea = new gvjs_KA(this);
+  this.D = b || gvjs_Oh()
+}
+gvjs_o(gvjs_tU, gvjs_Qn);
+gvjs_ = gvjs_tU.prototype;
+gvjs_.getSelection = function() {
+  return this.Se.getSelection()
+}
+;
+gvjs_.setSelection = function(a) {
+  var b = this.Se.setSelection(a);
+  if (this.container) {
+    var c = gvjs_ao(b.An, gvjs_Fb);
+    for (a = 0; a < c.length; a++)
+      gvjs_uU(this, c[a], gvjs_YT);
+    b = gvjs_ao(b.uB, gvjs_Fb);
+    for (a = 0; a < b.length; a++)
+      gvjs_uU(this, b[a], gvjs_ZT)
+  }
+}
+;
+function gvjs_oja(a, b, c) {
+  c = c.labelPosition;
+  a.D.qc(a.container);
+  var d = a.D.J(gvjs_ss, {
+    "class": gvjs_YT
+  })
+    , e = a.D.J(gvjs_ts, {
+    "class": gvjs_YT
+  });
+  a.D.appendChild(a.container, d);
+  a.D.appendChild(d, e);
+  a.xr = [];
+  a.bm = [];
+  var f = a.D.J(gvjs_vs, {
+    "class": gvjs_YT
+  });
+  for (d = 0; d < b.$(); d++) {
+    var g = null
+      , h = gvjs_eo(a.Se, d) ? gvjs_ZT : gvjs_YT;
+    h = a.D.J(gvjs_us, {
+      "class": h
+    });
+    a.D.appendChild(f, h);
+    a.xr[d] = h
+  }
+  c == gvjs_$c && (g = a.D.J(gvjs_vs, {
+    "class": gvjs_YT
+  }),
+    a.D.appendChild(e, g));
+  a.D.appendChild(e, f);
+  c == gvjs_j && (g = a.D.J(gvjs_vs, {
+    "class": gvjs_YT
+  }),
+    a.D.appendChild(e, g));
+  if (g)
+    for (d = 0; d < b.$(); d++)
+      c = a.D.J(gvjs_us, {
+        "class": a.xr[d].className
+      }),
+        a.D.appendChild(g, c),
+        a.bm[d] = c
+}
+function gvjs_pja(a, b, c) {
+  c = c.labelPosition;
+  a.D.qc(a.container);
+  var d = a.D.J(gvjs_ss, {
+    "class": gvjs_YT
+  })
+    , e = a.D.J(gvjs_ts, {
+    "class": gvjs_YT
+  });
+  a.D.appendChild(a.container, d);
+  a.D.appendChild(d, e);
+  a.xr = [];
+  a.bm = [];
+  for (d = 0; d < b.$(); d++) {
+    var f = gvjs_YT;
+    gvjs_eo(a.Se, d) && (f = gvjs_ZT);
+    var g = a.D.J(gvjs_vs, {
+      "class": f
+    });
+    a.D.appendChild(e, g);
+    var h = a.D.J(gvjs_us, {
+      "class": f
+    });
+    c == gvjs_j ? (a.D.appendChild(g, h),
+      f = a.D.J(gvjs_us, {
+        "class": f
+      }),
+      a.D.appendChild(g, f),
+      a.xr[d] = h,
+      a.bm[d] = f) : (c == gvjs_$c && (f = a.D.J(gvjs_us, {
+      "class": f
+    }),
+      a.D.appendChild(g, f),
+      a.bm[d] = f),
+      a.D.appendChild(g, h));
+    a.xr[d] = h
+  }
+}
+function gvjs_vU(a, b) {
+  for (var c = 0; c < b.length; c++) {
+    var d = b[c];
+    a.ea.o(d, gvjs_gd, gvjs_s(a.UC, a, c));
+    a.ea.o(d, gvjs_kd, gvjs_s(a.xqa, a, c));
+    a.ea.o(d, gvjs_ld, gvjs_s(a.yqa, a, c))
+  }
+}
+function gvjs_qja(a, b) {
+  for (var c = 0; c < a.bm.length; c++)
+    a.D.V3(a.bm[c], b.Ga(c))
+}
+gvjs_.Rd = function(a, b, c) {
+  var d = c || {}
+    , e = 0;
+  typeof d.title === gvjs_l && (d.title = [d.title]);
+  gvjs_Zg(new gvjs_wi(this,this.container), gvjs_s(function() {
+    this.lM(b);
+    "h" == d.layout ? gvjs_oja(this, b, d) : gvjs_pja(this, b, d);
+    var f = d.labelPosition == gvjs_$c || d.labelPosition == gvjs_j
+      , g = "h" == d.layout;
+    gvjs_vU(this, this.xr);
+    f && (gvjs_qja(this, b),
+      gvjs_vU(this, this.bm));
+    for (var h = this.xr, k = 0; k < h.length; k++) {
+      var l = h[k]
+        , m = new gvjs_fU(1,l)
+        , n = gvjs_x(d)
+        , p = m.oP(this.container, d)
+        , q = m.qI(this.container, d);
+      g ? (p && (n.width = Math.floor(p / h.length - 2)),
+      q && (n.height = q - 2),
+      f && (n.height -= this.bm[0].clientHeight)) : (q && (n.height = Math.floor(q / h.length - 2)),
+      p && (n.width = p - 2),
+      f && (n.width -= this.bm[0].clientWidth));
+      n.title = d.title ? d.title[k] : null;
+      n.min = d.min ? d.min[k] : null;
+      n.max = d.max ? d.max[k] : null;
+      n.singleColumnDisplay = k;
+      gvjs_oi(m, gvjs_Rb, gvjs_s(function(r) {
+        gvjs_I(this, gvjs_Rb, r)
+      }, this));
+      gvjs_oi(m, gvjs_i, gvjs_s(function() {
+        e++;
+        e == h.length && gvjs_I(this, gvjs_i, {})
+      }, this));
+      m.draw(b, n);
+      l.firstChild.className = "google-visualization-sparkline-image"
+    }
+  }, this))
+}
+;
+gvjs_.UC = function(a) {
+  a = gvjs_eo(this.Se, a) ? null : [{
+    column: a
+  }];
+  this.setSelection(a);
+  gvjs_I(this, gvjs_k, {})
+}
+;
+gvjs_.xqa = function(a) {
+  gvjs_uU(this, a, gvjs_eo(this.Se, a) ? gvjs_ZT : gvjs_YT)
+}
+;
+gvjs_.yqa = function(a) {
+  gvjs_uU(this, a, "google-visualization-sparkline-over")
+}
+;
+function gvjs_uU(a, b, c) {
+  a.xr[b].className = c;
+  a.bm[b] && (a.bm[b].className = c)
+}
+gvjs_.lM = function(a) {
+  for (var b = a.$(), c = 0; c < b; c++) {
+    var d = a.W(c);
+    if (d != gvjs_g)
+      throw Error("Invalid type in column " + c + ". Expected: number, actual: " + d + ".");
+  }
+}
+;
+gvjs_.M = function() {
+  gvjs_E(this.ea);
+  delete this.ea;
+  delete this.xr;
+  delete this.bm;
+  gvjs_Qn.prototype.M.call(this)
+}
+;
+gvjs_q(gvjs_vc, gvjs_mU, void 0);
+gvjs_mU.prototype.getImageUrl = gvjs_mU.prototype.Ooa;
+gvjs_mU.prototype.draw = gvjs_mU.prototype.draw;
+gvjs_q(gvjs_sc, gvjs_oU, void 0);
+gvjs_oU.prototype.draw = gvjs_oU.prototype.draw;
+gvjs_q(gvjs_tc, gvjs_pU, void 0);
+gvjs_pU.prototype.draw = gvjs_pU.prototype.draw;
+gvjs_q(gvjs_uc, gvjs_qU, void 0);
+gvjs_qU.prototype.draw = gvjs_qU.prototype.draw;
+gvjs_q(gvjs_wc, gvjs_rU, void 0);
+gvjs_rU.prototype.draw = gvjs_rU.prototype.draw;
+gvjs_q(gvjs_xc, gvjs_sU, void 0);
+gvjs_sU.prototype.draw = gvjs_sU.prototype.draw;
+gvjs_q(gvjs_yc, gvjs_tU, void 0);
+gvjs_tU.prototype.draw = gvjs_tU.prototype.draw;
+gvjs_tU.prototype.getSelection = gvjs_tU.prototype.getSelection;
+gvjs_tU.prototype.setSelection = gvjs_tU.prototype.setSelection;

--- a/cypress/fixtures/charts/jsapi_compiled_motionchart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_motionchart_module
@@ -1,0 +1,231 @@
+function gvjs_T_(a) {
+  gvjs_Qn.call(this, a);
+  this.Sd = new gvjs_wi(this,this.container);
+  this.Uu = "google.visualization.MotionChart-" + gvjs_qma++;
+  gvjs_U_[this.Uu] = this;
+  this.cU = this.Uu + "_swf";
+  a.id || (a.id = this.Uu);
+  this.Usa = gvjs_Dm()
+}
+gvjs_o(gvjs_T_, gvjs_Qn);
+gvjs_ = gvjs_T_.prototype;
+gvjs_.Rd = function(a, b, c) {
+  a = c || {};
+  this.Z = b;
+  c = this.container;
+  this.Sd.removeAll();
+  if (b) {
+    try {
+      this.lM(b)
+    } catch (e) {
+      this.Sd.Sc(e.message);
+      return
+    }
+    this.DN = !1;
+    null == this.CL && (this.CL = gvjs_rma);
+    var d = gvjs_Wz(a, 1);
+    this.Ym || d != this.Pda ? (this.Ym = !1,
+      this.Pda = d,
+      this.a3(c, a),
+      this.V0 = gvjs_sma(b)) : (b = gvjs_sma(b),
+      b == this.V0 ? this.zf().dataChanged() : (this.zf().metricTablesChanged(),
+        this.V0 = b))
+  } else
+    this.Sd.Sc("Data table is null")
+}
+;
+function gvjs_sma(a) {
+  for (var b = "", c = a.$(), d = 0; d < c; d++)
+    b += a.W(d) + ":" + a.Ga(d) + ",";
+  return b
+}
+gvjs_.zf = function() {
+  return null != this.cU ? gvjs_Ph().getElementById(this.cU) : null
+}
+;
+gvjs_.Mra = function(a) {
+  if (null != this.CL)
+    throw Error("Swf url already initialzed");
+  this.CL = a
+}
+;
+gvjs_.getState = function() {
+  return this.DN ? gvjs_Hi(this.zf().getState()) : null
+}
+;
+gvjs_.lM = function(a) {
+  if (3 > a.$())
+    throw Error("There should be at least three columns in the data.");
+  var b;
+  if (!(b = a.W(0) != gvjs_l)) {
+    b = a.W(1);
+    var c = !1
+      , d = a.getValue(0, 1);
+    switch (b) {
+      case gvjs_g:
+        c = 0 <= d && Math.floor(d) == d;
+        break;
+      case gvjs_l:
+        c = /^[0-9]{4}Q[1-4]{1}$/.test(d) || /^[0-9]{4}W[0-9]{2}$/.test(d) || /^[0-9]{4}-((0[1-9])|(1[0-2]))$/.test(d);
+        break;
+      case gvjs_Lb:
+      case gvjs_Mb:
+        c = !0
+    }
+    b = !c
+  }
+  if (b)
+    throw Error("First and second columns must be entity and time.");
+  c = b = 0;
+  d = a.$();
+  for (var e = 2; e < d; e++) {
+    if (a.W(e) != gvjs_g && a.W(e) != gvjs_l)
+      throw Error("All data columns must be string or numbers.");
+    a.W(e) == gvjs_g ? b++ : c++
+  }
+  if (1 > b)
+    throw Error("There must be at least one numeric column.");
+}
+;
+gvjs_.a3 = function(a, b) {
+  var c = this.CL.replace("/en/", "/" + this.Usa + "/")
+    , d = parseInt(b.width, 10) || 500
+    , e = parseInt(b.height, 10) || 300
+    , f = b.state;
+  f = typeof f === gvjs_l ? f : "";
+  var g = decodeURIComponent(f);
+  f = (/^\s*$/.test(g) ? 0 : /^[\],:{}\s\u2028\u2029]*$/.test(g.replace(/\\["\\\/bfnrtu]/g, "@").replace(/(?:"[^"\\\n\r\u2028\u2029\x00-\x08\x0a-\x1f]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)[\s\u2028\u2029]*(?=:|,|]|}|$)/g, "]").replace(/(?:^|:|,)(?:[\s\u2028\u2029]*\[)+/g, ""))) ? encodeURIComponent(f) : "";
+  f = {
+    state: f,
+    chartId: this.Uu || "",
+    js: "blocking"
+  };
+  g = {
+    id: this.cU
+  };
+  gvjs_V_("showSelectList", "opt_.featureConfig_selectListComponent", b, f);
+  gvjs_V_("showSidePanel", "opt_.featureConfig_sidePanel", b, f);
+  gvjs_V_("showXMetricPicker", "opt_.featureConfig_xMetricPicker", b, f);
+  gvjs_V_("showYMetricPicker", "opt_.featureConfig_yMetricPicker", b, f);
+  gvjs_V_("showXScalePicker", "opt_.featureConfig_xScalePicker", b, f);
+  gvjs_V_("showYScalePicker", "opt_.featureConfig_yScalePicker", b, f);
+  gvjs_V_("showHeader", "opt_.featureConfig_chartHeader", b, f);
+  gvjs_V_(gvjs_Tw, "opt_.featureConfig_chartButtons", b, f);
+  gvjs_V_("showAdvancedPanel", "opt_.featureConfig_advancedPanel", b, f);
+  gvjs_V_("showSliderTimeDisplay", "opt_.featureConfig_sliderTimeDisplay", b, f);
+  gvjs_hh(a);
+  b = gvjs_3g(a).createElement(gvjs_Ob);
+  var h = a.id + "_flashElement";
+  b.id = h;
+  a.appendChild(b);
+  new gvjs_EQ.J9(c,h,d,e,"9.0.0",!1,f,{
+    scale: gvjs_eu,
+    allowScriptAccess: "always",
+    wmode: "opaque",
+    bgcolor: gvjs_xr
+  },g)
+}
+;
+function gvjs_tma(a) {
+  gvjs_W_(a);
+  a = gvjs_U_[a];
+  for (var b = [{
+    name: a.Z.Ga(0),
+    id: "dim0"
+  }], c = [], d = a.Z.$(), e = 2; e < d; e++)
+    c.push({
+      id: e,
+      name: a.Z.Ga(e),
+      type: a.Z.W(e) == gvjs_g ? "continuous" : gvjs_ip,
+      hasTime: !0
+    });
+  return gvjs_Hi({
+    dimensions: b,
+    metrics: c
+  })
+}
+function gvjs_uma(a, b) {
+  gvjs_W_(a);
+  a = gvjs_U_[a];
+  var c = a.Z.W(1)
+    , d = []
+    , e = []
+    , f = [];
+  f.push(d);
+  f.push(e);
+  for (var g = new gvjs_O(2,a.Z.$() - 1), h = 0; h < b.length; h++) {
+    if (!gvjs_Bl(g, Number(b[h])))
+      throw Error("Column index out of range: " + b[h]);
+    f.push([])
+  }
+  g = a.Z.ca();
+  for (var k = 0; k < g; k++) {
+    h = (a.Z.Ha(k, 0) + "").replace(/[\\"']/g, "");
+    d.push(h);
+    h = e;
+    var l = h.push;
+    var m = a.Z.getValue(k, 1);
+    var n = c;
+    if (n == gvjs_g)
+      m = String(m);
+    else if (n == gvjs_l && (-1 < m.indexOf("Q") || -1 < m.indexOf("W") || 4 == m.indexOf("-")))
+      m = String(m);
+    else if (n == gvjs_Lb || n == gvjs_Mb) {
+      n = [];
+      n.push(String(m.getFullYear()));
+      var p = String(m.getMonth() + 1);
+      1 == p.length && (p = "0" + p);
+      n.push(p);
+      m = String(m.getDate());
+      1 == m.length && (m = "0" + m);
+      n.push(m);
+      m = n.join("-")
+    } else
+      m = null;
+    l.call(h, m);
+    for (h = 0; h < b.length; h++)
+      f[h + 2].push(a.Z.getValue(k, Number(b[h])))
+  }
+  return gvjs_Hi(f)
+}
+function gvjs_vma(a) {
+  gvjs_W_(a);
+  a = gvjs_U_[a];
+  gvjs_I(a, gvjs_Hd, null);
+  a.DN || (a.DN = !0,
+    gvjs_I(a, gvjs_i, null))
+}
+function gvjs_W_(a) {
+  if (null == gvjs_U_[a])
+    throw Error("No chart with id " + a + " exists");
+}
+function gvjs_V_(a, b, c, d) {
+  a = c[a];
+  null != a && (d[b] = !!a)
+}
+var gvjs_X_ = gvjs_FQ("flash_subdir", gvjs_fd, "1");
+gvjs_X_.Ch.subdir = "en";
+gvjs_X_.Ch.filename = "tlz-gviz.swf";
+var gvjs_rma = gvjs_ef(gvjs_DQ(gvjs_X_));
+gvjs_T_.prototype.Uu = null;
+gvjs_T_.prototype.cU = null;
+gvjs_T_.prototype.CL = null;
+var gvjs_qma = 0
+  , gvjs_U_ = {};
+gvjs_ = gvjs_T_.prototype;
+gvjs_.Ym = !0;
+gvjs_.Pda = -1;
+gvjs_.DN = !1;
+gvjs_.V0 = "";
+gvjs_.Z = null;
+gvjs_q(gvjs_Cc, gvjs_T_, void 0);
+gvjs_T_.prototype.draw = gvjs_T_.prototype.draw;
+gvjs_T_.prototype.getState = gvjs_T_.prototype.getState;
+gvjs_T_.prototype.getChart = gvjs_T_.prototype.zf;
+gvjs_T_.prototype.initSwfUrl = gvjs_T_.prototype.Mra;
+gvjs_q("google.visualization.getMetadata", gvjs_tma, void 0);
+gvjs_q("google.visualization.getMetricValues", gvjs_uma, void 0);
+gvjs_q("google.visualization.updateExternalState", gvjs_vma, void 0);
+gvjs_q("getMetadata", gvjs_tma, void 0);
+gvjs_q("getMetricValues", gvjs_uma, void 0);
+gvjs_q("updateExternalState", gvjs_vma, void 0);

--- a/cypress/fixtures/charts/jsapi_compiled_orgchart_module
+++ b/cypress/fixtures/charts/jsapi_compiled_orgchart_module
@@ -1,0 +1,272 @@
+var gvjs_BU = "google-visualization-orgchart-connrow-";
+function gvjs_CU(a) {
+  gvjs_Qn.call(this, a);
+  this.m = {};
+  this.Z = null;
+  this.D = gvjs_Oh();
+  this.Of = new gvjs_$n;
+  this.Jr = null
+}
+gvjs_o(gvjs_CU, gvjs_Qn);
+gvjs_ = gvjs_CU.prototype;
+gvjs_.Rd = function(a, b, c) {
+  this.m = a = c || {};
+  this.Z = b;
+  if (!this.container)
+    throw Error(gvjs_za);
+  if (!b)
+    throw Error(gvjs_as);
+  b = new gvjs_3L(b,{
+    W9: !1,
+    X9: !1,
+    v$: !1
+  });
+  this.Jr = new gvjs_4L(b,function(d) {
+      return new gvjs_DU(d)
+    }
+  );
+  this.sE(this.Jr, a);
+  gvjs_I(this, gvjs_i, {})
+}
+;
+function gvjs_EU(a, b) {
+  var c = [];
+  a.Jr.VL(function(d, e) {
+    e == b && c.push(d);
+    return !d.collapsed && e < b
+  }, a);
+  c.sort(function(d, e) {
+    return d.row - e.row
+  });
+  return c
+}
+function gvjs_FU(a, b) {
+  var c = b.getChildren()
+    , d = c.length;
+  if (0 == d)
+    b.x = a.v1++;
+  else {
+    for (var e = 0; e < d; e++)
+      gvjs_FU(a, c[e]);
+    b.x = (c[0].x + c[d - 1].x) / 2
+  }
+}
+gvjs_.sE = function(a, b) {
+  var c = this.container;
+  this.v1 = 0;
+  for (var d = gvjs_EU(this, 0), e = 0; e < d.length; e++)
+    gvjs_FU(this, d[e]);
+  d = b.size;
+  "large" != d && "small" != d && (d = gvjs_dd);
+  var f = this.D
+    , g = f.J(gvjs_ss, {
+    "class": "google-visualization-orgchart-table",
+    dir: gvjs_Dv,
+    cellpadding: "0",
+    cellspacing: "0",
+    align: gvjs_0
+  })
+    , h = f.J(gvjs_ts);
+  f.appendChild(g, h);
+  var k = 8 * this.v1 - 2
+    , l = f.J(gvjs_vs, null);
+  f.appendChild(h, l);
+  for (var m = 0; m < k; m++) {
+    var n = f.J(gvjs_us, {
+      "class": "google-visualization-orgchart-space-" + d
+    });
+    f.appendChild(l, n)
+  }
+  a = a.getHeight() + 1;
+  for (l = 0; l < a; l++) {
+    m = gvjs_EU(this, l);
+    if (0 < l) {
+      var p = [];
+      for (var q = 0; q < m.length; q++) {
+        var r = m[q];
+        n = r.getParent();
+        e = Math.round(8 * r.x + 3);
+        n.x >= r.x ? ((n = p[e]) || (n = p[e] = {}),
+          n.borderLeft = !0) : ((n = p[--e]) || (n = p[e] = {}),
+          n.borderRight = !0)
+      }
+      gvjs_GU(this, p, k, h, gvjs_BU + d, d, b)
+    }
+    p = [];
+    for (q = 0; q < m.length; q++)
+      r = m[q],
+        e = Math.round(8 * r.x),
+      (n = p[e]) || (n = p[e] = {}),
+        n.node = r,
+        n.span = 6;
+    gvjs_GU(this, p, k, h, "google-visualization-orgchart-noderow-" + d, d, b);
+    if (l != a) {
+      p = [];
+      for (q = 0; q < m.length; q++) {
+        r = m[q];
+        var t = r.getChildren();
+        if (0 < t.length && (e = Math.round(8 * r.x + 3),
+        (n = p[e]) || (n = p[e] = {}),
+          n.borderLeft = !0,
+          !r.collapsed))
+          for (r = Math.round(8 * t[t.length - 1].x + 3),
+                 e = Math.round(8 * t[0].x + 3); e < r; e++)
+            (n = p[e]) || (n = p[e] = {}),
+              n.borderBottom = !0
+      }
+      gvjs_GU(this, p, k, h, gvjs_BU + d, d, b)
+    }
+  }
+  f.qc(c);
+  f.appendChild(c, g)
+}
+;
+function gvjs_GU(a, b, c, d, e, f, g) {
+  var h = g.nodeClass || "google-visualization-orgchart-node"
+    , k = a.D;
+  e = k.J(gvjs_vs, {
+    "class": e
+  });
+  k.appendChild(d, e);
+  for (d = 0; d < c; d++) {
+    var l = b[d]
+      , m = k.J(gvjs_us, null);
+    if (!l) {
+      l = {
+        empty: !0
+      };
+      for (var n = d + 1; n < c && !b[n]; )
+        n++;
+      l.span = n - d
+    }
+    (n = l.span) && 1 < n && (m.colSpan = n,
+      d += n - 1);
+    if (l.node) {
+      l.node.Q4 = m;
+      n = h + " google-visualization-orgchart-node-" + f;
+      var p = l.node.row;
+      null != p && (gvjs_G(m, gvjs_gd, gvjs_s(a.ZZ, a, p)),
+        gvjs_G(m, gvjs_ld, gvjs_s(a.a_, a, p)),
+        gvjs_G(m, gvjs_kd, gvjs_s(a.$Z, a, p)),
+      a.m.allowCollapse && gvjs_G(m, gvjs_du, gvjs_s(a.Upa, a, p)))
+    } else
+      n = "google-visualization-orgchart-linenode",
+      l.borderLeft && (n += " google-visualization-orgchart-lineleft"),
+      l.borderRight && (n += " google-visualization-orgchart-lineright"),
+      l.borderBottom && (n += " google-visualization-orgchart-linebottom");
+    n && (m.className = n,
+    -1 < n.indexOf(h) && (g.color && (m.style.background = g.color),
+      n = l.node && l.node.style)) && (n = gvjs_PA(n),
+      m.style.cssText = gvjs_Ff(n));
+    n = l.node ? l.node.lI : "\u00a0";
+    l = l.node ? l.node.label : null;
+    null != l && (m.title = l);
+    g.allowHtml ? (l = gvjs_OA(n),
+      gvjs_cg(m, l)) : k.appendChild(m, k.createTextNode(n));
+    k.appendChild(e, m)
+  }
+}
+gvjs_.getSelection = function() {
+  return this.Of.getSelection()
+}
+;
+gvjs_.setSelection = function(a) {
+  var b = this.m
+    , c = this.Of.setSelection(a);
+  if (this.container) {
+    a = b.selectedNodeClass || "google-visualization-orgchart-nodesel";
+    for (var d = gvjs_bo(c.An), e = 0; e < d.length; e++) {
+      var f = d[e]
+        , g = 0 <= f ? this.Jr.uw[f] || null : null;
+      g && (f = g.Q4) && (gvjs_XC(f, a),
+      b.color && (f.style.background = b.color),
+        g = g.style) && (g = gvjs_PA(g),
+        f.style.cssText = gvjs_Ff(g))
+    }
+    c = gvjs_bo(c.uB);
+    for (e = 0; e < c.length; e++)
+      if (f = c[e],
+        g = 0 <= f ? this.Jr.uw[f] || null : null)
+        if (f = g.Q4)
+          if (gvjs_VC(f, a),
+          b.selectionColor && (f.style.background = b.selectionColor),
+            d = g.lwa)
+            d = gvjs_PA(d),
+              f.style.cssText = gvjs_Ff(d)
+  }
+}
+;
+gvjs_.ZZ = function(a) {
+  a = gvjs_do(this.Of, a) ? null : [{
+    row: a
+  }];
+  this.setSelection(a);
+  gvjs_I(this, gvjs_k, {})
+}
+;
+gvjs_.a_ = function(a) {
+  gvjs_I(this, gvjs_7v, {
+    row: a
+  })
+}
+;
+gvjs_.$Z = function(a) {
+  gvjs_I(this, gvjs_6v, {
+    row: a
+  })
+}
+;
+gvjs_.Upa = function(a) {
+  var b = this.Jr.uw[a] || null;
+  this.collapse(a, !(b && b.collapsed))
+}
+;
+gvjs_.Boa = function() {
+  return this.Jr.find(function(a) {
+    return a.collapsed
+  }).map(function(a) {
+    return a.row
+  })
+}
+;
+gvjs_.Aoa = function(a) {
+  a = this.Jr.uw[a] || null;
+  if (!a)
+    return [];
+  a = a.getChildren();
+  for (var b = [], c = 0; c < a.length; c++)
+    b.push(a[c].row);
+  return b
+}
+;
+gvjs_.collapse = function(a, b) {
+  var c = this.Jr.uw[a] || null;
+  c && c.getChildren() && 0 != c.getChildren().length && (b && !c.collapsed || !b && c.collapsed) && (c.collapsed = b,
+    this.D.qc(this.container),
+    this.sE(this.Jr, this.m),
+    gvjs_I(this, gvjs_i, {}),
+    gvjs_I(this, "collapse", {
+      collapsed: b,
+      row: a
+    }))
+}
+;
+gvjs_.v1 = 0;
+function gvjs_DU(a) {
+  gvjs__L.call(this, a.getId(), a.getName());
+  this.row = a.getId();
+  this.lI = gvjs_1L(a);
+  this.style = a.Ul(gvjs_Jd);
+  this.lwa = a.Ul("selectedStyle");
+  this.label = 3 == a.mb().$() ? a.Ha(2) : null;
+  this.Q4 = this.x = null;
+  this.collapsed = !1
+}
+gvjs_o(gvjs_DU, gvjs__L);
+gvjs_q(gvjs_Ic, gvjs_CU, void 0);
+gvjs_CU.prototype.draw = gvjs_CU.prototype.draw;
+gvjs_CU.prototype.getSelection = gvjs_CU.prototype.getSelection;
+gvjs_CU.prototype.setSelection = gvjs_CU.prototype.setSelection;
+gvjs_CU.prototype.getChildrenIndexes = gvjs_CU.prototype.Aoa;
+gvjs_CU.prototype.getCollapsedNodes = gvjs_CU.prototype.Boa;
+gvjs_CU.prototype.collapse = gvjs_CU.prototype.collapse;

--- a/cypress/fixtures/charts/jsapi_compiled_table_module
+++ b/cypress/fixtures/charts/jsapi_compiled_table_module
@@ -1,0 +1,142 @@
+function gvjs_LU(a) {
+  return a instanceof gvjs_Xm ? a.clone() : new gvjs_Xm(a,void 0)
+}
+;function gvjs_MU(a, b, c, d) {
+  this.cf = a;
+  this.eF = new gvjs_hM(b);
+  this.Sna = c;
+  gvjs_oi(this.eF, gvjs_cw, gvjs_s(this.yaa, this));
+  gvjs_oi(this.eF, "sort", gvjs_s(this.Wqa, this));
+  this.fU = a = void 0 !== d ? gvjs_x(d) : {};
+  this.P9 = d.page == gvjs_qu;
+  a.showRowNumber = !0;
+  a.pagingButtonsConfiguration = d.pagingButtonsConfiguration || gvjs_ut;
+  a.sort = null == d.sort || d.sort == gvjs_qu ? "event" : gvjs_ju;
+  this.P9 && (a.page = "event",
+    d = d.pageSize || 0,
+    this.aA = 0 >= d ? 10 : d,
+    a.pageSize = this.aA,
+    this.Nm = 0,
+    gvjs_NU(this, 0))
+}
+gvjs_ = gvjs_MU.prototype;
+gvjs_.GE = function() {
+  this.DX && this.DX();
+  var a = gvjs_LU(this.cf).cg.get("tq") || "";
+  a += " " + this.Zfa + " " + this.Vda;
+  this.Dw = new gvjs_En(this.cf);
+  this.Dw.Jn(a);
+  this.np(this.Ew);
+  this.abort();
+  this.eF.setSelection([]);
+  this.mE = new gvjs_uo(this.Dw,this.eF,this.fU,this.Sna);
+  this.mE.oT(gvjs_s(this.Hw, this));
+  this.mE.nT(this.X8);
+  this.mE.GE()
+}
+;
+gvjs_.abort = function() {
+  this.mE && this.mE.abort()
+}
+;
+gvjs_.Wqa = function(a) {
+  var b = a.column;
+  a = a.ascending;
+  this.fU.sortColumn = b;
+  this.fU.sortAscending = a;
+  this.Zfa = "order by `" + this.zs.Ne(b) + (a ? "`" : "` desc");
+  this.P9 ? this.yaa({
+    page: 0
+  }) : this.GE()
+}
+;
+gvjs_.np = function(a) {
+  this.Ew = Math.max(0, a);
+  this.Dw && this.Dw.np(this.Ew)
+}
+;
+gvjs_.yaa = function(a) {
+  var b = this.Nm
+    , c = 0;
+  switch (a.page) {
+    case 0:
+      c = 0;
+      break;
+    case 1:
+      c = b + 1;
+      break;
+    case -1:
+      c = b - 1
+  }
+  gvjs_NU(this, c);
+  this.GE()
+}
+;
+function gvjs_NU(a, b) {
+  var c = a.Nm, d = a.aA, e;
+  if (!(e = 0 > b || b > c + 1)) {
+    if (c = b == c + 1)
+      c = -1,
+      a.zs && (c = a.zs.ca()),
+        c = c <= d;
+    e = c
+  }
+  e || (a.Nm = b,
+    b = a.Nm * d,
+    a.Vda = "limit " + (d + 1) + " offset " + b,
+    a.fU.firstRowNumber = b + 1)
+}
+gvjs_.Hw = function(a) {
+  this.CX && this.CX(a);
+  this.zs = a.Xk() ? null : a.mb()
+}
+;
+gvjs_.oT = function(a) {
+  if (null != a) {
+    if (typeof a != gvjs_d)
+      throw Error(gvjs_Aa);
+    this.CX = a
+  }
+}
+;
+gvjs_.nT = function(a) {
+  if (null != a) {
+    if (typeof a != gvjs_d)
+      throw Error("Custom post-response handler must be a function.");
+    this.X8 = a
+  }
+}
+;
+gvjs_.ywa = function(a) {
+  if (null != a) {
+    if (typeof a != gvjs_d)
+      throw Error("Custom sendAndDraw must be a function.");
+    this.DX = a
+  }
+}
+;
+gvjs_.mE = null;
+gvjs_.Dw = null;
+gvjs_.zs = null;
+gvjs_.Zfa = "";
+gvjs_.Vda = "";
+gvjs_.aA = -1;
+gvjs_.Nm = -1;
+gvjs_.Ew = 0;
+gvjs_.DX = null;
+gvjs_.CX = null;
+gvjs_.X8 = null;
+gvjs_q(gvjs_Vc, gvjs_hM, void 0);
+gvjs_hM.prototype.draw = gvjs_hM.prototype.draw;
+gvjs_hM.prototype.getSelection = gvjs_hM.prototype.getSelection;
+gvjs_hM.prototype.setSelection = gvjs_hM.prototype.setSelection;
+gvjs_hM.prototype.getSortInfo = gvjs_hM.prototype.AP;
+gvjs_hM.prototype.clearChart = gvjs_hM.prototype.Jb;
+gvjs_q("google.visualization.TableQueryWrapper", gvjs_MU, void 0);
+gvjs_MU.prototype.sendAndDrawTable = gvjs_MU.prototype.GE;
+gvjs_MU.prototype.abort = gvjs_MU.prototype.abort;
+gvjs_MU.prototype.setCustomSendAndDraw = gvjs_MU.prototype.ywa;
+gvjs_MU.prototype.setCustomPostResponseHandler = gvjs_MU.prototype.nT;
+gvjs_MU.prototype.setCustomResponseHandler = gvjs_MU.prototype.oT;
+gvjs_MU.prototype.setRefreshInterval = gvjs_MU.prototype.np;
+gvjs_MU.prototype.abort = gvjs_MU.prototype.abort;

--- a/cypress/fixtures/charts/jsapi_compiled_ui_module
+++ b/cypress/fixtures/charts/jsapi_compiled_ui_module
@@ -1,0 +1,29661 @@
+/*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+var gvjs_ar = " - "
+  , gvjs_br = " and "
+  , gvjs_cr = " but expected type is "
+  , gvjs_dr = ' class="'
+  , gvjs_er = " does not have a domain column."
+  , gvjs_fr = " is of type "
+  , gvjs_gr = " of "
+  , gvjs_hr = " to "
+  , gvjs_ir = '" id="'
+  , gvjs_jr = '" value="'
+  , gvjs_X = '">'
+  , gvjs_kr = "#000"
+  , gvjs_lr = "#109618"
+  , gvjs_mr = "#222222"
+  , gvjs_nr = "#333333"
+  , gvjs_or = "#444444"
+  , gvjs_pr = "#666666"
+  , gvjs_qr = "#757575"
+  , gvjs_rr = "#994499"
+  , gvjs_sr = "#999"
+  , gvjs_tr = "#999999"
+  , gvjs_ur = "#CCCCCC"
+  , gvjs_vr = "#DC3912"
+  , gvjs_wr = "#FF9900"
+  , gvjs_xr = "#FFFFFF"
+  , gvjs_yr = "#ccc"
+  , gvjs_zr = "#cccccc"
+  , gvjs_Ar = "#e0e0e0"
+  , gvjs_Br = "#fff"
+  , gvjs_Cr = "&up__table_query_url="
+  , gvjs_Dr = "-caption"
+  , gvjs_Er = "-content"
+  , gvjs_Fr = "-default"
+  , gvjs_Gr = "-disabled"
+  , gvjs_Hr = "-dropdown"
+  , gvjs_Ir = "-inner-box"
+  , gvjs_Jr = "-outer-box"
+  , gvjs_Kr = "..."
+  , gvjs_Lr = ".enableInteractivity"
+  , gvjs_Mr = "0 0"
+  , gvjs_Nr = "0px"
+  , gvjs_Or = "100"
+  , gvjs_Pr = "1px"
+  , gvjs_Qr = "1px solid infotext"
+  , gvjs_Rr = "400"
+  , gvjs_Sr = "500"
+  , gvjs_Tr = "600"
+  , gvjs_Ur = "700"
+  , gvjs_Vr = "800"
+  , gvjs_Wr = "900"
+  , gvjs_Xr = ";stop-opacity:"
+  , gvjs_Yr = "</li>"
+  , gvjs_Zr = '<div id="chartArea"></div>'
+  , gvjs__r = "<style> v\\:* { behavior:url(#default#VML);}</style>"
+  , gvjs_0r = "All data columns targeting the same axis must be of the same data type.  Column #"
+  , gvjs_1r = "All domains must be of the same data type"
+  , gvjs_2r = "Arial"
+  , gvjs_3r = "BACKGROUND"
+  , gvjs_4r = "Cannot compute diff for this chart type."
+  , gvjs_5r = "Cannot set a non-zero base-line for a stacked chart"
+  , gvjs_6r = "Chart has not finished drawing."
+  , gvjs_7r = "Color"
+  , gvjs_8r = "Component already rendered"
+  , gvjs_9r = "Copy-Paste this code to an HTML page"
+  , gvjs_$r = "Data must contain at least two columns."
+  , gvjs_as = "Data table is not defined"
+  , gvjs_bs = "Drawing_Frame_"
+  , gvjs_cs = "First column must be a domain column"
+  , gvjs_ds = "Google_Visualization"
+  , gvjs_es = "Incompatible chart types."
+  , gvjs_fs = "Incompatible default series types."
+  , gvjs_gs = "Invalid data table format: must have at least 2 columns."
+  , gvjs_hs = "Invalid format in "
+  , gvjs_is = "Invalid orientation."
+  , gvjs_js = "Last domain does not have enough data columns (missing "
+  , gvjs_ks = "Lines"
+  , gvjs_ls = "MAP"
+  , gvjs_ms = "No data"
+  , gvjs_ns = "No datatable provided."
+  , gvjs_os = "ROW"
+  , gvjs_ps = "ROW_INDEX"
+  , gvjs_qs = "Roboto"
+  , gvjs_rs = "SUBTYPE"
+  , gvjs_ss = "TABLE"
+  , gvjs_ts = "TBODY"
+  , gvjs_us = "TD"
+  , gvjs_vs = "TR"
+  , gvjs_ws = "Theme must be a theme name or an options object."
+  , gvjs_xs = "Unable to set parent component"
+  , gvjs_ys = "Unexpected domain column (column #"
+  , gvjs_zs = "Unspecified chart type."
+  , gvjs_As = "Your browser does not support charts"
+  , gvjs_Bs = "_default_"
+  , gvjs_Cs = "_focusedLabels"
+  , gvjs_Ds = "_selectedLabels"
+  , gvjs_Es = "goog-button"
+  , gvjs_Fs = "goog-checkbox"
+  , gvjs_Gs = "goog-control"
+  , gvjs_Hs = "goog-custom-button"
+  , gvjs_Y = "goog-inline-block"
+  , gvjs_Is = "goog-inline-block "
+  , gvjs_Z = "goog-menu"
+  , gvjs_Js = "goog-menu-button"
+  , gvjs_Ks = "goog-menuheader"
+  , gvjs__ = "goog-menuitem"
+  , gvjs_Ls = "goog-menuseparator"
+  , gvjs_Ms = "goog-option"
+  , gvjs_Ns = "goog-option-selected"
+  , gvjs_Os = "goog-select"
+  , gvjs_Ps = "goog-submenu"
+  , gvjs_Qs = "goog-submenu-arrow"
+  , gvjs_Rs = "goog-submenu-arrow-rtl"
+  , gvjs_Ss = "action"
+  , gvjs_Ts = "activedescendant"
+  , gvjs_Us = "allowHtml"
+  , gvjs_Vs = "alternatingRowStyle"
+  , gvjs_Ws = "animation.duration"
+  , gvjs_Xs = "animationEasing"
+  , gvjs_Ys = "animationfinish"
+  , gvjs_Zs = "annotation"
+  , gvjs__s = "annotations.boxStyle"
+  , gvjs_0s = "annotations.domain.stemColor"
+  , gvjs_1s = "annotations.domain.style"
+  , gvjs_2s = "annotations.domain.textStyle"
+  , gvjs_3s = "annotations.highContrast"
+  , gvjs_4s = "annotations.stem.color"
+  , gvjs_5s = "annotations.stem.length"
+  , gvjs_6s = "annotations.stemColor"
+  , gvjs_7s = "annotations.stemLength"
+  , gvjs_8s = "annotations.style"
+  , gvjs_9s = "annotations.textStyle"
+  , gvjs_$s = "annotationtext"
+  , gvjs_at = "area"
+  , gvjs_bt = "areaOpacity"
+  , gvjs_ct = "aria-activedescendant"
+  , gvjs_dt = "aria-hidden"
+  , gvjs_et = "aria-label"
+  , gvjs_ft = "arial"
+  , gvjs_gt = "axisBackgroundColor"
+  , gvjs_ht = "backgroundColor"
+  , gvjs_it = "backgroundColor.fill"
+  , gvjs_jt = "bar.groupWidth"
+  , gvjs_kt = "bar.width"
+  , gvjs_lt = "bars"
+  , gvjs_mt = "baselineColor"
+  , gvjs_nt = "beforedrag"
+  , gvjs_ot = "beforehide"
+  , gvjs_pt = "beforeshow"
+  , gvjs_qt = "below"
+  , gvjs_rt = "black"
+  , gvjs_st = "bold"
+  , gvjs_tt = "border-box"
+  , gvjs_ut = "both"
+  , gvjs_vt = "bottom"
+  , gvjs_wt = "bottom-space"
+  , gvjs_xt = "bottom-vert"
+  , gvjs_yt = "bubble"
+  , gvjs_zt = "bubble.opacity"
+  , gvjs_At = "bubbles"
+  , gvjs_Bt = "button"
+  , gvjs_Ct = "candlestick"
+  , gvjs_Dt = "candlestick.fallingColor"
+  , gvjs_Et = "candlestick.risingColor"
+  , gvjs_Ft = "candlesticks"
+  , gvjs_Gt = "canvas"
+  , gvjs_Ht = "category"
+  , gvjs_It = "categorypoint"
+  , gvjs_Jt = "categorysensitivityarea"
+  , gvjs_0 = "center"
+  , gvjs_Kt = "change"
+  , gvjs_Lt = "character"
+  , gvjs_Mt = "chartArea"
+  , gvjs_Nt = "chartArea.backgroundColor"
+  , gvjs_Ot = "chartDragStart"
+  , gvjs_Pt = "chartMouseDown"
+  , gvjs_Qt = "chartMouseMove"
+  , gvjs_Rt = "chartRightClick"
+  , gvjs_St = "chartType"
+  , gvjs_Tt = "chartarea"
+  , gvjs_Ut = "checkbox"
+  , gvjs_Vt = "checked"
+  , gvjs_Wt = "click"
+  , gvjs_Xt = "clipped"
+  , gvjs_Yt = "close"
+  , gvjs_Zt = "closedPhase"
+  , gvjs__t = "col-resize"
+  , gvjs_1 = "color"
+  , gvjs_0t = "colorAxis.values must not contain nulls"
+  , gvjs_1t = "colorBar"
+  , gvjs_2t = "colors"
+  , gvjs_3t = "contextmenu"
+  , gvjs_4t = "crosshair.color"
+  , gvjs_5t = "crosshair.opacity"
+  , gvjs_6t = "crosshair.orientation"
+  , gvjs_7t = "curve"
+  , gvjs_8t = "curveType"
+  , gvjs_9t = "dash"
+  , gvjs_$t = "data"
+  , gvjs_au = "data-logicalname"
+  , gvjs_bu = "data-value"
+  , gvjs_cu = "dataOpacity"
+  , gvjs_du = "dblclick"
+  , gvjs_eu = "default"
+  , gvjs_fu = "dialogselect"
+  , gvjs_gu = "diff.newData.opacity"
+  , gvjs_hu = "diff.oldData.opacity"
+  , gvjs_iu = "direction"
+  , gvjs_ju = "disable"
+  , gvjs_ku = "display"
+  , gvjs_lu = "dive"
+  , gvjs_mu = "domain"
+  , gvjs_nu = "drag"
+  , gvjs_ou = "dragend"
+  , gvjs_pu = "dragstart"
+  , gvjs_qu = "enable"
+  , gvjs_ru = "enableInteractivity"
+  , gvjs_su = "explicit"
+  , gvjs_tu = "explorer"
+  , gvjs_uu = "explorer.actions"
+  , gvjs_vu = "finish"
+  , gvjs_wu = "fixed"
+  , gvjs_xu = "focus"
+  , gvjs_yu = "focusTarget"
+  , gvjs_zu = "focusin"
+  , gvjs_Au = "focusout"
+  , gvjs_Bu = "font-style"
+  , gvjs_Cu = "font-weight"
+  , gvjs_Du = "fontColor"
+  , gvjs_Eu = "forceIFrame"
+  , gvjs_Fu = "format"
+  , gvjs_Gu = "formatOptions.prefix"
+  , gvjs_Hu = "formatOptions.scaleFactor"
+  , gvjs_Iu = "formatOptions.suffix"
+  , gvjs_Ju = "frozen-column"
+  , gvjs_Ku = "frozenColumnsBackground"
+  , gvjs_Lu = "global"
+  , gvjs_Mu = "google-visualization-toolbar-html-code-explanation"
+  , gvjs_Nu = "google-visualization-tooltip"
+  , gvjs_Ou = "gotpointercapture"
+  , gvjs_Pu = "grid"
+  , gvjs_Qu = "gridlineColor"
+  , gvjs_Ru = "gridlines"
+  , gvjs_Su = "gridlines.color"
+  , gvjs_Tu = "gridlines.count"
+  , gvjs_Uu = "gridlines.interval"
+  , gvjs_Vu = "gridlines.minSpacing"
+  , gvjs_Wu = "gridlines.multiple"
+  , gvjs_Xu = "hAxis"
+  , gvjs_Yu = "haspopup"
+  , gvjs_Zu = "headerColor"
+  , gvjs__u = "headerHeight"
+  , gvjs_0u = "hidden"
+  , gvjs_1u = "hide"
+  , gvjs_2u = "highContrast"
+  , gvjs_3u = "highlight"
+  , gvjs_4u = "histogram"
+  , gvjs_5u = "histogram.bucketSize"
+  , gvjs_6u = "histogram.hideBucketItems"
+  , gvjs_7u = "histogram.lastBucketPercentile"
+  , gvjs_8u = "histogramBuckets"
+  , gvjs_9u = "hoverIn"
+  , gvjs_$u = "hoverOut"
+  , gvjs_av = "html"
+  , gvjs_bv = "image/png"
+  , gvjs_cv = "inAndOut"
+  , gvjs_dv = "infobackground"
+  , gvjs_ev = "inline"
+  , gvjs_fv = "input"
+  , gvjs_gv = "inside"
+  , gvjs_hv = "interpolateNulls"
+  , gvjs_iv = "interval"
+  , gvjs_jv = "isStacked"
+  , gvjs_kv = "key"
+  , gvjs_lv = "keydown"
+  , gvjs_mv = "keyup"
+  , gvjs_nv = "labelInLegend"
+  , gvjs_ov = "labeled"
+  , gvjs_pv = "labelledby"
+  , gvjs_qv = "last-frozen-column"
+  , gvjs_rv = "legend"
+  , gvjs_sv = "legend.alignment"
+  , gvjs_tv = "legend.maxLines"
+  , gvjs_uv = "legend.position"
+  , gvjs_vv = "legend.textStyle"
+  , gvjs_wv = "legendFontSize"
+  , gvjs_xv = "legendTextColor"
+  , gvjs_yv = "legendTextStyle"
+  , gvjs_zv = "legendentry"
+  , gvjs_Av = "legendscrollbutton"
+  , gvjs_Bv = "lineWidth"
+  , gvjs_Cv = "logScale"
+  , gvjs_Dv = "ltr"
+  , gvjs_Ev = "margin"
+  , gvjs_Fv = "material"
+  , gvjs_Gv = "max"
+  , gvjs_Hv = "max-width"
+  , gvjs_Iv = "maxAlternation"
+  , gvjs_Jv = "maxColor"
+  , gvjs_Kv = "maxDepth"
+  , gvjs_Lv = "maximized"
+  , gvjs_Mv = "midColor"
+  , gvjs_Nv = "middle"
+  , gvjs_Ov = "min"
+  , gvjs_Pv = "minColor"
+  , gvjs_Qv = "minorGridlines.color"
+  , gvjs_Rv = "minorGridlines.count"
+  , gvjs_Sv = "minorGridlines.interval"
+  , gvjs_Tv = "minorGridlines.minSpacing"
+  , gvjs_Uv = "minorGridlines.multiple"
+  , gvjs_Vv = "mirrorLog"
+  , gvjs_Wv = "mousewheel"
+  , gvjs_Xv = "move"
+  , gvjs_Yv = "move_offscreen"
+  , gvjs_Zv = "name"
+  , gvjs__v = "nonNegative"
+  , gvjs_0v = "normal"
+  , gvjs_1v = "nowrap"
+  , gvjs_2v = "numberOrString"
+  , gvjs_3v = "old-data"
+  , gvjs_4v = "onmousedown"
+  , gvjs_5v = "onmousemove"
+  , gvjs_6v = "onmouseout"
+  , gvjs_7v = "onmouseover"
+  , gvjs_8v = "opacity 1s linear"
+  , gvjs_9v = "orientation"
+  , gvjs_$v = "orientationchange"
+  , gvjs_aw = "out"
+  , gvjs_bw = "outside"
+  , gvjs_cw = "page"
+  , gvjs_dw = "paging-controls"
+  , gvjs_ew = "percentage"
+  , gvjs_fw = "pie"
+  , gvjs_gw = "pieSliceBorderColor"
+  , gvjs_hw = "pieSliceText"
+  , gvjs_iw = "piecewiseLinear"
+  , gvjs_jw = "pointSize"
+  , gvjs_kw = "pointer"
+  , gvjs_lw = "pointer-events"
+  , gvjs_mw = "points"
+  , gvjs_nw = "pointsVisible"
+  , gvjs_ow = "pointsensitivityarea"
+  , gvjs_pw = "polygon"
+  , gvjs_qw = "pretty"
+  , gvjs_rw = "primarydiagonalstripes"
+  , gvjs_sw = "range"
+  , gvjs_tw = "ratio"
+  , gvjs_uw = "removeseriebutton"
+  , gvjs_vw = "resize"
+  , gvjs_ww = "reverseAxis"
+  , gvjs_xw = "reverseCategories"
+  , gvjs_yw = "rgba(0,0,0,0)"
+  , gvjs_zw = "right-space"
+  , gvjs_Aw = "rightclick"
+  , gvjs_Bw = "rowlabels"
+  , gvjs_Cw = "rows"
+  , gvjs_Dw = "sans-serif"
+  , gvjs_Ew = "scaleType"
+  , gvjs_Fw = "screen"
+  , gvjs_Gw = "scroll"
+  , gvjs_Hw = "secondarydiagonalstripes"
+  , gvjs_Iw = "selected"
+  , gvjs_Jw = "selection"
+  , gvjs_Kw = "selectionMode"
+  , gvjs_Lw = "separator"
+  , gvjs_Mw = "series"
+  , gvjs_Nw = "series-color"
+  , gvjs_Ow = "series-color-dark"
+  , gvjs_Pw = "series-color-light"
+  , gvjs_Qw = "series."
+  , gvjs_Rw = "shape"
+  , gvjs_Sw = "show"
+  , gvjs_Tw = "showChartButtons"
+  , gvjs_Uw = "showTooltip"
+  , gvjs_Vw = "showTooltips"
+  , gvjs_Ww = "single"
+  , gvjs_Xw = "size"
+  , gvjs_Yw = "smoothingFactor"
+  , gvjs_Zw = "solid"
+  , gvjs__w = "sortColumn"
+  , gvjs_0w = "span"
+  , gvjs_1w = "square"
+  , gvjs_2w = "stack"
+  , gvjs_3w = "star"
+  , gvjs_2 = "start"
+  , gvjs_4w = "steppedArea"
+  , gvjs_5w = "steppedareabar"
+  , gvjs_6w = "stop-color:"
+  , gvjs_7w = "stroke-dasharray"
+  , gvjs_8w = "stroke-linecap"
+  , gvjs_9w = "tabindex"
+  , gvjs_$w = "targetAxisIndex"
+  , gvjs_ax = "text-decoration"
+  , gvjs_bx = "textStyle"
+  , gvjs_cx = "textpathok"
+  , gvjs_dx = "tick"
+  , gvjs_ex = "ticks"
+  , gvjs_fx = "title"
+  , gvjs_gx = "titleColor"
+  , gvjs_hx = "titleFontSize"
+  , gvjs_ix = "titleTextStyle"
+  , gvjs_jx = "titleY"
+  , gvjs_kx = "toggle_display"
+  , gvjs_lx = "tooltip.bounds"
+  , gvjs_mx = "tooltip.ignoreBounds"
+  , gvjs_nx = "tooltip.isHtml"
+  , gvjs_ox = "tooltip.showColorCode"
+  , gvjs_px = "tooltip.textStyle"
+  , gvjs_qx = "tooltip.trigger"
+  , gvjs_rx = "tooltipFontSize"
+  , gvjs_sx = "tooltipTextColor"
+  , gvjs_tx = "tooltipTextStyle"
+  , gvjs_ux = "tooltipTrigger"
+  , gvjs_vx = "top"
+  , gvjs_wx = "top-space"
+  , gvjs_xx = "trendlines."
+  , gvjs_yx = "unhighlight"
+  , gvjs_zx = "unselectable"
+  , gvjs_Ax = "urn:schemas-microsoft-com:vml"
+  , gvjs_Bx = "userSpaceOnUse"
+  , gvjs_Cx = "v-text-align"
+  , gvjs_Dx = "v:fill"
+  , gvjs_Ex = "v:oval"
+  , gvjs_Fx = "v:path"
+  , gvjs_Gx = "v:shape"
+  , gvjs_Hx = "vAxes"
+  , gvjs_Ix = "value-and-percentage"
+  , gvjs_Jx = "viewWindow.max"
+  , gvjs_Kx = "viewWindow.min"
+  , gvjs_Lx = "viewWindowMode"
+  , gvjs_Mx = "visible"
+  , gvjs_Nx = "visibleInLegend"
+  , gvjs_Ox = "white";
+function gvjs_Px(a, b) {
+  var c = b || document;
+  return c.querySelectorAll && c.querySelector ? c.querySelectorAll("." + a) : gvjs_7g(document, "*", a, b)
+}
+function gvjs_Qx(a) {
+  return gvjs_y && !gvjs_Eg("9") ? (a = a.getAttributeNode(gvjs_9w),
+  null != a && a.specified) : a.hasAttribute(gvjs_9w)
+}
+function gvjs_Rx(a) {
+  a = a.tabIndex;
+  return typeof a === gvjs_g && 0 <= a && 32768 > a
+}
+function gvjs_Sx(a) {
+  return gvjs_Qx(a) && gvjs_Rx(a)
+}
+function gvjs_Tx(a) {
+  try {
+    var b = a && a.activeElement;
+    return b && b.nodeName ? b : null
+  } catch (c) {
+    return null
+  }
+}
+function gvjs_Ux(a) {
+  gvjs_Zk(a);
+  return a.$m.pop()
+}
+function gvjs_Vx(a, b, c, d, e) {
+  b = e[b];
+  d === gvjs_fw ? (c = b.Cs,
+    d = null) : d = b.Cs;
+  return {
+    type: a,
+    data: {
+      row: c,
+      column: d
+    }
+  }
+}
+gvjs_8q.prototype.Is = gvjs_V(33, function(a, b, c, d) {
+  var e = this
+    , f = []
+    , g = b.focused
+    , h = a.focused;
+  if (g.Hb !== h.Hb || g.datum !== h.datum)
+    null != h.Hb && f.push(gvjs_Vx(gvjs_6v, h.Hb, h.datum, c, d)),
+    null != g.Hb && f.push(gvjs_Vx(gvjs_7v, g.Hb, g.datum, c, d));
+  g.Eb !== h.Eb && (null != h.Eb && f.push({
+    type: gvjs_6v,
+    data: {
+      row: h.Eb,
+      column: null
+    }
+  }),
+  null != g.Eb && f.push({
+    type: gvjs_7v,
+    data: {
+      row: g.Eb,
+      column: null
+    }
+  }));
+  g = b.annotations.focused;
+  h = a.annotations.focused;
+  !h || g && g.row === h.row && g.column === h.column || f.push({
+    type: gvjs_6v,
+    data: {
+      row: h.row,
+      column: h.column
+    }
+  });
+  !g || h && g.row === h.row && g.column === h.column || f.push({
+    type: gvjs_7v,
+    data: {
+      row: g.row,
+      column: g.column
+    }
+  });
+  g = b.legend.focused;
+  h = a.legend.focused;
+  g.Xc !== h.Xc && (null != h.Xc && f.push(gvjs_Vx(gvjs_6v, h.Xc, null, c, d)),
+  null != g.Xc && f.push(gvjs_Vx(gvjs_7v, g.Xc, null, c, d)));
+  b.selected.equals(a.selected) || f.push({
+    type: gvjs_k
+  });
+  b.legend.Xi === a.legend.Xi && b.legend.xF === a.legend.xF || f.push({
+    type: "legendpagination",
+    data: {
+      currentPageIndex: b.legend.Xi,
+      totalPages: b.legend.xF
+    }
+  });
+  gvjs_u(f, function(k) {
+    e.dispatchEvent(k.type, k.data)
+  })
+});
+gvjs_wq.prototype.Ou = gvjs_V(27, function() {
+  return !1
+});
+gvjs_Uq.prototype.Ou = gvjs_V(26, function() {
+  return !1
+});
+gvjs_wq.prototype.Qj = gvjs_V(25, function() {
+  if (!(null != this.eo || this.Ou() && null != this.eo || this.fireEvent("box", [this]) && null != this.eo))
+    throw "cannot determine bounding box until inserted into a scene.";
+  return this.eo
+});
+gvjs_Qn.prototype.ah = gvjs_V(24, function() {
+  return ""
+});
+gvjs_M.prototype.Do = gvjs_V(20, function() {
+  return gvjs_0e(this.bf)
+});
+gvjs_N.prototype.Do = gvjs_V(19, function() {
+  return this.FZ()
+});
+gvjs_Po.prototype.Do = gvjs_V(18, function() {
+  return this.bd.Do()
+});
+gvjs_ok.prototype.aU = gvjs_V(17, function(a) {
+  this.x -= a.x;
+  this.y -= a.y;
+  return this
+});
+gvjs_hj.prototype.J_ = gvjs_V(15, function(a) {
+  var b = new gvjs_hj;
+  a = gvjs_ej(a);
+  for (var c = 0; c < a.length; c++) {
+    var d = a[c];
+    this.contains(d) && b.add(d)
+  }
+});
+gvjs_H.prototype.uA = gvjs_V(14, function(a) {
+  this.g2 = a
+});
+gvjs_4g.prototype.Gq = gvjs_V(8, function(a) {
+  var b;
+  (b = "A" == a.tagName && a.hasAttribute("href") || a.tagName == gvjs_Na || a.tagName == gvjs_Vo || a.tagName == gvjs_Uo || a.tagName == gvjs_To ? !a.disabled && (!gvjs_Qx(a) || gvjs_Rx(a)) : gvjs_Sx(a)) && gvjs_y ? (a = typeof a.getBoundingClientRect !== gvjs_d || gvjs_y && null == a.parentElement ? {
+    height: a.offsetHeight,
+    width: a.offsetWidth
+  } : a.getBoundingClientRect(),
+    a = null != a && 0 < a.height && 0 < a.width) : a = b;
+  return a
+});
+gvjs_4g.prototype.Ly = gvjs_V(6, function() {
+  return gvjs_Tx(this.dd)
+});
+gvjs_4g.prototype.wq = gvjs_V(0, function(a, b) {
+  return gvjs_Px(a, b || this.dd)
+});
+function gvjs_Wx(a) {
+  return a
+}
+function gvjs_Xx(a, b, c) {
+  for (var d = a.length, e = typeof a === gvjs_l ? a.split("") : a, f = 0; f < d; f++)
+    if (f in e && b.call(c, e[f], f, a))
+      return f;
+  return -1
+}
+function gvjs_Yx(a, b, c) {
+  b = gvjs_Xx(a, b, c);
+  return 0 > b ? null : typeof a === gvjs_l ? a.charAt(b) : a[b]
+}
+var gvjs_kda = /^([^?#]*)(\?[^#]*)?(#[\s\S]*)?/;
+function gvjs_Zx(a, b, c) {
+  if (null == c)
+    return b;
+  if (typeof c === gvjs_l)
+    return c ? a + encodeURIComponent(c) : "";
+  for (var d in c)
+    if (Object.prototype.hasOwnProperty.call(c, d)) {
+      var e = c[d];
+      e = Array.isArray(e) ? e : [e];
+      for (var f = 0; f < e.length; f++) {
+        var g = e[f];
+        null != g && (b || (b = a),
+          b += (b.length > a.length ? "&" : "") + encodeURIComponent(d) + "=" + encodeURIComponent(String(g)))
+      }
+    }
+  return b
+}
+function gvjs__x(a, b) {
+  gvjs_cg(a, b)
+}
+function gvjs_0x(a) {
+  a = a.document;
+  a = gvjs_eh(a) ? a.documentElement : a.body;
+  return new gvjs_A(a.clientWidth,a.clientHeight)
+}
+function gvjs_1x(a) {
+  return a.scrollingElement ? a.scrollingElement : !gvjs_tg && gvjs_eh(a) ? a.documentElement : a.body || a.documentElement
+}
+function gvjs_2x(a) {
+  var b = gvjs_1x(a);
+  a = a.parentWindow || a.defaultView;
+  return gvjs_y && gvjs_Eg("10") && a.pageYOffset != b.scrollTop ? new gvjs_z(b.scrollLeft,b.scrollTop) : new gvjs_z(a.pageXOffset || b.scrollLeft,a.pageYOffset || b.scrollTop)
+}
+function gvjs_3x(a) {
+  return a ? a.parentWindow || a.defaultView : window
+}
+function gvjs_4x(a, b) {
+  var c = gvjs_ah(a, gvjs_b);
+  gvjs_y ? (b = gvjs_$f(gvjs_bg, b),
+    gvjs_cg(c, b),
+    c.removeChild(c.firstChild)) : gvjs_cg(c, b);
+  if (1 == c.childNodes.length)
+    c = c.removeChild(c.firstChild);
+  else {
+    for (a = a.createDocumentFragment(); c.firstChild; )
+      a.appendChild(c.firstChild);
+    c = a
+  }
+  return c
+}
+function gvjs_5x(a, b) {
+  a.left = Math.min(a.left, b.left);
+  a.top = Math.min(a.top, b.top);
+  a.right = Math.max(a.right, b.right);
+  a.bottom = Math.max(a.bottom, b.bottom)
+}
+function gvjs_6x(a, b) {
+  b = gvjs_re(gvjs_E, b);
+  a.xf ? b() : (a.Wz || (a.Wz = []),
+    a.Wz.push(b))
+}
+function gvjs_7x(a) {
+  return 0 == a.$i.button && !(gvjs_ug && a.ctrlKey)
+}
+function gvjs_8x(a, b, c) {
+  gvjs_yi(a, b, gvjs_Wd, void 0 === c ? !0 : c)
+}
+function gvjs_9x(a) {
+  if (a === gvjs_f)
+    return gvjs_f;
+  a = gvjs_vj(a);
+  a = Math.round((a[0] + a[1] + a[2]) / 3);
+  return gvjs_wj(a, a, a)
+}
+function gvjs_$x(a, b, c) {
+  this.style = a;
+  this.color = gvjs_yj(b);
+  this.Pp = gvjs_yj(null != c ? c : gvjs_ea)
+}
+gvjs_ = gvjs_$x.prototype;
+gvjs_.getStyle = function() {
+  return this.style
+}
+;
+gvjs_.ee = function() {
+  return this.color
+}
+;
+gvjs_.getBackgroundColor = function() {
+  return this.Pp
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_$x(this.style,this.color,this.Pp)
+}
+;
+gvjs_.yI = function() {
+  return new gvjs_$x(this.style,gvjs_9x(this.color),gvjs_9x(this.Pp))
+}
+;
+function gvjs_ay(a, b) {
+  null != b && (a.strokeOpacity = gvjs_0g(Number(b), 0, 1))
+}
+function gvjs_by(a, b) {
+  b && (a.pattern = b instanceof gvjs_$x ? b.clone() : new gvjs_$x(b.style,b.color,b.Pp))
+}
+function gvjs_cy(a, b) {
+  null === a.gradient ? a.gradient = gvjs_0e(b || null) : null != b && (Object.assign(a.gradient, b),
+    b.Vf = gvjs_yj(b.Vf || "", !0),
+    b.sf = gvjs_yj(b.sf || "", !0),
+  null === b.tn && delete b.tn,
+  null === b.un && delete b.un,
+  null === b.Sn && delete b.Sn,
+  null === b.sp && delete b.sp)
+}
+function gvjs_3(a) {
+  a = void 0 === a ? {} : a;
+  this.Rw = this.pattern = this.gradient = this.radiusY = this.radiusX = null;
+  this.fill = gvjs_f;
+  this.fillOpacity = 1;
+  this.stroke = gvjs_f;
+  this.strokeOpacity = this.strokeWidth = 1;
+  this.Mi = gvjs_Zw;
+  this.sr(a)
+}
+gvjs_ = gvjs_3.prototype;
+gvjs_.sr = function(a) {
+  (a = void 0 === a ? {} : a) || (a = {});
+  this.Te(a.fill);
+  this.mf(a.fillOpacity);
+  this.rd(a.stroke);
+  this.hl(a.strokeWidth);
+  gvjs_ay(this, a.strokeOpacity);
+  var b = a.Mi;
+  null != b && (this.Mi = b);
+  b = a.rx;
+  null != b && (this.radiusX = b);
+  b = a.ry;
+  null != b && (this.radiusY = b);
+  gvjs_by(this, a.pattern);
+  gvjs_cy(this, a.gradient);
+  this.Rw = a.Rw || null;
+  return this
+}
+;
+gvjs_.getProperties = function() {
+  var a = this.pattern
+    , b = null;
+  a && (b = {
+    style: a.getStyle(),
+    color: a.ee(),
+    Pp: a.getBackgroundColor()
+  });
+  return {
+    fill: this.fill,
+    fillOpacity: this.fillOpacity,
+    stroke: this.Uj(),
+    strokeWidth: this.strokeWidth,
+    strokeOpacity: this.strokeOpacity,
+    Mi: this.Mi,
+    rx: this.radiusX,
+    ry: this.radiusY,
+    pattern: b,
+    gradient: gvjs_0e(this.gradient),
+    Rw: gvjs_0e(this.Rw)
+  }
+}
+;
+gvjs_.toJSON = function() {
+  var a = this.gradient;
+  a && (a = {
+    color1: a.Vf,
+    color2: a.sf,
+    opacity1: a.tn,
+    opacity2: a.un,
+    x1: a.x1,
+    y1: a.y1,
+    x2: a.x2,
+    y2: a.y2,
+    useObjectBoundingBoxUnits: a.Sn,
+    sharpTransition: a.sp
+  });
+  var b = this.pattern ? {
+    style: this.pattern.getStyle(),
+    color: this.pattern.ee(),
+    Pp: this.pattern.getBackgroundColor()
+  } : {}
+    , c = this.Rw;
+  c && (c = {
+    radius: c.radius,
+    opacity: c.opacity,
+    xOffset: c.xOffset,
+    yOffset: c.yOffset
+  });
+  return gvjs_Hi({
+    fill: this.fill,
+    fillOpacity: this.fillOpacity,
+    stroke: this.Uj(),
+    strokeWidth: this.strokeWidth,
+    strokeOpacity: this.strokeOpacity,
+    strokeDashStyle: this.Mi,
+    rx: this.radiusX,
+    ry: this.radiusY,
+    gradient: a,
+    pattern: b,
+    shadow: c
+  })
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_3(this.getProperties())
+}
+;
+gvjs_.yI = function() {
+  var a = this.clone();
+  a.Te(gvjs_9x(this.fill));
+  a.rd(gvjs_9x(this.stroke));
+  var b = this.gradient;
+  if (b) {
+    var c = gvjs_x(b);
+    c.Vf = gvjs_9x(b.Vf);
+    c.sf = gvjs_9x(b.sf);
+    gvjs_cy(a, c)
+  }
+  this.pattern && gvjs_by(a, this.pattern.yI());
+  return a
+}
+;
+gvjs_.Te = function(a) {
+  null != a && (this.fill = gvjs_yj(a, !0));
+  return this
+}
+;
+gvjs_.qZ = gvjs_n(34);
+gvjs_.mf = function(a) {
+  null != a && (this.fillOpacity = gvjs_0g(a, 0, 1));
+  return this
+}
+;
+gvjs_.rd = function(a, b) {
+  null != a && (this.stroke = gvjs_yj(a, !0));
+  this.hl(b)
+}
+;
+gvjs_.Uj = function() {
+  return this.stroke
+}
+;
+gvjs_.hl = function(a) {
+  if (null != a && (typeof a === gvjs_l && (a = Number(a)),
+  typeof a === gvjs_g && !isNaN(a))) {
+    if (0 > a)
+      throw Error("Negative strokeWidth not allowed.");
+    0 <= a && (this.strokeWidth = a)
+  }
+}
+;
+gvjs_.equals = function(a) {
+  var b;
+  if (b = this.fill === a.fill && this.fillOpacity === a.fillOpacity && this.stroke === a.stroke && this.strokeWidth === a.strokeWidth && this.strokeOpacity === a.strokeOpacity && this.Mi === a.Mi && this.radiusX === a.radiusX && this.radiusY === a.radiusY) {
+    b = this.gradient;
+    var c = a.gradient;
+    b = b === c ? !0 : null === b || null === c ? !1 : b.Vf === c.Vf && b.sf === c.sf && b.x1 === c.x1 && b.y1 === c.y1 && b.x2 === c.x2 && b.y2 === c.y2 && b.Sn === c.Sn && b.sp === c.sp
+  }
+  b && (b = this.pattern || null,
+    a = a.pattern || null,
+    b = b === a ? !0 : null == b || null == a ? !1 : b.Pp === a.Pp && b.color === a.color && b.style === a.style);
+  return b
+}
+;
+function gvjs_dy(a) {
+  return null === a || "" === a || a === gvjs_f || gvjs_r(a) && gvjs_dy(a.color)
+}
+function gvjs_ey(a) {
+  return 0 < a.strokeWidth && 0 < a.strokeOpacity && !gvjs_dy(a.stroke)
+}
+function gvjs_fy(a) {
+  return gvjs_ey(a) ? a.strokeWidth : 0
+}
+function gvjs_gy(a) {
+  return 0 < a.fillOpacity && (!gvjs_dy(a.fill) || null != a.gradient || null != a.pattern)
+}
+function gvjs_hy(a) {
+  return gvjs_gy(a) && 1 <= a.fillOpacity
+}
+var gvjs_iy = {
+  stroke: gvjs_Ox,
+  strokeOpacity: 0,
+  fill: gvjs_Ox,
+  fillOpacity: 0
+};
+function gvjs_jy(a, b) {
+  null != b && (a.bold = b);
+  return a
+}
+function gvjs_ky(a, b) {
+  null != b && (a.Nc = b);
+  return a
+}
+function gvjs_ly(a) {
+  this.bb = gvjs_Dw;
+  this.fontSize = Number(10);
+  this.color = gvjs_rt;
+  this.opacity = 1;
+  this.Lb = "";
+  this.tG = 3;
+  this.Ue = this.Nc = this.bold = !1;
+  this.sr(a || {})
+}
+gvjs_ = gvjs_ly.prototype;
+gvjs_.sr = function(a) {
+  a = a || {};
+  this.Mw(a.bb);
+  this.om(a.fontSize);
+  this.setColor(a.color);
+  this.setOpacity(a.opacity);
+  var b = a.Lb;
+  null != b && (this.Lb = b);
+  b = a.tG;
+  null != b && (this.tG = b);
+  gvjs_jy(this, a.bold);
+  gvjs_ky(this, a.Nc);
+  a = a.Ue;
+  null != a && (this.Ue = a);
+  return this
+}
+;
+gvjs_.getProperties = function() {
+  return {
+    fontName: this.bb,
+    fontSize: this.fontSize,
+    color: this.color,
+    auraColor: this.Lb,
+    auraWidth: this.tG,
+    bold: this.bold,
+    italic: this.Nc,
+    underline: this.Ue,
+    opacity: this.opacity
+  }
+}
+;
+gvjs_.toJSON = function() {
+  return gvjs_Hi(this.getProperties())
+}
+;
+gvjs_.Mw = function(a) {
+  null != a && "" !== a && (this.bb = a);
+  return this
+}
+;
+gvjs_.om = function(a) {
+  if (null != a && (typeof a === gvjs_l && (a = Number(a)),
+  typeof a === gvjs_g)) {
+    if (0 > a)
+      throw Error("Negative fontSize not allowed.");
+    0 < a && (this.fontSize = a)
+  }
+  return this
+}
+;
+gvjs_.setColor = function(a) {
+  null != a && (this.color = a);
+  return this
+}
+;
+gvjs_.setOpacity = function(a) {
+  null != a && (this.opacity = a);
+  return this
+}
+;
+var gvjs_lda = {
+  fill: {
+    name: gvjs_np,
+    type: gvjs_1
+  },
+  fillOpacity: {
+    name: gvjs_sp,
+    type: gvjs_tw
+  },
+  stroke: {
+    name: gvjs_0p,
+    type: gvjs_1
+  },
+  strokeOpacity: {
+    name: gvjs_7p,
+    type: gvjs_tw
+  },
+  strokeWidth: {
+    name: gvjs_8p,
+    type: gvjs__v
+  },
+  Mi: {
+    name: "strokeDashStyle",
+    type: ["arrayOfNumber", {
+      type: gvjs_l,
+      eu: {
+        Cja: gvjs_Zw,
+        Zza: gvjs_9t
+      }
+    }]
+  },
+  rx: {
+    name: "rx",
+    type: gvjs_g
+  },
+  ry: {
+    name: "ry",
+    type: gvjs_g
+  },
+  gradient: {
+    name: gvjs_Bp,
+    type: gvjs_h,
+    properties: {
+      Vf: {
+        name: "color1",
+        type: gvjs_1
+      },
+      sf: {
+        name: "color2",
+        type: gvjs_1
+      },
+      tn: {
+        name: "opacity1",
+        type: gvjs_tw
+      },
+      un: {
+        name: "opacity2",
+        type: gvjs_tw
+      },
+      x1: {
+        name: "x1",
+        type: gvjs_2v
+      },
+      y1: {
+        name: "y1",
+        type: gvjs_2v
+      },
+      x2: {
+        name: "x2",
+        type: gvjs_2v
+      },
+      y2: {
+        name: "y2",
+        type: gvjs_2v
+      },
+      sp: {
+        name: "sharpTransition",
+        type: gvjs_zb
+      },
+      Sn: {
+        name: "useObjectBoundingBoxUnits",
+        type: gvjs_zb
+      }
+    }
+  },
+  Rw: {
+    name: "shadow",
+    type: gvjs_h,
+    properties: {
+      radius: {
+        name: "radius",
+        type: gvjs_g
+      },
+      opacity: {
+        name: gvjs_Kp,
+        type: gvjs_tw
+      },
+      xOffset: {
+        name: "xOffset",
+        type: gvjs_g
+      },
+      yOffset: {
+        name: "yOffset",
+        type: gvjs_g
+      }
+    }
+  },
+  pattern: {
+    name: gvjs_td,
+    type: gvjs_h,
+    properties: {
+      color: {
+        name: gvjs_1,
+        type: gvjs_1
+      },
+      backgroundColor: {
+        name: gvjs_ht,
+        type: gvjs_1
+      },
+      style: {
+        name: gvjs_Jd,
+        type: {
+          type: gvjs_l,
+          eu: {
+            dBa: gvjs_rw,
+            lBa: gvjs_Hw
+          }
+        }
+      }
+    }
+  }
+}
+  , gvjs_mda = {
+  color: {
+    name: gvjs_1,
+    type: gvjs_1
+  },
+  opacity: {
+    name: gvjs_Kp,
+    type: gvjs_tw
+  },
+  Lb: {
+    name: "auraColor",
+    type: gvjs_1
+  },
+  tG: {
+    name: "auraWidth",
+    type: gvjs__v
+  },
+  bb: {
+    name: gvjs_yp,
+    type: gvjs_l
+  },
+  fontSize: {
+    name: gvjs_zp,
+    type: gvjs__v
+  },
+  bold: {
+    name: gvjs_st,
+    type: gvjs_zb
+  },
+  Nc: {
+    name: gvjs_Gp,
+    type: gvjs_zb
+  },
+  Ue: {
+    name: gvjs_bq,
+    type: gvjs_zb
+  }
+};
+function gvjs_nda(a, b) {
+  b && (a = b(a));
+  return gvjs_lj(a)
+}
+function gvjs_my(a, b, c, d) {
+  return gvjs_Fj(a, gvjs_nda, {}, b, c || {}, d)
+}
+function gvjs_ny(a, b, c) {
+  return gvjs_Fj(a, gvjs_Pj, 0, b, c)
+}
+function gvjs_oy(a, b, c, d) {
+  return gvjs_Fj(a, gvjs_Qj, gvjs_f, b, c, d)
+}
+function gvjs_py(a, b, c) {
+  function d(f, g, h) {
+    function k() {
+      var m = f.type;
+      m === gvjs_h ? (m = f.properties,
+        l = gvjs_py(a.view(g), m, h)) : l = d(m, g || f.name, h || f.eu)
+    }
+    var l = null;
+    Array.isArray(f) ? gvjs_Yx(f, function(m) {
+      l = d(m, g, h);
+      return null != l
+    }) : gvjs_lj(f) ? k() : typeof f === gvjs_l ? l = d(gvjs_zj[f], g, h) : typeof f === gvjs_d && (l = f.call(a, g, h));
+    return l
+  }
+  var e = null;
+  gvjs_w(b, function(f, g) {
+    f = d(f, f.name, c && c[g]);
+    null != f && (null == e && (e = {}),
+      e[g] = f)
+  });
+  return e
+}
+function gvjs_qy(a, b, c) {
+  var d = null
+    , e = null;
+  c instanceof gvjs_3 ? d = new gvjs_3(c.getProperties()) : typeof c === gvjs_h ? d = new gvjs_3(c) : e = c;
+  a = a.ob(b, e);
+  a = gvjs_v(a, function(f) {
+    typeof f === gvjs_l && (f = {
+      fill: gvjs_Qj(f)
+    });
+    return f
+  });
+  a = gvjs_py(new gvjs_Aj(a), gvjs_lda);
+  d = d || new gvjs_3;
+  d.sr(a);
+  gvjs_gy(d) || (d.Te(gvjs_iy.fill),
+    d.mf(gvjs_iy.fillOpacity));
+  gvjs_ey(d) || (d.rd(gvjs_iy.stroke),
+    gvjs_ay(d, gvjs_iy.strokeOpacity));
+  return d
+}
+function gvjs_ry(a, b, c, d) {
+  a = a.ob(b);
+  d = gvjs_py(new gvjs_Aj(a), gvjs_mda, {
+    color: d,
+    Lb: d
+  });
+  c = new gvjs_ly(c || {});
+  c.sr(d);
+  return c
+}
+function gvjs_sy(a, b) {
+  a.Lh && (a.Lh.reject = b)
+}
+function gvjs_ty(a, b, c) {
+  var d = gvjs_do(a, b);
+  c && a.clear();
+  d ? a.qE(b) : a.Kp(b)
+}
+function gvjs_uy(a, b, c) {
+  var d = gvjs_eo(a, b);
+  c && a.clear();
+  d ? a.BS(b) : a.xd(b)
+}
+function gvjs_vy(a, b, c, d) {
+  var e = gvjs_fo(a, b, c);
+  d && a.clear();
+  e ? a.MK(b, c) : gvjs_go(a, b, c)
+}
+function gvjs_wy(a) {
+  if (a.eq !== gvjs_pq)
+    throw Error("Sanitized content was not of kind HTML.");
+  return gvjs_3f(a.toString(), a.TN || null)
+}
+function gvjs_xy() {
+  this.T_ = !1;
+  this.qx = null;
+  this.l6 = void 0;
+  this.Fi = 1;
+  this.Ws = this.Lx = 0;
+  this.HY = this.Am = null
+}
+function gvjs_yy(a) {
+  if (a.T_)
+    throw new TypeError("Generator is already running");
+  a.T_ = !0
+}
+gvjs_ = gvjs_xy.prototype;
+gvjs_.KA = function() {
+  this.T_ = !1
+}
+;
+gvjs_.bK = function(a) {
+  this.l6 = a
+}
+;
+gvjs_.LL = function(a) {
+  this.Am = {
+    a$: a,
+    Dba: !0
+  };
+  this.Fi = this.Lx || this.Ws
+}
+;
+gvjs_.return = function(a) {
+  this.Am = {
+    return: a
+  };
+  this.Fi = this.Ws
+}
+;
+function gvjs_zy(a, b, c) {
+  a.Fi = c;
+  return {
+    value: b
+  }
+}
+gvjs_.hh = function(a) {
+  this.Fi = a
+}
+;
+function gvjs_Ay(a) {
+  this.Sb = new gvjs_xy;
+  this.jva = a
+}
+gvjs_Ay.prototype.bK = function(a) {
+  gvjs_yy(this.Sb);
+  if (this.Sb.qx)
+    return gvjs_By(this, this.Sb.qx.next, a, this.Sb.bK);
+  this.Sb.bK(a);
+  return gvjs_Cy(this)
+}
+;
+function gvjs_oda(a, b) {
+  gvjs_yy(a.Sb);
+  var c = a.Sb.qx;
+  if (c)
+    return gvjs_By(a, "return"in c ? c["return"] : function(d) {
+        return {
+          value: d,
+          done: !0
+        }
+      }
+      , b, a.Sb.return);
+  a.Sb.return(b);
+  return gvjs_Cy(a)
+}
+gvjs_Ay.prototype.LL = function(a) {
+  gvjs_yy(this.Sb);
+  if (this.Sb.qx)
+    return gvjs_By(this, this.Sb.qx["throw"], a, this.Sb.bK);
+  this.Sb.LL(a);
+  return gvjs_Cy(this)
+}
+;
+function gvjs_By(a, b, c, d) {
+  try {
+    var e = b.call(a.Sb.qx, c);
+    if (!(e instanceof Object))
+      throw new TypeError("Iterator result " + e + " is not an object");
+    if (!e.done)
+      return a.Sb.KA(),
+        e;
+    var f = e.value
+  } catch (g) {
+    return a.Sb.qx = null,
+      a.Sb.LL(g),
+      gvjs_Cy(a)
+  }
+  a.Sb.qx = null;
+  d.call(a.Sb, f);
+  return gvjs_Cy(a)
+}
+function gvjs_Cy(a) {
+  for (; a.Sb.Fi; )
+    try {
+      var b = a.jva(a.Sb);
+      if (b)
+        return a.Sb.KA(),
+          {
+            value: b.value,
+            done: !1
+          }
+    } catch (c) {
+      a.Sb.l6 = void 0,
+        a.Sb.LL(c)
+    }
+  a.Sb.KA();
+  if (a.Sb.Am) {
+    b = a.Sb.Am;
+    a.Sb.Am = null;
+    if (b.Dba)
+      throw b.a$;
+    return {
+      value: b.return,
+      done: !0
+    }
+  }
+  return {
+    value: void 0,
+    done: !0
+  }
+}
+function gvjs_pda(a) {
+  this.next = function(b) {
+    return a.bK(b)
+  }
+  ;
+  this.throw = function(b) {
+    return a.LL(b)
+  }
+  ;
+  this.return = function(b) {
+    return gvjs_oda(a, b)
+  }
+  ;
+  this[Symbol.iterator] = function() {
+    return this
+  }
+}
+function gvjs_Dy(a, b) {
+  b = new gvjs_pda(new gvjs_Ay(b));
+  gvjs_ce && a.prototype && gvjs_ce(b, a.prototype);
+  return b
+}
+function gvjs_Ey(a, b) {
+  a: {
+    for (var c = typeof a === gvjs_l ? a.split("") : a, d = a.length - 1; 0 <= d; d--)
+      if (d in c && b.call(void 0, c[d], d, a)) {
+        b = d;
+        break a
+      }
+    b = -1
+  }
+  return 0 > b ? null : typeof a === gvjs_l ? a.charAt(b) : a[b]
+}
+function gvjs_Fy(a) {
+  if (!Array.isArray(a))
+    for (var b = a.length - 1; 0 <= b; b--)
+      delete a[b];
+  a.length = 0
+}
+function gvjs_Gy(a, b) {
+  gvjs_He(a, b) || a.push(b)
+}
+function gvjs_Hy(a, b, c, d, e) {
+  for (var f = 0, g = a.length, h; f < g; ) {
+    var k = f + (g - f >>> 1);
+    var l = c ? b.call(e, a[k], k, a) : b(d, a[k]);
+    0 < l ? f = k + 1 : (g = k,
+      h = !l)
+  }
+  return h ? f : -f - 1
+}
+function gvjs_Iy(a, b, c) {
+  return gvjs_Hy(a, c || gvjs_Re, !1, b)
+}
+function gvjs_Jy(a, b) {
+  if (!gvjs_ne(a) || !gvjs_ne(b) || a.length != b.length)
+    return !1;
+  for (var c = a.length, d = 0; d < c; d++)
+    if (a[d] !== b[d])
+      return !1;
+  return !0
+}
+function gvjs_Ky(a) {
+  var b = [];
+  if (0 > a - 0)
+    return [];
+  for (var c = 0; c < a; c += 1)
+    b.push(c);
+  return b
+}
+function gvjs_Ly(a) {
+  for (var b = [], c = 0; c < arguments.length; c++) {
+    var d = arguments[c];
+    if (Array.isArray(d))
+      for (var e = 0; e < d.length; e += 8192) {
+        var f = gvjs_Oe(d, e, e + 8192);
+        f = gvjs_Ly.apply(null, f);
+        for (var g = 0; g < f.length; g++)
+          b.push(f[g])
+      }
+    else
+      b.push(d)
+  }
+  return b
+}
+function gvjs_My(a) {
+  if (!arguments.length)
+    return [];
+  for (var b = [], c = arguments[0].length, d = 1; d < arguments.length; d++)
+    arguments[d].length < c && (c = arguments[d].length);
+  for (d = 0; d < c; d++) {
+    for (var e = [], f = 0; f < arguments.length; f++)
+      e.push(arguments[f][d]);
+    b.push(e)
+  }
+  return b
+}
+function gvjs_Ny(a, b, c) {
+  var d = {}, e;
+  for (e in a)
+    d[e] = b.call(c, a[e], e, a);
+  return d
+}
+function gvjs_Oy(a) {
+  for (var b in a)
+    return a[b]
+}
+function gvjs_Py(a) {
+  for (var b in a)
+    return !1;
+  return !0
+}
+function gvjs_Qy(a, b) {
+  b in a && delete a[b]
+}
+function gvjs_Ry(a, b, c) {
+  if (null !== a && b in a)
+    throw Error('The object already contains the key "' + b + '"');
+  a[b] = c
+}
+function gvjs_Sy(a, b, c) {
+  return null !== a && b in a ? a[b] : c
+}
+function gvjs_Ty(a, b, c) {
+  return b in a ? a[b] : a[b] = c
+}
+function gvjs_Uy(a) {
+  var b = {}, c;
+  for (c in a)
+    b[a[c]] = c;
+  return b
+}
+var gvjs_qda = /^((https:)?\/\/[0-9a-z.:[\]-]+\/|\/[^/\\]|[^:/\\%]+\/|[^:/\\%]*[?#]|about:blank#)/i
+  , gvjs_rda = /%{(\w+)}/g;
+function gvjs_sda(a, b) {
+  var c = gvjs_8e(a);
+  if (!gvjs_qda.test(c))
+    throw Error("Invalid TrustedResourceUrl format: " + c);
+  a = c.replace(gvjs_rda, function(d, e) {
+    if (!Object.prototype.hasOwnProperty.call(b, e))
+      throw Error('Found marker, "' + e + '", in format string, "' + c + '", but no valid label mapping found in args: ' + JSON.stringify(b));
+    d = b[e];
+    return d instanceof gvjs_5e ? gvjs_8e(d) : encodeURIComponent(String(d))
+  });
+  return gvjs_gf(a)
+}
+function gvjs_Vy(a, b, c) {
+  a = gvjs_sda(a, b);
+  a = gvjs_ef(a);
+  a = gvjs_kda.exec(a);
+  b = a[3] || "";
+  return gvjs_gf(a[1] + gvjs_Zx("?", a[2] || "", c) + gvjs_Zx("#", b, void 0))
+}
+function gvjs_Wy(a, b) {
+  if (a instanceof gvjs_vf)
+    return a;
+  a = typeof a == gvjs_h && a.Po ? a.Tk() : String(a);
+  if (b && /^data:/i.test(a) && (b = gvjs_yf(a) || gvjs_Cf,
+  b.Tk() == a))
+    return b;
+  gvjs_Af.test(a) || (a = gvjs_ob);
+  return gvjs_zf(a)
+}
+function gvjs_Xy(a, b, c) {
+  a = a instanceof gvjs_vf ? a : gvjs_Wy(a);
+  c = c instanceof gvjs_5e ? gvjs_8e(c) : c || "";
+  (b || gvjs_p).open(gvjs_xf(a), c)
+}
+function gvjs_Yy(a) {
+  return !/[^0-9]/.test(a)
+}
+function gvjs_Zy(a) {
+  return a.replace(/[\t\r\n ]+/g, " ").replace(/^[\t\r\n ]+|[\t\r\n ]+$/g, "")
+}
+function gvjs_tda(a) {
+  return a.replace(/&([^;]+);/g, function(b, c) {
+    switch (c) {
+      case "amp":
+        return "&";
+      case "lt":
+        return "<";
+      case "gt":
+        return ">";
+      case "quot":
+        return '"';
+      default:
+        return "#" != c.charAt(0) || (c = Number("0" + c.substr(1)),
+          isNaN(c)) ? b : String.fromCharCode(c)
+    }
+  })
+}
+var gvjs_uda = /&([^;\s<&]+);?/g;
+function gvjs_vda(a) {
+  var b = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"'
+  };
+  var c = gvjs_p.document.createElement(gvjs_Ob);
+  return a.replace(gvjs_uda, function(d, e) {
+    var f = b[d];
+    if (f)
+      return f;
+    "#" == e.charAt(0) && (e = Number("0" + e.substr(1)),
+    isNaN(e) || (f = String.fromCharCode(e)));
+    f || (f = gvjs_3f(d + " ", null),
+      gvjs_cg(c, f),
+      f = c.firstChild.nodeValue.slice(0, -1));
+    return b[d] = f
+  })
+}
+function gvjs__y(a) {
+  return gvjs_sf(a, "&") ? "document"in gvjs_p ? gvjs_vda(a) : gvjs_tda(a) : a
+}
+function gvjs_0y(a, b) {
+  a.length > b && (a = a.substring(0, b - 3) + gvjs_Kr);
+  return a
+}
+function gvjs_1y(a) {
+  for (var b = 0, c = 0; c < a.length; ++c)
+    b = 31 * b + a.charCodeAt(c) >>> 0;
+  return b
+}
+function gvjs_2y(a) {
+  return String(a).replace(/([A-Z])/g, "-$1").toLowerCase()
+}
+function gvjs_3y(a, b) {
+  a %= b;
+  return 0 > a * b ? a + b : a
+}
+function gvjs_4y(a, b, c) {
+  return a + c * (b - a)
+}
+function gvjs_5y(a) {
+  return gvjs_3y(a, 360)
+}
+function gvjs_6y(a) {
+  return a * Math.PI / 180
+}
+function gvjs_7y(a) {
+  return 180 * a / Math.PI
+}
+function gvjs_8y(a, b) {
+  return b * Math.cos(gvjs_6y(a))
+}
+function gvjs_9y(a, b) {
+  return b * Math.sin(gvjs_6y(a))
+}
+function gvjs_$y(a) {
+  return 0 < a ? 1 : 0 > a ? -1 : a
+}
+function gvjs_az(a) {
+  return Array.prototype.reduce.call(arguments, function(b, c) {
+    return b + c
+  }, 0)
+}
+function gvjs_bz(a) {
+  return gvjs_az.apply(null, arguments) / arguments.length
+}
+function gvjs_cz(a, b) {
+  var c = a.x - b.x;
+  a = a.y - b.y;
+  return Math.sqrt(c * c + a * a)
+}
+function gvjs_dz(a, b) {
+  return new gvjs_z(a.x - b.x,a.y - b.y)
+}
+function gvjs_ez(a, b) {
+  return new gvjs_z(a.x + b.x,a.y + b.y)
+}
+function gvjs_fz(a, b) {
+  return a == b ? !0 : a && b ? a.width == b.width && a.height == b.height : !1
+}
+function gvjs_gz(a, b, c) {
+  return gvjs_7g(document, a, b, c)
+}
+function gvjs_4(a, b, c) {
+  return gvjs_$g(document, arguments)
+}
+function gvjs_hz(a, b) {
+  for (; b = b.previousSibling; )
+    if (b == a)
+      return -1;
+  return 1
+}
+function gvjs_iz(a, b) {
+  var c = a.parentNode;
+  if (c == b)
+    return -1;
+  for (; b.parentNode != c; )
+    b = b.parentNode;
+  return gvjs_hz(b, a)
+}
+function gvjs_wda(a, b) {
+  if (a == b)
+    return 0;
+  if (a.compareDocumentPosition)
+    return a.compareDocumentPosition(b) & 2 ? 1 : -1;
+  if (gvjs_y && !gvjs_Fg(9)) {
+    if (9 == a.nodeType)
+      return -1;
+    if (9 == b.nodeType)
+      return 1
+  }
+  if ("sourceIndex"in a || a.parentNode && "sourceIndex"in a.parentNode) {
+    var c = 1 == a.nodeType
+      , d = 1 == b.nodeType;
+    if (c && d)
+      return a.sourceIndex - b.sourceIndex;
+    var e = a.parentNode
+      , f = b.parentNode;
+    return e == f ? gvjs_hz(a, b) : !c && gvjs_rh(e, b) ? -1 * gvjs_iz(a, b) : !d && gvjs_rh(f, a) ? gvjs_iz(b, a) : (c ? a.sourceIndex : e.sourceIndex) - (d ? b.sourceIndex : f.sourceIndex)
+  }
+  d = gvjs_5g(a);
+  c = d.createRange();
+  c.selectNode(a);
+  c.collapse(!0);
+  a = d.createRange();
+  a.selectNode(b);
+  a.collapse(!0);
+  return c.compareBoundaryPoints(gvjs_p.Range.START_TO_END, a)
+}
+function gvjs_jz(a, b) {
+  b ? a.tabIndex = 0 : (a.tabIndex = -1,
+    a.removeAttribute("tabIndex"))
+}
+function gvjs_kz(a) {
+  var b = [];
+  gvjs_xh(a, b, !1);
+  return b.join("")
+}
+function gvjs_lz(a, b) {
+  return a.left <= b.right && b.left <= a.right && a.top <= b.bottom && b.top <= a.bottom
+}
+function gvjs_mz(a, b, c) {
+  return a.left <= b.right + c && b.left <= a.right + c && a.top <= b.bottom + c && b.top <= a.bottom + c
+}
+function gvjs_nz(a, b) {
+  return a == b ? !0 : a && b ? a.left == b.left && a.width == b.width && a.top == b.top && a.height == b.height : !1
+}
+function gvjs_5(a, b, c, d) {
+  this.left = a;
+  this.top = b;
+  this.width = c;
+  this.height = d
+}
+gvjs_ = gvjs_5.prototype;
+gvjs_.clone = function() {
+  return new gvjs_5(this.left,this.top,this.width,this.height)
+}
+;
+function gvjs_oz(a) {
+  return new gvjs_B(a.top,a.left + a.width,a.top + a.height,a.left)
+}
+gvjs_.J_ = function(a) {
+  var b = Math.max(this.left, a.left)
+    , c = Math.min(this.left + this.width, a.left + a.width);
+  if (b <= c) {
+    var d = Math.max(this.top, a.top);
+    a = Math.min(this.top + this.height, a.top + a.height);
+    d <= a && (this.left = b,
+      this.top = d,
+      this.width = c - b,
+      this.height = a - d)
+  }
+}
+;
+gvjs_.intersects = function(a) {
+  return this.left <= a.left + a.width && a.left <= this.left + this.width && this.top <= a.top + a.height && a.top <= this.top + this.height
+}
+;
+gvjs_.contains = function(a) {
+  return a instanceof gvjs_z ? a.x >= this.left && a.x <= this.left + this.width && a.y >= this.top && a.y <= this.top + this.height : this.left <= a.left && this.left + this.width >= a.left + a.width && this.top <= a.top && this.top + this.height >= a.top + a.height
+}
+;
+gvjs_.distance = function(a) {
+  var b = a.x < this.left ? this.left - a.x : Math.max(a.x - (this.left + this.width), 0);
+  a = a.y < this.top ? this.top - a.y : Math.max(a.y - (this.top + this.height), 0);
+  return Math.sqrt(b * b + a * a)
+}
+;
+gvjs_.Tb = function() {
+  return new gvjs_A(this.width,this.height)
+}
+;
+gvjs_.getCenter = function() {
+  return new gvjs_z(this.left + this.width / 2,this.top + this.height / 2)
+}
+;
+gvjs_.ceil = function() {
+  this.left = Math.ceil(this.left);
+  this.top = Math.ceil(this.top);
+  this.width = Math.ceil(this.width);
+  this.height = Math.ceil(this.height);
+  return this
+}
+;
+gvjs_.floor = function() {
+  this.left = Math.floor(this.left);
+  this.top = Math.floor(this.top);
+  this.width = Math.floor(this.width);
+  this.height = Math.floor(this.height);
+  return this
+}
+;
+gvjs_.round = function() {
+  this.left = Math.round(this.left);
+  this.top = Math.round(this.top);
+  this.width = Math.round(this.width);
+  this.height = Math.round(this.height);
+  return this
+}
+;
+gvjs_.translate = function(a, b) {
+  a instanceof gvjs_z ? (this.left += a.x,
+    this.top += a.y) : (this.left += a,
+  typeof b === gvjs_g && (this.top += b));
+  return this
+}
+;
+gvjs_.scale = function(a, b) {
+  b = typeof b === gvjs_g ? b : a;
+  this.left *= a;
+  this.width *= a;
+  this.top *= b;
+  this.height *= b;
+  return this
+}
+;
+function gvjs_pz(a) {
+  return new gvjs_5(a.left,a.top,a.right - a.left,a.bottom - a.top)
+}
+function gvjs_qz(a, b) {
+  var c = a.style[gvjs_kg(b)];
+  return "undefined" !== typeof c ? c : a.style[gvjs_Ah(a, b)] || ""
+}
+function gvjs_rz(a, b) {
+  typeof a == gvjs_g && (a = (b ? Math.round(a) : a) + gvjs_T);
+  return a
+}
+function gvjs_sz(a, b, c) {
+  if (b instanceof gvjs_z) {
+    var d = b.x;
+    b = b.y
+  } else
+    d = b,
+      b = c;
+  a.style.left = gvjs_rz(d, !1);
+  a.style.top = gvjs_rz(b, !1)
+}
+function gvjs_tz(a) {
+  a = a ? gvjs_5g(a) : document;
+  return !gvjs_y || gvjs_Fg(9) || gvjs_eh(gvjs_3g(a).dd) ? a.documentElement : a.body
+}
+function gvjs_uz(a) {
+  try {
+    return a.getBoundingClientRect()
+  } catch (b) {
+    return {
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0
+    }
+  }
+}
+function gvjs_xda(a) {
+  if (gvjs_y && !gvjs_Fg(8))
+    return a.offsetParent;
+  var b = gvjs_5g(a)
+    , c = gvjs_Dh(a, gvjs_vd)
+    , d = c == gvjs_wu || c == gvjs_c;
+  for (a = a.parentNode; a && a != b; a = a.parentNode)
+    if (11 == a.nodeType && a.host && (a = a.host),
+      c = gvjs_Dh(a, gvjs_vd),
+      d = d && "static" == c && a != b.documentElement && a != b.body,
+    !d && (a.scrollWidth > a.clientWidth || a.scrollHeight > a.clientHeight || c == gvjs_wu || c == gvjs_c || c == gvjs_zd))
+      return a;
+  return null
+}
+function gvjs_vz(a) {
+  var b = gvjs_5g(a)
+    , c = new gvjs_z(0,0)
+    , d = gvjs_tz(b);
+  if (a == d)
+    return c;
+  a = gvjs_uz(a);
+  b = gvjs_2x(gvjs_3g(b).dd);
+  c.x = a.left + b.x;
+  c.y = a.top + b.y;
+  return c
+}
+function gvjs_wz(a) {
+  for (var b = new gvjs_B(0,Infinity,Infinity,0), c = gvjs_3g(a), d = c.kc().body, e = c.kc().documentElement, f = gvjs_1x(c.dd); a = gvjs_xda(a); )
+    if (!(gvjs_y && 0 == a.clientWidth || gvjs_tg && 0 == a.clientHeight && a == d) && a != d && a != e && gvjs_Dh(a, "overflow") != gvjs_Mx) {
+      var g = gvjs_vz(a)
+        , h = new gvjs_z(a.clientLeft,a.clientTop);
+      g.x += h.x;
+      g.y += h.y;
+      b.top = Math.max(b.top, g.y);
+      b.right = Math.min(b.right, g.x + a.clientWidth);
+      b.bottom = Math.min(b.bottom, g.y + a.clientHeight);
+      b.left = Math.max(b.left, g.x)
+    }
+  d = f.scrollLeft;
+  f = f.scrollTop;
+  b.left = Math.max(b.left, d);
+  b.top = Math.max(b.top, f);
+  c = c.Vj();
+  c = gvjs_0x(c || window);
+  b.right = Math.min(b.right, d + c.width);
+  b.bottom = Math.min(b.bottom, f + c.height);
+  return 0 <= b.top && 0 <= b.left && b.bottom > b.top && b.right > b.left ? b : null
+}
+function gvjs_xz(a) {
+  var b = a.offsetWidth
+    , c = a.offsetHeight
+    , d = gvjs_tg && !b && !c;
+  return (void 0 === b || d) && a.getBoundingClientRect ? (a = gvjs_uz(a),
+    new gvjs_A(a.right - a.left,a.bottom - a.top)) : new gvjs_A(b,c)
+}
+function gvjs_yz(a) {
+  a = gvjs_uz(a);
+  return new gvjs_z(a.left,a.top)
+}
+function gvjs_zz(a) {
+  if (1 == a.nodeType)
+    return gvjs_yz(a);
+  a = a.changedTouches ? a.changedTouches[0] : a;
+  return new gvjs_z(a.clientX,a.clientY)
+}
+function gvjs_Az(a, b) {
+  a = gvjs_zz(a);
+  b = gvjs_zz(b);
+  return new gvjs_z(a.x - b.x,a.y - b.y)
+}
+function gvjs_Bz(a, b) {
+  a.style.width = gvjs_rz(b, !0)
+}
+function gvjs_Cz(a, b, c) {
+  if (b instanceof gvjs_A)
+    c = b.height,
+      b = b.width;
+  else if (void 0 == c)
+    throw Error("missing height argument");
+  gvjs_Bz(a, b);
+  a.style.height = gvjs_rz(c, !0)
+}
+function gvjs_Dz(a) {
+  if (gvjs_Dh(a, gvjs_ku) != gvjs_f)
+    return gvjs_xz(a);
+  var b = a.style
+    , c = b.display
+    , d = b.visibility
+    , e = b.position;
+  b.visibility = gvjs_0u;
+  b.position = gvjs_c;
+  b.display = gvjs_ev;
+  a = gvjs_xz(a);
+  b.display = c;
+  b.position = e;
+  b.visibility = d;
+  return a
+}
+function gvjs_Ez(a) {
+  var b = gvjs_vz(a);
+  a = gvjs_Dz(a);
+  return new gvjs_5(b.x,b.y,a.width,a.height)
+}
+function gvjs_Fz(a, b) {
+  a = a.style;
+  gvjs_Kp in a ? a.opacity = b : "MozOpacity"in a ? a.MozOpacity = b : gvjs_tp in a && (a.filter = "" === b ? "" : "alpha(opacity=" + 100 * Number(b) + ")")
+}
+function gvjs_6(a, b) {
+  a.style.display = b ? "" : gvjs_f
+}
+function gvjs_Gz(a) {
+  return gvjs_Up == gvjs_Dh(a, gvjs_iu)
+}
+function gvjs_Hz(a, b, c) {
+  c = c ? null : a.getElementsByTagName("*");
+  if (gvjs_Fh) {
+    if (b = b ? gvjs_f : "",
+    a.style && (a.style[gvjs_Fh] = b),
+      c) {
+      a = 0;
+      for (var d; d = c[a]; a++)
+        d.style && (d.style[gvjs_Fh] = b)
+    }
+  } else if (gvjs_y || gvjs_qg)
+    if (b = b ? "on" : "",
+      a.setAttribute(gvjs_zx, b),
+      c)
+      for (a = 0; d = c[a]; a++)
+        d.setAttribute(gvjs_zx, b)
+}
+function gvjs_Iz(a, b) {
+  b = b || gvjs_1x(document);
+  var c = b || gvjs_1x(document);
+  var d = gvjs_vz(a)
+    , e = gvjs_vz(c)
+    , f = gvjs_Jh(c);
+  if (c == gvjs_1x(document)) {
+    var g = d.x - c.scrollLeft;
+    d = d.y - c.scrollTop;
+    gvjs_y && !gvjs_Fg(10) && (g += f.left,
+      d += f.top)
+  } else
+    g = d.x - e.x - f.left,
+      d = d.y - e.y - f.top;
+  a = gvjs_xz(a);
+  f = c.clientHeight - a.height;
+  e = c.scrollLeft;
+  var h = c.scrollTop;
+  e += Math.min(g, Math.max(g - (c.clientWidth - a.width), 0));
+  h += Math.min(d, Math.max(d - f, 0));
+  c = new gvjs_z(e,h);
+  b.scrollLeft = c.x;
+  b.scrollTop = c.y
+}
+function gvjs_Jz(a) {
+  var b = {};
+  a.split(/\s*;\s*/).forEach(function(c) {
+    var d = c.match(/\s*([\w-]+)\s*:(.+)/);
+    d && (c = d[1],
+      d = gvjs_kf(d[2]),
+      b[gvjs_kg(c.toLowerCase())] = d)
+  });
+  return b
+}
+function gvjs_Kz(a) {
+  var b = [];
+  gvjs_w(a, function(c, d) {
+    b.push(gvjs_2y(d), ":", c, ";")
+  });
+  return b.join("")
+}
+function gvjs_Lz(a) {
+  a.preventDefault()
+}
+var gvjs_Mz = {
+  ux: gvjs_gd,
+  wx: gvjs_md,
+  mB: "mousecancel",
+  Yia: gvjs_jd,
+  $ia: gvjs_ld,
+  Zia: gvjs_kd,
+  Wia: gvjs_hd,
+  Xia: gvjs_id
+};
+function gvjs_Nz(a, b) {
+  return a.getTime() - b.getTime()
+}
+function gvjs_Oz(a) {
+  if (a instanceof gvjs_5i)
+    return a;
+  if (typeof a.xk == gvjs_d)
+    return a.xk(!1);
+  if (gvjs_ne(a)) {
+    var b = 0
+      , c = new gvjs_5i;
+    c.rg = function() {
+      for (; ; ) {
+        if (b >= a.length)
+          throw gvjs_4i;
+        if (b in a)
+          return a[b++];
+        b++
+      }
+    }
+    ;
+    c.next = c.rg.bind(c);
+    return c
+  }
+  throw Error("Not implemented");
+}
+function gvjs_Pz(a, b, c) {
+  if (gvjs_ne(a))
+    try {
+      gvjs_u(a, b, c)
+    } catch (d) {
+      if (d !== gvjs_4i)
+        throw d;
+    }
+  else {
+    a = gvjs_Oz(a);
+    try {
+      for (; ; )
+        b.call(c, a.next(), void 0, a)
+    } catch (d) {
+      if (d !== gvjs_4i)
+        throw d;
+    }
+  }
+}
+function gvjs_Qz(a, b, c) {
+  var d = 0
+    , e = a
+    , f = c || 1;
+  1 < arguments.length && (d = a,
+    e = +b);
+  if (0 == f)
+    throw Error("Range step argument must not be zero");
+  var g = new gvjs_5i;
+  g.rg = function() {
+    if (0 < f && d >= e || 0 > f && d <= e)
+      throw gvjs_4i;
+    var h = d;
+    d += f;
+    return h
+  }
+  ;
+  g.next = g.rg.bind(g);
+  return g
+}
+function gvjs_yda(a) {
+  var b = gvjs_Oz(a);
+  a = new gvjs_5i;
+  var c = null;
+  a.rg = function() {
+    for (; ; ) {
+      if (null == c) {
+        var d = b.next();
+        c = gvjs_Oz(d)
+      }
+      try {
+        return c.next()
+      } catch (e) {
+        if (e !== gvjs_4i)
+          throw e;
+        c = null
+      }
+    }
+  }
+  ;
+  a.next = a.rg.bind(a);
+  return a
+}
+function gvjs_Rz(a) {
+  return gvjs_yda(arguments)
+}
+function gvjs_zda(a, b) {
+  a = [a];
+  for (var c = b.length - 1; 0 <= c; --c)
+    a.push(typeof b[c], b[c]);
+  return a.join("\x0B")
+}
+function gvjs_Sz(a) {
+  this.JJ = Math.max(1, a || Infinity);
+  this.cache = new Map
+}
+gvjs_ = gvjs_Sz.prototype;
+gvjs_.rwa = function(a) {
+  this.JJ = Math.max(a, 1);
+  null != this.JJ && this.truncate(this.JJ)
+}
+;
+gvjs_.clear = function() {
+  this.cache.clear()
+}
+;
+gvjs_.contains = function(a) {
+  return this.cache.has(a)
+}
+;
+gvjs_.get = function(a) {
+  var b = this.cache.get(a);
+  if ("undefined" === typeof b)
+    throw Error('Cache does not contain key "' + a + '"');
+  this.cache.delete(a);
+  this.cache.set(a, b);
+  return b
+}
+;
+gvjs_.put = function(a, b) {
+  this.cache.delete(a);
+  if ("undefined" !== typeof b)
+    return this.cache.set(a, b),
+    null != this.JJ && this.truncate(this.JJ),
+      b
+}
+;
+gvjs_.size = function() {
+  return this.cache.size
+}
+;
+gvjs_.truncate = function(a) {
+  for (var b = gvjs_8d(this.cache), c = b.next(); !c.done; c = b.next()) {
+    c = gvjs_8d(c.value).next().value;
+    if (this.cache.size <= a)
+      break;
+    this.cache.delete(c)
+  }
+}
+;
+function gvjs_Tz(a, b) {
+  b = void 0 === b ? {} : b;
+  var c = b.gT || gvjs_zda
+    , d = b.size || 1E3
+    , e = b.cache || new gvjs_Sz(d);
+  return Object.assign(function(f) {
+    for (var g = [], h = 0; h < arguments.length; ++h)
+      g[h - 0] = arguments[h];
+    h = c(gvjs_pe(a), [].concat(gvjs_9d(g)));
+    return e.contains(h) ? e.get(h) : e.put(h, a.apply(null, gvjs_9d(g)))
+  }, {
+    clear: function() {
+      e.clear()
+    },
+    rwa: function(f) {
+      e.clear();
+      e = b.cache || new gvjs_Sz(f)
+    }
+  })
+}
+function gvjs_Uz(a, b) {
+  if (null == a && null == b)
+    return a === b;
+  if (a === b)
+    return !0;
+  var c = gvjs_me(a)
+    , d = gvjs_me(b);
+  if (c !== d)
+    return !1;
+  d = gvjs_oe(a);
+  var e = gvjs_oe(b);
+  if (d !== e)
+    return !1;
+  switch (c) {
+    case gvjs_h:
+      if (d && e)
+        return 0 === gvjs_Nz(a, b);
+      for (var f in a)
+        if (a.hasOwnProperty(f) && (!b.hasOwnProperty(f) || !gvjs_Uz(a[f], b[f])))
+          return !1;
+      for (var g in b)
+        if (b.hasOwnProperty(g) && !a.hasOwnProperty(g))
+          return !1;
+      return !0;
+    case gvjs_sb:
+      if (a.length !== b.length)
+        return !1;
+      for (c = 0; c < a.length; ++c)
+        if (!gvjs_Uz(a[c], b[c]))
+          return !1;
+      return !0;
+    case gvjs_d:
+      return !0;
+    case gvjs_l:
+    case gvjs_g:
+    case gvjs_zb:
+      return !1;
+    default:
+      throw Error("Error while comparing " + a + gvjs_br + b + ": unexpected type of obj1 " + c);
+  }
+}
+function gvjs_Vz(a, b) {
+  function c(d, e, f) {
+    for (var g in d)
+      d.hasOwnProperty(g) && (typeof d[g] === gvjs_h ? c(d[g], e, f) : b.call(void 0, d[g], g, d) && f.push(d[g]));
+    return f
+  }
+  return c(a, gvjs_Tz(b), [])
+}
+function gvjs_Wz(a, b) {
+  var c = gvjs_me(a);
+  b = (31 * b + gvjs_1y(c)) % 67108864;
+  switch (c) {
+    case gvjs_h:
+      if (a.constructor === Date)
+        b = (31 * b + gvjs_1y(gvjs_Lb)) % 67108864,
+          b = gvjs_Wz(a.getTime(), b);
+      else {
+        c = gvjs_Ye(a);
+        gvjs_Qe(c);
+        c = gvjs_lq(c);
+        for (var d in c)
+          c.hasOwnProperty(d) && (b = gvjs_Wz(a[d], gvjs_Wz(d, b)))
+      }
+      break;
+    case gvjs_sb:
+      for (d = 0; d < a.length; d++)
+        b = gvjs_Wz(a[d], gvjs_Wz(String(d), b));
+      break;
+    default:
+      b = (31 * b + gvjs_1y(String(a))) % 67108864
+  }
+  return b
+}
+function gvjs_Xz(a, b) {
+  return a.size === b.size && [].concat(gvjs_9d(gvjs_nj(a))).every(function(c) {
+    return b.has(c)
+  })
+}
+function gvjs_Yz(a, b) {
+  var c = new Set(a);
+  b = gvjs_nj(b);
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d];
+    a.has(e) && c.delete(e)
+  }
+  return c
+}
+function gvjs_Zz(a, b, c) {
+  0 > c ? c += 1 : 1 < c && --c;
+  return 1 > 6 * c ? a + 6 * (b - a) * c : 1 > 2 * c ? b : 2 > 3 * c ? a + (b - a) * (2 / 3 - c) * 6 : a
+}
+function gvjs__z(a, b, c) {
+  a /= 360;
+  if (0 == b)
+    c = b = a = 255 * c;
+  else {
+    var d = .5 > c ? c * (1 + b) : c + b - b * c;
+    var e = 2 * c - d;
+    c = 255 * gvjs_Zz(e, d, a + 1 / 3);
+    b = 255 * gvjs_Zz(e, d, a);
+    a = 255 * gvjs_Zz(e, d, a - 1 / 3)
+  }
+  return [Math.round(c), Math.round(b), Math.round(a)]
+}
+function gvjs_0z(a) {
+  return !!(gvjs_rj.test("#" == a.charAt(0) ? a : "#" + a) || gvjs_tj(a).length || gvjs_pj && gvjs_pj[a.toLowerCase()])
+}
+function gvjs_1z(a, b) {
+  return gvjs_xj([0, 0, 0], a, b)
+}
+function gvjs_2z(a, b) {
+  return gvjs_xj([255, 255, 255], a, b)
+}
+function gvjs_Ada(a, b) {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]) + Math.abs(a[2] - b[2])
+}
+function gvjs_3z(a) {
+  return Math.round((299 * a[0] + 587 * a[1] + 114 * a[2]) / 1E3)
+}
+function gvjs_4z(a, b) {
+  for (var c = [], d = 0; d < b.length; d++)
+    c.push({
+      color: b[d],
+      Ih: Math.abs(gvjs_3z(b[d]) - gvjs_3z(a)) + gvjs_Ada(b[d], a)
+    });
+  c.sort(function(e, f) {
+    return f.Ih - e.Ih
+  });
+  return c[0].color
+}
+function gvjs_5z(a, b) {
+  a && (a.logicalname = b)
+}
+function gvjs_6z(a) {
+  return (a = gvjs_yh(a, function(b) {
+    return null != b.logicalname
+  }, !0)) ? a.logicalname : gvjs_Bs
+}
+function gvjs_7z(a, b, c) {
+  return a && a !== gvjs_f ? b && b !== gvjs_f ? gvjs_uj(gvjs_xj(gvjs_vj(a), gvjs_vj(b), c)) : a : b
+}
+function gvjs_Bda(a, b) {
+  a = gvjs_4x(a.dd, b);
+  var c = [];
+  a.hasAttribute(gvjs_au) && c.push(a);
+  Array.from(a.querySelectorAll("[data-logicalname]")).forEach(function(d) {
+    c.push(d)
+  });
+  c.forEach(function(d) {
+    var e = d.getAttribute(gvjs_au);
+    gvjs_5z(d, e)
+  });
+  return a
+}
+function gvjs_8z(a, b) {
+  return new gvjs_3({
+    stroke: gvjs_f,
+    fill: a,
+    fillOpacity: void 0 === b ? 1 : b
+  })
+}
+function gvjs_9z(a, b, c, d) {
+  return new gvjs_3({
+    stroke: a,
+    strokeWidth: b,
+    strokeOpacity: null != d ? d : 1,
+    fill: null != c && c ? gvjs_Br : gvjs_f
+  })
+}
+function gvjs_$z(a, b) {
+  return a === b ? !0 : null === a || null === b ? !1 : a.equals(b)
+}
+function gvjs_aA(a, b) {
+  var c = gvjs_mk.lastIndexOf(".");
+  if (0 > a || 0 >= b)
+    return gvjs_mk.substr(0, c);
+  a > b && (b = gvjs_8d([b, a]),
+    a = b.next().value,
+    b = b.next().value);
+  c = gvjs_mk.substr(0, c + 1);
+  a = "0".repeat(a) + "#".repeat(b - a);
+  return c + a
+}
+function gvjs_bA(a, b, c, d) {
+  this.x0 = a;
+  this.y0 = b;
+  this.x1 = c;
+  this.y1 = d
+}
+gvjs_bA.prototype.clone = function() {
+  return new gvjs_bA(this.x0,this.y0,this.x1,this.y1)
+}
+;
+gvjs_bA.prototype.equals = function(a) {
+  return this.x0 == a.x0 && this.y0 == a.y0 && this.x1 == a.x1 && this.y1 == a.y1
+}
+;
+function gvjs_cA(a) {
+  var b = a.x1 - a.x0;
+  a = a.y1 - a.y0;
+  return b * b + a * a
+}
+function gvjs_dA(a, b) {
+  return new gvjs_z(gvjs_4y(a.x0, a.x1, b),gvjs_4y(a.y0, a.y1, b))
+}
+function gvjs_eA(a, b) {
+  return new gvjs_ok(a.x + b.x,a.y + b.y)
+}
+function gvjs_fA(a, b) {
+  return new gvjs_ok(a.x - b.x,a.y - b.y)
+}
+function gvjs_gA(a) {
+  return null == a || "" === a ? null : Number(a)
+}
+function gvjs_Cda(a, b) {
+  return Math.abs(a - b)
+}
+function gvjs_hA(a, b, c) {
+  if (!a || !b)
+    return !0;
+  c = c || gvjs_Cda;
+  return gvjs_Ve(a, function(d, e) {
+    var f = b[e];
+    return void 0 === b[e] || .05 >= c(d, f)
+  })
+}
+function gvjs_Dda(a, b, c) {
+  if (0 === a.x || 0 === b.x)
+    return {
+      x: 0,
+      y: (0 === a.x && 0 === b.x ? 0 : 0 === a.x ? a.y : b.y) * c / 6
+    };
+  c = c / 3 * Math.min(Math.abs(a.x), Math.abs(b.x));
+  b = (a.y / a.x + b.y / b.x) / 2;
+  return 0 < a.x ? {
+    x: c,
+    y: c * b
+  } : {
+    x: -c,
+    y: -c * b
+  }
+}
+function gvjs_Eda(a, b, c) {
+  var d = Math.hypot(a.x, a.y)
+    , e = Math.hypot(b.x, b.y);
+  if (0 === d || 0 === e)
+    return new gvjs_ok(0,0);
+  d = Math.sqrt(d / e);
+  a = gvjs_eA(a.clone().scale(1 / d), b.clone().scale(d));
+  a.scale(c / 6);
+  return a
+}
+function gvjs_iA(a, b, c, d) {
+  var e = b + c;
+  for (d && (e = (e + a.length) % a.length); e !== b && 0 <= e && e < a.length; ) {
+    if (null != a[e])
+      return e;
+    e += c;
+    d && (e = (e + a.length) % a.length)
+  }
+  return null
+}
+function gvjs_jA(a, b, c, d, e) {
+  c = c ? gvjs_Dda : gvjs_Eda;
+  for (var f = [], g = 0; g < a.length; ++g) {
+    if (e) {
+      var h = gvjs_iA(a, g, 1, d);
+      var k = gvjs_iA(a, g, -1, d)
+    } else
+      h = d ? (g + 1) % a.length : g + 1,
+        k = d ? (a.length + g - 1) % a.length : g - 1;
+    null != h && null != k && null != a[g] && null != a[k] && null != a[h] ? (h = c(gvjs_fA(a[g], a[k]), gvjs_fA(a[h], a[g]), b),
+      f.push([gvjs_fA(a[g], h), gvjs_eA(a[g], h)])) : null != a[g] ? f.push([a[g].clone(), a[g].clone()]) : f.push(null)
+  }
+  return f
+}
+function gvjs_kA(a, b, c) {
+  c = void 0 === c ? 0 : c;
+  var d = gvjs_Xx(b, function(e) {
+    return e[c] > a
+  });
+  return -1 === d ? b.length - 1 : 0 === d ? 0 : b[d][c] - a < a - b[d - 1][c] ? d : d - 1
+}
+function gvjs_Fda(a, b, c) {
+  c = void 0 === c ? 0 : c;
+  var d = void 0 === d ? 0 : d;
+  if (0 < b.length && a <= gvjs_Ae(b)[d])
+    return c = gvjs_kA(a, b, d),
+      [c, b[c][d]];
+  var e = b.length - 1 - c
+    , f = gvjs_Ae(b)[d]
+    , g = b[e][d]
+    , h = f - g
+    , k = Math.floor((a - f) / h);
+  a = a - f - k * h;
+  e = gvjs_v(gvjs_Oe(b, e), function(l) {
+    return [l[d] - g]
+  });
+  a = gvjs_kA(a, e, 0);
+  return [b.length - 1 + k * c + a, f + k * h + e[a][0]]
+}
+function gvjs_lA(a, b) {
+  for (var c = [], d = 0; d < a; d++)
+    c[d] = b.call(void 0, d);
+  return c
+}
+function gvjs_mA(a) {
+  return null != a.max ? a.max : a.min
+}
+function gvjs_Gda(a, b, c, d) {
+  void 0 === c && (c = 0);
+  void 0 === d && (d = a.length);
+  c = b - c;
+  for (var e = 0, f = 0 <= c ? 0 : null, g = 0, h = 0, k = null, l = null; e < a.length; ) {
+    var m = a[e].min
+      , n = gvjs_mA(a[e]) - m;
+    g += m;
+    g <= c && (f = e + 1,
+      l = Math.min(c - g, n),
+      h = g + l,
+      l = m + l);
+    if (g > b)
+      return e >= d ? {
+        B1: e,
+        e0: k,
+        LK: b - (g - m)
+      } : null == f ? null : {
+        B1: f,
+        e0: l,
+        LK: c - h
+      };
+    k = Math.min(b - g, n);
+    g += k;
+    k = m + k;
+    e++
+  }
+  return {
+    B1: e,
+    e0: k,
+    LK: b - g
+  }
+}
+function gvjs_Hda(a, b, c) {
+  c = c || gvjs_Wx;
+  a = gvjs_v(a, c);
+  gvjs_Qe(a);
+  for (var d = c = 0; d < a.length; d++) {
+    var e = a.length - d
+      , f = (a[d] - c) * e;
+    if (f <= b)
+      c = a[d],
+        b -= f;
+    else {
+      c += b / e;
+      b = 0;
+      break
+    }
+  }
+  return {
+    bza: c,
+    LK: b
+  }
+}
+function gvjs_nA(a, b, c, d) {
+  var e = gvjs_Gda(a, b, c, d);
+  if (!e)
+    return null;
+  b = e.LK;
+  c = gvjs_Oe(a, 0, e.B1);
+  d = gvjs_Ee(c, function(k, l) {
+    return Math.max(k, l.extra.length)
+  }, 0);
+  var f = gvjs_v(c, gvjs_mA);
+  0 < f.length && (f[f.length - 1] = e.e0);
+  for (e = {
+    kB: 0
+  }; e.kB < d; e = {
+    kB: e.kB
+  },
+         e.kB++) {
+    var g = gvjs_Hda(c, b, function(k) {
+      return function(l) {
+        return l.extra[k.kB] || 0
+      }
+    }(e));
+    b = g.LK;
+    for (var h = 0; h < f.length; h++)
+      f[h] += Math.min(g.bza, a[h].extra[e.kB] || 0);
+    if (0 === b)
+      break
+  }
+  return f
+}
+function gvjs_oA(a, b) {
+  var c = gvjs_nA(a, b, void 0, void 0)
+    , d = {};
+  null != c && gvjs_u(a, function(e, f) {
+    e = e.key;
+    null == d[e] && (d[e] = []);
+    f < c.length && d[e].push(c[f])
+  });
+  return d
+}
+function gvjs_Ida(a, b) {
+  for (var c = 1; c < arguments.length; ++c)
+    ;
+  c = Array.prototype.slice.call(arguments, 1);
+  for (var d = [], e = 0; e < c.length; e += 2) {
+    var f = gvjs_Oe(a, Math.min(c[e], a.length), Math.min(c[e + 1], a.length));
+    gvjs_Me(d, f)
+  }
+  return d
+}
+function gvjs_pA(a) {
+  if (0 === a)
+    return 0;
+  a = Math.abs(a);
+  for (var b = 0; 16 > b; ++b) {
+    if (Math.abs(a - Math.round(a)) < 1E-15 * a)
+      return b;
+    a *= 10
+  }
+  return 16
+}
+function gvjs_qA(a, b) {
+  if (0 === b || 1E-290 > Math.abs(b))
+    return b;
+  var c = Math.floor(Math.log10(Math.abs(b))) + 1;
+  if (c > a)
+    return a = Math.pow(10, c - a),
+    Math.round(b / a) * a;
+  a = Math.pow(10, a - c);
+  return Math.round(b * a) / a
+}
+function gvjs_rA(a, b, c) {
+  return 0 > b || 0 > c ? null : a[b][c]
+}
+function gvjs_Jda(a, b, c, d, e, f) {
+  var g = []
+    , h = gvjs_rA(c, d - 1, e);
+  h && g.push({
+    gS: h,
+    kr: h.kr + 1,
+    rJ: d - 1,
+    SU: null,
+    sJ: null,
+    TU: null
+  });
+  (h = gvjs_rA(c, d, e - 1)) && g.push({
+    gS: h,
+    kr: h.kr + 1,
+    rJ: null,
+    SU: null,
+    sJ: e - 1,
+    TU: null
+  });
+  (c = gvjs_rA(c, d - 1, e - 1)) && f(a[d - 1], b[e - 1]) && g.push({
+    gS: c,
+    kr: c.kr,
+    rJ: d - 1,
+    SU: e - 1,
+    sJ: e - 1,
+    TU: d - 1
+  });
+  gvjs_Qe(g, function(k, l) {
+    return k.kr - l.kr
+  });
+  return 0 < g.length ? g[0] : {
+    gS: null,
+    kr: 0,
+    rJ: null,
+    SU: null,
+    sJ: null,
+    TU: null
+  }
+}
+function gvjs_sA(a, b, c) {
+  c = c || function(k, l) {
+    return k === l
+  }
+  ;
+  for (var d = [], e = a.length, f = b.length, g = 0; g <= e; g++) {
+    d[g] = d[g] || [];
+    for (var h = 0; h <= f; h++)
+      d[g][h] = gvjs_Jda(a, b, d, g, h, c)
+  }
+  a = {};
+  b = {};
+  d = d[e][f];
+  for (e = d.kr; d; )
+    null != d.rJ && (a[d.rJ] = d.SU),
+    null != d.sJ && (b[d.sJ] = d.TU),
+      d = d.gS;
+  return {
+    kr: e,
+    vca: a,
+    wca: b
+  }
+}
+function gvjs_Kda(a, b, c) {
+  function d(n, p, q) {
+    if (null == q)
+      return 0;
+    if (q === p.length - 1 || null == n)
+      return q;
+    var r = c(p[q]);
+    if (null == r)
+      return q + 1;
+    p = c(p[q + 1]);
+    return null == p ? q : Math.abs(n - r) <= Math.abs(n - p) ? q : q + 1
+  }
+  if (!a || !b || 0 === a.length || 0 === b.length)
+    return null;
+  var e = [];
+  c || (c = gvjs_Wx);
+  for (var f = 0, g = 0, h, k; f < a.length || g < b.length; )
+    f < a.length && (h = c(a[f])),
+    g < b.length && (k = c(b[g])),
+      f < a.length && g < b.length && h === k ? (e.push({
+        value: h,
+        yB: f,
+        zB: g
+      }),
+        f++,
+        g++) : f < a.length && (null == h || g === b.length || h < k) ? (e.push({
+        value: h,
+        yB: f,
+        zB: void 0
+      }),
+        f++) : g < b.length && (null == k || f === a.length || k < h) && (e.push({
+        value: k,
+        yB: void 0,
+        zB: g
+      }),
+        g++);
+  var l = null
+    , m = null;
+  gvjs_u(e, function(n) {
+    null == n.yB ? n.yB = d(n.value, a, l) : l = n.yB;
+    null == n.zB ? n.zB = d(n.value, b, m) : m = n.zB
+  });
+  return e
+}
+function gvjs_tA(a, b) {
+  for (var c in a)
+    if (!gvjs_He(b, c))
+      return !1;
+  return !0
+}
+function gvjs_uA(a, b, c, d) {
+  var e = {};
+  gvjs_w(a, function(f, g) {
+    for (var h = 0; h < b.length; h++) {
+      var k = (0,
+        b[h])(a, g, d);
+      f = c(f, k)
+    }
+    e[g] = f
+  });
+  return e
+}
+function gvjs_Lda(a, b, c, d) {
+  for (var e = 1, f = 0; 1E3 > f; f++) {
+    var g = gvjs_uA(a, b, c, e)
+      , h = gvjs_uA(a, b, c, 0)
+      , k = gvjs_hA(a, g, d);
+    h = gvjs_hA(a, h, d);
+    if (k && h)
+      break;
+    a = g;
+    e *= .99
+  }
+  return a
+}
+function gvjs_vA(a, b) {
+  var c = gvjs_Iy(a, b, function(e, f) {
+    return gvjs_Re(e, f.x)
+  });
+  if (0 <= c)
+    return a[c].y;
+  var d = -(c + 1);
+  if (0 === d || d === a.length)
+    return null;
+  c = a[d - 1];
+  a = a[d];
+  return gvjs_dA(new gvjs_bA(c.x,c.y,a.x,a.y), (b - c.x) / (a.x - c.x)).y
+}
+function gvjs_wA(a, b, c) {
+  if (c)
+    return gvjs_vA(gvjs_De(a, function(e) {
+      return null != e
+    }), b);
+  var d = -1;
+  for (c = 0; c < a.length; c++)
+    if (null == a[c]) {
+      d = gvjs_Oe(a, d + 1, c);
+      d = gvjs_vA(d, b);
+      if (null !== d)
+        return d;
+      d = c
+    }
+  a = gvjs_Oe(a, d + 1);
+  return gvjs_vA(a, b)
+}
+var gvjs_xA = "Milliseconds Seconds Minutes Hours Date Month FullYear".split(" ")
+  , gvjs_Mda = [0, 0, 0, 0, 1, 0, 0];
+function gvjs_yA(a, b) {
+  for (var c = new Date(a.getTime()), d = !1, e = b.length, f = Math.floor, g = 0; g < e; ++g) {
+    var h = a["set" + gvjs_xA[g]]
+      , k = a["get" + gvjs_xA[g]].apply(a)
+      , l = b[g]
+      , m = gvjs_Mda[g];
+    if (0 === l)
+      d = d || 0 !== k && !1,
+        h.apply(c, [m]);
+    else {
+      d ? h.apply(c, [m + l * (1 + Math.floor((k - m) / l))]) : h.apply(c, [m + l * f((k - m) / l)]);
+      break
+    }
+  }
+  return c
+}
+var gvjs_Nda = [500, 30, 30, 12, 15, 6, 0];
+function gvjs_Oda(a, b) {
+  var c = Math.round, d = gvjs_Le(a), e;
+  for (e = 0; e < d.length && 0 === b[e]; ++e)
+    d[e] = 0;
+  if (0 === e)
+    return d[0] = c(a[0] / b[0]) * b[0],
+      d;
+  var f = 0;
+  a[e - 1] >= gvjs_Nda[e - 1] ? f = .7 : 0 < a[e - 1] && (f = .1);
+  d[e] = c((a[e] + f) / b[e]) * b[e];
+  return d
+}
+function gvjs_zA(a, b) {
+  a = new Date(a.getTime());
+  var c;
+  a: {
+    for (c = 0; c < b.length; ++c)
+      if (0 !== b[c]) {
+        c = !1;
+        break a
+      }
+    c = !0
+  }
+  if (c)
+    return a;
+  for (c = 0; c < b.length; ++c)
+    if (0 !== b[c]) {
+      var d = gvjs_xA[c]
+        , e = a["set" + d];
+      d = a["get" + d].apply(a, []);
+      e.apply(a, [d + -1 * b[c]])
+    }
+  return a
+}
+function gvjs_AA(a, b, c, d) {
+  this.tY = b;
+  this.ova = d;
+  this.fga = a.getTime();
+  this.A5 = a["get" + gvjs_xA[c]].apply(a, []);
+  this.Lwa = a["set" + gvjs_xA[c]];
+  this.Qz = new Date(this.fga)
+}
+gvjs_AA.prototype.next = function() {
+  var a = this.Qz;
+  this.Qz = new Date(this.fga);
+  this.A5 += this.ova;
+  this.Lwa.apply(this.Qz, [this.A5]);
+  return a
+}
+;
+gvjs_AA.prototype.peek = function() {
+  return this.Qz <= this.tY ? this.Qz : null
+}
+;
+function gvjs_BA(a) {
+  a = gvjs_Xx(a, function(b) {
+    return 0 !== b
+  });
+  return Math.max(0, a)
+}
+var gvjs_CA = [1, 1E3, 6E4, 36E5, 864E5, 2629743830, 31556926E3];
+function gvjs_DA(a) {
+  for (var b = [], c = gvjs_CA.length - 1; 0 <= c; c--)
+    b[c] = Math.floor(a / gvjs_CA[c]),
+      a -= b[c] * gvjs_CA[c];
+  return b
+}
+function gvjs_EA(a) {
+  if (null == a)
+    return -1;
+  for (var b = 0, c = a.length, d = 0; d < c; ++d)
+    b += a[d] * gvjs_CA[d];
+  return b
+}
+function gvjs_FA(a, b, c) {
+  var d = gvjs_v(b, function(e) {
+    return [Math.log(gvjs_EA(e))]
+  });
+  if (!c)
+    return d = gvjs_kA(Math.log(a), d),
+      b[d];
+  a = gvjs_Fda(Math.log(a), d, c);
+  c = a[0];
+  return c <= d.length - 1 ? b[c] : gvjs_Oda(gvjs_DA(Math.exp(a[1])), gvjs_Ae(b))
+}
+function gvjs_GA(a) {
+  a = gvjs_pk(a);
+  return gvjs_EA(a)
+}
+function gvjs_Pda(a, b) {
+  return gvjs_v(a, function(c) {
+    return c * b
+  })
+}
+var gvjs_HA = [[1], [0, 1], [0, 0, 1], [0, 0, 0, 1], [0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 1]];
+function gvjs_IA(a, b) {
+  gvjs_H.call(this);
+  this.Zv = a || 1;
+  this.ML = b || gvjs_p;
+  this.R7 = gvjs_s(this.Y4, this);
+  this.zJ = gvjs_se()
+}
+gvjs_t(gvjs_IA, gvjs_H);
+gvjs_ = gvjs_IA.prototype;
+gvjs_.enabled = !1;
+gvjs_.Hc = null;
+gvjs_.setInterval = function(a) {
+  this.Zv = a;
+  this.Hc && this.enabled ? (this.stop(),
+    this.start()) : this.Hc && this.stop()
+}
+;
+gvjs_.Y4 = function() {
+  if (this.enabled) {
+    var a = gvjs_se() - this.zJ;
+    0 < a && a < .8 * this.Zv ? this.Hc = this.ML.setTimeout(this.R7, this.Zv - a) : (this.Hc && (this.ML.clearTimeout(this.Hc),
+      this.Hc = null),
+      this.dispatchEvent(gvjs_dx),
+    this.enabled && (this.stop(),
+      this.start()))
+  }
+}
+;
+gvjs_.start = function() {
+  this.enabled = !0;
+  this.Hc || (this.Hc = this.ML.setTimeout(this.R7, this.Zv),
+    this.zJ = gvjs_se())
+}
+;
+gvjs_.stop = function() {
+  this.enabled = !1;
+  this.Hc && (this.ML.clearTimeout(this.Hc),
+    this.Hc = null)
+}
+;
+gvjs_.M = function() {
+  gvjs_IA.G.M.call(this);
+  this.stop();
+  delete this.ML
+}
+;
+var gvjs_JA = [];
+function gvjs_KA(a) {
+  gvjs_F.call(this);
+  this.pd = a;
+  this.ad = {}
+}
+gvjs_t(gvjs_KA, gvjs_F);
+gvjs_ = gvjs_KA.prototype;
+gvjs_.o = function(a, b, c, d) {
+  return gvjs_LA(this, a, b, c, d)
+}
+;
+function gvjs_MA(a, b, c, d, e) {
+  gvjs_LA(a, b, c, d, !1, e)
+}
+function gvjs_LA(a, b, c, d, e, f) {
+  Array.isArray(c) || (c && (gvjs_JA[0] = c.toString()),
+    c = gvjs_JA);
+  for (var g = 0; g < c.length; g++) {
+    var h = gvjs_G(b, c[g], d || a.handleEvent, e || !1, f || a.pd || a);
+    if (!h)
+      break;
+    a.ad[h.key] = h
+  }
+  return a
+}
+gvjs_.vD = function(a, b, c, d) {
+  return gvjs_NA(this, a, b, c, d)
+}
+;
+function gvjs_NA(a, b, c, d, e, f) {
+  if (Array.isArray(c))
+    for (var g = 0; g < c.length; g++)
+      gvjs_NA(a, b, c[g], d, e, f);
+  else {
+    b = gvjs_ei(b, c, d || a.handleEvent, e, f || a.pd || a);
+    if (!b)
+      return a;
+    a.ad[b.key] = b
+  }
+  return a
+}
+gvjs_.Ab = function(a, b, c, d, e) {
+  if (Array.isArray(b))
+    for (var f = 0; f < b.length; f++)
+      this.Ab(a, b[f], c, d, e);
+  else
+    c = c || this.handleEvent,
+      d = gvjs_r(d) ? !!d.capture : !!d,
+      e = e || this.pd || this,
+      c = gvjs_fi(c),
+      d = !!d,
+      b = gvjs_7h(a) ? a.uI(b, c, d, e) : a ? (a = gvjs_hi(a)) ? a.uI(b, c, d, e) : null : null,
+    b && (gvjs_ki(b),
+      delete this.ad[b.key]);
+  return this
+}
+;
+gvjs_.removeAll = function() {
+  gvjs_w(this.ad, function(a, b) {
+    this.ad.hasOwnProperty(b) && gvjs_ki(a)
+  }, this);
+  this.ad = {}
+}
+;
+gvjs_.M = function() {
+  gvjs_KA.G.M.call(this);
+  this.removeAll()
+}
+;
+gvjs_.handleEvent = function() {
+  throw Error("EventHandler.handleEvent not implemented");
+}
+;
+function gvjs_OA(a) {
+  return gvjs_Em ? gvjs_eca.sanitize(a) : gvjs_3f(a, null)
+}
+function gvjs_PA(a) {
+  if (gvjs_Em)
+    if (gvjs_y && 10 > document.documentMode)
+      a = gvjs_Gf;
+    else {
+      var b = document;
+      typeof HTMLTemplateElement === gvjs_d && (b = gvjs_dh("TEMPLATE").content.ownerDocument);
+      b = b.implementation.createHTMLDocument("").createElement(gvjs_b);
+      b.style.cssText = a;
+      a = gvjs_om(b.style, void 0)
+    }
+  else
+    a = new gvjs_Df(a,gvjs_Ef);
+  return a
+}
+function gvjs_QA(a) {
+  var b = null
+    , c = null;
+  typeof a === gvjs_d ? b = a : c = a;
+  this.ama = b;
+  this.H = c;
+  this.ZQ = null
+}
+gvjs_QA.prototype.kp = function(a) {
+  this.ZQ = a;
+  this.H && gvjs_5z(this.H, a)
+}
+;
+gvjs_QA.prototype.xv = function() {
+  return this.H ? gvjs_6z(this.H) : this.ZQ
+}
+;
+gvjs_QA.prototype.j = function() {
+  this.H || (this.H = this.ama(),
+  null !== this.ZQ && gvjs_5z(this.H, this.ZQ));
+  return this.H
+}
+;
+function gvjs_RA(a, b) {
+  return {
+    type: gvjs_Xv,
+    data: {
+      x: a,
+      y: b
+    }
+  }
+}
+function gvjs_SA() {
+  this.vc = []
+}
+gvjs_ = gvjs_SA.prototype;
+gvjs_.Cj = function(a) {
+  this.vc.push(a)
+}
+;
+gvjs_.move = function(a, b) {
+  this.Cj(gvjs_RA(a, b))
+}
+;
+gvjs_.va = function(a, b) {
+  this.Cj({
+    type: gvjs_e,
+    data: {
+      x: a,
+      y: b
+    }
+  })
+}
+;
+gvjs_.Jp = function(a, b, c, d, e, f) {
+  this.Cj({
+    type: gvjs_7t,
+    data: {
+      x1: a,
+      y1: b,
+      x2: c,
+      y2: d,
+      x: e,
+      y: f
+    }
+  })
+}
+;
+gvjs_.Sf = function(a, b, c, d, e, f, g) {
+  this.Cj({
+    type: "arc",
+    data: {
+      cx: a,
+      cy: b,
+      rx: c,
+      ry: d,
+      Gy: e,
+      ou: f,
+      zba: g
+    }
+  })
+}
+;
+function gvjs_TA(a, b, c) {
+  if (0 != b.length)
+    if (0 == a.vc.length ? a.move(b[0].x, b[0].y) : a.va(b[0].x, b[0].y),
+      c)
+      for (var d = 1; d < b.length; ++d)
+        a.Jp(c[d - 1][1].x, c[d - 1][1].y, c[d][0].x, c[d][0].y, b[d].x, b[d].y);
+    else
+      for (d = 1; d < b.length; ++d)
+        a.va(b[d].x, b[d].y)
+}
+gvjs_.close = function() {
+  this.Cj({
+    type: gvjs_Yt,
+    data: null
+  })
+}
+;
+function gvjs_UA(a, b) {
+  var c = new gvjs_SA;
+  0 < a.length && (gvjs_TA(c, a),
+  b || c.close());
+  return c
+}
+function gvjs_VA(a, b, c) {
+  switch (c) {
+    case gvjs_2:
+      c = a;
+      a += b;
+      break;
+    case gvjs_R:
+      c = a - b;
+      break;
+    case gvjs_0:
+      c = a - b / 2;
+      a += b / 2;
+      break;
+    default:
+      c = a = NaN
+  }
+  return {
+    start: c,
+    end: a
+  }
+}
+function gvjs_WA(a, b, c, d) {
+  d && (c = c === gvjs_2 ? gvjs_R : c === gvjs_R ? gvjs_2 : c);
+  switch (c) {
+    case gvjs_R:
+      return b;
+    case gvjs_0:
+      return gvjs_bz(a, b);
+    default:
+      return a
+  }
+}
+function gvjs_XA(a, b) {
+  gvjs_F.call(this);
+  this.container = a;
+  this.jF = b;
+  this.kw = null;
+  this.me = gvjs_Tz(function(c, d, e) {
+    return this.KC(c, d, e)
+  }
+    .bind(this), {
+    gT: function(c, d) {
+      var e = [c, d[0]];
+      gvjs_w(d[1], function(f, g) {
+        e.push(f);
+        e.push(g)
+      });
+      e.push(+d[2]);
+      return "getTextSize_" + e.join("_")
+    }
+  });
+  this.Kw = null
+}
+gvjs_t(gvjs_XA, gvjs_F);
+gvjs_ = gvjs_XA.prototype;
+gvjs_.width = 0;
+gvjs_.height = 0;
+gvjs_.Lm = function(a, b) {
+  a = this.bO(a, b);
+  a.kp(gvjs_Bs);
+  return this.kw = a
+}
+;
+gvjs_.deleteContents = function() {
+  this.WX()
+}
+;
+gvjs_.flush = function() {}
+;
+gvjs_.clear = function() {
+  this.He()
+}
+;
+gvjs_.He = function() {
+  this.kw = null
+}
+;
+gvjs_.M = function() {
+  this.He();
+  gvjs_XA.G.M.call(this)
+}
+;
+gvjs_.getContainer = function() {
+  return this.container
+}
+;
+gvjs_.kp = function(a, b) {
+  a && (a.constructor == gvjs_QA ? a.kp(b) : gvjs_5z(a, b))
+}
+;
+gvjs_.xv = function(a) {
+  return gvjs_6z(a)
+}
+;
+gvjs_.appendChild = function(a, b) {
+  if (b) {
+    if (b.constructor == gvjs_QA) {
+      if (!b.H)
+        return;
+      b = b.j()
+    }
+    a.j().appendChild(b)
+  }
+}
+;
+function gvjs_YA(a, b) {
+  b instanceof gvjs_QA && (b = b.j());
+  for (var c; c = b.firstChild; )
+    gvjs_YA(a, c);
+  b.parentElement.removeChild(b)
+}
+gvjs_.replaceChild = function(a, b, c) {
+  a = a.j();
+  gvjs_qh(c) != a ? (gvjs_YA(this, c),
+    a.appendChild(b)) : a.replaceChild(b, c)
+}
+;
+gvjs_.qc = function(a) {
+  if (a.H) {
+    var b = a.j();
+    this.gv.qc(b);
+    a.j()
+  }
+}
+;
+gvjs_.Sa = function(a) {
+  a = null != a ? a : !1;
+  var b = new gvjs_QA(this.nX.bind(this));
+  a || b.j();
+  return b
+}
+;
+gvjs_.dC = function() {}
+;
+gvjs_.HH = function() {
+  return null
+}
+;
+function gvjs_ZA(a, b, c, d, e, f) {
+  var g = new gvjs_SA;
+  g.move(b, c);
+  g.va(d, e);
+  return a.Dc(g, f)
+}
+gvjs_.Dc = function(a, b) {
+  for (var c = [], d = 0; d < a.vc.length; d++) {
+    var e = c
+      , f = a.vc[d];
+    switch (f.type) {
+      case gvjs_Xv:
+        f = f.data;
+        this.nd(e, f.x, f.y);
+        break;
+      case gvjs_e:
+        f = f.data;
+        this.Ma(e, f.x, f.y);
+        break;
+      case gvjs_7t:
+        f = f.data;
+        this.Yr(e, f.x1, f.y1, f.x2, f.y2, f.x, f.y);
+        break;
+      case "arc":
+        f = f.data;
+        this.Bm(e, f.cx, f.cy, f.rx, f.ry, f.Gy, f.ou, f.zba);
+        break;
+      case gvjs_Yt:
+        this.Qi(e)
+    }
+  }
+  return this.tX(c, b)
+}
+;
+gvjs_.Ke = function(a, b, c, d, e) {
+  a = this.$x(a, b, c, d);
+  this.appendChild(e, a);
+  return a
+}
+;
+gvjs_.Gl = function(a, b, c, d, e, f) {
+  a = this.mX(a, b, c, d, e);
+  this.appendChild(f, a);
+  return a
+}
+;
+gvjs_.yb = function(a, b, c, d, e, f) {
+  a = this.Bl(a, b, c, d, e);
+  this.appendChild(f, a);
+  return a
+}
+;
+gvjs_.jY = function(a, b, c, d, e, f) {
+  a = gvjs_ZA(this, a, b, c, d, e);
+  this.appendChild(f, a)
+}
+;
+gvjs_.Ia = function(a, b, c) {
+  a = this.Dc(a, b);
+  this.appendChild(c, a);
+  return a
+}
+;
+gvjs_.ce = function(a, b, c, d, e, f, g, h, k) {
+  a = this.by(a, b, c, d, e, f, g, k);
+  this.appendChild(h, a);
+  return a
+}
+;
+gvjs_.Zi = function(a, b, c, d, e, f, g, h, k, l) {
+  a = this.pH(a, b, c, d, e, f, g, h, l);
+  this.appendChild(k, a);
+  return a
+}
+;
+function gvjs_Qda(a, b, c, d, e, f, g, h, k, l) {
+  b = a.ys(b, c, d, e, f, g, h, k, void 0);
+  a.appendChild(l, b)
+}
+gvjs_.Wl = function(a, b) {
+  return this.me(a, b).width
+}
+;
+gvjs_.cw = gvjs_n(36);
+gvjs_.ic = function() {}
+;
+gvjs_.ws = gvjs_ye;
+function gvjs__A() {
+  var a = gvjs_Oh().Vj();
+  a.__googleVisualizationAbstractRendererElementsCount__ = a.__googleVisualizationAbstractRendererElementsCount__ || 0;
+  var b = "_ABSTRACT_RENDERER_ID_" + a.__googleVisualizationAbstractRendererElementsCount__.toString();
+  a.__googleVisualizationAbstractRendererElementsCount__ = Number(a.__googleVisualizationAbstractRendererElementsCount__) + 1;
+  return b
+}
+function gvjs_0A(a) {
+  return gvjs_yh(a, function(b) {
+    return b.referencepoint
+  }, !0)
+}
+function gvjs_1A(a) {
+  gvjs_H.call(this);
+  this.H = a;
+  a = gvjs_y ? gvjs_Au : gvjs_Yo;
+  this.Ssa = gvjs_G(this.H, gvjs_y ? gvjs_zu : gvjs_xu, this, !gvjs_y);
+  this.Tsa = gvjs_G(this.H, a, this, !gvjs_y)
+}
+gvjs_t(gvjs_1A, gvjs_H);
+gvjs_1A.prototype.handleEvent = function(a) {
+  var b = new gvjs_5h(a.$i);
+  b.type = a.type == gvjs_zu || a.type == gvjs_xu ? gvjs_zu : gvjs_Au;
+  this.dispatchEvent(b)
+}
+;
+gvjs_1A.prototype.M = function() {
+  gvjs_1A.G.M.call(this);
+  gvjs_ki(this.Ssa);
+  gvjs_ki(this.Tsa);
+  delete this.H
+}
+;
+function gvjs_2A() {}
+gvjs_2A.prototype.Mf = function() {}
+;
+function gvjs_3A(a) {
+  var b = a.offsetLeft
+    , c = a.offsetParent;
+  c || gvjs_Eh(a) != gvjs_wu || (c = gvjs_5g(a).documentElement);
+  if (!c)
+    return b;
+  if (gvjs_sg && !gvjs_Eg(58)) {
+    var d = gvjs_Jh(c);
+    b += d.left
+  } else
+    gvjs_Fg(8) && !gvjs_Fg(9) && (d = gvjs_Jh(c),
+      b -= d.left);
+  return gvjs_Gz(c) ? c.clientWidth - (b + a.offsetWidth) : b
+}
+function gvjs_4A(a) {
+  if (a = a.offsetParent) {
+    var b = "HTML" == a.tagName || "BODY" == a.tagName;
+    if (!b || "static" != gvjs_Eh(a)) {
+      var c = gvjs_vz(a);
+      if (!b) {
+        b = gvjs_Gz(a);
+        var d;
+        if (d = b) {
+          d = gvjs_Lg && 0 <= gvjs_tf(gvjs_oq, 10);
+          var e = gvjs_Iaa && 0 <= gvjs_tf(gvjs_gda, 10)
+            , f = gvjs_Kg && 0 <= gvjs_tf(gvjs_oq, 85);
+          d = gvjs_sg || d || e || f
+        }
+        b = d ? -a.scrollLeft : !b || gvjs_Caa && gvjs_Eg("8") || gvjs_Dh(a, "overflowX") == gvjs_Mx ? a.scrollLeft : a.scrollWidth - a.clientWidth - a.scrollLeft;
+        c = gvjs_dz(c, new gvjs_z(b,a.scrollTop))
+      }
+    }
+  }
+  return c || new gvjs_z
+}
+function gvjs_5A(a, b) {
+  return (b & 8 && gvjs_Gz(a) ? b ^ 4 : b) & -9
+}
+function gvjs_6A(a, b, c, d, e, f, g) {
+  a = a.clone();
+  var h = gvjs_5A(b, c);
+  c = gvjs_Dz(b);
+  g = g ? g.clone() : c.clone();
+  a = a.clone();
+  g = g.clone();
+  var k = 0;
+  if (d || 0 != h)
+    h & 4 ? a.x -= g.width + (d ? d.right : 0) : h & 2 ? a.x -= g.width / 2 : d && (a.x += d.left),
+      h & 1 ? a.y -= g.height + (d ? d.bottom : 0) : d && (a.y += d.top);
+  if (f) {
+    if (e) {
+      d = a;
+      h = g;
+      k = 0;
+      65 == (f & 65) && (d.x < e.left || d.x >= e.right) && (f &= -2);
+      132 == (f & 132) && (d.y < e.top || d.y >= e.bottom) && (f &= -5);
+      d.x < e.left && f & 1 && (d.x = e.left,
+        k |= 1);
+      if (f & 16) {
+        var l = d.x;
+        d.x < e.left && (d.x = e.left,
+          k |= 4);
+        d.x + h.width > e.right && (h.width = Math.min(e.right - d.x, l + h.width - e.left),
+          h.width = Math.max(h.width, 0),
+          k |= 4)
+      }
+      d.x + h.width > e.right && f & 1 && (d.x = Math.max(e.right - h.width, e.left),
+        k |= 1);
+      f & 2 && (k |= (d.x < e.left ? 16 : 0) | (d.x + h.width > e.right ? 32 : 0));
+      d.y < e.top && f & 4 && (d.y = e.top,
+        k |= 2);
+      f & 32 && (l = d.y,
+      d.y < e.top && (d.y = e.top,
+        k |= 8),
+      d.y + h.height > e.bottom && (h.height = Math.min(e.bottom - d.y, l + h.height - e.top),
+        h.height = Math.max(h.height, 0),
+        k |= 8));
+      d.y + h.height > e.bottom && f & 4 && (d.y = Math.max(e.bottom - h.height, e.top),
+        k |= 2);
+      f & 8 && (k |= (d.y < e.top ? 64 : 0) | (d.y + h.height > e.bottom ? 128 : 0));
+      e = k
+    } else
+      e = 256;
+    k = e
+  }
+  f = new gvjs_5(0,0,0,0);
+  f.left = a.x;
+  f.top = a.y;
+  f.width = g.width;
+  f.height = g.height;
+  e = k;
+  if (e & 496)
+    return e;
+  gvjs_sz(b, new gvjs_z(f.left,f.top));
+  g = f.Tb();
+  gvjs_fz(c, g) || (c = g,
+    a = gvjs_eh(gvjs_3g(gvjs_5g(b)).dd),
+    !gvjs_y || gvjs_Eg("10") || a && gvjs_Eg("8") ? (b = b.style,
+      gvjs_sg ? b.MozBoxSizing = gvjs_tt : gvjs_tg ? b.WebkitBoxSizing = gvjs_tt : b.boxSizing = gvjs_tt,
+      b.width = Math.max(c.width, 0) + gvjs_T,
+      b.height = Math.max(c.height, 0) + gvjs_T) : (g = b.style,
+      a ? (a = gvjs_Ih(b),
+        b = gvjs_Jh(b),
+        g.pixelWidth = c.width - b.left - a.left - a.right - b.right,
+        g.pixelHeight = c.height - b.top - a.top - a.bottom - b.bottom) : (g.pixelWidth = c.width,
+        g.pixelHeight = c.height)));
+  return e
+}
+function gvjs_7A(a, b, c, d, e, f, g, h, k) {
+  var l = gvjs_4A(c)
+    , m = gvjs_Ez(a)
+    , n = gvjs_wz(a);
+  n && m.J_(gvjs_pz(n));
+  n = gvjs_3g(a);
+  var p = gvjs_3g(c);
+  if (n.kc() != p.kc()) {
+    var q = n.kc().body;
+    p = p.Vj();
+    var r = new gvjs_z(0,0)
+      , t = gvjs_3x(gvjs_5g(q));
+    if (gvjs_og(t, "parent")) {
+      var u = q;
+      do {
+        var v = t == p ? gvjs_vz(u) : gvjs_yz(u);
+        r.x += v.x;
+        r.y += v.y
+      } while (t && t != p && t != t.parent && (u = t.frameElement) && (t = t.parent))
+    }
+    q = gvjs_dz(r, gvjs_vz(q));
+    !gvjs_y || gvjs_Fg(9) || gvjs_eh(n.dd) || (q = gvjs_dz(q, gvjs_2x(n.dd)));
+    m.left += q.x;
+    m.top += q.y
+  }
+  a = gvjs_5A(a, b);
+  b = m.left;
+  a & 4 ? b += m.width : a & 2 && (b += m.width / 2);
+  m = new gvjs_z(b,m.top + (a & 1 ? m.height : 0));
+  m = gvjs_dz(m, l);
+  e && (m.x += (a & 4 ? -1 : 1) * e.x,
+    m.y += (a & 1 ? -1 : 1) * e.y);
+  if (g)
+    if (k)
+      var w = k;
+    else if (w = gvjs_wz(c))
+      w.top -= l.y,
+        w.right -= l.x,
+        w.bottom -= l.y,
+        w.left -= l.x;
+  return gvjs_6A(m, c, d, f, w, g, h)
+}
+function gvjs_8A(a, b, c) {
+  this.element = a;
+  this.lH = b;
+  this.Lua = c
+}
+gvjs_t(gvjs_8A, gvjs_2A);
+gvjs_8A.prototype.Mf = function(a, b, c) {
+  gvjs_7A(this.element, this.lH, a, b, void 0, c, this.Lua)
+}
+;
+function gvjs_9A(a, b) {
+  this.Na = a instanceof gvjs_z ? a : new gvjs_z(a,b)
+}
+gvjs_t(gvjs_9A, gvjs_2A);
+gvjs_9A.prototype.Mf = function(a, b, c, d) {
+  gvjs_7A(gvjs_tz(a), 0, a, b, this.Na, c, null, d)
+}
+;
+function gvjs_$A(a) {
+  if (48 <= a && 57 >= a || 96 <= a && 106 >= a || 65 <= a && 90 >= a || (gvjs_tg || gvjs_rg) && 0 == a)
+    return !0;
+  switch (a) {
+    case 32:
+    case 43:
+    case 63:
+    case 64:
+    case 107:
+    case 109:
+    case 110:
+    case 111:
+    case 186:
+    case 59:
+    case 189:
+    case 187:
+    case 61:
+    case 188:
+    case 190:
+    case 191:
+    case 192:
+    case 222:
+    case 219:
+    case 220:
+    case 221:
+    case 163:
+    case 58:
+      return !0;
+    case 173:
+      return gvjs_sg;
+    default:
+      return !1
+  }
+}
+function gvjs_Rda(a) {
+  switch (a) {
+    case 61:
+      return 187;
+    case 59:
+      return 186;
+    case 173:
+      return 189;
+    case 224:
+      return 91;
+    case 0:
+      return 224;
+    default:
+      return a
+  }
+}
+function gvjs_aB(a) {
+  if (gvjs_sg)
+    a = gvjs_Rda(a);
+  else if (gvjs_ug && gvjs_tg)
+    switch (a) {
+      case 93:
+        a = 91
+    }
+  return a
+}
+function gvjs_bB(a, b, c, d, e, f) {
+  if (gvjs_tg && !gvjs_Eg("525"))
+    return !0;
+  if (gvjs_ug && e)
+    return gvjs_$A(a);
+  if (e && !d)
+    return !1;
+  if (!gvjs_sg) {
+    typeof b === gvjs_g && (b = gvjs_aB(b));
+    var g = 17 == b || 18 == b || gvjs_ug && 91 == b;
+    if ((!c || gvjs_ug) && g || gvjs_ug && 16 == b && (d || f))
+      return !1
+  }
+  if ((gvjs_tg || gvjs_rg) && d && c)
+    switch (a) {
+      case 220:
+      case 219:
+      case 221:
+      case 192:
+      case 186:
+      case 189:
+      case 187:
+      case 188:
+      case 190:
+      case 191:
+      case 192:
+      case 222:
+        return !1
+    }
+  if (gvjs_y && d && b == a)
+    return !1;
+  switch (a) {
+    case 13:
+      return gvjs_sg ? f || e ? !1 : !(c && d) : !0;
+    case 27:
+      return !(gvjs_tg || gvjs_rg || gvjs_sg)
+  }
+  return gvjs_sg && (d || e || f) ? !1 : gvjs_$A(a)
+}
+function gvjs_cB(a, b) {
+  gvjs_H.call(this);
+  this.pd = new gvjs_KA(this);
+  this.sA(a || null);
+  b && this.rp(b)
+}
+gvjs_t(gvjs_cB, gvjs_H);
+gvjs_ = gvjs_cB.prototype;
+gvjs_.H = null;
+gvjs_.y7 = !0;
+gvjs_.w7 = null;
+gvjs_.x7 = null;
+gvjs_.lD = !1;
+gvjs_.Uwa = !1;
+gvjs_.j0 = -1;
+gvjs_.pra = !1;
+gvjs_.zna = !0;
+gvjs_.pf = gvjs_kx;
+gvjs_.getType = function() {
+  return this.pf
+}
+;
+gvjs_.rp = function(a) {
+  this.pf = a
+}
+;
+gvjs_.j = function() {
+  return this.H
+}
+;
+gvjs_.sA = function(a) {
+  gvjs_dB(this);
+  this.H = a
+}
+;
+gvjs_.iT = gvjs_n(37);
+gvjs_.QE = gvjs_n(39);
+gvjs_.hc = function() {
+  return this.pd
+}
+;
+function gvjs_dB(a) {
+  if (a.lD)
+    throw Error("Can not change this state of the popup while showing.");
+}
+gvjs_.isVisible = function() {
+  return this.lD
+}
+;
+gvjs_.setVisible = function(a) {
+  this.UE && this.UE.stop();
+  this.ZC && this.ZC.stop();
+  a ? this.i4() : this.$C()
+}
+;
+gvjs_.Mf = gvjs_ke;
+gvjs_.i4 = function() {
+  if (!this.lD && this.N1()) {
+    if (!this.H)
+      throw Error("Caller must call setElement before trying to show the popup");
+    this.Mf();
+    var a = gvjs_5g(this.H);
+    this.pra && this.pd.o(a, gvjs_lv, this.nua, !0);
+    if (this.y7)
+      if (this.pd.o(a, gvjs_gd, this.Cda, !0),
+        gvjs_y) {
+        try {
+          var b = a.activeElement
+        } catch (d) {}
+        for (; b && b.nodeName == gvjs_Ma; ) {
+          try {
+            var c = gvjs_sh(b)
+          } catch (d) {
+            break
+          }
+          a = c;
+          b = a.activeElement
+        }
+        this.pd.o(a, gvjs_gd, this.Cda, !0);
+        this.pd.o(a, "deactivate", this.Bda)
+      } else
+        this.pd.o(a, gvjs_Yo, this.Bda);
+    this.pf == gvjs_kx ? (this.H.style.visibility = gvjs_Mx,
+      gvjs_6(this.H, !0)) : this.pf == gvjs_Yv && this.Mf();
+    this.lD = !0;
+    this.j0 = Date.now();
+    this.UE ? (gvjs_ei(this.UE, gvjs_R, this.Zz, !1, this),
+      this.UE.play()) : this.Zz()
+  }
+}
+;
+gvjs_.$C = function(a) {
+  if (!this.lD || !this.dispatchEvent({
+    type: gvjs_ot,
+    target: a
+  }))
+    return !1;
+  this.pd && this.pd.removeAll();
+  this.lD = !1;
+  Date.now();
+  this.ZC ? (gvjs_ei(this.ZC, gvjs_R, gvjs_re(this.G8, a), !1, this),
+    this.ZC.play()) : this.G8(a);
+  return !0
+}
+;
+gvjs_.G8 = function(a) {
+  this.pf == gvjs_kx ? this.Uwa ? gvjs_pl(this.Zaa, 0, this) : this.Zaa() : this.pf == gvjs_Yv && (this.H.style.top = "-10000px");
+  this.yw(a)
+}
+;
+gvjs_.Zaa = function() {
+  this.H.style.visibility = gvjs_0u;
+  gvjs_6(this.H, !1)
+}
+;
+gvjs_.N1 = function() {
+  return this.dispatchEvent(gvjs_pt)
+}
+;
+gvjs_.Zz = function() {
+  this.dispatchEvent(gvjs_Sw)
+}
+;
+gvjs_.yw = function(a) {
+  this.dispatchEvent({
+    type: gvjs_1u,
+    target: a
+  })
+}
+;
+gvjs_.Cda = function(a) {
+  a = a.target;
+  gvjs_rh(this.H, a) || gvjs_eB(this, a) || this.x7 && !gvjs_rh(this.x7, a) || 150 > Date.now() - this.j0 || this.$C(a)
+}
+;
+gvjs_.nua = function(a) {
+  27 == a.keyCode && this.$C(a.target) && (a.preventDefault(),
+    a.stopPropagation())
+}
+;
+gvjs_.Bda = function(a) {
+  if (this.zna) {
+    var b = gvjs_5g(this.H);
+    if ("undefined" != typeof document.activeElement) {
+      if (a = b.activeElement,
+      !a || gvjs_rh(this.H, a) || "BODY" == a.tagName || gvjs_eB(this, a))
+        return
+    } else if (a.target != b)
+      return;
+    150 > Date.now() - this.j0 || this.$C()
+  }
+}
+;
+function gvjs_eB(a, b) {
+  return gvjs_Fe(a.w7 || [], function(c) {
+    return b === c || gvjs_rh(c, b)
+  })
+}
+gvjs_.M = function() {
+  gvjs_cB.G.M.call(this);
+  this.pd.pa();
+  gvjs_E(this.UE);
+  gvjs_E(this.ZC);
+  delete this.H;
+  delete this.pd;
+  delete this.w7
+}
+;
+function gvjs_fB(a, b) {
+  this.bva = 8;
+  this.Qa = b || void 0;
+  gvjs_cB.call(this, a)
+}
+gvjs_t(gvjs_fB, gvjs_cB);
+gvjs_fB.prototype.getPosition = function() {
+  return this.Qa || null
+}
+;
+gvjs_fB.prototype.setPosition = function(a) {
+  this.Qa = a || void 0;
+  this.isVisible() && this.Mf()
+}
+;
+gvjs_fB.prototype.Mf = function() {
+  if (this.Qa) {
+    var a = !this.isVisible() && this.getType() != gvjs_Yv
+      , b = this.j();
+    a && (b.style.visibility = gvjs_0u,
+      gvjs_6(b, !0));
+    this.Qa.Mf(b, this.bva, this.$Da);
+    a && gvjs_6(b, !1)
+  }
+}
+;
+var gvjs_gB = [];
+function gvjs_hB(a, b) {
+  gvjs_9A.call(this, a, b)
+}
+gvjs_t(gvjs_hB, gvjs_9A);
+gvjs_hB.prototype.Mf = function(a, b, c) {
+  b = gvjs_tz(a);
+  b = gvjs_wz(b);
+  c = c ? new gvjs_B(c.top + 10,c.right,c.bottom,c.left + 10) : new gvjs_B(10,0,0,10);
+  gvjs_6A(this.Na, a, 8, c, b, 9) & 496 && gvjs_6A(this.Na, a, 8, c, b, 5)
+}
+;
+function gvjs_iB(a) {
+  gvjs_8A.call(this, a, 5)
+}
+gvjs_t(gvjs_iB, gvjs_8A);
+gvjs_iB.prototype.Mf = function(a, b, c) {
+  var d = new gvjs_z(10,0);
+  gvjs_7A(this.element, this.lH, a, b, d, c, 9) & 496 && gvjs_7A(this.element, 4, a, 1, d, c, 5)
+}
+;
+function gvjs_jB(a, b, c) {
+  this.D = c || (a ? gvjs_3g(gvjs_6g(document, a)) : gvjs_3g());
+  gvjs_fB.call(this, this.D.J(gvjs_b, {
+    style: "position:absolute;display:none;"
+  }));
+  this.xb = new gvjs_z(1,1);
+  this.hb = new gvjs_hj;
+  this.WA = null;
+  a && this.CB(a);
+  null != b && this.du(b)
+}
+gvjs_t(gvjs_jB, gvjs_fB);
+gvjs_ = gvjs_jB.prototype;
+gvjs_.qf = null;
+gvjs_.className = "goog-tooltip";
+gvjs_.JT = 500;
+gvjs_.Xaa = 0;
+gvjs_.wa = function() {
+  return this.D
+}
+;
+gvjs_.CB = function(a) {
+  a = gvjs_6g(document, a);
+  this.hb.add(a);
+  gvjs_G(a, gvjs_ld, this.Lo, !1, this);
+  gvjs_G(a, gvjs_kd, this.QP, !1, this);
+  gvjs_G(a, gvjs_jd, this.uaa, !1, this);
+  gvjs_G(a, gvjs_xu, this.Iv, !1, this);
+  gvjs_G(a, gvjs_Yo, this.QP, !1, this)
+}
+;
+gvjs_.detach = function(a) {
+  if (a)
+    a = gvjs_6g(document, a),
+      gvjs_kB(this, a),
+      this.hb.remove(a);
+  else {
+    for (var b = this.hb.ob(), c = 0; a = b[c]; c++)
+      gvjs_kB(this, a);
+    this.hb.clear()
+  }
+}
+;
+function gvjs_kB(a, b) {
+  gvjs_ji(b, gvjs_ld, a.Lo, !1, a);
+  gvjs_ji(b, gvjs_kd, a.QP, !1, a);
+  gvjs_ji(b, gvjs_jd, a.uaa, !1, a);
+  gvjs_ji(b, gvjs_xu, a.Iv, !1, a);
+  gvjs_ji(b, gvjs_Yo, a.QP, !1, a)
+}
+gvjs_.du = function(a) {
+  gvjs_th(this.j(), a)
+}
+;
+gvjs_.BT = gvjs_n(40);
+gvjs_.sA = function(a) {
+  var b = this.j();
+  b && gvjs_kh(b);
+  gvjs_jB.G.sA.call(this, a);
+  a ? (b = this.D.kc().body,
+    b.insertBefore(a, b.lastChild),
+    gvjs_E(this.WA),
+    this.WA = new gvjs_1A(this.j()),
+    gvjs_6x(this, this.WA),
+    gvjs_G(this.WA, gvjs_zu, this.XG, void 0, this),
+    gvjs_G(this.WA, gvjs_Au, this.YT, void 0, this)) : (gvjs_E(this.WA),
+    this.WA = null)
+}
+;
+gvjs_.dn = gvjs_n(44);
+gvjs_.qP = function() {
+  return this.j().innerHTML
+}
+;
+gvjs_.getState = function() {
+  return this.Sw ? this.isVisible() ? 4 : 1 : this.RI ? 3 : this.isVisible() ? 2 : 0
+}
+;
+gvjs_.N1 = function() {
+  if (!gvjs_cB.prototype.N1.call(this))
+    return !1;
+  if (this.anchor)
+    for (var a, b = 0; a = gvjs_gB[b]; b++)
+      gvjs_rh(a.j(), this.anchor) || a.setVisible(!1);
+  gvjs_Gy(gvjs_gB, this);
+  a = this.j();
+  a.className = this.className;
+  this.XG();
+  gvjs_G(a, gvjs_ld, this.Haa, !1, this);
+  gvjs_G(a, gvjs_kd, this.Gaa, !1, this);
+  gvjs_lB(this);
+  return !0
+}
+;
+gvjs_.yw = function() {
+  gvjs_Ie(gvjs_gB, this);
+  for (var a = this.j(), b, c = 0; b = gvjs_gB[c]; c++)
+    b.anchor && gvjs_rh(a, b.anchor) && b.setVisible(!1);
+  this.Yda && this.Yda.YT();
+  gvjs_ji(a, gvjs_ld, this.Haa, !1, this);
+  gvjs_ji(a, gvjs_kd, this.Gaa, !1, this);
+  this.anchor = void 0;
+  0 == this.getState() && (this.ZS = !1);
+  gvjs_cB.prototype.yw.call(this)
+}
+;
+gvjs_.Nca = function(a, b) {
+  this.anchor == a && this.hb.contains(this.anchor) && (this.ZS || !this.oEa ? (this.setVisible(!1),
+  this.isVisible() || (this.anchor = a,
+    this.setPosition(b || this.uP(0)),
+    this.setVisible(!0))) : this.anchor = void 0);
+  this.Sw = void 0
+}
+;
+gvjs_.rI = function() {
+  return this.hb
+}
+;
+gvjs_.Ly = function() {
+  return this.qf
+}
+;
+gvjs_.ita = function(a) {
+  this.RI = void 0;
+  if (a == this.anchor) {
+    a = this.wa();
+    var b = a.Ly();
+    a = b && this.j() && a.contains(this.j(), b);
+    null != this.qf && (this.qf == this.j() || this.hb.contains(this.qf)) || a || this.m8 && this.m8.qf || this.setVisible(!1)
+  }
+}
+;
+function gvjs_mB(a, b) {
+  var c = gvjs_2x(a.D.dd);
+  a.xb.x = b.clientX + c.x;
+  a.xb.y = b.clientY + c.y
+}
+gvjs_.Lo = function(a) {
+  var b = gvjs_nB(this, a.target);
+  this.qf = b;
+  this.XG();
+  b != this.anchor && (this.anchor = b,
+  this.Sw || (this.Sw = gvjs_pl(gvjs_s(this.Nca, this, b, void 0), this.JT)),
+    gvjs_oB(this),
+    gvjs_mB(this, a))
+}
+;
+function gvjs_nB(a, b) {
+  try {
+    for (; b && !a.hb.contains(b); )
+      b = b.parentNode;
+    return b
+  } catch (c) {
+    return null
+  }
+}
+gvjs_.uaa = function(a) {
+  gvjs_mB(this, a);
+  this.ZS = !0
+}
+;
+gvjs_.Iv = function(a) {
+  this.qf = a = gvjs_nB(this, a.target);
+  this.ZS = !0;
+  if (this.anchor != a) {
+    this.anchor = a;
+    var b = this.uP(1);
+    this.XG();
+    this.Sw || (this.Sw = gvjs_pl(gvjs_s(this.Nca, this, a, b), this.JT));
+    gvjs_oB(this)
+  }
+}
+;
+gvjs_.uP = function(a) {
+  return 0 == a ? (a = this.xb.clone(),
+    new gvjs_hB(a)) : new gvjs_iB(this.qf)
+}
+;
+function gvjs_oB(a) {
+  if (a.anchor)
+    for (var b, c = 0; b = gvjs_gB[c]; c++)
+      gvjs_rh(b.j(), a.anchor) && (b.m8 = a,
+        a.Yda = b)
+}
+gvjs_.QP = function(a) {
+  var b = gvjs_nB(this, a.target)
+    , c = gvjs_nB(this, a.relatedTarget);
+  b != c && (b == this.qf && (this.qf = null),
+    gvjs_lB(this),
+    this.ZS = !1,
+    !this.isVisible() || a.relatedTarget && gvjs_rh(this.j(), a.relatedTarget) ? this.anchor = void 0 : this.YT())
+}
+;
+gvjs_.Haa = function() {
+  var a = this.j();
+  this.qf != a && (this.XG(),
+    this.qf = a)
+}
+;
+gvjs_.Gaa = function(a) {
+  var b = this.j();
+  this.qf != b || a.relatedTarget && gvjs_rh(b, a.relatedTarget) || (this.qf = null,
+    this.YT())
+}
+;
+function gvjs_lB(a) {
+  a.Sw && (gvjs_ql(a.Sw),
+    a.Sw = void 0)
+}
+gvjs_.YT = function() {
+  2 == this.getState() && (this.RI = gvjs_pl(gvjs_s(this.ita, this, this.anchor), this.Xaa))
+}
+;
+gvjs_.XG = function() {
+  this.RI && (gvjs_ql(this.RI),
+    this.RI = void 0)
+}
+;
+gvjs_.M = function() {
+  this.setVisible(!1);
+  gvjs_lB(this);
+  this.detach();
+  this.j() && gvjs_kh(this.j());
+  this.qf = null;
+  delete this.D;
+  gvjs_jB.G.M.call(this)
+}
+;
+function gvjs_pB(a, b) {
+  gvjs_XA.call(this, a, b);
+  this.gv = gvjs_3g(a);
+  this.zO = this.gv.kc();
+  this.qu = [];
+  this.ea = new gvjs_KA
+}
+gvjs_t(gvjs_pB, gvjs_XA);
+function gvjs_Sda(a, b, c, d) {
+  b = new gvjs_jB(b);
+  var e = a.gv.J(gvjs_b);
+  c = c.split("\n");
+  e.appendChild(a.gv.createTextNode(c[0]));
+  for (var f = 1; f < c.length; ++f)
+    e.appendChild(a.gv.J("BR")),
+      e.appendChild(a.gv.createTextNode(c[f]));
+  gvjs_C(e, d);
+  b.j().appendChild(e);
+  b.JT = 100;
+  b.Xaa = 100;
+  a.qu.push(b)
+}
+gvjs_ = gvjs_pB.prototype;
+gvjs_.Re = function(a) {
+  this.gv.removeNode(a);
+  gvjs_li(a)
+}
+;
+gvjs_.clear = function() {
+  this.ea.removeAll();
+  gvjs_E(this.ea);
+  this.ea = new gvjs_KA;
+  gvjs_pB.G.clear.call(this)
+}
+;
+gvjs_.He = function() {
+  gvjs_pB.G.He.call(this);
+  gvjs_u(this.qu, function(a) {
+    gvjs_E(a)
+  });
+  gvjs_Fy(this.qu);
+  this.gv.qc(this.container);
+  this.ea.removeAll();
+  gvjs_E(this.ea)
+}
+;
+gvjs_.Qj = function(a) {
+  var b = gvjs_0A(a);
+  return b ? (b = gvjs_Az(a, b),
+    a = gvjs_Dz(a),
+    new gvjs_B(b.y,b.x + a.width,b.y + a.height,b.x)) : null
+}
+;
+function gvjs_qB(a) {
+  for (var b = a.target; b.parentNode; )
+    b = b.parentNode;
+  9 === b.nodeType || 11 === b.nodeType ? (b = gvjs_0A(a.target),
+    a = gvjs_Az(a, b)) : a = null;
+  return a
+}
+gvjs_.ic = function(a, b, c) {
+  a.constructor == gvjs_QA && (a = a.j());
+  this.ea.o(a, b, c)
+}
+;
+gvjs_.replaceChild = function(a, b, c) {
+  gvjs_pB.G.replaceChild.call(this, a, b, c);
+  gvjs_li(c)
+}
+;
+function gvjs_rB(a, b) {
+  gvjs_pB.call(this, a, b);
+  this.Ba = null;
+  a = gvjs_3g(b).createElement(gvjs_Gt);
+  this.jF.appendChild(a);
+  this.sga = a.getContext("2d");
+  this.vn = this.ya = this.NN = null;
+  this.i2 = !1
+}
+gvjs_t(gvjs_rB, gvjs_pB);
+function gvjs_sB(a) {
+  a.i2 || (a.Ba.beginPath(),
+    a.vn = new gvjs_B(Infinity,-Infinity,-Infinity,Infinity),
+    a.i2 = !0)
+}
+function gvjs_tB(a, b, c) {
+  a.vn && (a.vn.left = Math.min(a.vn.left, b),
+    a.vn.top = Math.min(a.vn.top, c),
+    a.vn.right = Math.max(a.vn.right, b),
+    a.vn.bottom = Math.max(a.vn.bottom, c))
+}
+gvjs_ = gvjs_rB.prototype;
+gvjs_.bO = function(a, b) {
+  var c = gvjs_3g(this.container).createElement(gvjs_Gt);
+  c.setAttribute(gvjs_Xd, a);
+  c.setAttribute(gvjs_4c, b);
+  this.ya = new gvjs_A(a,b);
+  this.container.appendChild(c);
+  this.Ba = c.getContext("2d");
+  return new gvjs_QA(c)
+}
+;
+gvjs_.WX = function() {
+  var a = this.kw.j();
+  this.Ba.clearRect(0, 0, a.width, a.height)
+}
+;
+function gvjs_uB(a) {
+  return gvjs_3g(a.container).createElement("empty")
+}
+function gvjs_vB(a, b) {
+  if (a == gvjs_f)
+    return gvjs_yw;
+  b == gvjs_f && (b = 1);
+  return "rgba(" + gvjs_vj(gvjs_qj(a).hex) + "," + b + ")"
+}
+function gvjs_wB(a, b) {
+  "undefined" !== typeof a.setLineDash ? a.setLineDash(b) : a.dEa = b
+}
+function gvjs_xB(a, b, c, d, e) {
+  var f = /^(\d+(\.\d*)?)%$/;
+  typeof b === gvjs_l && f.test(b) ? (b = parseFloat(f.exec(b)[1]) / 100,
+    c && null != e ? b = d ? e.height * b + e.top : e.width * b + e.left : null != a.ya && (b = d ? a.ya.height * b : a.ya.width * b)) : b = +b;
+  return b
+}
+gvjs_.Li = function(a, b) {
+  this.Ba.strokeStyle = gvjs_vB(a.Uj(), a.strokeOpacity);
+  this.Ba.fillStyle = gvjs_vB(a.fill, a.fillOpacity);
+  var c = a.Mi;
+  null != c && c == gvjs_9t ? gvjs_wB(this.Ba, [8, 2]) : Array.isArray(c) ? gvjs_wB(this.Ba, c) : gvjs_wB(this.Ba, []);
+  var d = a.pattern;
+  c = a.gradient;
+  if (null != d) {
+    c = null;
+    switch (d.getStyle()) {
+      case gvjs_rw:
+        c = this.zO.createElement(gvjs_Gt),
+          c.setAttribute(gvjs_Xd, 4),
+          c.setAttribute(gvjs_4c, 4),
+          b = c.getContext("2d"),
+          b.fillStyle = d.getBackgroundColor(),
+          b.fillRect(0, 0, 4, 4),
+          b.strokeStyle = d.ee(),
+          b.beginPath(),
+          b.lineWidth = 2,
+          b.lineCap = gvjs_1w,
+          b.moveTo(2, 0),
+          b.lineTo(4, 2),
+          b.moveTo(0, 2),
+          b.lineTo(2, 4),
+          b.stroke()
+    }
+    this.Ba.fillStyle = this.Ba.createPattern(c, "repeat")
+  } else if (null != c) {
+    var e = c.Sn || !1;
+    d = gvjs_xB(this, c.x1, e, !1, b);
+    var f = gvjs_xB(this, c.y1, e, !0, b)
+      , g = gvjs_xB(this, c.x2, e, !1, b);
+    b = gvjs_xB(this, c.y2, e, !0, b);
+    b = this.Ba.createLinearGradient(d, f, g, b);
+    b.addColorStop(0, c.Vf);
+    b.addColorStop(1, c.sf);
+    this.Ba.fillStyle = b
+  }
+  this.Ba.lineWidth = a.strokeWidth
+}
+;
+function gvjs_yB(a, b) {
+  b.Lb && b.Lb != gvjs_f ? (a.strokeStyle = b.Lb,
+    a.lineWidth = 3) : a.strokeStyle = gvjs_yw;
+  a.fillStyle = gvjs_vB(b.color, b.opacity ? b.opacity : 1);
+  gvjs_wB(a, []);
+  var c = "";
+  b.Nc && (c = "italic ");
+  b.bold && (c += "bold ");
+  c += b.fontSize + "px " + b.bb;
+  a.font = c
+}
+gvjs_.$x = function(a, b, c, d) {
+  this.Ba.beginPath();
+  this.Li(d, new gvjs_5(a - c,b - c,2 * c,2 * c));
+  this.Ba.arc(a, b, c, 0, 2 * Math.PI);
+  this.Ba.closePath();
+  this.Ba.fill();
+  this.Ba.stroke();
+  return gvjs_uB(this)
+}
+;
+gvjs_.mX = function(a, b, c, d, e) {
+  this.Ba.save();
+  this.Li(e, new gvjs_5(a - c,b - d,2 * c,2 * d));
+  this.Ba.translate(a, b);
+  c > d ? (this.Ba.scale(1, d / c),
+    a = c) : (this.Ba.scale(c / d, 1),
+    a = d);
+  this.Ba.arc(0, 0, a, 0, 2 * Math.PI, !1);
+  this.Ba.fill();
+  this.Ba.stroke();
+  this.Ba.restore();
+  return gvjs_uB(this)
+}
+;
+gvjs_.Bl = function(a, b, c, d, e) {
+  this.Li(e, new gvjs_5(a,b,c,d));
+  this.Ba.fillRect(a, b, c, d);
+  this.Ba.strokeRect(a, b, c, d);
+  return gvjs_uB(this)
+}
+;
+gvjs_.AD = gvjs_n(47);
+gvjs_.tX = function(a, b) {
+  this.Li(b, gvjs_pz(this.vn));
+  this.Ba.fill();
+  this.Ba.stroke();
+  this.i2 = !1;
+  this.vn = null;
+  return gvjs_uB(this)
+}
+;
+gvjs_.by = function(a, b, c, d, e, f, g) {
+  return this.ys(a, b, c, d, 0, e, f, g)
+}
+;
+gvjs_.pH = function(a, b, c, d, e, f, g, h) {
+  var k = gvjs_WA(b, d, f)
+    , l = gvjs_WA(c, e, f);
+  return this.ys(a, k, l, Math.sqrt(gvjs_cA(new gvjs_bA(b,c,d,e))), gvjs_5y(gvjs_7y(Math.atan2(e - c, d - b))), f, g, h)
+}
+;
+gvjs_.ys = function(a, b, c, d, e, f, g, h) {
+  gvjs_yB(this.Ba, h);
+  this.Ba.save();
+  e = gvjs_6y(e);
+  d = b * Math.sin(-e) + c * Math.cos(-e);
+  b = b * Math.cos(-e) - c * Math.sin(-e);
+  this.Ba.rotate(e);
+  g == gvjs_2 ? d += 4 * h.fontSize / 5 : g == gvjs_0 ? d += h.fontSize / 3 : g == gvjs_R && (d -= h.fontSize / 5);
+  f != gvjs_2 && (f == gvjs_0 ? b -= this.KC(a, h).width / 2 : f == gvjs_R && (b -= this.KC(a, h).width));
+  this.Ba.strokeText(a, b, d);
+  this.Ba.fillText(a, b, d);
+  h.Ue && (this.Ba.beginPath(),
+    e = h.fontSize / 15,
+    d += e + 1,
+  1 > e && (e = 1),
+    this.Ba.lineWidth = e,
+    this.Ba.moveTo(b, d),
+    this.Ba.lineTo(this.Ba.measureText(a).width + b, d),
+    this.Ba.strokeStyle = this.Ba.fillStyle,
+    this.Ba.stroke());
+  this.Ba.restore();
+  return gvjs_uB(this)
+}
+;
+gvjs_.nX = function() {
+  return gvjs_uB(this)
+}
+;
+gvjs_.dC = function(a) {
+  null !== a && (this.NN = a,
+    this.Ba.save(),
+    this.Ba.beginPath(),
+    this.Ba.fillStyle = gvjs_yw,
+    this.Ba.rect(a.left, a.top, a.width, a.height),
+    this.Ba.clip())
+}
+;
+gvjs_.HH = function() {
+  var a = this.NN;
+  this.NN && (this.NN = null,
+    this.Ba.restore());
+  return a
+}
+;
+gvjs_.ZG = function() {
+  return gvjs_uB(this)
+}
+;
+gvjs_.nd = function(a, b, c) {
+  gvjs_sB(this);
+  this.Ba.moveTo(b, c);
+  gvjs_tB(this, b, c)
+}
+;
+gvjs_.Ma = function(a, b, c) {
+  gvjs_sB(this);
+  this.Ba.lineTo(b, c);
+  gvjs_tB(this, b, c)
+}
+;
+gvjs_.Yr = function(a, b, c, d, e, f, g) {
+  gvjs_sB(this);
+  this.Ba.bezierCurveTo(b, c, d, e, f, g);
+  gvjs_tB(this, b, c);
+  gvjs_tB(this, d, e);
+  gvjs_tB(this, f, g)
+}
+;
+gvjs_.Qi = function() {
+  gvjs_sB(this);
+  this.Ba.closePath()
+}
+;
+gvjs_.Bm = function(a, b, c, d, e, f, g, h) {
+  gvjs_sB(this);
+  f = gvjs_6y(f - 90);
+  g = gvjs_6y(g - 90);
+  a = Math.max(d, e);
+  this.Ba.save();
+  this.Ba.translate(b, c);
+  this.Ba.scale(d / a, e / a);
+  this.Ba.arc(0, 0, a, f, g, !h);
+  this.Ba.restore()
+}
+;
+gvjs_.mp = function() {}
+;
+gvjs_.Ug = function() {}
+;
+gvjs_.fl = function() {}
+;
+gvjs_.tA = gvjs_n(50);
+gvjs_.xA = gvjs_n(53);
+gvjs_.rd = function() {}
+;
+gvjs_.KC = function(a, b) {
+  gvjs_yB(this.sga, b);
+  return new gvjs_A(this.sga.measureText(a).width,b.fontSize)
+}
+;
+gvjs_.IC = gvjs_n(56);
+gvjs_.rj = function() {}
+;
+function gvjs_Tda() {
+  var a = [0, 10, 1, 2, 1, 18, 95, 33, 13, 1, 594, 112, 275, 7, 263, 45, 1, 1, 1, 2, 1, 2, 1, 1, 56, 6, 10, 11, 1, 1, 46, 21, 16, 1, 101, 7, 1, 1, 6, 2, 2, 1, 4, 33, 1, 1, 1, 30, 27, 91, 11, 58, 9, 34, 4, 1, 9, 1, 3, 1, 5, 43, 3, 120, 14, 1, 32, 1, 17, 37, 1, 1, 1, 1, 3, 8, 4, 1, 2, 1, 7, 8, 2, 2, 21, 7, 1, 1, 2, 17, 39, 1, 1, 1, 2, 6, 6, 1, 9, 5, 4, 2, 2, 12, 2, 15, 2, 1, 17, 39, 2, 3, 12, 4, 8, 6, 17, 2, 3, 14, 1, 17, 39, 1, 1, 3, 8, 4, 1, 20, 2, 29, 1, 2, 17, 39, 1, 1, 2, 1, 6, 6, 9, 6, 4, 2, 2, 13, 1, 16, 1, 18, 41, 1, 1, 1, 12, 1, 9, 1, 40, 1, 3, 17, 31, 1, 5, 4, 3, 5, 7, 8, 3, 2, 8, 2, 29, 1, 2, 17, 39, 1, 1, 1, 1, 2, 1, 3, 1, 5, 1, 8, 9, 1, 3, 2, 29, 1, 2, 17, 38, 3, 1, 2, 5, 7, 1, 1, 8, 1, 10, 2, 30, 2, 22, 48, 5, 1, 2, 6, 7, 1, 18, 2, 13, 46, 2, 1, 1, 1, 6, 1, 12, 8, 50, 46, 2, 1, 1, 1, 9, 11, 6, 14, 2, 58, 2, 27, 1, 1, 1, 1, 1, 4, 2, 49, 14, 1, 4, 1, 1, 2, 5, 48, 9, 1, 57, 33, 12, 4, 1, 6, 1, 2, 2, 2, 1, 16, 2, 4, 2, 2, 4, 3, 1, 3, 2, 7, 3, 4, 13, 1, 1, 1, 2, 6, 1, 1, 14, 1, 98, 96, 72, 88, 349, 3, 931, 15, 2, 1, 14, 15, 2, 1, 14, 15, 2, 15, 15, 14, 35, 17, 2, 1, 7, 8, 1, 2, 9, 1, 1, 9, 1, 45, 3, 1, 118, 2, 34, 1, 87, 28, 3, 3, 4, 2, 9, 1, 6, 3, 20, 19, 29, 44, 84, 23, 2, 2, 1, 4, 45, 6, 2, 1, 1, 1, 8, 1, 1, 1, 2, 8, 6, 13, 48, 84, 1, 14, 33, 1, 1, 5, 1, 1, 5, 1, 1, 1, 7, 31, 9, 12, 2, 1, 7, 23, 1, 4, 2, 2, 2, 2, 2, 11, 3, 2, 36, 2, 1, 1, 2, 3, 1, 1, 3, 2, 12, 36, 8, 8, 2, 2, 21, 3, 128, 3, 1, 13, 1, 7, 4, 1, 4, 2, 1, 3, 2, 198, 64, 523, 1, 1, 1, 2, 24, 7, 49, 16, 96, 33, 1324, 1, 34, 1, 1, 1, 82, 2, 98, 1, 14, 1, 1, 4, 86, 1, 1418, 3, 141, 1, 96, 32, 554, 6, 105, 2, 30164, 4, 1, 10, 32, 2, 80, 2, 272, 1, 3, 1, 4, 1, 23, 2, 2, 1, 24, 30, 4, 4, 3, 8, 1, 1, 13, 2, 16, 34, 16, 1, 1, 26, 18, 24, 24, 4, 8, 2, 23, 11, 1, 1, 12, 32, 3, 1, 5, 3, 3, 36, 1, 2, 4, 2, 1, 3, 1, 36, 1, 32, 35, 6, 2, 2, 2, 2, 12, 1, 8, 1, 1, 18, 16, 1, 3, 6, 1, 1, 1, 3, 48, 1, 1, 3, 2, 2, 5, 2, 1, 1, 32, 9, 1, 2, 2, 5, 1, 1, 201, 14, 2, 1, 1, 9, 8, 2, 1, 2, 1, 2, 1, 1, 1, 18, 11184, 27, 49, 1028, 1024, 6942, 1, 737, 16, 16, 16, 207, 1, 158, 2, 89, 3, 513, 1, 226, 1, 149, 5, 1670, 15, 40, 7, 1, 165, 2, 1305, 1, 1, 1, 53, 14, 1, 56, 1, 2, 1, 45, 3, 4, 2, 1, 1, 2, 1, 66, 3, 36, 5, 1, 6, 2, 62, 1, 12, 2, 1, 48, 3, 9, 1, 1, 1, 2, 6, 3, 95, 3, 3, 2, 1, 1, 2, 6, 1, 160, 1, 3, 7, 1, 21, 2, 2, 56, 1, 1, 1, 1, 1, 12, 1, 9, 1, 10, 4, 15, 192, 3, 8, 2, 1, 2, 1, 1, 105, 1, 2, 6, 1, 1, 2, 1, 1, 2, 1, 1, 1, 235, 1, 2, 6, 4, 2, 1, 1, 1, 27, 2, 82, 3, 8, 2, 1, 1, 1, 1, 106, 1, 1, 1, 2, 6, 1, 1, 101, 3, 2, 4, 1, 4, 1, 1283, 1, 14, 1, 1, 82, 23, 1, 7, 1, 2, 1, 2, 20025, 5, 59, 7, 1050, 62, 4, 19722, 2, 1, 4, 5313, 1, 1, 3, 3, 1, 5, 8, 8, 2, 7, 30, 4, 148, 3, 1979, 55, 4, 50, 8, 1, 14, 1, 22, 1424, 2213, 7, 109, 7, 2203, 26, 264, 1, 53, 1, 52, 1, 17, 1, 13, 1, 16, 1, 3, 1, 25, 3, 2, 1, 2, 3, 30, 1, 1, 1, 13, 5, 66, 2, 2, 11, 21, 4, 4, 1, 1, 9, 3, 1, 4, 3, 1, 3, 3, 1, 30, 1, 16, 2, 106, 1, 4, 1, 71, 2, 4, 1, 21, 1, 4, 2, 81, 1, 92, 3, 3, 5, 48, 1, 17, 1, 16, 1, 16, 3, 9, 1, 11, 1, 587, 5, 1, 1, 7, 1, 9, 10, 3, 2, 788162, 31];
+  this.rva = a;
+  for (var b = 1; b < a.length; b++)
+    null == a[b] ? a[b] = a[b - 1] + 1 : a[b] += a[b - 1];
+  this.values = [1, 13, 1, 12, 1, 0, 1, 0, 1, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 2, 0, 2, 3, 0, 2, 0, 2, 0, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 3, 2, 4, 0, 5, 2, 4, 2, 0, 4, 2, 4, 6, 4, 0, 2, 5, 0, 2, 0, 5, 0, 2, 4, 0, 5, 2, 0, 2, 4, 2, 4, 6, 0, 2, 5, 0, 2, 0, 5, 0, 2, 4, 0, 5, 2, 4, 2, 6, 2, 5, 0, 2, 0, 2, 4, 0, 5, 2, 0, 4, 2, 4, 6, 0, 2, 0, 2, 4, 0, 5, 2, 0, 2, 4, 2, 4, 6, 2, 5, 0, 2, 0, 5, 0, 2, 0, 5, 2, 4, 2, 4, 6, 0, 2, 0, 2, 4, 0, 5, 0, 5, 0, 2, 4, 2, 6, 2, 5, 0, 2, 0, 2, 4, 0, 5, 2, 0, 4, 2, 4, 2, 4, 2, 4, 2, 6, 2, 5, 0, 2, 0, 2, 4, 0, 5, 0, 2, 4, 2, 4, 6, 3, 0, 2, 0, 2, 0, 4, 0, 5, 6, 2, 4, 2, 4, 2, 0, 4, 0, 5, 0, 2, 0, 4, 2, 6, 0, 2, 0, 5, 0, 2, 0, 4, 2, 0, 2, 0, 5, 0, 2, 0, 2, 0, 2, 0, 2, 0, 4, 5, 2, 4, 2, 6, 0, 2, 0, 2, 0, 2, 0, 5, 0, 2, 4, 2, 0, 6, 4, 2, 5, 0, 5, 0, 4, 2, 5, 2, 5, 0, 5, 0, 5, 2, 5, 2, 0, 4, 2, 0, 2, 5, 0, 2, 0, 7, 8, 9, 0, 2, 0, 5, 2, 6, 0, 5, 2, 6, 0, 5, 2, 0, 5, 2, 5, 0, 2, 4, 2, 4, 2, 4, 2, 6, 2, 0, 2, 0, 2, 1, 0, 2, 0, 2, 0, 5, 0, 2, 4, 2, 4, 2, 4, 2, 0, 5, 0, 5, 0, 5, 2, 4, 2, 0, 5, 0, 5, 4, 2, 4, 2, 6, 0, 2, 0, 2, 4, 2, 0, 2, 4, 0, 5, 2, 4, 2, 4, 2, 4, 2, 4, 6, 5, 0, 2, 0, 2, 4, 0, 5, 4, 2, 4, 2, 6, 2, 5, 0, 5, 0, 5, 0, 2, 4, 2, 4, 2, 4, 2, 6, 0, 5, 4, 2, 4, 2, 0, 5, 0, 2, 0, 2, 4, 2, 0, 2, 0, 4, 2, 0, 2, 0, 2, 0, 1, 2, 15, 1, 0, 1, 0, 1, 0, 2, 0, 16, 0, 17, 0, 17, 0, 17, 0, 16, 0, 17, 0, 16, 0, 17, 0, 2, 0, 6, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 6, 5, 2, 5, 4, 2, 4, 0, 5, 0, 5, 0, 5, 0, 5, 0, 4, 0, 5, 4, 6, 2, 0, 2, 0, 5, 0, 2, 0, 5, 2, 4, 6, 0, 7, 2, 4, 0, 5, 0, 5, 2, 4, 2, 4, 2, 4, 6, 0, 2, 0, 5, 2, 4, 2, 4, 2, 0, 2, 0, 2, 4, 0, 5, 0, 5, 0, 5, 0, 2, 0, 5, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 5, 4, 2, 4, 0, 4, 6, 0, 5, 0, 5, 0, 5, 0, 4, 2, 4, 2, 4, 0, 4, 6, 0, 11, 8, 9, 0, 2, 0, 2, 0, 2, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 6, 0, 2, 0, 4, 2, 4, 0, 2, 6, 0, 6, 2, 4, 0, 4, 2, 4, 6, 2, 0, 3, 0, 2, 0, 2, 4, 2, 6, 0, 2, 0, 2, 4, 0, 4, 2, 4, 6, 0, 3, 0, 2, 0, 4, 2, 4, 2, 6, 2, 0, 2, 0, 2, 4, 2, 6, 0, 2, 4, 0, 2, 0, 2, 4, 2, 4, 6, 0, 2, 0, 4, 2, 0, 4, 2, 4, 6, 2, 4, 2, 0, 2, 4, 2, 4, 2, 4, 2, 4, 2, 4, 6, 2, 0, 2, 4, 2, 4, 2, 4, 6, 2, 0, 2, 0, 4, 2, 4, 2, 4, 6, 2, 0, 2, 4, 2, 4, 2, 6, 2, 0, 2, 4, 2, 4, 2, 6, 0, 4, 2, 4, 6, 0, 2, 4, 2, 4, 2, 4, 2, 0, 2, 0, 2, 0, 4, 2, 0, 2, 0, 1, 0, 2, 4, 2, 0, 4, 2, 1, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 14, 0, 17, 0, 17, 0, 17, 0, 16, 0, 17, 0, 17, 0, 17, 0, 16, 0, 16, 0, 16, 0, 17, 0, 17, 0, 18, 0, 16, 0, 16, 0, 19, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 17, 0, 16, 0, 17, 0, 17, 0, 17, 0, 16, 0, 16, 0, 16, 0, 16, 0, 17, 0, 16, 0, 16, 0, 17, 0, 17, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 1, 2]
+}
+var gvjs_zB = null;
+function gvjs_AB(a, b) {
+  var c = a.charCodeAt(b);
+  55296 <= c && 56319 >= c && b + 1 < a.length ? (a = a.charCodeAt(b + 1),
+  56320 <= a && 57343 >= a && (c = 55296 <= c && 56319 >= c && 56320 <= a && 57343 >= a ? (c << 10) - 56623104 + (a - 56320 + 65536) : null)) : 56320 <= c && 57343 >= c && 0 < b && (a = a.charCodeAt(b - 1),
+  55296 <= a && 56319 >= a && (c = -(55296 <= a && 56319 >= a && 56320 <= c && 57343 >= c ? (a << 10) - 56623104 + (c - 56320 + 65536) : 0)));
+  return 0 > c ? -c : c
+}
+function gvjs_BB(a) {
+  if (44032 <= a && 55203 >= a)
+    return 16 === a % 28 ? 10 : 11;
+  gvjs_zB || (gvjs_zB = new gvjs_Tda);
+  for (var b = gvjs_zB, c = b.rva, d = 0, e = c.length; 8 < e - d; ) {
+    var f = e + d >> 1;
+    c[f] <= a ? d = f : e = f
+  }
+  for (; d < e && !(a < c[d]); ++d)
+    ;
+  a = d - 1;
+  return 0 > a ? null : b.values[a]
+}
+function gvjs_Uda(a, b) {
+  var c = typeof a === gvjs_l ? gvjs_AB(a, a.length - 1) : a
+    , d = typeof b === gvjs_l ? gvjs_AB(b, 0) : b;
+  b = gvjs_BB(c);
+  var e = gvjs_BB(d)
+    , f = typeof a === gvjs_l;
+  if (12 === b && 13 === e)
+    return !1;
+  if (1 === b || 12 === b || 13 === b || 1 === e || 12 === e || 13 === e)
+    return !0;
+  if (7 === b && (7 === e || 8 === e || 10 === e || 11 === e) || !(10 !== b && 8 !== b || 8 !== e && 9 !== e) || (11 === b || 9 === b) && 9 === e || 2 === e || 15 === e || 6 === e)
+    return !1;
+  var g;
+  if (f) {
+    if (18 === e) {
+      d = a;
+      var h = d.length - 1;
+      var k = c;
+      for (g = b; 0 < h && 2 === g; )
+        h -= 65536 <= k && 1114111 >= k ? 2 : 1,
+          k = gvjs_AB(d, h),
+          g = gvjs_BB(k);
+      if (16 === g || 19 === g)
+        return !1
+    }
+  } else if ((16 === b || 19 === b) && 18 === e)
+    return !1;
+  if (15 === b && (17 === e || 19 === e))
+    return !1;
+  if (f) {
+    if (14 === e) {
+      e = 0;
+      d = a;
+      h = d.length - 1;
+      k = c;
+      for (g = b; 0 < h && 14 === g; )
+        e++,
+          h -= 65536 <= k && 1114111 >= k ? 2 : 1,
+          k = gvjs_AB(d, h),
+          g = gvjs_BB(k);
+      14 === g && e++;
+      if (1 === e % 2)
+        return !1
+    }
+  } else if (14 === b && 14 === e)
+    return !1;
+  return !0
+}
+function gvjs_Vda(a) {
+  if (null != a)
+    switch (a.TN) {
+      case 1:
+        return 1;
+      case -1:
+        return -1;
+      case 0:
+        return 0
+    }
+  return null
+}
+function gvjs_CB(a, b) {
+  for (var c in b)
+    c in a || (a[c] = b[c]);
+  return a
+}
+var gvjs_Wda = /<(?:!|\/?([a-zA-Z][a-zA-Z0-9:\-]*))(?:[^>'"]|"[^"]*"|'[^']*')*>/g
+  , gvjs_Xda = /</g
+  , gvjs_Yda = {
+  "\x00": "&#0;",
+  "\t": "&#9;",
+  "\n": "&#10;",
+  "\x0B": "&#11;",
+  "\f": "&#12;",
+  "\r": "&#13;",
+  " ": "&#32;",
+  '"': gvjs_ga,
+  "&": "&amp;",
+  "'": "&#39;",
+  "-": "&#45;",
+  "/": "&#47;",
+  "<": gvjs_fa,
+  "=": "&#61;",
+  ">": "&gt;",
+  "`": "&#96;",
+  "\u0085": "&#133;",
+  "\u00a0": "&#160;",
+  "\u2028": "&#8232;",
+  "\u2029": "&#8233;"
+};
+function gvjs_DB(a) {
+  return gvjs_Yda[a]
+}
+var gvjs_EB = /[\x00\x22\x26\x27\x3c\x3e]/g;
+function gvjs_FB(a) {
+  return null != a && a.eq === gvjs_pq ? a : a instanceof gvjs_Zf ? gvjs_W(gvjs_0f(a), a.getDirection()) : gvjs_W(String(String(a)).replace(gvjs_EB, gvjs_DB), gvjs_Vda(a))
+}
+var gvjs_Zda = /[\x00\x22\x27\x3c\x3e]/g;
+function gvjs_GB(a) {
+  return String(a).replace(gvjs_Zda, gvjs_DB)
+}
+function gvjs_7(a) {
+  null != a && a.eq === gvjs_pq ? (a = a.getContent(),
+    a = String(a).replace(gvjs_Wda, "").replace(gvjs_Xda, gvjs_fa),
+    a = gvjs_GB(a)) : a = String(a).replace(gvjs_EB, gvjs_DB);
+  return a
+}
+var gvjs__da = /^[a-zA-Z0-9+\/_-]+={0,2}$/;
+function gvjs_HB(a) {
+  a = String(a);
+  return gvjs__da.test(a) ? a : "zSoyz"
+}
+function gvjs_IB(a) {
+  return gvjs_r(a) ? a instanceof gvjs_qq ? gvjs_wy(a) : gvjs_2f("zSoyz") : gvjs_2f(String(a))
+}
+var gvjs_JB = {};
+function gvjs_KB(a, b, c, d) {
+  b = gvjs_IB(b(c || gvjs_JB, d));
+  gvjs_cg(a, b)
+}
+function gvjs_LB(a, b, c, d) {
+  a = a(b || gvjs_JB, c);
+  d = (d || gvjs_3g()).createElement(gvjs_b);
+  a = gvjs_IB(a);
+  gvjs_cg(d, a);
+  1 == d.childNodes.length && (a = d.firstChild,
+  1 == a.nodeType && (d = a));
+  return d
+}
+function gvjs_0da(a, b) {
+  var c = a.YDa
+    , d = a.frameId
+    , e = a.width;
+  a = a.height;
+  d = '<iframe name="' + gvjs_7(d) + gvjs_ir + gvjs_7(d) + '" type="' + (c ? "" : "image/svg+xml") + '" frameBorder="0" scrolling="no" marginHeight="0" marginWidth="0" width="' + gvjs_7(e) + '" height="' + gvjs_7(a) + '" allowTransparency="true" srcdoc="';
+  e = b && b.CCa;
+  b = b && b.DCa;
+  c = gvjs_W((c ? '<html xmlns:v="urn:schemas-microsoft-com:vml"><head>\n          <style' + (b ? ' nonce="' + gvjs_7(gvjs_HB(b)) + '"' : "") + ">\n            v\\:* {\n              behavior:url(#default#VML);\n            }\n          </style>\n        </head>" : '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><head></head>') + '<body marginwidth="0" marginheight="0" style="background:transparent"><div id="renderers"></div>\n      <script' + (e ? ' nonce="' + gvjs_7(gvjs_HB(e)) + '"' : "") + ">\n        var _loaded = false;\n        function CHART_loaded() {\n          _loaded = true;\n        }\n        document.body.onload = CHART_loaded;\n      \x3c/script>\n      </body></html>");
+  return gvjs_W(d + gvjs_7(String(gvjs_FB(c))) + '"></iframe>')
+}
+function gvjs_MB(a) {
+  gvjs_F.call(this);
+  this.ma = a;
+  this.ea = new gvjs_KA
+}
+gvjs_o(gvjs_MB, gvjs_F);
+gvjs_ = gvjs_MB.prototype;
+gvjs_.getContainer = function() {
+  return this.ma
+}
+;
+gvjs_.clear = function() {
+  this.YG();
+  this.ea = new gvjs_KA
+}
+;
+gvjs_.YG = function() {
+  gvjs_hh(this.ma);
+  this.ea.removeAll();
+  gvjs_E(this.ea)
+}
+;
+gvjs_.M = function() {
+  this.YG();
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_.ic = function(a, b, c) {
+  this.ea.o(a, b, c)
+}
+;
+function gvjs_NB(a, b) {
+  var c = Array.prototype.slice.call(arguments)
+    , d = c.shift();
+  if ("undefined" == typeof d)
+    throw Error("[goog.string.format] Template required");
+  return d.replace(/%([0\- \+]*)(\d+)?(\.(\d+))?([%sfdiu])/g, function(e, f, g, h, k, l, m, n) {
+    if ("%" == l)
+      return "%";
+    var p = c.shift();
+    if ("undefined" == typeof p)
+      throw Error("[goog.string.format] Not enough arguments");
+    arguments[0] = p;
+    return gvjs_tq[l].apply(null, arguments)
+  })
+}
+function gvjs_OB(a, b) {
+  if (Array.isArray(a))
+    return a.join(",");
+  switch (a) {
+    case gvjs_Zw:
+      return "0";
+    case gvjs_9t:
+      return String(4 * b) + "," + String(b);
+    default:
+      return gvjs_OB(gvjs_Zw, b)
+  }
+}
+function gvjs_PB(a, b) {
+  gvjs_pB.call(this, a, b);
+  this.jq = null;
+  this.hS = {};
+  this.IZ = {};
+  this.X3 = {};
+  this.KC("-._.-*^*-._.-*^*-._.-", {
+    fontSize: 8,
+    bb: gvjs_2r,
+    bold: !1,
+    Nc: !1
+  });
+  this.AQ = !1;
+  for (a = this.container.parentElement.parentElement; a; ) {
+    if (null != a.getAttribute("dir")) {
+      this.AQ = a.getAttribute("dir") === gvjs_Up;
+      break
+    }
+    a = a.parentElement
+  }
+}
+gvjs_o(gvjs_PB, gvjs_pB);
+function gvjs_QB(a, b) {
+  a.jq = a.kb(gvjs_hp);
+  var c = gvjs__A();
+  a.jq.setAttribute(gvjs_5c, c);
+  a.hS = {};
+  a.IZ = {};
+  a.X3 = {};
+  b.appendChild(a.jq)
+}
+gvjs_ = gvjs_PB.prototype;
+gvjs_.bO = function(a, b) {
+  this.width = a;
+  this.height = b;
+  var c = this.kb(gvjs_9p);
+  c.setAttribute(gvjs_Xd, a);
+  c.setAttribute(gvjs_4c, b);
+  c.style.overflow = gvjs_0u;
+  c.setAttribute(gvjs_et, "A chart.");
+  this.container.appendChild(c);
+  gvjs_QB(this, c);
+  return new gvjs_QA(c)
+}
+;
+gvjs_.Qj = function(a) {
+  var b = gvjs_Oh().Vj().SVGElement;
+  return typeof b === gvjs_h && a instanceof b && a.tagName.toLowerCase() !== gvjs_Lp && a.tagName.toLowerCase() !== gvjs_9p ? (b = a.getBBox(),
+    b.y | b.x | b.height | b.width ? new gvjs_B(b.y,b.x + b.width,b.y + b.height,b.x) : gvjs_pB.prototype.Qj.call(this, a)) : gvjs_pB.prototype.Qj.call(this, a)
+}
+;
+gvjs_.WX = function() {
+  for (var a = this.kw.j(), b = a.childNodes, c = b.length; 1 < c; )
+    a.removeChild(b[0]),
+      c--;
+  gvjs_QB(this, a)
+}
+;
+gvjs_.Poa = function() {
+  return this.container.innerHTML
+}
+;
+gvjs_.round = function(a) {
+  return Math.round(100 * a) / 100
+}
+;
+gvjs_.$x = function(a, b, c, d) {
+  var e = this.kb(gvjs_4o);
+  e.setAttribute("cx", a);
+  e.setAttribute("cy", b);
+  e.setAttribute("r", c);
+  this.rj(e, d);
+  return e
+}
+;
+gvjs_.mX = function(a, b, c, d, e) {
+  var f = this.kb(gvjs_jp);
+  f.setAttribute("cx", a);
+  f.setAttribute("cy", b);
+  f.setAttribute("rx", c);
+  f.setAttribute("ry", d);
+  this.rj(f, e);
+  return f
+}
+;
+gvjs_.Bl = function(a, b, c, d, e) {
+  var f = this.kb(gvjs_Qp);
+  f.setAttribute("x", a);
+  f.setAttribute("y", b);
+  f.setAttribute(gvjs_Xd, c);
+  f.setAttribute(gvjs_4c, d);
+  this.rj(f, e);
+  return f
+}
+;
+gvjs_.AD = gvjs_n(46);
+gvjs_.tX = function(a, b) {
+  var c = this.kb(gvjs_Lp);
+  0 < a.length && c.setAttribute("d", a.join(""));
+  this.rj(c, b);
+  return c
+}
+;
+gvjs_.by = function(a, b, c, d, e, f, g, h) {
+  return this.ys(a, b, c, d, 0, e, f, g, h)
+}
+;
+gvjs_.pH = function(a, b, c, d, e, f, g, h, k) {
+  var l = gvjs_WA(b, d, f, k)
+    , m = gvjs_WA(c, e, f, k);
+  return this.ys(a, l, m, Math.sqrt(gvjs_cA(new gvjs_bA(b,c,d,e))), gvjs_5y(gvjs_7y(Math.atan2(e - c, d - b))), f, g, h, k)
+}
+;
+gvjs_.ys = function(a, b, c, d, e, f, g, h, k) {
+  var l = void 0 !== h.opacity ? h.opacity : 1
+    , m = new gvjs_3({
+    fill: h.color,
+    fillOpacity: l
+  });
+  if (h.color && h.color != gvjs_f && h.Lb && h.Lb != gvjs_f) {
+    l = new gvjs_3({
+      fill: h.color,
+      fillOpacity: l,
+      stroke: h.Lb,
+      strokeOpacity: l,
+      strokeWidth: h.tG
+    });
+    var n = this.Sa();
+    this.RH(a, b, c, d, e, f, g, h, l, n, k).setAttribute(gvjs_dt, gvjs_Rd);
+    this.RH(a, b, c, d, e, f, g, h, m, n, k);
+    return n.j()
+  }
+  return this.oH(a, b, c, d, e, f, g, h, m, k)
+}
+;
+gvjs_.oH = function(a, b, c, d, e, f, g, h, k, l) {
+  d = this.kb(gvjs_m);
+  g = gvjs_VA(0, h.fontSize, g);
+  g = gvjs_WA(g.start, g.end, gvjs_R);
+  g -= .15 * h.fontSize;
+  g = new gvjs_ok(0,g);
+  g.rotate(gvjs_6y(e));
+  c = new gvjs_ok(b,c);
+  c.add(g);
+  b = c.x;
+  c = c.y;
+  d.appendChild(this.zO.createTextNode(a));
+  switch (f) {
+    case gvjs_2:
+      d.setAttribute(gvjs_$p, gvjs_2);
+      break;
+    case gvjs_0:
+      d.setAttribute(gvjs_$p, gvjs_Nv);
+      break;
+    case gvjs_R:
+      d.setAttribute(gvjs_$p, gvjs_R)
+  }
+  d.setAttribute("x", b);
+  d.setAttribute("y", c);
+  d.setAttribute("font-family", h.bb);
+  d.setAttribute("font-size", h.fontSize || 0);
+  h.bold && d.setAttribute(gvjs_Cu, gvjs_st);
+  h.Nc && d.setAttribute(gvjs_Bu, gvjs_Gp);
+  h.Ue && d.setAttribute(gvjs_ax, gvjs_bq);
+  l && d.setAttribute(gvjs_iu, gvjs_Up);
+  0 != e && d.setAttribute(gvjs_aq, gvjs_Tp + e + " " + b + " " + c + ")");
+  this.rj(d, k);
+  return d
+}
+;
+gvjs_.RH = function(a, b, c, d, e, f, g, h, k, l, m) {
+  a = this.oH(a, b, c, d, e, f, g, h, k, m);
+  this.appendChild(l, a);
+  return a
+}
+;
+gvjs_.nX = function() {
+  return this.kb("g")
+}
+;
+gvjs_.ZG = function(a, b, c) {
+  var d = gvjs__A()
+    , e = this.kb("clipPath");
+  c ? (c = this.kb(gvjs_jp),
+    c.setAttribute("cx", b.left + b.width / 2),
+    c.setAttribute("cy", b.top + b.height / 2),
+    c.setAttribute("rx", b.width / 2),
+    c.setAttribute("ry", b.height / 2),
+    e.appendChild(c)) : (c = this.kb(gvjs_Qp),
+    c.setAttribute("x", b.left),
+    c.setAttribute("y", b.top),
+    c.setAttribute(gvjs_Xd, b.width),
+    c.setAttribute(gvjs_4c, b.height),
+    e.appendChild(c));
+  e.setAttribute(gvjs_5c, d);
+  this.jq.appendChild(e);
+  a = a.j();
+  a.setAttribute(gvjs_5o, gvjs_RB(d));
+  return a
+}
+;
+function gvjs_RB(a) {
+  var b = "";
+  gvjs_y && "9.0" === gvjs_Dg || (b = window.location.href.split("#")[0]);
+  return "url(" + b + "#" + a + ")"
+}
+gvjs_.nd = function(a, b, c) {
+  a.push("M" + b + "," + c)
+}
+;
+gvjs_.Ma = function(a, b, c) {
+  a.push("L" + b + "," + c)
+}
+;
+gvjs_.Yr = function(a, b, c, d, e, f, g) {
+  a.push("C" + b + "," + c + "," + d + "," + e + "," + f + "," + g)
+}
+;
+gvjs_.Qi = function(a) {
+  a.push("Z")
+}
+;
+gvjs_.Bm = function(a, b, c, d, e, f, g, h) {
+  if (0 < d && 0 < e) {
+    var k = gvjs_5y(g) - gvjs_5y(f);
+    180 < k ? k -= 360 : -180 >= k && (k = 360 + k);
+    var l = 2 * Math.PI * Math.min(d, e);
+    .1 > Math.abs(k / 360 * l) && (k = (.1 / l * 360 - Math.abs(k)) * gvjs_$y(k) / 2,
+      f -= k,
+      g += k)
+  }
+  f = gvjs_5y(f);
+  g = gvjs_5y(g);
+  l = gvjs_8y(g - 90, d);
+  var m = gvjs_9y(g - 90, e);
+  k = h ? g - f : f - g;
+  0 > k && (k += 360);
+  a.push("A" + d + "," + e + ",0," + (180 < k ? 1 : 0) + "," + (h ? 1 : 0) + "," + (b + l) + "," + (c + m))
+}
+;
+gvjs_.mp = function(a, b, c) {
+  a.setAttribute(gvjs_aq, "translate(" + b + gvjs_ha + c + ")")
+}
+;
+gvjs_.Ug = function(a, b) {
+  a.setAttribute(gvjs_Xd, b)
+}
+;
+gvjs_.fl = function(a, b) {
+  a.setAttribute(gvjs_4c, b)
+}
+;
+gvjs_.tA = gvjs_n(49);
+gvjs_.xA = gvjs_n(52);
+gvjs_.rd = function(a, b, c) {
+  a.setAttribute(gvjs_2p, c);
+  b && a.setAttribute(gvjs_0p, b)
+}
+;
+gvjs_.KC = function(a, b, c) {
+  var d = this.jF;
+  if (3 === d.firstChild.nodeType)
+    d.firstChild.data = a;
+  else
+    throw Error("Unexpected type of text node " + d.firstChild.nodeType);
+  a = d.style;
+  a.fontFamily = b.bb;
+  a.fontSize = b.fontSize + gvjs_T;
+  a.fontWeight = b.bold ? gvjs_st : "";
+  a.fontStyle = b.Nc ? gvjs_Gp : "";
+  a.display = gvjs_xb;
+  null != c && (b = gvjs_NB("rotate(%ddeg)", c),
+    a.transform = b,
+    a.transformOrigin = gvjs_Mr,
+    a.WebkitTransform = b,
+    a.WebkitTransformOrigin = gvjs_Mr,
+    a.MozTransform = b,
+    a.MozTransformOrigin = gvjs_Mr,
+    a.WAa = b,
+    a.XAa = gvjs_Mr,
+    a.msTransform = b,
+    a.eEa = gvjs_Mr);
+  b = d.clientWidth;
+  d = d.clientHeight;
+  a.display = gvjs_f;
+  return new gvjs_A(b,d)
+}
+;
+gvjs_.IC = gvjs_n(55);
+gvjs_.kb = function(a) {
+  return this.zO.createElementNS(gvjs_Ep, a)
+}
+;
+gvjs_.rj = function(a, b) {
+  gvjs_ey(b) ? (a.setAttribute(gvjs_0p, b.Uj()),
+    a.setAttribute(gvjs_2p, b.strokeWidth),
+    gvjs_ey(b) && 1 <= b.strokeOpacity ? a.removeAttribute(gvjs_1p) : a.setAttribute(gvjs_1p, b.strokeOpacity),
+    b.Mi !== gvjs_Zw ? a.setAttribute(gvjs_7w, gvjs_OB(b.Mi, b.strokeWidth)) : a.removeAttribute(gvjs_7w)) : (a.setAttribute(gvjs_0p, gvjs_f),
+    a.setAttribute(gvjs_2p, 0));
+  gvjs_hy(b) ? a.removeAttribute(gvjs_op) : a.setAttribute(gvjs_op, b.fillOpacity);
+  var c = b.radiusX;
+  typeof c === gvjs_g && a.setAttribute("rx", c);
+  c = b.radiusY;
+  typeof c === gvjs_g && a.setAttribute("ry", c);
+  var d = b.gradient
+    , e = b.pattern;
+  if (d) {
+    e = gvjs_Wz(d, 1).toString();
+    c = this.IZ[e];
+    if (!c) {
+      c = gvjs__A();
+      this.IZ[e] = c;
+      e = this.kb(gvjs_Ip);
+      var f = d.x1
+        , g = d.x2
+        , h = d.y1
+        , k = d.y2
+        , l = d.Vf
+        , m = d.sf
+        , n = 1;
+      if (0 === d.tn || d.tn)
+        n = d.tn;
+      var p = 1;
+      if (0 === d.un || d.un)
+        p = d.un;
+      var q = d.Sn ? "objectBoundingBox" : gvjs_Bx;
+      e.setAttribute(gvjs_5c, c);
+      e.setAttribute("x1", f);
+      e.setAttribute("y1", h);
+      e.setAttribute("x2", g);
+      e.setAttribute("y2", k);
+      e.setAttribute("gradientUnits", q);
+      f = gvjs_6w + l + gvjs_Xr + n;
+      m = gvjs_6w + m + gvjs_Xr + p;
+      p = this.kb(gvjs__p);
+      p.setAttribute(gvjs_Jp, gvjs_Ro);
+      p.setAttribute(gvjs_Jd, f);
+      e.appendChild(p);
+      d.sp && (d = this.kb(gvjs__p),
+        d.setAttribute(gvjs_Jp, "49.99%"),
+        d.setAttribute(gvjs_Jd, f),
+        e.appendChild(d),
+        d = this.kb(gvjs__p),
+        d.setAttribute(gvjs_Jp, "50%"),
+        d.setAttribute(gvjs_Jd, m),
+        e.appendChild(d));
+      d = this.kb(gvjs__p);
+      d.setAttribute(gvjs_Jp, gvjs_So);
+      d.setAttribute(gvjs_Jd, m);
+      e.appendChild(d);
+      this.jq.appendChild(e)
+    }
+    a.setAttribute(gvjs_np, gvjs_RB(c))
+  } else if (e) {
+    c = e.getStyle() + "_" + e.ee() + "_" + e.getBackgroundColor();
+    if (!(c in this.hS)) {
+      d = null;
+      switch (e.getStyle()) {
+        case gvjs_rw:
+          d = this.kb(gvjs_td);
+          d.setAttribute("patternUnits", gvjs_Bx);
+          d.setAttribute("x", "0");
+          d.setAttribute("y", "0");
+          d.setAttribute(gvjs_Xd, "4");
+          d.setAttribute(gvjs_4c, "4");
+          d.setAttribute("viewBox", "0 0 4 4");
+          m = this.kb(gvjs_Qp);
+          m.setAttribute("x", "0");
+          m.setAttribute("y", "0");
+          m.setAttribute(gvjs_Xd, "4");
+          m.setAttribute(gvjs_4c, "4");
+          m.setAttribute(gvjs_np, e.getBackgroundColor());
+          d.appendChild(m);
+          m = this.kb("g");
+          m.setAttribute(gvjs_0p, e.ee());
+          m.setAttribute(gvjs_8w, gvjs_1w);
+          e = this.kb(gvjs_e);
+          e.setAttribute("x1", "2");
+          e.setAttribute("y1", "0");
+          e.setAttribute("x2", "4");
+          e.setAttribute("y2", "2");
+          e.setAttribute(gvjs_2p, "2");
+          m.appendChild(e);
+          e = this.kb(gvjs_e);
+          e.setAttribute("x1", "0");
+          e.setAttribute("y1", "2");
+          e.setAttribute("x2", "2");
+          e.setAttribute("y2", "4");
+          e.setAttribute(gvjs_2p, "2");
+          m.appendChild(e);
+          d.appendChild(m);
+          break;
+        case gvjs_Hw:
+          d = this.kb(gvjs_td),
+            d.setAttribute("patternUnits", gvjs_Bx),
+            d.setAttribute("x", "0"),
+            d.setAttribute("y", "0"),
+            d.setAttribute(gvjs_Xd, "6"),
+            d.setAttribute(gvjs_4c, "6"),
+            d.setAttribute("viewBox", "0 0 4 4"),
+            m = this.kb(gvjs_Qp),
+            m.setAttribute("x", "0"),
+            m.setAttribute("y", "0"),
+            m.setAttribute(gvjs_Xd, "4"),
+            m.setAttribute(gvjs_4c, "4"),
+            m.setAttribute(gvjs_np, e.getBackgroundColor()),
+            d.appendChild(m),
+            m = this.kb("g"),
+            m.setAttribute(gvjs_0p, e.ee()),
+            m.setAttribute(gvjs_8w, gvjs_1w),
+            e = this.kb(gvjs_e),
+            e.setAttribute("x1", "2"),
+            e.setAttribute("y1", "0"),
+            e.setAttribute("x2", "0"),
+            e.setAttribute("y2", "2"),
+            e.setAttribute(gvjs_2p, "2"),
+            m.appendChild(e),
+            e = this.kb(gvjs_e),
+            e.setAttribute("x1", "4"),
+            e.setAttribute("y1", "2"),
+            e.setAttribute("x2", "2"),
+            e.setAttribute("y2", "4"),
+            e.setAttribute(gvjs_2p, "2"),
+            m.appendChild(e),
+            d.appendChild(m)
+      }
+      e = gvjs__A();
+      d.setAttribute(gvjs_5c, e);
+      this.jq.appendChild(d);
+      this.hS[c] = e
+    }
+    c = this.hS[c];
+    a.setAttribute(gvjs_np, gvjs_RB(c))
+  } else
+    a.setAttribute(gvjs_np, b.fill);
+  null != b.Rw && (e = b.Rw,
+    c = gvjs_Wz(e, 1).toString(),
+    b = this.X3[c],
+  b || (b = gvjs__A(),
+    this.X3[c] = b,
+    c = this.kb(gvjs_tp),
+    c.setAttribute(gvjs_5c, b),
+    d = this.kb(gvjs_lp),
+    d.setAttribute(gvjs_Fp, "SourceAlpha"),
+    d.setAttribute("stdDeviation", e.radius || 0),
+    c.appendChild(d),
+    d = this.kb("feOffset"),
+    d.setAttribute("dx", e.xOffset || 0),
+    d.setAttribute("dy", e.yOffset || 0),
+    c.appendChild(d),
+  null != e.opacity && (d = this.kb(gvjs_kp),
+    m = this.kb("feFuncA"),
+    m.setAttribute(gvjs_Sd, gvjs_Hp),
+    m.setAttribute("slope", e.opacity),
+    d.appendChild(m),
+    c.appendChild(d)),
+    e = this.kb("feMerge"),
+    d = this.kb(gvjs_mp),
+    e.appendChild(d),
+    d = this.kb(gvjs_mp),
+    d.setAttribute(gvjs_Fp, "SourceGraphic"),
+    e.appendChild(d),
+    c.appendChild(e),
+    this.jq.appendChild(c)),
+    a.setAttribute(gvjs_tp, gvjs_RB(b)))
+}
+;
+gvjs_.ws = function() {
+  var a = gvjs_4(gvjs_b, {
+    "aria-label": "A tabular representation of the data in the chart.",
+    style: "position:absolute;left:" + (this.AQ ? 1E4 : -1E4) + "px;top:auto;width:1px;height:1px;overflow:hidden"
+  });
+  this.container.appendChild(a);
+  this.container.setAttribute(gvjs_et, "A chart.");
+  return a
+}
+;
+function gvjs_SB(a) {
+  if (Array.isArray(a))
+    return a.join(" ");
+  switch (a) {
+    case gvjs_Zw:
+      return gvjs_Zw;
+    case gvjs_9t:
+      return "shortdash";
+    default:
+      return gvjs_SB(gvjs_Zw)
+  }
+}
+function gvjs_TB(a, b) {
+  gvjs_pB.call(this, a, b);
+  this.Xw = null
+}
+gvjs_o(gvjs_TB, gvjs_pB);
+gvjs_ = gvjs_TB.prototype;
+gvjs_.bO = function(a, b) {
+  this.width = a;
+  this.height = b;
+  var c = this.Qd(gvjs_Ob);
+  this.qk(c, -5E4, -5E4, this.width + 1E5, this.height + 1E5);
+  this.container.appendChild(c);
+  var d = this.Sa()
+    , e = d.j();
+  e.coordorigin = gvjs_Mr;
+  e.coordsize = a + " " + b;
+  e.style.top = this.Ub(5E4);
+  e.style.left = this.Ub(5E4);
+  c.appendChild(e);
+  return d
+}
+;
+gvjs_.WX = function() {
+  for (var a = this.kw.j(), b = a.childNodes, c = b.length; 1 < c; )
+    a.removeChild(b[0]),
+      c--
+}
+;
+gvjs_.round = function(a) {
+  return Math.round(a)
+}
+;
+gvjs_.$x = function(a, b, c, d) {
+  var e = this.Qd(gvjs_Ex)
+    , f = 2 * c;
+  this.qk(e, a - c, b - c, f, f);
+  this.rj(e, d, !1);
+  return e
+}
+;
+gvjs_.mX = function(a, b, c, d, e) {
+  var f = this.Qd(gvjs_Ex);
+  this.qk(f, a - c, b - d, 2 * c, 2 * d);
+  this.rj(f, e, !1);
+  return f
+}
+;
+gvjs_.Bl = function(a, b, c, d, e) {
+  var f = this.Qd("v:rect")
+    , g = gvjs_hy(e) && 1 <= d && 1 <= c && null == e.gradient;
+  this.rj(f, e, g);
+  if (gvjs_ey(e) || g)
+    c = Math.max(c - 1, 0),
+      d = Math.max(d - 1, 0);
+  this.qk(f, a, b, c, d);
+  return f
+}
+;
+gvjs_.AD = gvjs_n(45);
+gvjs_.tX = function(a, b) {
+  for (var c = this.Qd(gvjs_Gx), d = this.Qd(gvjs_Fx); 0 < a.length && gvjs_hf(gvjs_Ae(a), "M"); )
+    a = gvjs_Oe(a, 0, a.length - 1);
+  d.setAttribute("v", a.join(""));
+  this.qk(c, 0, 0, this.width, this.height);
+  c.appendChild(d);
+  this.rj(c, b, !1);
+  return c
+}
+;
+gvjs_.by = function(a, b, c, d, e, f, g) {
+  b = gvjs_VA(b, d, e);
+  c = gvjs_VA(c, g.fontSize, f);
+  f = gvjs_0;
+  c = gvjs_WA(c.start, c.end, f);
+  return this.pH(a, b.start, c, b.end, c, e, f, g)
+}
+;
+gvjs_.pH = function(a, b, c, d, e, f, g, h) {
+  var k = new gvjs_3({
+    fill: h.color
+  });
+  if (h.color && h.color != gvjs_f && h.Lb && h.Lb != gvjs_f) {
+    var l = new gvjs_3({
+      fill: h.color,
+      stroke: h.Lb,
+      strokeWidth: 2
+    })
+      , m = this.Sa();
+    this.RH(a, b, c, d, e, f, g, h, l, m);
+    this.RH(a, b, c, d, e, f, g, h, k, m);
+    return m.j()
+  }
+  return this.oH(a, b, c, d, e, f, g, h, k)
+}
+;
+gvjs_.ys = function(a, b, c, d, e, f, g, h) {
+  e = gvjs_6y(e);
+  d = gvjs_VA(b, d, f);
+  b = new gvjs_ok(b,c);
+  var k = new gvjs_ok(d.start,c);
+  k = k.clone().aU(b).rotate(e).add(b);
+  c = new gvjs_ok(d.end,c);
+  c = c.clone().aU(b).rotate(e).add(b);
+  return this.pH(a, k.x, k.y, c.x, c.y, f, g, h)
+}
+;
+gvjs_.oH = function(a, b, c, d, e, f, g, h, k) {
+  var l = this.Qd(gvjs_Gx);
+  this.qk(l, 0, 0, this.width, this.height);
+  g != gvjs_0 && (g = gvjs_VA(0, h.fontSize, g),
+    g = gvjs_WA(g.start, g.end, gvjs_0),
+    g = new gvjs_ok(0,g),
+    g.rotate(gvjs_6y(gvjs_5y(gvjs_7y(Math.atan2(e - c, d - b))))),
+    c = new gvjs_ok(b,c),
+    e = new gvjs_ok(d,e),
+    c.add(g),
+    e.add(g),
+    b = c.x,
+    c = c.y,
+    d = e.x,
+    e = e.y);
+  b = Math.round(b);
+  c = Math.round(c);
+  d = Math.round(d);
+  e = Math.round(e);
+  g = this.Qd(gvjs_Fx);
+  g.setAttribute("v", "M" + b + "," + c + "L" + d + "," + e + "E");
+  g.setAttribute(gvjs_cx, gvjs_Rd);
+  b = this.Qd("v:textpath");
+  b.setAttribute("on", gvjs_Rd);
+  d = b.style;
+  d.fontSize = h.fontSize || "";
+  d.fontFamily = h.bb || "";
+  switch (f) {
+    case gvjs_2:
+      d.setAttribute(gvjs_Cx, gvjs_$c);
+      break;
+    case gvjs_0:
+      d.setAttribute(gvjs_Cx, gvjs_0);
+      break;
+    case gvjs_R:
+      d.setAttribute(gvjs_Cx, gvjs_j)
+  }
+  h.bold && (d.fontWeight = gvjs_st);
+  h.Nc && (d.fontStyle = gvjs_Gp);
+  b.setAttribute(gvjs_l, a);
+  l.appendChild(g);
+  l.appendChild(b);
+  this.rj(l, k, !1);
+  return l
+}
+;
+gvjs_.RH = function(a, b, c, d, e, f, g, h, k, l) {
+  a = this.oH(a, b, c, d, e, f, g, h, k);
+  this.appendChild(l, a);
+  return a
+}
+;
+gvjs_.nX = function() {
+  var a = this.Qd("v:group");
+  this.qk(a, 0, 0, this.width, this.height);
+  return a
+}
+;
+gvjs_.ZG = function(a, b) {
+  var c = this.Qd(gvjs_Ob);
+  c.style.clip = "rect(" + [this.Ub(5E4 + b.top), this.Ub(5E4 + b.left + b.width), this.Ub(5E4 + b.top + b.height), this.Ub(5E4 + b.left)].join(gvjs_ha) + ")";
+  this.qk(c, 0, 0, this.width + 1E5, this.height + 1E5);
+  a.j();
+  b = new gvjs_QA(c);
+  this.appendChild(b, a);
+  this.yb(1, 1, 1, 1, new gvjs_3({
+    fill: gvjs_Ox
+  }), b);
+  return c
+}
+;
+gvjs_.nd = function(a, b, c) {
+  a.push("M" + Math.round(b) + "," + Math.round(c))
+}
+;
+gvjs_.Ma = function(a, b, c) {
+  a.push("L" + Math.round(b) + "," + Math.round(c))
+}
+;
+gvjs_.Yr = function(a, b, c, d, e, f, g) {
+  a.push("C" + Math.round(b) + "," + Math.round(c) + "," + Math.round(d) + "," + Math.round(e) + "," + Math.round(f) + "," + Math.round(g))
+}
+;
+gvjs_.Qi = function(a) {
+  a.push("X")
+}
+;
+gvjs_.Bm = function(a, b, c, d, e, f, g, h) {
+  f = gvjs_5y(f);
+  g = gvjs_5y(g);
+  var k = Math.round(gvjs_8y(f - 90, d))
+    , l = Math.round(gvjs_9y(f - 90, e))
+    , m = Math.round(gvjs_8y(g - 90, d))
+    , n = Math.round(gvjs_9y(g - 90, e));
+  d = Math.round(d);
+  e = Math.round(e);
+  b = Math.round(b);
+  c = Math.round(c);
+  k === m && l === n && (h && 180 > gvjs_5y(g - f) || !h && 180 > gvjs_5y(f - g)) || a.push((h ? "WA" : "AT") + (b - d) + "," + (c - e) + "," + (b + d) + "," + (c + e) + "," + (b + k) + "," + (c + l) + "," + (b + m) + "," + (c + n))
+}
+;
+gvjs_.mp = function(a, b, c) {
+  a.style.top = this.Ub(c);
+  a.style.left = this.Ub(b)
+}
+;
+gvjs_.Ug = function(a, b) {
+  a.style.width = this.Ub(b)
+}
+;
+gvjs_.fl = function(a, b) {
+  a.style.height = this.Ub(b)
+}
+;
+gvjs_.tA = gvjs_n(48);
+gvjs_.xA = gvjs_n(51);
+gvjs_.rd = function(a, b, c) {
+  0 == c ? a.stroked = !1 : (a.stroked = !0,
+  b && (a.strokecolor = b),
+    a.strokeweight = c)
+}
+;
+gvjs_.KC = function(a, b) {
+  var c = this.jF;
+  c.firstChild.data = a;
+  a = c.style;
+  a.fontFamily = b.bb;
+  a.fontSize = this.Ub(b.fontSize || 0);
+  a.fontWeight = b.bold ? gvjs_st : "";
+  a.fontStyle = b.Nc ? gvjs_Gp : "";
+  a.display = gvjs_xb;
+  var d = c.clientWidth;
+  c = c.clientHeight;
+  a.display = gvjs_f;
+  b.bold && (d *= 1.1);
+  b.Nc && (d *= .9);
+  return new gvjs_A(d,c)
+}
+;
+gvjs_.IC = gvjs_n(54);
+gvjs_.Ub = function(a) {
+  return Math.round(a) + gvjs_T
+}
+;
+gvjs_.Qd = function(a) {
+  return this.zO.createElement(a)
+}
+;
+gvjs_.rj = function(a, b, c) {
+  for (var d = a.children, e = 0; e < d.length; e++)
+    a.children[e].tagName != gvjs_np && a.children[e].tagName != gvjs_0p || a.removeChild(d[e]);
+  c = null != c ? c : !0;
+  if (gvjs_ey(b)) {
+    if (a.stroked = !0,
+      a.strokeweight = b.strokeWidth,
+      a.strokecolor = b.Uj(),
+      c = !(gvjs_ey(b) && 1 <= b.strokeOpacity),
+      d = b.Mi !== gvjs_Zw,
+    c || d)
+      e = this.Qd("v:stroke"),
+      c && (e.opacity = String(Math.round(100 * b.strokeOpacity)) + "%"),
+      d && (e.dashstyle = gvjs_SB(b.Mi)),
+        a.appendChild(e)
+  } else
+    c && gvjs_hy(b) ? (a.stroked = !0,
+      a.strokeweight = 1,
+      a.strokecolor = b.fill) : a.stroked = !1;
+  void 0 !== a.filled && (a.filled = !0);
+  c = b.gradient;
+  if (null != c) {
+    b = this.Qd(gvjs_Dx);
+    b.setAttribute(gvjs_1, c.Vf);
+    b.setAttribute("color2", c.sf);
+    b.setAttribute(gvjs_Kp, c.tn || 1);
+    b.setAttribute("opacity2", c.un || 1);
+    d = c.x1;
+    e = c.y1;
+    var f = c.x2;
+    c = c.y2;
+    typeof d == gvjs_l && (d = parseInt(d, 10));
+    typeof e == gvjs_l && (e = parseInt(e, 10));
+    typeof f == gvjs_l && (f = parseInt(f, 10));
+    typeof c == gvjs_l && (c = parseInt(c, 10));
+    c = gvjs_5y(gvjs_7y(Math.atan2(c - e, f - d)));
+    c = gvjs_3y(270 - c, 360);
+    b.setAttribute("angle", c);
+    b.setAttribute(gvjs_Sd, gvjs_Bp);
+    a.appendChild(b)
+  } else
+    b.pattern ? (c = b.pattern,
+      b = this.Qd(gvjs_Dx),
+      b.setAttribute(gvjs_Sd, gvjs_td),
+      b.setAttribute(gvjs_1, c.ee()),
+      b.setAttribute("color2", c.getBackgroundColor()),
+      c = gvjs_je("google.charts.loader.makeCssUrl")({
+        subdir1: "core",
+        subdir2: "patterns",
+        filename: c.getStyle() + ".gif"
+      }),
+      b.setAttribute("src", c),
+      a.appendChild(b)) : b.fill == gvjs_f ? a.filled = !1 : gvjs_hy(b) ? a.fillcolor = b.fill : (c = this.Qd(gvjs_Dx),
+      c.opacity = String(Math.round(100 * b.fillOpacity)) + "%",
+      c.color = b.fill,
+      a.appendChild(c))
+}
+;
+gvjs_.qk = function(a, b, c, d, e) {
+  a = a.style;
+  a.position = gvjs_c;
+  a.left = this.Ub(b);
+  a.top = this.Ub(c);
+  a.width = this.Ub(d);
+  a.height = this.Ub(e)
+}
+;
+gvjs_.cw = gvjs_n(35);
+var gvjs_UB;
+function gvjs_VB(a, b) {
+  b ? a.setAttribute(gvjs_Bd, b) : a.removeAttribute(gvjs_Bd)
+}
+function gvjs_WB(a, b, c) {
+  Array.isArray(c) && (c = c.join(" "));
+  var d = "aria-" + b;
+  "" === c || void 0 == c ? (gvjs_UB || (gvjs_UB = {
+    atomic: !1,
+    autocomplete: gvjs_f,
+    dropeffect: gvjs_f,
+    haspopup: !1,
+    live: "off",
+    multiline: !1,
+    multiselectable: !1,
+    orientation: gvjs_U,
+    readonly: !1,
+    relevant: "additions text",
+    required: !1,
+    sort: gvjs_f,
+    busy: !1,
+    disabled: !1,
+    hidden: !1,
+    invalid: gvjs_Sb
+  }),
+    c = gvjs_UB,
+    b in c ? a.setAttribute(d, c[b]) : a.removeAttribute(d)) : a.setAttribute(d, c)
+}
+function gvjs_XB(a, b) {
+  a = a.getAttribute("aria-" + b);
+  return null == a || void 0 == a ? "" : String(a)
+}
+function gvjs_YB(a) {
+  var b = gvjs_XB(a, gvjs_Ts);
+  return gvjs_5g(a).getElementById(b)
+}
+function gvjs_ZB(a, b) {
+  var c = "";
+  b && (c = b.id);
+  gvjs_WB(a, gvjs_Ts, c)
+}
+function gvjs__B(a) {
+  return gvjs_XB(a, gvjs_8c)
+}
+function gvjs_0B(a, b) {
+  gvjs_WB(a, gvjs_8c, b)
+}
+function gvjs_1B(a, b) {
+  var c = gvjs_3g(a)
+    , d = c.createElement(gvjs_Ob)
+    , e = d.style
+    , f = b ? b.height + 10 : 0;
+  b = b ? b.width + 10 : 0;
+  e.display = gvjs_f;
+  e.position = gvjs_c;
+  e.top = f + gvjs_T;
+  e.left = b + gvjs_T;
+  e.whiteSpace = gvjs_1v;
+  gvjs_WB(d, gvjs_0u, !0);
+  d.setAttribute(gvjs_dt, !0);
+  c.appendChild(d, c.createTextNode(" "));
+  c.appendChild(a, d);
+  return d
+}
+function gvjs_2B(a, b, c, d) {
+  a.call() ? b.call() : gvjs_1da(a, b, c, d)
+}
+function gvjs_1da(a, b, c, d) {
+  d = null != d ? d : 10;
+  setTimeout(c(function() {
+    gvjs_2B(a, b, c, d)
+  }), d)
+}
+function gvjs_3B(a, b, c, d) {
+  gvjs_F.call(this);
+  if (!(gvjs_y ? 0 <= gvjs_tf(gvjs_Dg, "5.5") : gvjs_sg ? 0 <= gvjs_tf(gvjs_Dg, "1.8") : gvjs_qg ? 0 <= gvjs_tf(gvjs_Dg, "9.0") : gvjs_tg ? 0 <= gvjs_tf(gvjs_Dg, "420+") : gvjs_rg))
+    throw Error("Graphics is not supported");
+  for (var e = Math.floor(1E5 * Math.random()); window.frames[gvjs_bs + e]; )
+    e++;
+  this.Pl = gvjs_bs + e;
+  (a = this.jM = a) && (a.referencepoint = !0);
+  gvjs_hh(this.jM);
+  this.El = gvjs_3g(this.jM);
+  this.container = this.El.createElement(gvjs_Ob);
+  this.container.style.position = gvjs_zd;
+  this.jM.appendChild(this.container);
+  this.dimensions = b;
+  this.W4 = this.km = null;
+  this.ot = !1;
+  this.tE = [];
+  this.Hi = null;
+  b = gvjs_Ph();
+  this.Dva = (b = gvjs_y ? null != b.documentMode ? 9 > b.documentMode : !gvjs_Eg("9") : !1) ? gvjs_TB : gvjs_PB;
+  if (this.OU = b || d)
+    a = d = "",
+    this.dimensions && (d = this.dimensions.width.toString() + gvjs_T,
+      a = this.dimensions.height.toString() + gvjs_T),
+      d = gvjs_LB(gvjs_0da, {
+        isVml: b,
+        frameId: this.Pl,
+        width: d,
+        height: a
+      }),
+      this.El.appendChild(this.container, d);
+  gvjs_4B(this, c)
+}
+gvjs_o(gvjs_3B, gvjs_F);
+function gvjs_4B(a, b) {
+  var c = a.esa.bind(a);
+  a = a.sua.bind(a);
+  gvjs_2B(c, a, b)
+}
+gvjs_ = gvjs_3B.prototype;
+gvjs_.sua = function() {
+  if (this.OU) {
+    var a = (a = this.El.j(this.Pl)) ? this.El.Noa(a) : null;
+    var b = this.km = a.getElementById("renderers");
+    b && (b.referencepoint = !0);
+    this.W4 = gvjs_1B(a.body, this.dimensions)
+  } else
+    this.km = this.El.createElement(gvjs_Ob),
+      gvjs_C(this.km, gvjs_vd, gvjs_zd),
+    this.dimensions && gvjs_Cz(this.km, this.dimensions),
+      this.km.dir = gvjs_Dv,
+      this.container.appendChild(this.km),
+      this.W4 = gvjs_1B(this.container, this.dimensions);
+  this.ot = !0
+}
+;
+gvjs_.esa = function() {
+  if (!this.OU)
+    return !0;
+  var a = this.El.j(this.Pl);
+  if (a)
+    a: {
+      try {
+        var b = a.contentWindow || (a.contentDocument ? gvjs_3x(a.contentDocument) : null);
+        break a
+      } catch (c) {}
+      b = null
+    }
+  else
+    b = null;
+  return (a = b) ? 1 == a._loaded : !1
+}
+;
+gvjs_.Oa = function(a) {
+  var b = void 0 === b ? !0 : b;
+  if (!this.ot)
+    return null;
+  for (a = null != a ? a : 0; this.tE.length <= a; ) {
+    var c = b;
+    c = void 0 === c ? !0 : c;
+    var d = gvjs_3g(this.km).createElement(gvjs_Ob);
+    c && (gvjs_C(d, gvjs_vd, gvjs_c),
+      gvjs_sz(d, 0, 0));
+    gvjs_Cz(d, gvjs_So, gvjs_So);
+    this.km.appendChild(d);
+    c = new this.Dva(d,this.W4);
+    gvjs_6x(this, c);
+    this.tE.push(c)
+  }
+  return this.tE[a]
+}
+;
+gvjs_.yq = function() {
+  if (!this.ot)
+    return null;
+  if (!this.Hi) {
+    var a = this.El.createElement(gvjs_Ob);
+    this.Hi = new gvjs_MB(a);
+    this.El.appendChild(this.container, this.Hi.getContainer())
+  }
+  return this.Hi
+}
+;
+gvjs_.rl = function(a, b) {
+  var c = this;
+  gvjs_2B(function() {
+    return null != c.km
+  }, a, b)
+}
+;
+gvjs_.update = function(a, b) {
+  if (null != a && !gvjs_fz(this.dimensions, a))
+    if (this.dimensions = a,
+      this.OU) {
+      if (a = this.El.j(this.Pl))
+        a.width = this.dimensions.width.toString(),
+          a.height = this.dimensions.height.toString()
+    } else
+      this.ot && gvjs_Cz(this.km, this.dimensions);
+  this.ot || gvjs_4B(this, b)
+}
+;
+gvjs_.M = function() {
+  try {
+    this.El.qc(this.jM),
+      gvjs_E(this.Hi),
+      gvjs_u(this.tE, function(a) {
+        gvjs_E(a)
+      })
+  } catch (a) {}
+  gvjs_F.prototype.M.call(this)
+}
+;
+function gvjs_5B(a) {
+  switch (a.type) {
+    case gvjs_Xv:
+    case gvjs_e:
+    case gvjs_7t:
+      return a = a.data,
+        new gvjs_z(a.x,a.y);
+    case "arc":
+      a = a.data;
+      var b = gvjs_5y(a.ou);
+      return new gvjs_z(a.cx + gvjs_8y(b - 90, a.rx),a.cy + gvjs_9y(b - 90, a.ry));
+    default:
+      return new gvjs_z(0,0)
+  }
+}
+function gvjs_6B() {
+  this.vc = []
+}
+gvjs_ = gvjs_6B.prototype;
+gvjs_.Cj = function(a, b) {
+  this.vc.push({
+    brush: a,
+    s3: b
+  })
+}
+;
+gvjs_.move = function(a, b) {
+  this.Cj(null, gvjs_RA(a, b))
+}
+;
+gvjs_.va = function(a, b, c) {
+  this.Cj(a, {
+    type: gvjs_e,
+    data: {
+      x: b,
+      y: c
+    }
+  })
+}
+;
+gvjs_.Jp = function(a, b, c, d, e, f, g) {
+  this.Cj(a, {
+    type: gvjs_7t,
+    data: {
+      x1: b,
+      y1: c,
+      x2: d,
+      y2: e,
+      x: f,
+      y: g
+    }
+  })
+}
+;
+gvjs_.Sf = function(a, b, c, d, e, f, g) {
+  this.Cj(a, {
+    type: "arc",
+    data: {
+      cx: b,
+      cy: c,
+      rx: d,
+      ry: e,
+      Gy: f,
+      ou: g,
+      zba: void 0
+    }
+  })
+}
+;
+gvjs_.close = function(a) {
+  var b = this.vc[0].s3.data;
+  this.va(a, b.x, b.y)
+}
+;
+gvjs_.Dc = function(a) {
+  for (var b = [], c = null, d = 0; d < this.vc.length; d++) {
+    var e = this.vc[d]
+      , f = e.s3;
+    if (f.type == gvjs_Xv)
+      c = gvjs_5B(f);
+    else {
+      a: {
+        var g = b;
+        e = e.brush;
+        for (var h = 0; h < g.length; h++) {
+          var k = g[h];
+          if (gvjs_$z(e, k.brush)) {
+            g = k;
+            break a
+          }
+        }
+        k = {
+          brush: e,
+          vc: new gvjs_SA,
+          ef: null
+        };
+        g.push(k);
+        g = k
+      }
+      gvjs_2g(g.ef, c) || g.vc.move(c.x, c.y);
+      g.vc.Cj(f);
+      c = g.ef = gvjs_5B(f)
+    }
+  }
+  if (0 == b.length)
+    a = null;
+  else if (1 == b.length)
+    a = a.Dc(b[0].vc, b[0].brush);
+  else {
+    c = a.Sa();
+    for (d = 0; d < b.length; d++)
+      f = b[d],
+        f = a.Dc(f.vc, f.brush),
+        a.appendChild(c, f);
+    a = c.j()
+  }
+  return a
+}
+;
+function gvjs_7B(a) {
+  for (var b = new gvjs_SA, c = 0; c < a.vc.length; c++)
+    b.Cj(a.vc[c].s3);
+  return b
+}
+function gvjs_8B(a, b) {
+  if (null == b)
+    return a;
+  b = new gvjs_O(b,b);
+  return a ? new gvjs_O(Math.min(a.start, b.start),Math.max(a.end, b.end)) : b
+}
+function gvjs_9B(a, b, c) {
+  var d = null != b ? b : a && null != c && c < a.start ? c : a ? a.start : null;
+  a = null != c ? c : a && null != b && b > a.end ? b : a ? a.end : null;
+  return null != d && null != a ? new gvjs_O(d,a) : null
+}
+function gvjs_$B(a) {
+  if (0 == a.length)
+    return null;
+  for (var b = a[0].clone(), c = 1; c < a.length; c++)
+    gvjs_5x(b, a[c]);
+  return b
+}
+function gvjs_aC(a, b) {
+  var c = a.dm;
+  a = a.n;
+  var d = b.dm;
+  b = b.n;
+  isFinite(c) || (c = Infinity);
+  isFinite(d) || (d = Infinity);
+  if (c == d || 1E-5 >= Math.abs(c - d))
+    return a == b || 1E-5 >= Math.abs(a - b) ? Infinity : null;
+  if (Infinity == c)
+    return new gvjs_z(a,d * a + b);
+  if (Infinity == d)
+    return new gvjs_z(b,c * b + a);
+  var e = d - c;
+  return new gvjs_z(-(b - a) / e,(a * d - c * b) / e)
+}
+function gvjs_bC(a, b) {
+  b = (a.x - b.x) / (b.y - a.y);
+  isFinite(b) ? a = a.y - b * a.x : (b = Infinity,
+    a = a.x);
+  return {
+    dm: b,
+    n: a
+  }
+}
+function gvjs_cC(a, b) {
+  var c = new gvjs_SA;
+  a = a.vc;
+  if (0 == a.length || 1 == a.length)
+    return c;
+  for (var d = [null], e = 0; e < a.length; e++) {
+    var f = a[e];
+    f.data && d.push(new gvjs_z(f.data.x,f.data.y))
+  }
+  d.push(null);
+  f = a[a.length - 1].type == gvjs_Yt;
+  e = d[1].clone();
+  var g = d[2].clone()
+    , h = d[d.length - 3].clone()
+    , k = d[d.length - 2].clone();
+  f ? (d[0] = k,
+    d[d.length - 1] = e) : gvjs_2g(e, k) ? (d[0] = h,
+    d[d.length - 1] = g) : (d[0] = gvjs_dA(new gvjs_bA(e.x,e.y,g.x,g.y), -1),
+    d[d.length - 1] = gvjs_dA(new gvjs_bA(k.x,k.y,h.x,h.y), -1));
+  g = 0 > b;
+  var l = null
+    , m = null;
+  k = null;
+  h = d.length - 2;
+  for (e = 0; e <= h; e++)
+    if (!gvjs_2g(d[e], d[e + 1])) {
+      var n = d[e];
+      var p = d[e + 1]
+        , q = (p.y - n.y) / (p.x - n.x);
+      var r = isFinite(q) ? {
+        dm: q,
+        n: n.y - q * n.x
+      } : {
+        dm: Infinity,
+        n: n.x
+      };
+      q = r.dm;
+      r = r.n;
+      if (Infinity == q)
+        n = {
+          dm: Infinity,
+          n: 0 > p.y - n.y ? r + b : r - b
+        };
+      else {
+        var t = b * Math.sqrt(1 + q * q);
+        n = {
+          dm: q,
+          n: 0 < p.x - n.x ? r + t : r - t
+        }
+      }
+      if (l) {
+        q = gvjs_aC(l, n);
+        gvjs_r(q) ? (p = gvjs_aC(gvjs_bC(m, d[e]), l),
+          r = gvjs_aC(gvjs_bC(d[e], m), l),
+          p = gvjs_Bl(new gvjs_O(p.x,r.x), q.x) && gvjs_Bl(new gvjs_O(p.y,r.y), q.y)) : p = Infinity == q;
+        l = p && Infinity != q ? q : gvjs_aC(gvjs_bC(d[e], m), l);
+        m = c;
+        q = m.Cj;
+        t = k;
+        var u = l;
+        k = gvjs_0e(t);
+        switch (t.type) {
+          case gvjs_Xv:
+          case gvjs_e:
+            k.data.x = u.x;
+            k.data.y = u.y;
+            break;
+          case gvjs_7t:
+            k.data.x = u.x,
+              k.data.y = u.y,
+              r = u.x - t.data.x,
+              t = u.y - t.data.y,
+              k.data.x1 += r,
+              k.data.y1 += t,
+              k.data.x2 += r,
+              k.data.y2 += t
+        }
+        q.call(m, k);
+        p || (k = gvjs_aC(gvjs_bC(d[e], d[e + 1]), n),
+          c.Sf(d[e].x, d[e].y, Math.abs(b), Math.abs(b), 180 - gvjs_7y(Math.atan2(l.x - d[e].x, l.y - d[e].y)), 180 - gvjs_7y(Math.atan2(k.x - d[e].x, k.y - d[e].y)), g));
+        l = n;
+        m = d[e];
+        k = a[e]
+      } else
+        l = n,
+          m = d[e],
+          k = gvjs_RA(a[e].data.x, a[e].data.y)
+    }
+  f && c.close();
+  return c
+}
+function gvjs_dC(a, b, c) {
+  this.c8 = b;
+  this.b8 = c;
+  this.cI = {
+    add: [],
+    click: [],
+    mousemove: [],
+    mouseenter: [],
+    mouseleave: [],
+    redraw: [],
+    remove: []
+  }
+}
+gvjs_o(gvjs_dC, gvjs_uq);
+gvjs_dC.prototype.width = function() {
+  return this.c8
+}
+;
+gvjs_dC.prototype.height = function() {
+  return this.b8
+}
+;
+var gvjs_eC = {
+  NONE: gvjs_f,
+  z6: gvjs_fw,
+  u6: gvjs_d,
+  wV: gvjs_Dd,
+  Iza: gvjs_yt,
+  Cia: gvjs_4u
+}
+  , gvjs_fC = {
+  NONE: gvjs_f,
+  LINE: gvjs_e,
+  AREA: gvjs_at,
+  yBa: gvjs_4w,
+  nV: gvjs_lt,
+  Lza: gvjs_Ft,
+  wV: gvjs_Dd,
+  Jza: gvjs_At
+}
+  , gvjs_gC = {
+  nV: gvjs_lt,
+  ABa: "sticks",
+  Hza: "boxes",
+  POINTS: gvjs_mw,
+  LINE: gvjs_e,
+  AREA: gvjs_at,
+  NONE: gvjs_f
+}
+  , gvjs_hC = {
+  Yza: gvjs_Ow,
+  DAa: gvjs_Pw,
+  COLOR: gvjs_Nw
+}
+  , gvjs_2da = {
+  oV: gvjs_Ht,
+  L6: gvjs_Vd,
+  Nza: gvjs_It
+}
+  , gvjs_3da = {
+  cBa: gvjs_qw,
+  IAa: gvjs_Lv,
+  qV: gvjs_su
+}
+  , gvjs_4da = {
+  NONE: gvjs_f,
+  rja: gvjs_j,
+  Dia: gvjs_$c,
+  I6: gvjs_vx,
+  p6: gvjs_vt,
+  INSIDE: gvjs_Fp,
+  AAa: gvjs_ov,
+  Eza: gvjs_xt
+}
+  , gvjs_5da = {
+  NONE: gvjs_f,
+  I6: gvjs_vx,
+  p6: gvjs_vt,
+  INSIDE: gvjs_Fp
+}
+  , gvjs_iC = {
+  MM: gvjs_U,
+  IM: gvjs_S
+}
+  , gvjs_6da = {
+  Gja: gvjs_2,
+  CENTER: gvjs_0,
+  sia: gvjs_R
+}
+  , gvjs_jC = {
+  NONE: gvjs_f,
+  INSIDE: gvjs_Fp,
+  OUTSIDE: gvjs_aw
+}
+  , gvjs_7da = {
+  Fza: "bound",
+  PBa: "unbound"
+}
+  , gvjs_8da = {
+  nAa: "high",
+  FAa: "low"
+}
+  , gvjs_9da = {
+  NONE: gvjs_f,
+  zAa: gvjs_8c,
+  L6: gvjs_Vd,
+  mja: gvjs_ew,
+  TBa: gvjs_Ix
+}
+  , gvjs_kC = {
+  NONE: gvjs_f,
+  HM: gvjs_ut,
+  L6: gvjs_Vd,
+  mja: gvjs_ew
+}
+  , gvjs_lC = {
+  RAa: "multiple",
+  tBa: gvjs_Ww
+}
+  , gvjs_mC = {
+  NONE: gvjs_f,
+  xia: gvjs_xu,
+  wja: gvjs_Jw,
+  HM: gvjs_ut
+}
+  , gvjs_$da = {
+  NONE: gvjs_f,
+  xia: gvjs_xu,
+  wja: gvjs_Jw,
+  HM: gvjs_ut
+}
+  , gvjs_nC = {
+  IM: gvjs_S,
+  MM: gvjs_U,
+  HM: gvjs_ut
+}
+  , gvjs_aea = {
+  DEFAULT: gvjs_eu,
+  dAa: gvjs_lu
+}
+  , gvjs_bea = {
+  cAa: gvjs_gp,
+  oV: gvjs_Ht,
+  yja: gvjs_Mw
+}
+  , gvjs_cea = {
+  YF: gvjs_ub,
+  oV: gvjs_Ht,
+  yja: gvjs_Mw,
+  NONE: gvjs_f
+}
+  , gvjs_oC = {
+  NONE: gvjs_f,
+  u6: gvjs_d,
+  $Aa: "phase",
+  Sza: gvjs_Zt
+}
+  , gvjs_dea = {
+  xza: "attachToStart",
+  wza: "attachToEnd"
+}
+  , gvjs_pC = {
+  CAa: "letter",
+  POINT: gvjs_Np,
+  LINE: gvjs_e
+};
+function gvjs_qC(a, b, c, d, e) {
+  this.Sg = !!b;
+  this.node = null;
+  this.tj = 0;
+  this.K4 = !1;
+  this.SN = !c;
+  a && this.setPosition(a, d);
+  this.depth = void 0 != e ? e : this.tj || 0;
+  this.Sg && (this.depth *= -1)
+}
+gvjs_t(gvjs_qC, gvjs_5i);
+gvjs_ = gvjs_qC.prototype;
+gvjs_.setPosition = function(a, b, c) {
+  if (this.node = a)
+    this.tj = typeof b === gvjs_g ? b : 1 != this.node.nodeType ? 0 : this.Sg ? -1 : 1;
+  typeof c === gvjs_g && (this.depth = c)
+}
+;
+gvjs_.$N = function(a) {
+  this.node = a.node;
+  this.tj = a.tj;
+  this.depth = a.depth;
+  this.Sg = a.Sg;
+  this.SN = a.SN
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_qC(this.node,this.Sg,!this.SN,this.tj,this.depth)
+}
+;
+gvjs_.rg = function() {
+  if (this.K4) {
+    if (!this.node || this.SN && 0 == this.depth)
+      throw gvjs_4i;
+    var a = this.node;
+    var b = this.Sg ? -1 : 1;
+    if (this.tj == b) {
+      var c = this.Sg ? a.lastChild : a.firstChild;
+      c ? this.setPosition(c) : this.setPosition(a, -1 * b)
+    } else
+      (c = this.Sg ? a.previousSibling : a.nextSibling) ? this.setPosition(c) : this.setPosition(a.parentNode, -1 * b);
+    this.depth += this.tj * (this.Sg ? -1 : 1)
+  } else
+    this.K4 = !0;
+  a = this.node;
+  if (!this.node)
+    throw gvjs_4i;
+  return a
+}
+;
+gvjs_.next = gvjs_qC.prototype.rg;
+gvjs_.equals = function(a) {
+  return a.node == this.node && (!this.node || a.tj == this.tj)
+}
+;
+gvjs_.splice = function(a) {
+  var b = this.node
+    , c = this.Sg ? 1 : -1;
+  this.tj == c && (this.tj = -1 * c,
+    this.depth += this.tj * (this.Sg ? -1 : 1));
+  this.Sg = !this.Sg;
+  gvjs_qC.prototype.next.call(this);
+  this.Sg = !this.Sg;
+  c = gvjs_ne(arguments[0]) ? arguments[0] : arguments;
+  for (var d = c.length - 1; 0 <= d; d--)
+    gvjs_jh(c[d], b);
+  gvjs_kh(b)
+}
+;
+function gvjs_rC() {}
+gvjs_rC.prototype.Nba = function() {
+  return !1
+}
+;
+gvjs_rC.prototype.kc = function() {
+  return gvjs_5g(gvjs_y ? this.getContainer() : this.ej())
+}
+;
+gvjs_rC.prototype.Vj = function() {
+  return gvjs_3x(this.kc())
+}
+;
+function gvjs_sC(a, b) {
+  gvjs_qC.call(this, a, b, !0)
+}
+gvjs_t(gvjs_sC, gvjs_qC);
+function gvjs_tC(a, b, c, d, e) {
+  this.fd = this.sd = null;
+  this.Ad = this.td = 0;
+  this.kj = !!e;
+  if (a) {
+    this.sd = a;
+    this.td = b;
+    this.fd = c;
+    this.Ad = d;
+    if (1 == a.nodeType && "BR" != a.tagName)
+      if (a = a.childNodes,
+        b = a[b])
+        this.sd = b,
+          this.td = 0;
+      else {
+        a.length && (this.sd = gvjs_Ae(a));
+        var f = !0
+      }
+    1 == c.nodeType && ((this.fd = c.childNodes[d]) ? this.Ad = 0 : this.fd = c)
+  }
+  gvjs_qC.call(this, this.kj ? this.fd : this.sd, this.kj, !0);
+  if (f)
+    try {
+      this.next()
+    } catch (g) {
+      if (g != gvjs_4i)
+        throw g;
+    }
+}
+gvjs_t(gvjs_tC, gvjs_sC);
+gvjs_ = gvjs_tC.prototype;
+gvjs_.ej = function() {
+  return this.sd
+}
+;
+gvjs_.Sl = function() {
+  return this.fd
+}
+;
+gvjs_.rg = function() {
+  if (this.K4 && (this.node != (this.kj ? this.sd : this.fd) ? 0 : this.kj ? this.td ? -1 != this.tj : 1 == this.tj : !this.Ad || 1 != this.tj))
+    throw gvjs_4i;
+  return gvjs_tC.G.next.call(this)
+}
+;
+gvjs_.next = gvjs_tC.prototype.rg;
+gvjs_.$N = function(a) {
+  this.sd = a.sd;
+  this.fd = a.fd;
+  this.td = a.td;
+  this.Ad = a.Ad;
+  this.kj = a.kj;
+  gvjs_tC.G.$N.call(this, a)
+}
+;
+gvjs_.clone = function() {
+  var a = new gvjs_tC(this.sd,this.td,this.fd,this.Ad,this.kj);
+  a.$N(this);
+  return a
+}
+;
+function gvjs_uC() {}
+gvjs_uC.prototype.WB = function(a, b) {
+  b = b && !a.isCollapsed();
+  a = a.Ua;
+  try {
+    return b ? 0 <= this.Hm(a, 0, 1) && 0 >= this.Hm(a, 1, 0) : 0 <= this.Hm(a, 0, 0) && 0 >= this.Hm(a, 1, 1)
+  } catch (c) {
+    if (!gvjs_y)
+      throw c;
+    return !1
+  }
+}
+;
+gvjs_uC.prototype.containsNode = function(a, b) {
+  return this.WB(gvjs_vC(a), b)
+}
+;
+gvjs_uC.prototype.xk = function() {
+  return new gvjs_tC(this.ej(),this.cn(),this.Sl(),this.Eo())
+}
+;
+function gvjs_wC(a) {
+  this.Ua = a
+}
+gvjs_t(gvjs_wC, gvjs_uC);
+function gvjs_xC(a) {
+  var b = gvjs_5g(a).createRange();
+  if (3 == a.nodeType)
+    b.setStart(a, 0),
+      b.setEnd(a, a.length);
+  else if (gvjs_yC(a)) {
+    for (var c, d = a; (c = d.firstChild) && gvjs_yC(c); )
+      d = c;
+    b.setStart(d, 0);
+    for (d = a; (c = d.lastChild) && gvjs_yC(c); )
+      d = c;
+    b.setEnd(d, 1 == d.nodeType ? d.childNodes.length : d.length)
+  } else
+    c = a.parentNode,
+      a = Array.prototype.indexOf.call(c.childNodes, a),
+      b.setStart(c, a),
+      b.setEnd(c, a + 1);
+  return b
+}
+function gvjs_zC(a, b, c, d) {
+  var e = gvjs_5g(a).createRange();
+  e.setStart(a, b);
+  e.setEnd(c, d);
+  return e
+}
+gvjs_ = gvjs_wC.prototype;
+gvjs_.clone = function() {
+  return new this.constructor(this.Ua.cloneRange())
+}
+;
+gvjs_.getContainer = function() {
+  return this.Ua.commonAncestorContainer
+}
+;
+gvjs_.ej = function() {
+  return this.Ua.startContainer
+}
+;
+gvjs_.cn = function() {
+  return this.Ua.startOffset
+}
+;
+gvjs_.Sl = function() {
+  return this.Ua.endContainer
+}
+;
+gvjs_.Eo = function() {
+  return this.Ua.endOffset
+}
+;
+gvjs_.Hm = function(a, b, c) {
+  return this.Ua.compareBoundaryPoints(1 == c ? 1 == b ? gvjs_p.Range.START_TO_START : gvjs_p.Range.START_TO_END : 1 == b ? gvjs_p.Range.END_TO_START : gvjs_p.Range.END_TO_END, a)
+}
+;
+gvjs_.isCollapsed = function() {
+  return this.Ua.collapsed
+}
+;
+gvjs_.dn = gvjs_n(43);
+gvjs_.select = function(a) {
+  var b = gvjs_3x(gvjs_5g(this.ej()));
+  this.cL(b.getSelection(), a)
+}
+;
+gvjs_.cL = function(a) {
+  a.removeAllRanges();
+  a.addRange(this.Ua)
+}
+;
+gvjs_.surroundContents = function(a) {
+  this.Ua.surroundContents(a);
+  return a
+}
+;
+gvjs_.insertNode = function(a, b) {
+  var c = this.Ua.cloneRange();
+  c.collapse(b);
+  c.insertNode(a);
+  c.detach();
+  return a
+}
+;
+gvjs_.collapse = function(a) {
+  this.Ua.collapse(a)
+}
+;
+function gvjs_AC(a) {
+  this.Ua = a
+}
+gvjs_t(gvjs_AC, gvjs_wC);
+gvjs_AC.prototype.cL = function(a, b) {
+  !b || this.isCollapsed() ? gvjs_AC.G.cL.call(this, a, b) : (a.collapse(this.Sl(), this.Eo()),
+    a.extend(this.ej(), this.cn()))
+}
+;
+function gvjs_BC(a, b) {
+  this.fd = this.sd = this.Zq = null;
+  this.Ad = this.td = -1;
+  this.Ua = a;
+  this.Kj = b
+}
+gvjs_t(gvjs_BC, gvjs_uC);
+function gvjs_CC(a) {
+  var b = gvjs_5g(a).body.createTextRange();
+  if (1 == a.nodeType)
+    b.moveToElementText(a),
+    gvjs_yC(a) && !a.childNodes.length && b.collapse(!1);
+  else {
+    for (var c = 0, d = a; d = d.previousSibling; ) {
+      var e = d.nodeType;
+      if (3 == e)
+        c += d.length;
+      else if (1 == e) {
+        b.moveToElementText(d);
+        break
+      }
+    }
+    d || b.moveToElementText(a.parentNode);
+    b.collapse(!d);
+    c && b.move(gvjs_Lt, c);
+    b.moveEnd(gvjs_Lt, a.length)
+  }
+  return b
+}
+gvjs_ = gvjs_BC.prototype;
+gvjs_.clone = function() {
+  var a = new gvjs_BC(this.Ua.duplicate(),this.Kj);
+  a.Zq = this.Zq;
+  a.sd = this.sd;
+  a.fd = this.fd;
+  return a
+}
+;
+gvjs_.WG = function() {
+  this.Zq = this.sd = this.fd = null;
+  this.td = this.Ad = -1
+}
+;
+gvjs_.getContainer = function() {
+  if (!this.Zq) {
+    var a = this.Ua.text
+      , b = this.Ua.duplicate()
+      , c = a.replace(/ +$/, "");
+    (c = a.length - c.length) && b.moveEnd(gvjs_Lt, -c);
+    c = b.parentElement();
+    b = b.htmlText.replace(/(\r\n|\r|\n)+/g, " ").length;
+    if (this.isCollapsed() && 0 < b)
+      return this.Zq = c;
+    for (; b > c.outerHTML.replace(/(\r\n|\r|\n)+/g, " ").length; )
+      c = c.parentNode;
+    for (; 1 == c.childNodes.length && c.innerText == gvjs_eea(c.firstChild) && gvjs_yC(c.firstChild); )
+      c = c.firstChild;
+    0 == a.length && (c = gvjs_DC(this, c));
+    this.Zq = c
+  }
+  return this.Zq
+}
+;
+function gvjs_DC(a, b) {
+  for (var c = b.childNodes, d = 0, e = c.length; d < e; d++) {
+    var f = c[d];
+    if (gvjs_yC(f)) {
+      var g = gvjs_CC(f)
+        , h = g.htmlText != f.outerHTML;
+      if (a.isCollapsed() && h ? 0 <= a.Hm(g, 1, 1) && 0 >= a.Hm(g, 1, 0) : a.Ua.inRange(g))
+        return gvjs_DC(a, f)
+    }
+  }
+  return b
+}
+gvjs_.ej = function() {
+  this.sd || (this.sd = gvjs_EC(this, 1),
+  this.isCollapsed() && (this.fd = this.sd));
+  return this.sd
+}
+;
+gvjs_.cn = function() {
+  0 > this.td && (this.td = this.FC(1),
+  this.isCollapsed() && (this.Ad = this.td));
+  return this.td
+}
+;
+gvjs_.Sl = function() {
+  if (this.isCollapsed())
+    return this.ej();
+  this.fd || (this.fd = gvjs_EC(this, 0));
+  return this.fd
+}
+;
+gvjs_.Eo = function() {
+  if (this.isCollapsed())
+    return this.cn();
+  0 > this.Ad && (this.Ad = this.FC(0),
+  this.isCollapsed() && (this.td = this.Ad));
+  return this.Ad
+}
+;
+gvjs_.Hm = function(a, b, c) {
+  return this.Ua.compareEndPoints((1 == b ? "Start" : "End") + "To" + (1 == c ? "Start" : "End"), a)
+}
+;
+function gvjs_EC(a, b, c) {
+  c = c || a.getContainer();
+  if (!c || !c.firstChild)
+    return c;
+  for (var d = 1 == b, e = 0, f = c.childNodes.length; e < f; e++) {
+    var g = d ? e : f - e - 1
+      , h = c.childNodes[g];
+    try {
+      var k = gvjs_vC(h)
+    } catch (m) {
+      continue
+    }
+    var l = k.Ua;
+    if (a.isCollapsed())
+      if (!gvjs_yC(h)) {
+        if (0 == a.Hm(l, 1, 1)) {
+          a.td = a.Ad = g;
+          break
+        }
+      } else {
+        if (k.WB(a))
+          return gvjs_EC(a, b, h)
+      }
+    else {
+      if (a.WB(k)) {
+        if (!gvjs_yC(h)) {
+          d ? a.td = g : a.Ad = g + 1;
+          break
+        }
+        return gvjs_EC(a, b, h)
+      }
+      if (0 > a.Hm(l, 1, 0) && 0 < a.Hm(l, 0, 1))
+        return gvjs_EC(a, b, h)
+    }
+  }
+  return c
+}
+gvjs_.FC = function(a) {
+  var b = 1 == a
+    , c = b ? this.ej() : this.Sl();
+  if (1 == c.nodeType) {
+    c = c.childNodes;
+    for (var d = c.length, e = b ? 1 : -1, f = b ? 0 : d - 1; 0 <= f && f < d; f += e) {
+      var g = c[f];
+      if (!gvjs_yC(g) && 0 == this.Ua.compareEndPoints((1 == a ? "Start" : "End") + "To" + (1 == a ? "Start" : "End"), gvjs_vC(g).Ua))
+        return b ? f : f + 1
+    }
+    return -1 == f ? 0 : f
+  }
+  a = this.Ua.duplicate();
+  d = gvjs_CC(c);
+  a.setEndPoint(b ? "EndToEnd" : "StartToStart", d);
+  a = a.text.length;
+  return b ? c.length - a : a
+}
+;
+function gvjs_eea(a) {
+  return 3 == a.nodeType ? a.nodeValue : a.innerText
+}
+gvjs_.isCollapsed = function() {
+  return 0 == this.Ua.compareEndPoints("StartToEnd", this.Ua)
+}
+;
+gvjs_.dn = gvjs_n(42);
+gvjs_.select = function() {
+  this.Ua.select()
+}
+;
+function gvjs_FC(a, b, c) {
+  c = c || gvjs_3g(a.parentElement());
+  var d, e = d = b.id;
+  d || (d = b.id = "goog_" + gvjs_ig++);
+  a.pasteHTML(b.outerHTML);
+  (b = c.j(d)) && (e || b.removeAttribute(gvjs_5c));
+  return b
+}
+gvjs_.surroundContents = function(a) {
+  gvjs_kh(a);
+  var b = gvjs_3f(this.Ua.htmlText, null);
+  gvjs_cg(a, b);
+  (a = gvjs_FC(this.Ua, a)) && this.Ua.moveToElementText(a);
+  this.WG();
+  return a
+}
+;
+gvjs_.insertNode = function(a, b) {
+  var c = this.Ua.duplicate();
+  var d = d || gvjs_3g(c.parentElement());
+  if (1 != a.nodeType) {
+    var e = !0;
+    a = d.J(gvjs_b, null, a)
+  }
+  c.collapse(b);
+  a = gvjs_FC(c, a, d);
+  if (e) {
+    b = a.firstChild;
+    c = a;
+    if ((d = c.parentNode) && 11 != d.nodeType)
+      if (c.removeNode)
+        c.removeNode(!1);
+      else {
+        for (; a = c.firstChild; )
+          d.insertBefore(a, c);
+        gvjs_kh(c)
+      }
+    a = b
+  }
+  b = a;
+  this.WG();
+  return b
+}
+;
+gvjs_.collapse = function(a) {
+  this.Ua.collapse(a);
+  a ? (this.fd = this.sd,
+    this.Ad = this.td) : (this.sd = this.fd,
+    this.td = this.Ad)
+}
+;
+function gvjs_GC(a) {
+  this.Ua = a
+}
+gvjs_t(gvjs_GC, gvjs_wC);
+gvjs_GC.prototype.cL = function(a) {
+  a.collapse(this.ej(), this.cn());
+  this.Sl() == this.ej() && this.Eo() == this.cn() || a.extend(this.Sl(), this.Eo());
+  0 == a.rangeCount && a.addRange(this.Ua)
+}
+;
+function gvjs_HC(a) {
+  this.Ua = a
+}
+gvjs_t(gvjs_HC, gvjs_wC);
+gvjs_HC.prototype.Hm = function(a, b, c) {
+  return gvjs_Eg("528") ? gvjs_HC.G.Hm.call(this, a, b, c) : this.Ua.compareBoundaryPoints(1 == c ? 1 == b ? gvjs_p.Range.START_TO_START : gvjs_p.Range.END_TO_START : 1 == b ? gvjs_p.Range.START_TO_END : gvjs_p.Range.END_TO_END, a)
+}
+;
+gvjs_HC.prototype.cL = function(a, b) {
+  b ? a.setBaseAndExtent(this.Sl(), this.Eo(), this.ej(), this.cn()) : a.setBaseAndExtent(this.ej(), this.cn(), this.Sl(), this.Eo())
+}
+;
+function gvjs_vC(a) {
+  if (gvjs_y && !gvjs_Fg(9)) {
+    var b = new gvjs_BC(gvjs_CC(a),gvjs_5g(a));
+    if (gvjs_yC(a)) {
+      for (var c, d = a; (c = d.firstChild) && gvjs_yC(c); )
+        d = c;
+      b.sd = d;
+      b.td = 0;
+      for (d = a; (c = d.lastChild) && gvjs_yC(c); )
+        d = c;
+      b.fd = d;
+      b.Ad = 1 == d.nodeType ? d.childNodes.length : d.length;
+      b.Zq = a
+    } else
+      b.sd = b.fd = b.Zq = a.parentNode,
+        b.td = Array.prototype.indexOf.call(b.Zq.childNodes, a),
+        b.Ad = b.td + 1;
+    a = b
+  } else
+    a = gvjs_tg ? new gvjs_HC(gvjs_xC(a)) : gvjs_sg ? new gvjs_AC(gvjs_xC(a)) : gvjs_qg ? new gvjs_GC(gvjs_xC(a)) : new gvjs_wC(gvjs_xC(a));
+  return a
+}
+function gvjs_yC(a) {
+  return gvjs_fh(a) || 3 == a.nodeType
+}
+;function gvjs_IC() {
+  this.Ad = this.fd = this.td = this.sd = this.Lu = null;
+  this.kj = !1
+}
+gvjs_t(gvjs_IC, gvjs_rC);
+gvjs_ = gvjs_IC.prototype;
+gvjs_.clone = function() {
+  var a = new gvjs_IC;
+  a.Lu = this.Lu && this.Lu.clone();
+  a.sd = this.sd;
+  a.td = this.td;
+  a.fd = this.fd;
+  a.Ad = this.Ad;
+  a.kj = this.kj;
+  return a
+}
+;
+gvjs_.getType = function() {
+  return gvjs_m
+}
+;
+gvjs_.WG = function() {
+  this.sd = this.td = this.fd = this.Ad = null
+}
+;
+function gvjs_JC(a) {
+  var b;
+  if (!(b = a.Lu)) {
+    b = a.ej();
+    var c = a.cn()
+      , d = a.Sl()
+      , e = a.Eo();
+    if (gvjs_y && !gvjs_Fg(9)) {
+      var f = b
+        , g = c
+        , h = d
+        , k = e
+        , l = !1;
+      1 == f.nodeType && (g = f.childNodes[g],
+        l = !g,
+        f = g || f.lastChild || f,
+        g = 0);
+      var m = gvjs_CC(f);
+      g && m.move(gvjs_Lt, g);
+      f == h && g == k ? m.collapse(!0) : (l && m.collapse(!1),
+        l = !1,
+      1 == h.nodeType && (h = (g = h.childNodes[k]) || h.lastChild || h,
+        k = 0,
+        l = !g),
+        f = gvjs_CC(h),
+        f.collapse(!l),
+      k && f.moveEnd(gvjs_Lt, k),
+        m.setEndPoint("EndToEnd", f));
+      k = new gvjs_BC(m,gvjs_5g(b));
+      k.sd = b;
+      k.td = c;
+      k.fd = d;
+      k.Ad = e;
+      b = k
+    } else
+      b = gvjs_tg ? new gvjs_HC(gvjs_zC(b, c, d, e)) : gvjs_sg ? new gvjs_AC(gvjs_zC(b, c, d, e)) : gvjs_qg ? new gvjs_GC(gvjs_zC(b, c, d, e)) : new gvjs_wC(gvjs_zC(b, c, d, e));
+    b = a.Lu = b
+  }
+  return b
+}
+gvjs_.getContainer = function() {
+  return gvjs_JC(this).getContainer()
+}
+;
+gvjs_.ej = function() {
+  return this.sd || (this.sd = gvjs_JC(this).ej())
+}
+;
+gvjs_.cn = function() {
+  return null != this.td ? this.td : this.td = gvjs_JC(this).cn()
+}
+;
+gvjs_.Sl = function() {
+  return this.fd || (this.fd = gvjs_JC(this).Sl())
+}
+;
+gvjs_.Eo = function() {
+  return null != this.Ad ? this.Ad : this.Ad = gvjs_JC(this).Eo()
+}
+;
+gvjs_.Nba = function() {
+  return this.kj
+}
+;
+gvjs_.WB = function(a, b) {
+  var c = a.getType();
+  return c == gvjs_m ? gvjs_JC(this).WB(gvjs_JC(a), b) : "control" == c ? (a = a.rI(),
+    (b ? gvjs_Fe : gvjs_Ge)(a, function(d) {
+      return this.containsNode(d, b)
+    }, this)) : !1
+}
+;
+gvjs_.containsNode = function(a, b) {
+  var c = this.WB;
+  a = gvjs_vC(a);
+  var d = new gvjs_IC;
+  d.Lu = a;
+  d.kj = !1;
+  return c.call(this, d, b)
+}
+;
+gvjs_.isCollapsed = function() {
+  return gvjs_JC(this).isCollapsed()
+}
+;
+gvjs_.dn = gvjs_n(41);
+gvjs_.xk = function() {
+  return new gvjs_tC(this.ej(),this.cn(),this.Sl(),this.Eo())
+}
+;
+gvjs_.select = function() {
+  gvjs_JC(this).select(this.kj)
+}
+;
+gvjs_.surroundContents = function(a) {
+  a = gvjs_JC(this).surroundContents(a);
+  this.WG();
+  return a
+}
+;
+gvjs_.insertNode = function(a, b) {
+  a = gvjs_JC(this).insertNode(a, b);
+  this.WG();
+  return a
+}
+;
+gvjs_.collapse = function(a) {
+  a = this.Nba() ? !a : a;
+  this.Lu && this.Lu.collapse(a);
+  a ? (this.fd = this.sd,
+    this.Ad = this.td) : (this.sd = this.fd,
+    this.td = this.Ad);
+  this.kj = !1
+}
+;
+function gvjs_fea(a, b, c, d) {
+  if (a == c)
+    return d < b;
+  var e;
+  if (1 == a.nodeType && b)
+    if (e = a.childNodes[b])
+      a = e,
+        b = 0;
+    else if (gvjs_rh(a, c))
+      return !0;
+  if (1 == c.nodeType && d)
+    if (e = c.childNodes[d])
+      c = e,
+        d = 0;
+    else if (gvjs_rh(c, a))
+      return !1;
+  return 0 < (gvjs_wda(a, c) || b - d)
+}
+;function gvjs_KC() {}
+gvjs_le(gvjs_KC);
+gvjs_KC.prototype.Lta = 0;
+gvjs_KC.prototype.Dra = "";
+function gvjs_LC(a) {
+  return a.Dra + ":" + (a.Lta++).toString(36)
+}
+;function gvjs_MC(a) {
+  gvjs_H.call(this);
+  this.D = a || gvjs_3g();
+  this.gr = gvjs_gea;
+  this.ac = null;
+  this.Bb = !1;
+  this.H = null;
+  this.Fv = void 0;
+  this.jo = this.Uc = this.qd = this.Zh = null;
+  this.eA = this.sha = !1
+}
+gvjs_t(gvjs_MC, gvjs_H);
+gvjs_MC.prototype.Bra = gvjs_KC.Lc();
+var gvjs_gea = null;
+function gvjs_NC(a, b) {
+  switch (a) {
+    case 1:
+      return b ? gvjs_ju : gvjs_qu;
+    case 2:
+      return b ? gvjs_3u : gvjs_yx;
+    case 4:
+      return b ? "activate" : "deactivate";
+    case 8:
+      return b ? gvjs_k : "unselect";
+    case 16:
+      return b ? "check" : "uncheck";
+    case 32:
+      return b ? gvjs_xu : gvjs_Yo;
+    case 64:
+      return b ? "open" : gvjs_Yt
+  }
+  throw Error("Invalid component state");
+}
+gvjs_ = gvjs_MC.prototype;
+gvjs_.getId = function() {
+  return this.ac || (this.ac = gvjs_LC(this.Bra))
+}
+;
+gvjs_.lL = function(a) {
+  this.qd && this.qd.jo && (gvjs_Qy(this.qd.jo, this.ac),
+    gvjs_Ry(this.qd.jo, a, this));
+  this.ac = a
+}
+;
+gvjs_.j = function() {
+  return this.H
+}
+;
+gvjs_.wq = function(a) {
+  return this.H ? this.D.wq(a, this.H) : []
+}
+;
+gvjs_.hd = gvjs_n(1);
+gvjs_.yP = gvjs_n(3);
+gvjs_.hc = function() {
+  this.Fv || (this.Fv = new gvjs_KA(this));
+  return this.Fv
+}
+;
+function gvjs_OC(a, b) {
+  if (a == b)
+    throw Error(gvjs_xs);
+  if (b && a.qd && a.ac && a.qd.CC(a.ac) && a.qd != b)
+    throw Error(gvjs_xs);
+  a.qd = b;
+  gvjs_MC.G.uA.call(a, b)
+}
+gvjs_.getParent = function() {
+  return this.qd
+}
+;
+gvjs_.uA = function(a) {
+  if (this.qd && this.qd != a)
+    throw Error("Method not supported");
+  gvjs_MC.G.uA.call(this, a)
+}
+;
+gvjs_.wa = function() {
+  return this.D
+}
+;
+gvjs_.J = function() {
+  this.H = this.D.createElement(gvjs_b)
+}
+;
+gvjs_.R = function(a) {
+  this.sE(a)
+}
+;
+gvjs_.sE = function(a, b) {
+  if (this.Bb)
+    throw Error(gvjs_8r);
+  this.H || this.J();
+  a ? a.insertBefore(this.H, b || null) : this.D.kc().body.appendChild(this.H);
+  this.qd && !this.qd.Bb || this.Nb()
+}
+;
+gvjs_.fb = function(a) {
+  if (this.Bb)
+    throw Error(gvjs_8r);
+  if (a && this.Fh(a)) {
+    this.sha = !0;
+    var b = gvjs_5g(a);
+    this.D && this.D.kc() == b || (this.D = gvjs_3g(a));
+    this.vf(a);
+    this.Nb()
+  } else
+    throw Error("Invalid element to decorate");
+}
+;
+gvjs_.Fh = function() {
+  return !0
+}
+;
+gvjs_.vf = function(a) {
+  this.H = a
+}
+;
+gvjs_.Nb = function() {
+  this.Bb = !0;
+  gvjs_PC(this, function(a) {
+    !a.Bb && a.j() && a.Nb()
+  })
+}
+;
+gvjs_.Le = function() {
+  gvjs_PC(this, function(a) {
+    a.Bb && a.Le()
+  });
+  this.Fv && this.Fv.removeAll();
+  this.Bb = !1
+}
+;
+gvjs_.M = function() {
+  this.Bb && this.Le();
+  this.Fv && (this.Fv.pa(),
+    delete this.Fv);
+  gvjs_PC(this, function(a) {
+    a.pa()
+  });
+  !this.sha && this.H && gvjs_kh(this.H);
+  this.qd = this.Zh = this.H = this.jo = this.Uc = null;
+  gvjs_MC.G.M.call(this)
+}
+;
+gvjs_.addChild = function(a, b) {
+  this.zx(a, this.ze(), b)
+}
+;
+gvjs_.zx = function(a, b, c) {
+  if (a.Bb && (c || !this.Bb))
+    throw Error(gvjs_8r);
+  if (0 > b || b > this.ze())
+    throw Error("Child component index out of bounds");
+  this.jo && this.Uc || (this.jo = {},
+    this.Uc = []);
+  if (a.getParent() == this) {
+    var d = a.getId();
+    this.jo[d] = a;
+    gvjs_Ie(this.Uc, a)
+  } else
+    gvjs_Ry(this.jo, a.getId(), a);
+  gvjs_OC(a, this);
+  gvjs_fq(this.Uc, a, b);
+  a.Bb && this.Bb && a.getParent() == this ? (c = this.ib(),
+  (c.childNodes[b] || null) != a.j() && (a.j().parentElement == c && c.removeChild(a.j()),
+    b = c.childNodes[b] || null,
+    c.insertBefore(a.j(), b))) : c ? (this.H || this.J(),
+    b = this.Ye(b + 1),
+    a.sE(this.ib(), b ? b.H : null)) : this.Bb && !a.Bb && a.H && a.H.parentNode && 1 == a.H.parentNode.nodeType && a.Nb()
+}
+;
+gvjs_.ib = function() {
+  return this.H
+}
+;
+gvjs_.gh = function() {
+  null == this.gr && (this.gr = gvjs_Gz(this.Bb ? this.H : this.D.kc().body));
+  return this.gr
+}
+;
+gvjs_.vA = function(a) {
+  if (this.Bb)
+    throw Error(gvjs_8r);
+  this.gr = a
+}
+;
+gvjs_.ze = function() {
+  return this.Uc ? this.Uc.length : 0
+}
+;
+gvjs_.CC = function(a) {
+  return this.jo && a ? gvjs_Sy(this.jo, a) || null : null
+}
+;
+gvjs_.Ye = function(a) {
+  return this.Uc ? this.Uc[a] || null : null
+}
+;
+function gvjs_PC(a, b, c) {
+  a.Uc && a.Uc.forEach(b, c)
+}
+function gvjs_QC(a, b) {
+  return a.Uc && b ? a.Uc.indexOf(b) : -1
+}
+gvjs_.removeChild = function(a, b) {
+  if (a) {
+    var c = typeof a === gvjs_l ? a : a.getId();
+    a = this.CC(c);
+    c && a && (gvjs_Qy(this.jo, c),
+      gvjs_Ie(this.Uc, a),
+    b && (a.Le(),
+    a.H && gvjs_kh(a.H)),
+      gvjs_OC(a, null))
+  }
+  if (!a)
+    throw Error("Child is not in parent component");
+  return a
+}
+;
+gvjs_.qc = function(a) {
+  for (var b = []; this.Uc && 0 != this.Uc.length; ) {
+    var c = b
+      , d = c.push;
+    var e = a;
+    e = this.removeChild(this.Ye(0), e);
+    d.call(c, e)
+  }
+  return b
+}
+;
+function gvjs_RC(a) {
+  return typeof a.className == gvjs_l ? a.className : a.getAttribute && a.getAttribute(gvjs_Cb) || ""
+}
+function gvjs_SC(a) {
+  return a.classList ? a.classList : gvjs_RC(a).match(/\S+/g) || []
+}
+function gvjs_TC(a, b) {
+  typeof a.className == gvjs_l ? a.className = b : a.setAttribute && a.setAttribute(gvjs_Cb, b)
+}
+function gvjs_UC(a, b) {
+  return a.classList ? a.classList.contains(b) : gvjs_He(gvjs_SC(a), b)
+}
+function gvjs_VC(a, b) {
+  if (a.classList)
+    a.classList.add(b);
+  else if (!gvjs_UC(a, b)) {
+    var c = gvjs_RC(a);
+    gvjs_TC(a, c + (0 < c.length ? " " + b : b))
+  }
+}
+function gvjs_WC(a, b) {
+  if (a.classList)
+    Array.prototype.forEach.call(b, function(e) {
+      gvjs_VC(a, e)
+    });
+  else {
+    var c = {};
+    Array.prototype.forEach.call(gvjs_SC(a), function(e) {
+      c[e] = !0
+    });
+    Array.prototype.forEach.call(b, function(e) {
+      c[e] = !0
+    });
+    b = "";
+    for (var d in c)
+      b += 0 < b.length ? " " + d : d;
+    gvjs_TC(a, b)
+  }
+}
+function gvjs_XC(a, b) {
+  a.classList ? a.classList.remove(b) : gvjs_UC(a, b) && gvjs_TC(a, Array.prototype.filter.call(gvjs_SC(a), function(c) {
+    return c != b
+  }).join(" "))
+}
+function gvjs_YC(a, b) {
+  a.classList ? Array.prototype.forEach.call(b, function(c) {
+    gvjs_XC(a, c)
+  }) : gvjs_TC(a, Array.prototype.filter.call(gvjs_SC(a), function(c) {
+    return !gvjs_He(b, c)
+  }).join(" "))
+}
+function gvjs_ZC(a, b, c) {
+  c ? gvjs_VC(a, b) : gvjs_XC(a, b)
+}
+;function gvjs__C(a, b, c) {
+  gvjs_H.call(this);
+  this.target = a;
+  this.SC = b || a;
+  this.u0 = c || new gvjs_5(NaN,NaN,NaN,NaN);
+  this.dd = gvjs_5g(a);
+  this.ea = new gvjs_KA(this);
+  gvjs_6x(this, this.ea);
+  this.deltaY = this.deltaX = this.xp = this.wL = this.screenY = this.screenX = this.clientY = this.clientX = 0;
+  this.kg = !0;
+  this.lq = !1;
+  this.qea = !0;
+  this.gba = 0;
+  this.bB = this.Era = !1;
+  gvjs_G(this.SC, ["touchstart", gvjs_gd], this.ega, !1, this);
+  this.PU = gvjs_hea
+}
+gvjs_t(gvjs__C, gvjs_H);
+var gvjs_hea = gvjs_p.document && gvjs_p.document.documentElement && !!gvjs_p.document.documentElement.setCapture && !!gvjs_p.document.releaseCapture;
+gvjs_ = gvjs__C.prototype;
+gvjs_.pq = gvjs_n(58);
+gvjs_.hc = function() {
+  return this.ea
+}
+;
+function gvjs_0C(a, b) {
+  a.u0 = b || new gvjs_5(NaN,NaN,NaN,NaN)
+}
+gvjs_.Gb = function(a) {
+  this.kg = a
+}
+;
+gvjs_.M = function() {
+  gvjs__C.G.M.call(this);
+  gvjs_ji(this.SC, ["touchstart", gvjs_gd], this.ega, !1, this);
+  this.ea.removeAll();
+  this.PU && this.dd.releaseCapture();
+  this.SC = this.target = null
+}
+;
+gvjs_.jJ = function() {
+  void 0 === this.gr && (this.gr = gvjs_Gz(this.target));
+  return this.gr
+}
+;
+gvjs_.ega = function(a) {
+  var b = a.type == gvjs_gd;
+  if (!this.kg || this.lq || b && !gvjs_7x(a))
+    this.dispatchEvent("earlycancel");
+  else {
+    if (0 == this.gba)
+      if (this.dispatchEvent(new gvjs_1C(gvjs_2,this,a.clientX,a.clientY,a)))
+        this.lq = !0,
+        this.qea && b && a.preventDefault();
+      else
+        return;
+    else
+      this.qea && b && a.preventDefault();
+    b = this.dd;
+    var c = b.documentElement
+      , d = !this.PU;
+    this.ea.o(b, ["touchmove", gvjs_jd], this.TP, {
+      capture: d,
+      passive: !1
+    });
+    this.ea.o(b, ["touchend", gvjs_md], this.PO, d);
+    this.PU ? (c.setCapture(!1),
+      this.ea.o(c, "losecapture", this.PO)) : this.ea.o(gvjs_3x(b), gvjs_Yo, this.PO);
+    gvjs_y && this.Era && this.ea.o(b, gvjs_pu, gvjs_Lz);
+    this.iwa && this.ea.o(this.iwa, gvjs_Gw, this.Bua, d);
+    this.clientX = this.wL = a.clientX;
+    this.clientY = this.xp = a.clientY;
+    this.screenX = a.screenX;
+    this.screenY = a.screenY;
+    this.deltaX = this.bB ? gvjs_3A(this.target) : this.target.offsetLeft;
+    this.deltaY = this.target.offsetTop;
+    this.d2 = gvjs_2x(gvjs_3g(this.dd).dd)
+  }
+}
+;
+gvjs_.PO = function(a, b) {
+  this.ea.removeAll();
+  this.PU && this.dd.releaseCapture();
+  this.lq ? (this.lq = !1,
+    this.dispatchEvent(new gvjs_1C(gvjs_R,this,a.clientX,a.clientY,a,gvjs_2C(this, this.deltaX),gvjs_3C(this, this.deltaY),b || "touchcancel" == a.type))) : this.dispatchEvent("earlycancel")
+}
+;
+gvjs_.TP = function(a) {
+  if (this.kg) {
+    var b = (this.bB && this.jJ() ? -1 : 1) * (a.clientX - this.clientX)
+      , c = a.clientY - this.clientY;
+    this.clientX = a.clientX;
+    this.clientY = a.clientY;
+    this.screenX = a.screenX;
+    this.screenY = a.screenY;
+    if (!this.lq) {
+      var d = this.wL - this.clientX
+        , e = this.xp - this.clientY;
+      if (d * d + e * e > this.gba)
+        if (this.dispatchEvent(new gvjs_1C(gvjs_2,this,a.clientX,a.clientY,a)))
+          this.lq = !0;
+        else {
+          this.xf || this.PO(a);
+          return
+        }
+    }
+    c = gvjs_4C(this, b, c);
+    b = c.x;
+    c = c.y;
+    this.lq && this.dispatchEvent(new gvjs_1C(gvjs_nt,this,a.clientX,a.clientY,a,b,c)) && (gvjs_5C(this, a, b, c),
+      a.preventDefault())
+  }
+}
+;
+function gvjs_4C(a, b, c) {
+  var d = gvjs_2x(gvjs_3g(a.dd).dd);
+  b += d.x - a.d2.x;
+  c += d.y - a.d2.y;
+  a.d2 = d;
+  a.deltaX += b;
+  a.deltaY += c;
+  return new gvjs_z(gvjs_2C(a, a.deltaX),gvjs_3C(a, a.deltaY))
+}
+gvjs_.Bua = function(a) {
+  var b = gvjs_4C(this, 0, 0);
+  a.clientX = this.clientX;
+  a.clientY = this.clientY;
+  gvjs_5C(this, a, b.x, b.y)
+}
+;
+function gvjs_5C(a, b, c, d) {
+  a.ky(c, d);
+  a.dispatchEvent(new gvjs_1C(gvjs_nu,a,b.clientX,b.clientY,b,c,d))
+}
+function gvjs_2C(a, b) {
+  var c = a.u0;
+  a = isNaN(c.left) ? null : c.left;
+  c = isNaN(c.width) ? 0 : c.width;
+  return Math.min(null != a ? a + c : Infinity, Math.max(null != a ? a : -Infinity, b))
+}
+function gvjs_3C(a, b) {
+  var c = a.u0;
+  a = isNaN(c.top) ? null : c.top;
+  c = isNaN(c.height) ? 0 : c.height;
+  return Math.min(null != a ? a + c : Infinity, Math.max(null != a ? a : -Infinity, b))
+}
+gvjs_.ky = function(a, b) {
+  this.bB && this.jJ() ? this.target.style.right = a + gvjs_T : this.target.style.left = a + gvjs_T;
+  this.target.style.top = b + gvjs_T
+}
+;
+function gvjs_1C(a, b, c, d, e, f, g) {
+  gvjs_1h.call(this, a);
+  this.clientX = c;
+  this.clientY = d;
+  this.Wka = e;
+  this.left = void 0 !== f ? f : b.deltaX;
+  this.top = void 0 !== g ? g : b.deltaY;
+  this.eY = b
+}
+gvjs_t(gvjs_1C, gvjs_1h);
+function gvjs_6C(a) {
+  this.qa = new Map;
+  var b = arguments.length;
+  if (1 < b) {
+    if (b % 2)
+      throw Error(gvjs_kb);
+    for (var c = 0; c < b; c += 2)
+      this.set(arguments[c], arguments[c + 1])
+  } else
+    a && this.addAll(a)
+}
+gvjs_ = gvjs_6C.prototype;
+gvjs_.Cd = function() {
+  return this.qa.size
+}
+;
+gvjs_.ob = function() {
+  return Array.from(this.qa.values())
+}
+;
+gvjs_.cj = function() {
+  return Array.from(this.qa.keys())
+}
+;
+gvjs_.tf = function(a) {
+  return this.qa.has(a)
+}
+;
+gvjs_.XB = function(a) {
+  return this.ob().some(function(b) {
+    return b == a
+  })
+}
+;
+gvjs_.equals = function(a, b) {
+  var c = this;
+  b = void 0 === b ? function(d, e) {
+      return d === e
+    }
+    : b;
+  return this === a ? !0 : this.qa.size != a.Cd() ? !1 : this.cj().every(function(d) {
+    return b(c.qa.get(d), a.get(d))
+  })
+}
+;
+gvjs_.isEmpty = function() {
+  return 0 == this.qa.size
+}
+;
+gvjs_.clear = function() {
+  this.qa.clear()
+}
+;
+gvjs_.remove = function(a) {
+  return this.qa.delete(a)
+}
+;
+gvjs_.get = function(a, b) {
+  return this.qa.has(a) ? this.qa.get(a) : b
+}
+;
+gvjs_.set = function(a, b) {
+  this.qa.set(a, b);
+  return this
+}
+;
+gvjs_.addAll = function(a) {
+  if (a instanceof gvjs_6C) {
+    a = gvjs_8d(a.qa);
+    for (var b = a.next(); !b.done; b = a.next()) {
+      var c = gvjs_8d(b.value);
+      b = c.next().value;
+      c = c.next().value;
+      this.qa.set(b, c)
+    }
+  } else if (a)
+    for (a = gvjs_8d(Object.entries(a)),
+           b = a.next(); !b.done; b = a.next())
+      c = gvjs_8d(b.value),
+        b = c.next().value,
+        c = c.next().value,
+        this.qa.set(b, c)
+}
+;
+gvjs_.forEach = function(a, b) {
+  var c = this;
+  b = void 0 === b ? this : b;
+  this.qa.forEach(function(d, e) {
+    return a.call(b, d, e, c)
+  })
+}
+;
+gvjs_.clone = function() {
+  return new gvjs_6C(this)
+}
+;
+(function() {
+    for (var a = ["ms", "moz", "webkit", "o"], b, c = 0; b = a[c] && !gvjs_p.requestAnimationFrame; ++c)
+      gvjs_p.requestAnimationFrame = gvjs_p[b + "RequestAnimationFrame"],
+        gvjs_p.cancelAnimationFrame = gvjs_p[b + "CancelAnimationFrame"] || gvjs_p[b + "CancelRequestAnimationFrame"];
+    if (!gvjs_p.requestAnimationFrame) {
+      var d = 0;
+      gvjs_p.requestAnimationFrame = function(e) {
+        var f = (new Date).getTime()
+          , g = Math.max(0, 16 - (f - d));
+        d = f + g;
+        return gvjs_p.setTimeout(function() {
+          e(f + g)
+        }, g)
+      }
+      ;
+      gvjs_p.cancelAnimationFrame || (gvjs_p.cancelAnimationFrame = function(e) {
+          clearTimeout(e)
+        }
+      )
+    }
+  }
+)();
+var gvjs_7C = [[], []]
+  , gvjs_8C = 0
+  , gvjs_9C = !1
+  , gvjs_iea = 0;
+function gvjs_jea(a, b) {
+  var c = gvjs_iea++
+    , d = {
+    kta: {
+      id: c,
+      Xs: a.measure,
+      context: b
+    },
+    Ita: {
+      id: c,
+      Xs: a.Hta,
+      context: b
+    },
+    state: {},
+    Ch: void 0,
+    BQ: !1
+  };
+  return function() {
+    0 < arguments.length ? (d.Ch || (d.Ch = []),
+      d.Ch.length = 0,
+      d.Ch.push.apply(d.Ch, arguments),
+      d.Ch.push(d.state)) : d.Ch && 0 != d.Ch.length ? (d.Ch[0] = d.state,
+      d.Ch.length = 1) : d.Ch = [d.state];
+    d.BQ || (d.BQ = !0,
+      gvjs_7C[gvjs_8C].push(d));
+    gvjs_9C || (gvjs_9C = !0,
+      window.requestAnimationFrame(gvjs_kea))
+  }
+}
+function gvjs_kea() {
+  gvjs_9C = !1;
+  var a = gvjs_7C[gvjs_8C]
+    , b = a.length;
+  gvjs_8C = (gvjs_8C + 1) % 2;
+  for (var c, d = 0; d < b; ++d) {
+    c = a[d];
+    var e = c.kta;
+    c.BQ = !1;
+    e.Xs && e.Xs.apply(e.context, c.Ch)
+  }
+  for (d = 0; d < b; ++d)
+    c = a[d],
+      e = c.Ita,
+      c.BQ = !1,
+    e.Xs && e.Xs.apply(e.context, c.Ch),
+      c.state = {};
+  a.length = 0
+}
+;var gvjs_$C = gvjs_y ? gvjs_gf(gvjs_8e(gvjs_9e('javascript:""'))) : gvjs_gf(gvjs_8e(gvjs_9e("about:blank")));
+gvjs_ef(gvjs_$C);
+var gvjs_lea = gvjs_y ? gvjs_gf(gvjs_8e(gvjs_9e('javascript:""'))) : gvjs_gf(gvjs_8e(gvjs_9e("javascript:undefined")));
+gvjs_ef(gvjs_lea);
+function gvjs_mea(a, b) {
+  this.H = a;
+  this.D = b
+}
+;function gvjs_aD(a, b) {
+  gvjs_MC.call(this, b);
+  this.Rya = !!a;
+  this.qD = null;
+  this.Pea = gvjs_jea({
+    Hta: this.FS
+  }, this)
+}
+gvjs_t(gvjs_aD, gvjs_MC);
+gvjs_ = gvjs_aD.prototype;
+gvjs_.KY = null;
+gvjs_.Db = !1;
+gvjs_.ul = null;
+gvjs_.Si = null;
+gvjs_.yp = null;
+gvjs_.dW = !1;
+gvjs_.sa = function() {
+  return "goog-modalpopup"
+}
+;
+gvjs_.AC = function() {
+  return this.ul
+}
+;
+gvjs_.J = function() {
+  gvjs_aD.G.J.call(this);
+  var a = this.j()
+    , b = gvjs_kf(this.sa()).split(" ");
+  gvjs_WC(a, b);
+  gvjs_jz(a, !0);
+  gvjs_6(a, !1);
+  gvjs_bD(this);
+  gvjs_cD(this)
+}
+;
+function gvjs_bD(a) {
+  if (a.Rya && !a.Si) {
+    var b = a.wa().J(gvjs_Ma, {
+      frameborder: 0,
+      style: "border:0;vertical-align:bottom;"
+    });
+    b.src = gvjs_ef(gvjs_$C);
+    a.Si = b;
+    a.Si.className = a.sa() + "-bg";
+    gvjs_6(a.Si, !1);
+    gvjs_Fz(a.Si, 0)
+  }
+  a.ul || (a.ul = a.wa().J(gvjs_b, a.sa() + "-bg"),
+    gvjs_6(a.ul, !1))
+}
+function gvjs_cD(a) {
+  a.yp || (a.yp = a.wa().createElement(gvjs_6a),
+    gvjs_6(a.yp, !1),
+    gvjs_jz(a.yp, !0),
+    a.yp.style.position = gvjs_c)
+}
+gvjs_.Oea = function() {
+  this.dW = !1
+}
+;
+gvjs_.Fh = function(a) {
+  return !!a && a.tagName == gvjs_b
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_aD.G.vf.call(this, a);
+  a = gvjs_kf(this.sa()).split(" ");
+  gvjs_WC(this.j(), a);
+  gvjs_bD(this);
+  gvjs_cD(this);
+  gvjs_jz(this.j(), !0);
+  gvjs_6(this.j(), !1)
+}
+;
+gvjs_.Nb = function() {
+  this.Si && gvjs_ih(this.Si, this.j());
+  gvjs_ih(this.ul, this.j());
+  gvjs_aD.G.Nb.call(this);
+  gvjs_jh(this.yp, this.j());
+  this.KY = new gvjs_1A(this.wa().kc());
+  this.hc().o(this.KY, gvjs_zu, this.rua);
+  gvjs_dD(this, !1)
+}
+;
+gvjs_.Le = function() {
+  this.isVisible() && this.setVisible(!1);
+  gvjs_E(this.KY);
+  gvjs_aD.G.Le.call(this);
+  gvjs_kh(this.Si);
+  gvjs_kh(this.ul);
+  gvjs_kh(this.yp)
+}
+;
+gvjs_.setVisible = function(a) {
+  a != this.Db && (this.gA && this.gA.stop(),
+  this.GB && this.GB.stop(),
+  this.fA && this.fA.stop(),
+  this.FB && this.FB.stop(),
+  this.Bb && gvjs_dD(this, a),
+    a ? this.i4() : this.$C())
+}
+;
+function gvjs_dD(a, b) {
+  a.$ca || (a.$ca = new gvjs_mea(a.H,a.D));
+  a = a.$ca;
+  if (b) {
+    a.XC || (a.XC = []);
+    b = a.D.getChildren(a.D.kc().body);
+    for (var c = 0; c < b.length; c++) {
+      var d = b[c];
+      d == a.H || gvjs_XB(d, gvjs_0u) || (gvjs_WB(d, gvjs_0u, !0),
+        a.XC.push(d))
+    }
+  } else if (a.XC) {
+    for (c = 0; c < a.XC.length; c++)
+      a.XC[c].removeAttribute(gvjs_dt);
+    a.XC = null
+  }
+}
+gvjs_.QE = gvjs_n(38);
+gvjs_.i4 = function() {
+  if (this.dispatchEvent(gvjs_pt)) {
+    try {
+      this.qD = this.wa().kc().activeElement
+    } catch (a) {}
+    this.FS();
+    this.Mf();
+    this.hc().o(this.wa().Vj(), gvjs_vw, this.FS).o(this.wa().Vj(), gvjs_$v, this.Pea);
+    gvjs_eD(this, !0);
+    this.focus();
+    this.Db = !0;
+    this.gA && this.GB ? (gvjs_ei(this.gA, gvjs_R, this.Zz, !1, this),
+      this.GB.play(),
+      this.gA.play()) : this.Zz()
+  }
+}
+;
+gvjs_.$C = function() {
+  if (this.dispatchEvent(gvjs_ot)) {
+    this.hc().Ab(this.wa().Vj(), gvjs_vw, this.FS).Ab(this.wa().Vj(), gvjs_$v, this.Pea);
+    this.Db = !1;
+    this.fA && this.FB ? (gvjs_ei(this.fA, gvjs_R, this.yw, !1, this),
+      this.FB.play(),
+      this.fA.play()) : this.yw();
+    a: {
+      try {
+        var a = this.wa()
+          , b = a.kc().body
+          , c = a.kc().activeElement || b;
+        if (!this.qD || this.qD == b) {
+          this.qD = null;
+          break a
+        }
+        (c == b || a.contains(this.j(), c)) && this.qD.focus()
+      } catch (d) {}
+      this.qD = null
+    }
+  }
+}
+;
+function gvjs_eD(a, b) {
+  a.Si && gvjs_6(a.Si, b);
+  a.ul && gvjs_6(a.ul, b);
+  gvjs_6(a.j(), b);
+  gvjs_6(a.yp, b)
+}
+gvjs_.Zz = function() {
+  this.dispatchEvent(gvjs_Sw)
+}
+;
+gvjs_.yw = function() {
+  gvjs_eD(this, !1);
+  this.dispatchEvent(gvjs_1u)
+}
+;
+gvjs_.isVisible = function() {
+  return this.Db
+}
+;
+gvjs_.focus = function() {
+  this.q$()
+}
+;
+gvjs_.FS = function() {
+  this.Si && gvjs_6(this.Si, !1);
+  this.ul && gvjs_6(this.ul, !1);
+  var a = this.wa().kc()
+    , b = gvjs_0x(gvjs_3x(a) || window || window)
+    , c = Math.max(b.width, Math.max(a.body.scrollWidth, a.documentElement.scrollWidth));
+  a = Math.max(b.height, Math.max(a.body.scrollHeight, a.documentElement.scrollHeight));
+  this.Si && (gvjs_6(this.Si, !0),
+    gvjs_Cz(this.Si, c, a));
+  this.ul && (gvjs_6(this.ul, !0),
+    gvjs_Cz(this.ul, c, a))
+}
+;
+gvjs_.Mf = function() {
+  var a = this.wa().kc()
+    , b = gvjs_3x(a) || window;
+  if (gvjs_Eh(this.j()) == gvjs_wu)
+    var c = a = 0;
+  else
+    c = gvjs_2x(this.wa().dd),
+      a = c.x,
+      c = c.y;
+  var d = gvjs_Dz(this.j());
+  b = gvjs_0x(b || window);
+  a = Math.max(a + b.width / 2 - d.width / 2, 0);
+  c = Math.max(c + b.height / 2 - d.height / 2, 0);
+  gvjs_sz(this.j(), a, c);
+  gvjs_sz(this.yp, a, c)
+}
+;
+gvjs_.rua = function(a) {
+  this.dW ? this.Oea() : a.target == this.yp && gvjs_pl(this.q$, 0, this)
+}
+;
+gvjs_.q$ = function() {
+  try {
+    gvjs_y && this.wa().kc().body.focus(),
+      this.j().focus()
+  } catch (a) {}
+}
+;
+gvjs_.M = function() {
+  gvjs_E(this.gA);
+  this.gA = null;
+  gvjs_E(this.fA);
+  this.fA = null;
+  gvjs_E(this.GB);
+  this.GB = null;
+  gvjs_E(this.FB);
+  this.FB = null;
+  gvjs_aD.G.M.call(this)
+}
+;
+function gvjs_fD(a, b, c) {
+  gvjs_aD.call(this, b, c);
+  this.Fj = a || "modal-dialog";
+  this.ki = (new gvjs_gD).Pi(gvjs_hD, !0).Pi(gvjs_iD, !1, !0)
+}
+gvjs_t(gvjs_fD, gvjs_aD);
+gvjs_ = gvjs_fD.prototype;
+gvjs_.Tna = !0;
+gvjs_.JI = !0;
+gvjs_.WJ = !0;
+gvjs_.dY = !0;
+gvjs_.fN = .5;
+gvjs_.Pn = "";
+gvjs_.Wi = null;
+gvjs_.Lj = null;
+gvjs_.JH = !1;
+gvjs_.ml = null;
+gvjs_.tk = null;
+gvjs_.PL = null;
+gvjs_.vj = null;
+gvjs_.Gk = null;
+gvjs_.Dh = null;
+gvjs_.xK = "dialog";
+gvjs_.Yra = !1;
+gvjs_.sa = function() {
+  return this.Fj
+}
+;
+gvjs_.setTitle = function(a) {
+  this.Pn = a;
+  this.tk && gvjs_th(this.tk, a)
+}
+;
+gvjs_.getTitle = function() {
+  return this.Pn
+}
+;
+gvjs_.V3 = gvjs_n(7);
+function gvjs_jD(a, b) {
+  a.Wi = b;
+  a.Gk && gvjs_cg(a.Gk, b)
+}
+gvjs_.getContent = function() {
+  return null != this.Wi ? gvjs_0f(this.Wi) : ""
+}
+;
+gvjs_.yv = function() {
+  return this.xK
+}
+;
+gvjs_.R3 = function(a) {
+  this.xK = a
+}
+;
+function gvjs_kD(a) {
+  a.j() || a.R()
+}
+gvjs_.ib = function() {
+  gvjs_kD(this);
+  return this.Gk
+}
+;
+gvjs_.AC = function() {
+  gvjs_kD(this);
+  return gvjs_fD.G.AC.call(this)
+}
+;
+function gvjs_lD(a, b) {
+  a.fN = b;
+  a.j() && (b = a.AC()) && gvjs_Fz(b, a.fN)
+}
+function gvjs_mD(a, b) {
+  a.WJ = b;
+  if (a.Bb) {
+    var c = a.wa()
+      , d = a.AC()
+      , e = a.Si;
+    b ? (e && c.H_(e, a.j()),
+      c.H_(d, a.j())) : (c.removeNode(e),
+      c.removeNode(d))
+  }
+  a.isVisible() && gvjs_dD(a, b)
+}
+gvjs_.setDraggable = function(a) {
+  this.dY = a;
+  gvjs_nD(this, a && this.Bb)
+}
+;
+gvjs_.getDraggable = function() {
+  return this.dY
+}
+;
+function gvjs_nD(a, b) {
+  var c = gvjs_kf(a.Fj + "-title-draggable").split(" ");
+  a.j() && (b ? gvjs_WC(a.ml, c) : gvjs_YC(a.ml, c));
+  b && !a.Lj ? (b = new gvjs__C(a.j(),a.ml),
+    a.Lj = b,
+    gvjs_WC(a.ml, c),
+    gvjs_G(a.Lj, gvjs_2, a.I3, !1, a)) : !b && a.Lj && (a.Lj.pa(),
+    a.Lj = null)
+}
+gvjs_.J = function() {
+  gvjs_fD.G.J.call(this);
+  var a = this.j()
+    , b = this.wa();
+  this.PL = this.getId();
+  var c = this.getId() + ".contentEl";
+  this.ml = b.J(gvjs_b, this.Fj + "-title", this.tk = b.J(gvjs_6a, {
+    className: this.Fj + "-title-text",
+    id: this.PL
+  }, this.Pn), this.vj = b.J(gvjs_6a, this.Fj + "-title-close"));
+  gvjs_gh(a, this.ml, this.Gk = b.J(gvjs_b, {
+    className: this.Fj + gvjs_Er,
+    id: c
+  }), this.Dh = b.J(gvjs_b, this.Fj + "-buttons"));
+  gvjs_VB(this.tk, "heading");
+  gvjs_VB(this.vj, gvjs_Bt);
+  gvjs_jz(this.vj, !0);
+  gvjs_0B(this.vj, "Close");
+  gvjs_VB(a, this.yv());
+  gvjs_WB(a, gvjs_pv, this.PL || "");
+  this.Wi && (gvjs_cg(this.Gk, this.Wi),
+  this.Yra && c && gvjs_WB(a, "describedby", c));
+  gvjs_6(this.vj, this.JI);
+  this.ki && (a = this.ki,
+    a.H = this.Dh,
+    a.R());
+  gvjs_6(this.Dh, !!this.ki);
+  gvjs_lD(this, this.fN)
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_fD.G.vf.call(this, a);
+  a = this.j();
+  var b = this.Fj + gvjs_Er;
+  this.Gk = gvjs_gz(null, b, a)[0];
+  this.Gk || (this.Gk = this.wa().J(gvjs_b, b),
+  this.Wi && gvjs_cg(this.Gk, this.Wi),
+    a.appendChild(this.Gk));
+  b = this.Fj + "-title";
+  var c = this.Fj + "-title-text"
+    , d = this.Fj + "-title-close";
+  (this.ml = gvjs_gz(null, b, a)[0]) ? (this.tk = gvjs_gz(null, c, this.ml)[0],
+    this.vj = gvjs_gz(null, d, this.ml)[0]) : (this.ml = this.wa().J(gvjs_b, b),
+    a.insertBefore(this.ml, this.Gk));
+  this.tk ? (this.Pn = gvjs_wh(this.tk),
+  this.tk.id || (this.tk.id = this.getId())) : (this.tk = gvjs_4(gvjs_6a, {
+    className: c,
+    id: this.getId()
+  }),
+    this.ml.appendChild(this.tk));
+  this.PL = this.tk.id;
+  gvjs_WB(a, gvjs_pv, this.PL || "");
+  this.vj || (this.vj = this.wa().J(gvjs_6a, d),
+    this.ml.appendChild(this.vj));
+  gvjs_6(this.vj, this.JI);
+  b = this.Fj + "-buttons";
+  (this.Dh = gvjs_gz(null, b, a)[0]) ? (this.ki = new gvjs_gD(this.wa()),
+    this.ki.fb(this.Dh)) : (this.Dh = this.wa().J(gvjs_b, b),
+    a.appendChild(this.Dh),
+  this.ki && (a = this.ki,
+    a.H = this.Dh,
+    a.R()),
+    gvjs_6(this.Dh, !!this.ki));
+  gvjs_lD(this, this.fN)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_fD.G.Nb.call(this);
+  this.hc().o(this.j(), gvjs_lv, this.Eda).o(this.j(), gvjs_7c, this.Eda);
+  this.hc().o(this.Dh, gvjs_Wt, this.hua);
+  gvjs_nD(this, this.dY);
+  this.hc().o(this.vj, gvjs_Wt, this.Dua);
+  var a = this.j();
+  gvjs_VB(a, this.yv());
+  "" !== this.tk.id && gvjs_WB(a, gvjs_pv, this.tk.id);
+  this.WJ || gvjs_mD(this, !1)
+}
+;
+gvjs_.Le = function() {
+  this.isVisible() && this.setVisible(!1);
+  gvjs_nD(this, !1);
+  gvjs_fD.G.Le.call(this)
+}
+;
+gvjs_.setVisible = function(a) {
+  a != this.isVisible() && (this.Bb || this.R(),
+    gvjs_fD.G.setVisible.call(this, a))
+}
+;
+gvjs_.Zz = function() {
+  gvjs_fD.G.Zz.call(this);
+  this.dispatchEvent("aftershow")
+}
+;
+gvjs_.yw = function() {
+  gvjs_fD.G.yw.call(this);
+  this.dispatchEvent("afterhide");
+  this.JH && this.pa()
+}
+;
+gvjs_.I3 = function() {
+  var a = this.wa().kc()
+    , b = gvjs_0x(gvjs_3x(a) || window || window)
+    , c = Math.max(a.body.scrollWidth, b.width);
+  a = Math.max(a.body.scrollHeight, b.height);
+  var d = gvjs_Dz(this.j());
+  gvjs_Eh(this.j()) == gvjs_wu ? gvjs_0C(this.Lj, new gvjs_5(0,0,Math.max(0, b.width - d.width),Math.max(0, b.height - d.height))) : gvjs_0C(this.Lj, new gvjs_5(0,0,c - d.width,a - d.height))
+}
+;
+gvjs_.Dua = function() {
+  gvjs_oD(this)
+}
+;
+function gvjs_oD(a) {
+  if (a.JI) {
+    var b = a.ki
+      , c = b && b.zN;
+    c ? (b = b.get(c),
+    a.dispatchEvent(new gvjs_pD(c,b)) && a.setVisible(!1)) : a.setVisible(!1)
+  }
+}
+gvjs_.qT = gvjs_n(59);
+gvjs_.M = function() {
+  this.Dh = this.vj = null;
+  gvjs_fD.G.M.call(this)
+}
+;
+gvjs_.hua = function(a) {
+  a: {
+    for (a = a.target; null != a && a != this.Dh; ) {
+      if (a.tagName == gvjs_To)
+        break a;
+      a = a.parentNode
+    }
+    a = null
+  }
+  if (a && !a.disabled) {
+    a = a.name;
+    var b = this.ki.get(a);
+    this.dispatchEvent(new gvjs_pD(a,b)) && this.setVisible(!1)
+  }
+}
+;
+gvjs_.Eda = function(a) {
+  var b = !1
+    , c = !1
+    , d = this.ki
+    , e = a.target;
+  if (a.type == gvjs_lv)
+    if (this.Tna && 27 == a.keyCode) {
+      var f = d && d.zN;
+      e = e.tagName == gvjs_Uo && !e.disabled;
+      f && !e ? (c = !0,
+        b = d.get(f),
+        b = this.dispatchEvent(new gvjs_pD(f,b))) : e || (b = !0)
+    } else {
+      if (9 == a.keyCode && a.shiftKey && e == this.j()) {
+        this.dW = !0;
+        try {
+          this.yp.focus()
+        } catch (k) {}
+        gvjs_pl(this.Oea, 0, this)
+      }
+    }
+  else if (13 == a.keyCode) {
+    if (e.tagName == gvjs_To && !e.disabled)
+      f = e.name;
+    else if (e == this.vj)
+      gvjs_oD(this);
+    else if (d) {
+      var g = d.qO
+        , h = g && gvjs_qD(d, g);
+      e = (e.tagName == gvjs_Vo || e.tagName == gvjs_Uo || "A" == e.tagName) && !e.disabled;
+      !h || h.disabled || e || (f = g)
+    }
+    f && d && (c = !0,
+      b = this.dispatchEvent(new gvjs_pD(f,String(d.get(f)))))
+  } else
+    e != this.vj || 32 != a.keyCode && " " != a.key || gvjs_oD(this);
+  if (b || c)
+    a.stopPropagation(),
+      a.preventDefault();
+  b && this.setVisible(!1)
+}
+;
+function gvjs_pD(a, b) {
+  this.type = gvjs_fu;
+  this.key = a;
+  this.caption = b
+}
+gvjs_t(gvjs_pD, gvjs_1h);
+function gvjs_gD(a) {
+  gvjs_6C.call(this);
+  this.D = a || gvjs_3g();
+  this.Fj = "goog-buttonset";
+  this.zN = this.H = this.qO = null
+}
+gvjs_t(gvjs_gD, gvjs_6C);
+gvjs_ = gvjs_gD.prototype;
+gvjs_.clear = function() {
+  gvjs_6C.prototype.clear.call(this);
+  this.qO = this.zN = null
+}
+;
+gvjs_.set = function(a, b, c, d) {
+  gvjs_6C.prototype.set.call(this, a, b);
+  c && (this.qO = a);
+  d && (this.zN = a);
+  return this
+}
+;
+gvjs_.Pi = function(a, b, c) {
+  return this.set(a.key, a.caption, b, c)
+}
+;
+gvjs_.R = function() {
+  if (this.H) {
+    gvjs_cg(this.H, gvjs_9f);
+    var a = gvjs_3g(this.H);
+    this.forEach(function(b, c) {
+      b = a.J(gvjs_To, {
+        name: c
+      }, b);
+      c == this.qO && (b.className = this.Fj + gvjs_Fr);
+      this.H.appendChild(b)
+    }, this)
+  }
+}
+;
+gvjs_.fb = function(a) {
+  if (a && 1 == a.nodeType) {
+    this.H = a;
+    a = (this.H || document).getElementsByTagName(gvjs_To);
+    for (var b = 0, c, d, e; c = a[b]; b++)
+      if (d = c.name || c.id,
+        e = gvjs_wh(c) || c.value,
+        d) {
+        var f = 0 == b;
+        this.set(d, e, f, c.name == gvjs_Ab);
+        f && gvjs_VC(c, this.Fj + gvjs_Fr)
+      }
+  }
+}
+;
+gvjs_.j = function() {
+  return this.H
+}
+;
+gvjs_.wa = function() {
+  return this.D
+}
+;
+function gvjs_qD(a, b) {
+  a = (a.H || document).getElementsByTagName(gvjs_To);
+  for (var c = 0, d; d = a[c]; c++)
+    if (d.name == b || d.id == b)
+      return d;
+  return null
+}
+var gvjs_hD = {
+  key: "ok",
+  caption: "OK"
+}
+  , gvjs_iD = {
+  key: gvjs_Ab,
+  caption: "Cancel"
+}
+  , gvjs_rD = {
+  key: "yes",
+  caption: "Yes"
+}
+  , gvjs_sD = {
+  key: "no",
+  caption: "No"
+}
+  , gvjs_nea = {
+  key: "save",
+  caption: "Save"
+}
+  , gvjs_oea = {
+  key: "continue",
+  caption: "Continue"
+};
+"undefined" != typeof document && ((new gvjs_gD).Pi(gvjs_hD, !0, !0),
+  (new gvjs_gD).Pi(gvjs_hD, !0).Pi(gvjs_iD, !1, !0),
+  (new gvjs_gD).Pi(gvjs_rD, !0).Pi(gvjs_sD, !1, !0),
+  (new gvjs_gD).Pi(gvjs_rD).Pi(gvjs_sD, !0).Pi(gvjs_iD, !1, !0),
+  (new gvjs_gD).Pi(gvjs_oea).Pi(gvjs_nea).Pi(gvjs_iD, !0, !0));
+function gvjs_tD(a, b, c, d) {
+  gvjs_5h.call(this, d);
+  this.type = gvjs_kv;
+  this.keyCode = a;
+  this.charCode = b;
+  this.repeat = c
+}
+gvjs_t(gvjs_tD, gvjs_5h);
+function gvjs_uD(a, b) {
+  gvjs_H.call(this);
+  a && this.CB(a, b)
+}
+gvjs_t(gvjs_uD, gvjs_H);
+gvjs_ = gvjs_uD.prototype;
+gvjs_.H = null;
+gvjs_.FQ = null;
+gvjs_.a0 = null;
+gvjs_.GQ = null;
+gvjs_.Yk = -1;
+gvjs_.ih = -1;
+gvjs_.Mp = !1;
+var gvjs_vD = {
+  3: 13,
+  12: 144,
+  63232: 38,
+  63233: 40,
+  63234: 37,
+  63235: 39,
+  63236: 112,
+  63237: 113,
+  63238: 114,
+  63239: 115,
+  63240: 116,
+  63241: 117,
+  63242: 118,
+  63243: 119,
+  63244: 120,
+  63245: 121,
+  63246: 122,
+  63247: 123,
+  63248: 44,
+  63272: 46,
+  63273: 36,
+  63275: 35,
+  63276: 33,
+  63277: 34,
+  63289: 144,
+  63302: 45
+}
+  , gvjs_wD = {
+  Up: 38,
+  Down: 40,
+  Left: 37,
+  Right: 39,
+  Enter: 13,
+  F1: 112,
+  F2: 113,
+  F3: 114,
+  F4: 115,
+  F5: 116,
+  F6: 117,
+  F7: 118,
+  F8: 119,
+  F9: 120,
+  F10: 121,
+  F11: 122,
+  F12: 123,
+  "U+007F": 46,
+  Home: 36,
+  End: 35,
+  PageUp: 33,
+  PageDown: 34,
+  Insert: 45
+}
+  , gvjs_xD = !gvjs_tg || gvjs_Eg("525")
+  , gvjs_yD = gvjs_ug && gvjs_sg;
+gvjs_ = gvjs_uD.prototype;
+gvjs_.gn = function(a) {
+  if (gvjs_tg || gvjs_rg)
+    if (17 == this.Yk && !a.ctrlKey || 18 == this.Yk && !a.altKey || gvjs_ug && 91 == this.Yk && !a.metaKey)
+      this.ih = this.Yk = -1;
+  -1 == this.Yk && (a.ctrlKey && 17 != a.keyCode ? this.Yk = 17 : a.altKey && 18 != a.keyCode ? this.Yk = 18 : a.metaKey && 91 != a.keyCode && (this.Yk = 91));
+  gvjs_xD && !gvjs_bB(a.keyCode, this.Yk, a.shiftKey, a.ctrlKey, a.altKey, a.metaKey) ? this.handleEvent(a) : (this.ih = gvjs_aB(a.keyCode),
+  gvjs_yD && (this.Mp = a.altKey))
+}
+;
+gvjs_.kqa = function(a) {
+  this.ih = this.Yk = -1;
+  this.Mp = a.altKey
+}
+;
+gvjs_.handleEvent = function(a) {
+  var b = a.$i
+    , c = b.altKey;
+  if (gvjs_y && a.type == gvjs_7c) {
+    var d = this.ih;
+    var e = 13 != d && 27 != d ? b.keyCode : 0
+  } else
+    (gvjs_tg || gvjs_rg) && a.type == gvjs_7c ? (d = this.ih,
+      e = 0 <= b.charCode && 63232 > b.charCode && gvjs_$A(d) ? b.charCode : 0) : gvjs_qg && !gvjs_tg ? (d = this.ih,
+      e = gvjs_$A(d) ? b.keyCode : 0) : (a.type == gvjs_7c ? (gvjs_yD && (c = this.Mp),
+      b.keyCode == b.charCode ? 32 > b.keyCode ? (d = b.keyCode,
+        e = 0) : (d = this.ih,
+        e = b.charCode) : (d = b.keyCode || this.ih,
+        e = b.charCode || 0)) : (d = b.keyCode || this.ih,
+      e = b.charCode || 0),
+    gvjs_ug && 63 == e && 224 == d && (d = 191));
+  var f = d = gvjs_aB(d);
+  d ? 63232 <= d && d in gvjs_vD ? f = gvjs_vD[d] : 25 == d && a.shiftKey && (f = 9) : b.keyIdentifier && b.keyIdentifier in gvjs_wD && (f = gvjs_wD[b.keyIdentifier]);
+  gvjs_sg && gvjs_xD && a.type == gvjs_7c && !gvjs_bB(f, this.Yk, a.shiftKey, a.ctrlKey, c, a.metaKey) || (a = f == this.Yk,
+    this.Yk = f,
+    b = new gvjs_tD(f,e,a,b),
+    b.altKey = c,
+    this.dispatchEvent(b))
+}
+;
+gvjs_.j = function() {
+  return this.H
+}
+;
+gvjs_.CB = function(a, b) {
+  this.GQ && this.detach();
+  this.H = a;
+  this.FQ = gvjs_G(this.H, gvjs_7c, this, b);
+  this.a0 = gvjs_G(this.H, gvjs_lv, this.gn, b, this);
+  this.GQ = gvjs_G(this.H, gvjs_mv, this.kqa, b, this)
+}
+;
+gvjs_.detach = function() {
+  this.FQ && (gvjs_ki(this.FQ),
+    gvjs_ki(this.a0),
+    gvjs_ki(this.GQ),
+    this.GQ = this.a0 = this.FQ = null);
+  this.H = null;
+  this.ih = this.Yk = -1
+}
+;
+gvjs_.M = function() {
+  gvjs_uD.G.M.call(this);
+  this.detach()
+}
+;
+function gvjs_zD() {}
+var gvjs_AD;
+gvjs_le(gvjs_zD);
+var gvjs_pea = {
+  button: "pressed",
+  checkbox: gvjs_Vt,
+  menuitem: gvjs_Iw,
+  menuitemcheckbox: gvjs_Vt,
+  menuitemradio: gvjs_Vt,
+  radio: gvjs_Vt,
+  tab: gvjs_Iw,
+  treeitem: gvjs_Iw
+};
+gvjs_ = gvjs_zD.prototype;
+gvjs_.Qk = function() {}
+;
+gvjs_.J = function(a) {
+  return a.wa().J(gvjs_b, this.Rl(a).join(" "), a.getContent())
+}
+;
+gvjs_.ib = function(a) {
+  return a
+}
+;
+gvjs_.Qs = function(a, b, c) {
+  if (a = a.j ? a.j() : a) {
+    var d = [b];
+    gvjs_y && !gvjs_Eg("7") && (d = gvjs_BD(gvjs_SC(a), b),
+      d.push(b));
+    (c ? gvjs_WC : gvjs_YC)(a, d)
+  }
+}
+;
+gvjs_.Fh = function() {
+  return !0
+}
+;
+gvjs_.fb = function(a, b) {
+  b.id && a.lL(b.id);
+  var c = this.ib(b);
+  c && c.firstChild ? a.JE(c.firstChild.nextSibling ? gvjs_Le(c.childNodes) : c.firstChild) : a.JE(null);
+  var d = 0
+    , e = this.sa()
+    , f = this.sa()
+    , g = !1
+    , h = !1
+    , k = !1
+    , l = gvjs_Le(gvjs_SC(b));
+  l.forEach(function(n) {
+    g || n != e ? h || n != f ? d |= this.BP(n) : h = !0 : (g = !0,
+    f == e && (h = !0));
+    1 == this.BP(n) && gvjs_Sx(c) && gvjs_jz(c, !1)
+  }, this);
+  a.K = d;
+  g || (l.push(e),
+  f == e && (h = !0));
+  h || l.push(f);
+  (a = a.yo) && l.push.apply(l, a);
+  if (gvjs_y && !gvjs_Eg("7")) {
+    var m = gvjs_BD(l);
+    0 < m.length && (l.push.apply(l, m),
+      k = !0)
+  }
+  g && h && !a && !k || gvjs_TC(b, l.join(" "));
+  return b
+}
+;
+gvjs_.ln = function(a) {
+  a.gh() && this.vA(a.j(), !0);
+  a.isEnabled() && this.jp(a, a.isVisible())
+}
+;
+function gvjs_CD(a, b, c) {
+  if (a = c || a.Qk())
+    c = b.getAttribute(gvjs_Bd) || null,
+    a != c && gvjs_VB(b, a)
+}
+function gvjs_DD(a, b, c) {
+  var d = b.r7;
+  null != d && a.B3(c, d);
+  b.isVisible() || gvjs_WB(c, gvjs_0u, !b.isVisible());
+  b.isEnabled() || a.Lr(c, 1, !b.isEnabled());
+  gvjs_ED(b, 8) && a.Lr(c, 8, b.CQ());
+  gvjs_ED(b, 16) && a.Lr(c, 16, b.nn());
+  gvjs_ED(b, 64) && a.Lr(c, 64, gvjs_FD(b, 64))
+}
+gvjs_.B3 = function(a, b) {
+  gvjs_0B(a, b)
+}
+;
+gvjs_.gL = function(a, b) {
+  gvjs_Hz(a, !b, !gvjs_y && !gvjs_qg)
+}
+;
+gvjs_.vA = function(a, b) {
+  this.Qs(a, this.sa() + "-rtl", b)
+}
+;
+gvjs_.Gq = function(a) {
+  var b;
+  return gvjs_ED(a, 32) && (b = a.Kg()) ? gvjs_Sx(b) : !1
+}
+;
+gvjs_.jp = function(a, b) {
+  var c;
+  if (gvjs_ED(a, 32) && (c = a.Kg())) {
+    if (!b && gvjs_FD(a, 32)) {
+      try {
+        c.blur()
+      } catch (d) {}
+      gvjs_FD(a, 32) && a.$y(null)
+    }
+    gvjs_Sx(c) != b && gvjs_jz(c, b)
+  }
+}
+;
+gvjs_.setVisible = function(a, b) {
+  gvjs_6(a, b);
+  a && gvjs_WB(a, gvjs_0u, !b)
+}
+;
+gvjs_.setState = function(a, b, c) {
+  var d = a.j();
+  if (d) {
+    var e = this.oI(b);
+    e && this.Qs(a, e, c);
+    this.Lr(d, b, c)
+  }
+}
+;
+gvjs_.Lr = function(a, b, c) {
+  gvjs_AD || (gvjs_AD = {
+    1: "disabled",
+    8: gvjs_Iw,
+    16: gvjs_Vt,
+    64: "expanded"
+  });
+  b = gvjs_AD[b];
+  var d = a.getAttribute(gvjs_Bd) || null;
+  d && (d = gvjs_pea[d] || b,
+    b = b == gvjs_Vt || b == gvjs_Iw ? d : b);
+  b && gvjs_WB(a, b, c)
+}
+;
+gvjs_.setContent = function(a, b) {
+  var c = this.ib(a);
+  c && (gvjs_hh(c),
+  b && (typeof b === gvjs_l ? gvjs_th(c, b) : (a = function(d) {
+    if (d) {
+      var e = gvjs_5g(c);
+      c.appendChild(typeof d === gvjs_l ? e.createTextNode(d) : d)
+    }
+  }
+    ,
+    Array.isArray(b) ? b.forEach(a) : !gvjs_ne(b) || gvjs_pd in b ? a(b) : gvjs_Le(b).forEach(a))))
+}
+;
+gvjs_.Kg = function(a) {
+  return a.j()
+}
+;
+gvjs_.sa = function() {
+  return gvjs_Gs
+}
+;
+gvjs_.Rl = function(a) {
+  var b = this.sa()
+    , c = [b]
+    , d = this.sa();
+  d != b && c.push(d);
+  b = a.getState();
+  for (d = []; b; ) {
+    var e = b & -b;
+    d.push(this.oI(e));
+    b &= ~e
+  }
+  c.push.apply(c, d);
+  (a = a.yo) && c.push.apply(c, a);
+  gvjs_y && !gvjs_Eg("7") && c.push.apply(c, gvjs_BD(c));
+  return c
+}
+;
+function gvjs_BD(a, b) {
+  var c = [];
+  b && (a = gvjs_Ke(a, [b]));
+  [].forEach(function(d) {
+    !gvjs_Ge(d, gvjs_re(gvjs_He, a)) || b && !gvjs_He(d, b) || c.push(d.join("_"))
+  });
+  return c
+}
+gvjs_.oI = function(a) {
+  this.HN || gvjs_GD(this);
+  return this.HN[a]
+}
+;
+gvjs_.BP = function(a) {
+  this.jga || (this.HN || gvjs_GD(this),
+    this.jga = gvjs_Uy(this.HN));
+  a = parseInt(this.jga[a], 10);
+  return isNaN(a) ? 0 : a
+}
+;
+function gvjs_GD(a) {
+  var b = a.sa();
+  gvjs_sf(b.replace(/\xa0|\s/g, " "), " ");
+  a.HN = {
+    1: b + gvjs_Gr,
+    2: b + "-hover",
+    4: b + "-active",
+    8: b + "-selected",
+    16: b + "-checked",
+    32: b + "-focused",
+    64: b + "-open"
+  }
+}
+;function gvjs_HD(a, b) {
+  if (!a)
+    throw Error("Invalid class name " + a);
+  if (typeof b !== gvjs_d)
+    throw Error("Invalid decorator function " + b);
+  gvjs_ID[a] = b
+}
+function gvjs_JD(a) {
+  a = gvjs_SC(a);
+  for (var b = 0, c = a.length; b < c; b++) {
+    var d = a[b];
+    if (d = d in gvjs_ID ? gvjs_ID[d]() : null)
+      return d
+  }
+  return null
+}
+var gvjs_KD = {}
+  , gvjs_ID = {};
+function gvjs_LD(a, b, c) {
+  gvjs_MC.call(this, c);
+  if (!b) {
+    for (b = this.constructor; b; ) {
+      var d = gvjs_pe(b);
+      if (d = gvjs_KD[d])
+        break;
+      b = (b = Object.getPrototypeOf(b.prototype)) && b.constructor
+    }
+    b = d ? typeof d.Lc === gvjs_d ? d.Lc() : new d : null
+  }
+  this.F = b;
+  this.JE(void 0 !== a ? a : null);
+  this.r7 = null
+}
+gvjs_t(gvjs_LD, gvjs_MC);
+gvjs_ = gvjs_LD.prototype;
+gvjs_.Wi = null;
+gvjs_.K = 0;
+gvjs_.BL = 39;
+gvjs_.cs = 255;
+gvjs_.ju = 0;
+gvjs_.Db = !0;
+gvjs_.yo = null;
+gvjs_.OP = !0;
+gvjs_.YM = !1;
+gvjs_.xK = null;
+function gvjs_MD(a, b) {
+  a.Bb && b != a.OP && gvjs_ND(a, b);
+  a.OP = b
+}
+gvjs_.Kg = function() {
+  return this.F.Kg(this)
+}
+;
+gvjs_.rP = function() {
+  return this.Gf || (this.Gf = new gvjs_uD)
+}
+;
+gvjs_.Oa = function() {
+  return this.F
+}
+;
+gvjs_.AT = gvjs_n(61);
+gvjs_.Xr = function(a) {
+  a && (this.yo ? gvjs_He(this.yo, a) || this.yo.push(a) : this.yo = [a],
+    this.F.Qs(this, a, !0))
+}
+;
+gvjs_.Qs = function(a, b) {
+  b ? this.Xr(a) : a && this.yo && gvjs_Ie(this.yo, a) && (0 == this.yo.length && (this.yo = null),
+    this.F.Qs(this, a, !1))
+}
+;
+gvjs_.J = function() {
+  var a = this.F.J(this);
+  this.H = a;
+  gvjs_CD(this.F, a, this.yv());
+  this.YM || this.F.gL(a, !1);
+  this.isVisible() || this.F.setVisible(a, !1)
+}
+;
+gvjs_.yv = function() {
+  return this.xK
+}
+;
+gvjs_.R3 = function(a) {
+  this.xK = a
+}
+;
+gvjs_.B3 = function(a) {
+  this.r7 = a;
+  var b = this.j();
+  b && this.F.B3(b, a)
+}
+;
+gvjs_.ib = function() {
+  return this.F.ib(this.j())
+}
+;
+gvjs_.Fh = function(a) {
+  return this.F.Fh(a)
+}
+;
+gvjs_.vf = function(a) {
+  this.H = a = this.F.fb(this, a);
+  gvjs_CD(this.F, a, this.yv());
+  this.YM || this.F.gL(a, !1);
+  this.Db = a.style.display != gvjs_f
+}
+;
+gvjs_.Nb = function() {
+  gvjs_LD.G.Nb.call(this);
+  gvjs_DD(this.F, this, this.H);
+  this.F.ln(this);
+  if (this.BL & -2 && (this.OP && gvjs_ND(this, !0),
+    gvjs_ED(this, 32))) {
+    var a = this.Kg();
+    if (a) {
+      var b = this.rP();
+      b.CB(a);
+      this.hc().o(b, gvjs_kv, this.gj).o(a, gvjs_xu, this.Iv).o(a, gvjs_Yo, this.$y)
+    }
+  }
+}
+;
+function gvjs_ND(a, b) {
+  var c = a.eA ? gvjs_4h : gvjs_Mz
+    , d = a.hc()
+    , e = a.j();
+  b ? (d.o(e, c.ux, a.Cf).o(e, [c.wx, c.mB], a.Mo).o(e, gvjs_ld, a.Lo).o(e, gvjs_kd, a.PP),
+  a.eA && d.o(e, gvjs_Ou, a.nS),
+  a.CI != gvjs_ke && d.o(e, gvjs_3t, a.CI),
+  gvjs_y && (gvjs_Eg(9) || d.o(e, gvjs_du, a.maa),
+  a.XI || (a.XI = new gvjs_OD(a),
+    gvjs_6x(a, a.XI)))) : (d.Ab(e, c.ux, a.Cf).Ab(e, [c.wx, c.mB], a.Mo).Ab(e, gvjs_ld, a.Lo).Ab(e, gvjs_kd, a.PP),
+  a.eA && d.Ab(e, gvjs_Ou, a.nS),
+  a.CI != gvjs_ke && d.Ab(e, gvjs_3t, a.CI),
+  gvjs_y && (gvjs_Eg(9) || d.Ab(e, gvjs_du, a.maa),
+    gvjs_E(a.XI),
+    a.XI = null))
+}
+gvjs_.Le = function() {
+  gvjs_LD.G.Le.call(this);
+  this.Gf && this.Gf.detach();
+  this.isVisible() && this.isEnabled() && this.F.jp(this, !1)
+}
+;
+gvjs_.M = function() {
+  gvjs_LD.G.M.call(this);
+  this.Gf && (this.Gf.pa(),
+    delete this.Gf);
+  delete this.F;
+  this.XI = this.yo = this.Wi = null
+}
+;
+gvjs_.getContent = function() {
+  return this.Wi
+}
+;
+gvjs_.setContent = function(a) {
+  this.F.setContent(this.j(), a);
+  this.JE(a)
+}
+;
+gvjs_.JE = function(a) {
+  this.Wi = a
+}
+;
+gvjs_.bj = function() {
+  var a = this.getContent();
+  if (!a)
+    return "";
+  a = typeof a === gvjs_l ? a : Array.isArray(a) ? a.map(gvjs_kz).join("") : gvjs_wh(a);
+  return gvjs_Zy(a)
+}
+;
+gvjs_.vA = function(a) {
+  gvjs_LD.G.vA.call(this, a);
+  var b = this.j();
+  b && this.F.vA(b, a)
+}
+;
+gvjs_.gL = function(a) {
+  this.YM = a;
+  var b = this.j();
+  b && this.F.gL(b, a)
+}
+;
+gvjs_.isVisible = function() {
+  return this.Db
+}
+;
+gvjs_.setVisible = function(a, b) {
+  return b || this.Db != a && this.dispatchEvent(a ? gvjs_Sw : gvjs_1u) ? ((b = this.j()) && this.F.setVisible(b, a),
+  this.isEnabled() && this.F.jp(this, a),
+    this.Db = a,
+    !0) : !1
+}
+;
+gvjs_.isEnabled = function() {
+  return !gvjs_FD(this, 1)
+}
+;
+gvjs_.Gb = function(a) {
+  var b = this.getParent();
+  b && typeof b.isEnabled == gvjs_d && !b.isEnabled() || !gvjs_PD(this, 1, !a) || (a || (this.setActive(!1),
+    this.ci(!1)),
+  this.isVisible() && this.F.jp(this, a),
+    this.setState(1, !a, !0))
+}
+;
+gvjs_.ci = function(a) {
+  gvjs_PD(this, 2, a) && this.setState(2, a)
+}
+;
+gvjs_.ak = function() {
+  return gvjs_FD(this, 4)
+}
+;
+gvjs_.setActive = function(a) {
+  gvjs_PD(this, 4, a) && this.setState(4, a)
+}
+;
+gvjs_.CQ = function() {
+  return gvjs_FD(this, 8)
+}
+;
+gvjs_.qp = function(a) {
+  gvjs_PD(this, 8, a) && this.setState(8, a)
+}
+;
+gvjs_.nn = function() {
+  return gvjs_FD(this, 16)
+}
+;
+gvjs_.bi = function(a) {
+  gvjs_PD(this, 16, a) && this.setState(16, a)
+}
+;
+gvjs_.KE = function(a) {
+  gvjs_PD(this, 32, a) && this.setState(32, a)
+}
+;
+gvjs_.Kd = function(a) {
+  gvjs_PD(this, 64, a) && this.setState(64, a)
+}
+;
+gvjs_.getState = function() {
+  return this.K
+}
+;
+function gvjs_FD(a, b) {
+  return !!(a.K & b)
+}
+gvjs_.setState = function(a, b, c) {
+  c || 1 != a ? gvjs_ED(this, a) && b != gvjs_FD(this, a) && (this.F.setState(this, a, b),
+    this.K = b ? this.K | a : this.K & ~a) : this.Gb(!b)
+}
+;
+function gvjs_ED(a, b) {
+  return !!(a.BL & b)
+}
+gvjs_.eg = function(a, b) {
+  if (this.Bb && gvjs_FD(this, a) && !b)
+    throw Error(gvjs_8r);
+  !b && gvjs_FD(this, a) && this.setState(a, !1);
+  this.BL = b ? this.BL | a : this.BL & ~a
+}
+;
+function gvjs_QD(a, b) {
+  return !!(a.cs & b) && gvjs_ED(a, b)
+}
+function gvjs_PD(a, b, c) {
+  return gvjs_ED(a, b) && gvjs_FD(a, b) != c && (!(a.ju & b) || a.dispatchEvent(gvjs_NC(b, c))) && !a.xf
+}
+gvjs_.Lo = function(a) {
+  !gvjs_RD(a, this.j()) && this.dispatchEvent("enter") && this.isEnabled() && gvjs_QD(this, 2) && this.ci(!0)
+}
+;
+gvjs_.PP = function(a) {
+  !gvjs_RD(a, this.j()) && this.dispatchEvent("leave") && (gvjs_QD(this, 4) && this.setActive(!1),
+  gvjs_QD(this, 2) && this.ci(!1))
+}
+;
+gvjs_.nS = function(a) {
+  var b = a.target;
+  b.releasePointerCapture && b.releasePointerCapture(a.pointerId)
+}
+;
+gvjs_.CI = gvjs_ke;
+function gvjs_RD(a, b) {
+  return !!a.relatedTarget && gvjs_rh(b, a.relatedTarget)
+}
+gvjs_.Cf = function(a) {
+  this.isEnabled() && (gvjs_QD(this, 2) && this.ci(!0),
+  gvjs_7x(a) && (gvjs_QD(this, 4) && this.setActive(!0),
+  this.F && this.F.Gq(this) && this.Kg().focus()));
+  !this.YM && gvjs_7x(a) && a.preventDefault()
+}
+;
+gvjs_.Mo = function(a) {
+  this.isEnabled() && (gvjs_QD(this, 2) && this.ci(!0),
+  this.ak() && this.$h(a) && gvjs_QD(this, 4) && this.setActive(!1))
+}
+;
+gvjs_.maa = function(a) {
+  this.isEnabled() && this.$h(a)
+}
+;
+gvjs_.$h = function(a) {
+  gvjs_QD(this, 16) && this.bi(!this.nn());
+  gvjs_QD(this, 8) && this.qp(!0);
+  gvjs_QD(this, 64) && this.Kd(!gvjs_FD(this, 64));
+  var b = new gvjs_1h(gvjs_Ss,this);
+  a && (b.altKey = a.altKey,
+    b.ctrlKey = a.ctrlKey,
+    b.metaKey = a.metaKey,
+    b.shiftKey = a.shiftKey,
+    b.m2 = a.m2);
+  return this.dispatchEvent(b)
+}
+;
+gvjs_.Iv = function() {
+  gvjs_QD(this, 32) && this.KE(!0)
+}
+;
+gvjs_.$y = function() {
+  gvjs_QD(this, 4) && this.setActive(!1);
+  gvjs_QD(this, 32) && this.KE(!1)
+}
+;
+gvjs_.gj = function(a) {
+  return this.isVisible() && this.isEnabled() && this.Wj(a) ? (a.preventDefault(),
+    a.stopPropagation(),
+    !0) : !1
+}
+;
+gvjs_.Wj = function(a) {
+  return 13 == a.keyCode && this.$h(a)
+}
+;
+if (typeof gvjs_LD !== gvjs_d)
+  throw Error("Invalid component class " + gvjs_LD);
+if (typeof gvjs_zD !== gvjs_d)
+  throw Error("Invalid renderer class " + gvjs_zD);
+var gvjs_qea = gvjs_pe(gvjs_LD);
+gvjs_KD[gvjs_qea] = gvjs_zD;
+gvjs_HD(gvjs_Gs, function() {
+  return new gvjs_LD(null)
+});
+function gvjs_OD(a) {
+  gvjs_F.call(this);
+  this.ZN = a;
+  this.MN = !1;
+  this.pd = new gvjs_KA(this);
+  gvjs_6x(this, this.pd);
+  var b = this.ZN.H;
+  a = a.eA ? gvjs_4h : gvjs_Mz;
+  this.pd.o(b, a.ux, this.UC).o(b, a.wx, this.RP).o(b, gvjs_Wt, this.et)
+}
+gvjs_t(gvjs_OD, gvjs_F);
+var gvjs_SD = !gvjs_y || gvjs_Fg(9);
+gvjs_OD.prototype.UC = function() {
+  this.MN = !1
+}
+;
+gvjs_OD.prototype.RP = function() {
+  this.MN = !0
+}
+;
+function gvjs_TD(a, b) {
+  if (!gvjs_SD)
+    return a.button = 0,
+      a.type = b,
+      a;
+  var c = document.createEvent("MouseEvents");
+  c.initMouseEvent(b, a.bubbles, a.cancelable, a.view || null, a.detail, a.screenX, a.screenY, a.clientX, a.clientY, a.ctrlKey, a.altKey, a.shiftKey, a.metaKey, 0, a.relatedTarget || null);
+  return c
+}
+gvjs_OD.prototype.et = function(a) {
+  if (this.MN)
+    this.MN = !1;
+  else {
+    var b = a.$i
+      , c = b.button
+      , d = b.type
+      , e = gvjs_TD(b, gvjs_gd);
+    this.ZN.Cf(new gvjs_5h(e,a.currentTarget));
+    e = gvjs_TD(b, gvjs_md);
+    this.ZN.Mo(new gvjs_5h(e,a.currentTarget));
+    gvjs_SD || (b.button = c,
+      b.type = d)
+  }
+}
+;
+gvjs_OD.prototype.M = function() {
+  this.ZN = null;
+  gvjs_OD.G.M.call(this)
+}
+;
+function gvjs_UD() {
+  this.SW = []
+}
+gvjs_t(gvjs_UD, gvjs_zD);
+gvjs_le(gvjs_UD);
+function gvjs_VD(a, b) {
+  var c = a.SW[b];
+  if (!c) {
+    switch (b) {
+      case 0:
+        c = a.sa() + "-highlight";
+        break;
+      case 1:
+        c = a.sa() + "-checkbox";
+        break;
+      case 2:
+        c = a.sa() + gvjs_Er
+    }
+    a.SW[b] = c
+  }
+  return c
+}
+gvjs_ = gvjs_UD.prototype;
+gvjs_.Qk = function() {
+  return "menuitem"
+}
+;
+gvjs_.J = function(a) {
+  var b = a.wa().J(gvjs_b, this.Rl(a).join(" "), gvjs_WD(this, a.getContent(), a.wa()));
+  gvjs_XD(this, a, b, gvjs_ED(a, 8) || gvjs_ED(a, 16));
+  return b
+}
+;
+gvjs_.ib = function(a) {
+  return a && a.firstChild
+}
+;
+gvjs_.fb = function(a, b) {
+  var c = gvjs_mh(b)
+    , d = gvjs_VD(this, 2);
+  c && gvjs_UC(c, d) || b.appendChild(gvjs_WD(this, b.childNodes, a.wa()));
+  gvjs_UC(b, gvjs_Ms) && (a.kT(!0),
+    this.kT(a, b, !0));
+  return gvjs_UD.G.fb.call(this, a, b)
+}
+;
+gvjs_.setContent = function(a, b) {
+  var c = this.ib(a)
+    , d = gvjs_YD(this, a) ? c.firstChild : null;
+  gvjs_UD.G.setContent.call(this, a, b);
+  d && !gvjs_YD(this, a) && c.insertBefore(d, c.firstChild || null)
+}
+;
+function gvjs_WD(a, b, c) {
+  a = gvjs_VD(a, 2);
+  return c.J(gvjs_b, a, b)
+}
+gvjs_.S3 = function(a, b, c) {
+  a && b && gvjs_XD(this, a, b, c)
+}
+;
+gvjs_.kT = function(a, b, c) {
+  a && b && gvjs_XD(this, a, b, c)
+}
+;
+function gvjs_YD(a, b) {
+  return (b = a.ib(b)) ? (b = b.firstChild,
+    a = gvjs_VD(a, 1),
+  !!b && gvjs_ph(b) && gvjs_UC(b, a)) : !1
+}
+function gvjs_XD(a, b, c, d) {
+  gvjs_CD(a, c, b.yv());
+  gvjs_DD(a, b, c);
+  d != gvjs_YD(a, c) && (gvjs_ZC(c, gvjs_Ms, d),
+    c = a.ib(c),
+    d ? (a = gvjs_VD(a, 1),
+      c.insertBefore(b.wa().J(gvjs_b, a), c.firstChild || null)) : c.removeChild(c.firstChild))
+}
+gvjs_.oI = function(a) {
+  switch (a) {
+    case 2:
+      return gvjs_VD(this, 0);
+    case 16:
+    case 8:
+      return gvjs_Ns;
+    default:
+      return gvjs_UD.G.oI.call(this, a)
+  }
+}
+;
+gvjs_.BP = function(a) {
+  var b = gvjs_VD(this, 0);
+  switch (a) {
+    case gvjs_Ns:
+      return 16;
+    case b:
+      return 2;
+    default:
+      return gvjs_UD.G.BP.call(this, a)
+  }
+}
+;
+gvjs_.sa = function() {
+  return gvjs__
+}
+;
+function gvjs_ZD(a, b, c, d) {
+  gvjs_LD.call(this, a, d || gvjs_UD.Lc(), c);
+  this.Wa(b)
+}
+gvjs_t(gvjs_ZD, gvjs_LD);
+gvjs_ = gvjs_ZD.prototype;
+gvjs_.getValue = function() {
+  var a = this.Zh;
+  return null != a ? a : this.bj()
+}
+;
+gvjs_.Wa = function(a) {
+  this.Zh = a
+}
+;
+gvjs_.eg = function(a, b) {
+  gvjs_ZD.G.eg.call(this, a, b);
+  switch (a) {
+    case 8:
+      this.nn() && !b && this.bi(!1);
+      (a = this.j()) && this.Oa().S3(this, a, b);
+      break;
+    case 16:
+      (a = this.j()) && this.Oa().kT(this, a, b)
+  }
+}
+;
+gvjs_.S3 = function(a) {
+  this.eg(8, a)
+}
+;
+gvjs_.kT = function(a) {
+  this.eg(16, a)
+}
+;
+gvjs_.bj = function() {
+  var a = this.getContent();
+  return Array.isArray(a) ? (a = gvjs_v(a, function(b) {
+    return gvjs_ph(b) && (gvjs_UC(b, "goog-menuitem-accel") || gvjs_UC(b, "goog-menuitem-mnemonic-separator")) ? "" : gvjs_kz(b)
+  }).join(""),
+    gvjs_Zy(a)) : gvjs_ZD.G.bj.call(this)
+}
+;
+gvjs_.Mo = function(a) {
+  var b = this.getParent();
+  if (b) {
+    var c = b.Nda;
+    b.Nda = null;
+    if (c && typeof a.clientX === gvjs_g && gvjs_2g(c, new gvjs_z(a.clientX,a.clientY)))
+      return
+  }
+  gvjs_ZD.G.Mo.call(this, a)
+}
+;
+gvjs_.Wj = function(a) {
+  return a.keyCode == this.g1 && this.$h(a) ? !0 : gvjs_ZD.G.Wj.call(this, a)
+}
+;
+gvjs_.Soa = function() {
+  return this.g1
+}
+;
+gvjs_HD(gvjs__, function() {
+  return new gvjs_ZD(null)
+});
+gvjs_ZD.prototype.yv = function() {
+  return gvjs_ED(this, 16) ? "menuitemcheckbox" : gvjs_ED(this, 8) ? "menuitemradio" : gvjs_ZD.G.yv.call(this)
+}
+;
+gvjs_ZD.prototype.getParent = function() {
+  return gvjs_LD.prototype.getParent.call(this)
+}
+;
+gvjs_ZD.prototype.GC = function() {
+  return gvjs_LD.prototype.GC.call(this)
+}
+;
+function gvjs__D(a, b, c, d) {
+  gvjs_8A.call(this, a, b);
+  this.MQ = c ? 5 : 0;
+  this.Z1 = d || void 0
+}
+gvjs_t(gvjs__D, gvjs_8A);
+gvjs__D.prototype.Qoa = function() {
+  return this.MQ
+}
+;
+gvjs__D.prototype.Mf = function(a, b, c, d) {
+  var e = gvjs_7A(this.element, this.lH, a, b, null, c, 10, d, this.Z1);
+  if (e & 496) {
+    var f = gvjs_0D(e, this.lH);
+    b = gvjs_0D(e, b);
+    e = gvjs_7A(this.element, f, a, b, null, c, 10, d, this.Z1);
+    e & 496 && (f = gvjs_0D(e, f),
+      b = gvjs_0D(e, b),
+      gvjs_7A(this.element, f, a, b, null, c, this.MQ, d, this.Z1))
+  }
+}
+;
+function gvjs_0D(a, b) {
+  a & 48 && (b ^= 4);
+  a & 192 && (b ^= 1);
+  return b
+}
+;function gvjs_1D(a, b, c, d) {
+  gvjs__D.call(this, a, b, c || d);
+  if (c || d)
+    this.MQ = 65 | (d ? 32 : 132)
+}
+gvjs_t(gvjs_1D, gvjs__D);
+function gvjs_2D() {}
+gvjs_t(gvjs_2D, gvjs_zD);
+gvjs_le(gvjs_2D);
+gvjs_ = gvjs_2D.prototype;
+gvjs_.Qk = function() {
+  return gvjs_Bt
+}
+;
+gvjs_.Lr = function(a, b, c) {
+  switch (b) {
+    case 8:
+    case 16:
+      gvjs_WB(a, "pressed", c);
+      break;
+    default:
+    case 64:
+    case 1:
+      gvjs_2D.G.Lr.call(this, a, b, c)
+  }
+}
+;
+gvjs_.J = function(a) {
+  var b = gvjs_2D.G.J.call(this, a);
+  this.il(b, a.en());
+  var c = a.getValue();
+  c && this.Wa(b, c);
+  gvjs_ED(a, 16) && this.Lr(b, 16, a.nn());
+  return b
+}
+;
+gvjs_.fb = function(a, b) {
+  b = gvjs_2D.G.fb.call(this, a, b);
+  var c = this.getValue(b);
+  a.$d = c;
+  a.PE(this.en(b));
+  gvjs_ED(a, 16) && this.Lr(b, 16, a.nn());
+  return b
+}
+;
+gvjs_.getValue = gvjs_ke;
+gvjs_.Wa = gvjs_ke;
+gvjs_.en = function(a) {
+  return a.title
+}
+;
+gvjs_.il = function(a, b) {
+  a && (b ? a.title = b : a.removeAttribute(gvjs_fx))
+}
+;
+gvjs_.Lw = function(a, b) {
+  var c = a.gh()
+    , d = this.sa() + "-collapse-left"
+    , e = this.sa() + "-collapse-right";
+  a.Qs(c ? e : d, !!(b & 1));
+  a.Qs(c ? d : e, !!(b & 2))
+}
+;
+gvjs_.sa = function() {
+  return gvjs_Es
+}
+;
+function gvjs_3D() {}
+gvjs_t(gvjs_3D, gvjs_2D);
+gvjs_le(gvjs_3D);
+gvjs_ = gvjs_3D.prototype;
+gvjs_.Qk = function() {}
+;
+gvjs_.J = function(a) {
+  gvjs_MD(a, !1);
+  a.cs &= -256;
+  a.eg(32, !1);
+  return a.wa().J(gvjs_To, {
+    "class": this.Rl(a).join(" "),
+    disabled: !a.isEnabled(),
+    title: a.en() || "",
+    value: a.getValue() || ""
+  }, a.bj() || "")
+}
+;
+gvjs_.Fh = function(a) {
+  return a.tagName == gvjs_To || a.tagName == gvjs_Na && (a.type == gvjs_Bt || "submit" == a.type || "reset" == a.type)
+}
+;
+gvjs_.fb = function(a, b) {
+  gvjs_MD(a, !1);
+  a.cs &= -256;
+  a.eg(32, !1);
+  if (b.disabled) {
+    var c = this.oI(1);
+    gvjs_VC(b, c)
+  }
+  return gvjs_3D.G.fb.call(this, a, b)
+}
+;
+gvjs_.ln = function(a) {
+  a.hc().o(a.j(), gvjs_Wt, a.$h)
+}
+;
+gvjs_.gL = gvjs_ke;
+gvjs_.vA = gvjs_ke;
+gvjs_.Gq = function(a) {
+  return a.isEnabled()
+}
+;
+gvjs_.jp = gvjs_ke;
+gvjs_.setState = function(a, b, c) {
+  gvjs_3D.G.setState.call(this, a, b, c);
+  (a = a.j()) && 1 == b && (a.disabled = c)
+}
+;
+gvjs_.getValue = function(a) {
+  return a.value
+}
+;
+gvjs_.Wa = function(a, b) {
+  a && (a.value = b)
+}
+;
+gvjs_.Lr = gvjs_ke;
+function gvjs_4D(a, b, c) {
+  gvjs_LD.call(this, a, b || gvjs_3D.Lc(), c)
+}
+gvjs_t(gvjs_4D, gvjs_LD);
+gvjs_ = gvjs_4D.prototype;
+gvjs_.getValue = function() {
+  return this.$d
+}
+;
+gvjs_.Wa = function(a) {
+  this.$d = a;
+  this.Oa().Wa(this.j(), a)
+}
+;
+gvjs_.en = function() {
+  return this.xa
+}
+;
+gvjs_.il = function(a) {
+  this.xa = a;
+  this.Oa().il(this.j(), a)
+}
+;
+gvjs_.PE = function(a) {
+  this.xa = a
+}
+;
+gvjs_.Lw = function(a) {
+  this.Oa().Lw(this, a)
+}
+;
+gvjs_.M = function() {
+  gvjs_4D.G.M.call(this);
+  delete this.$d;
+  delete this.xa
+}
+;
+gvjs_.Nb = function() {
+  gvjs_4D.G.Nb.call(this);
+  if (gvjs_ED(this, 32)) {
+    var a = this.Kg();
+    a && this.hc().o(a, gvjs_mv, this.Wj)
+  }
+}
+;
+gvjs_.Wj = function(a) {
+  return 13 == a.keyCode && a.type == gvjs_kv || 32 == a.keyCode && a.type == gvjs_mv ? this.$h(a) : 32 == a.keyCode
+}
+;
+gvjs_HD(gvjs_Es, function() {
+  return new gvjs_4D(null)
+});
+function gvjs_5D(a) {
+  this.dN = a
+}
+gvjs_le(gvjs_5D);
+gvjs_ = gvjs_5D.prototype;
+gvjs_.Qk = function() {
+  return this.dN
+}
+;
+function gvjs_6D(a, b) {
+  a && (a.tabIndex = b ? 0 : -1)
+}
+gvjs_.J = function(a) {
+  return a.wa().J(gvjs_b, this.Rl(a).join(" "))
+}
+;
+gvjs_.ib = function(a) {
+  return a
+}
+;
+gvjs_.Fh = function(a) {
+  return a.tagName == gvjs_b
+}
+;
+gvjs_.fb = function(a, b) {
+  b.id && a.lL(b.id);
+  var c = this.sa()
+    , d = !1
+    , e = gvjs_SC(b);
+  e && Array.prototype.forEach.call(e, function(f) {
+    f == c ? d = !0 : f && this.T3(a, f, c)
+  }, this);
+  d || gvjs_VC(b, c);
+  gvjs_7D(this, a, this.ib(b));
+  return b
+}
+;
+gvjs_.T3 = function(a, b, c) {
+  b == c + gvjs_Gr ? a.Gb(!1) : b == c + "-horizontal" ? a.setOrientation(gvjs_S) : b == c + "-vertical" && a.setOrientation(gvjs_U)
+}
+;
+function gvjs_7D(a, b, c) {
+  if (c)
+    for (var d = c.firstChild, e; d && d.parentNode == c; ) {
+      e = d.nextSibling;
+      if (1 == d.nodeType) {
+        var f = a.lZ(d);
+        f && (f.H = d,
+        b.isEnabled() || f.Gb(!1),
+          b.addChild(f),
+          f.fb(d))
+      } else
+        d.nodeValue && "" != gvjs_kf(d.nodeValue) || c.removeChild(d);
+      d = e
+    }
+}
+gvjs_.lZ = function(a) {
+  return gvjs_JD(a)
+}
+;
+gvjs_.ln = function(a) {
+  a = a.j();
+  gvjs_Hz(a, !0, gvjs_sg);
+  gvjs_y && (a.hideFocus = !0);
+  var b = this.Qk();
+  b && gvjs_VB(a, b)
+}
+;
+gvjs_.Kg = function(a) {
+  return a.j()
+}
+;
+gvjs_.sa = function() {
+  return "goog-container"
+}
+;
+gvjs_.Rl = function(a) {
+  var b = this.sa()
+    , c = a.vi() == gvjs_S;
+  c = [b, c ? b + "-horizontal" : b + "-vertical"];
+  a.isEnabled() || c.push(b + gvjs_Gr);
+  return c
+}
+;
+function gvjs_8D(a, b, c) {
+  gvjs_MC.call(this, c);
+  this.F = b || gvjs_5D.Lc();
+  this.tb = a || gvjs_U
+}
+gvjs_t(gvjs_8D, gvjs_MC);
+gvjs_ = gvjs_8D.prototype;
+gvjs_.b0 = null;
+gvjs_.Gf = null;
+gvjs_.F = null;
+gvjs_.tb = null;
+gvjs_.Db = !0;
+gvjs_.kg = !0;
+gvjs_.MY = !0;
+gvjs_.fe = -1;
+gvjs_.Pg = null;
+gvjs_.Uq = !1;
+gvjs_.oka = !1;
+gvjs_.Eua = !0;
+gvjs_.os = null;
+gvjs_.Kg = function() {
+  return this.b0 || this.F.Kg(this)
+}
+;
+gvjs_.rP = function() {
+  return this.Gf || (this.Gf = new gvjs_uD(this.Kg()))
+}
+;
+gvjs_.Oa = function() {
+  return this.F
+}
+;
+gvjs_.AT = gvjs_n(60);
+gvjs_.J = function() {
+  this.H = this.F.J(this)
+}
+;
+gvjs_.ib = function() {
+  return this.F.ib(this.j())
+}
+;
+gvjs_.Fh = function(a) {
+  return this.F.Fh(a)
+}
+;
+gvjs_.vf = function(a) {
+  this.H = this.F.fb(this, a);
+  a.style.display == gvjs_f && (this.Db = !1)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_8D.G.Nb.call(this);
+  gvjs_PC(this, function(c) {
+    c.Bb && gvjs_9D(this, c)
+  }, this);
+  var a = this.j();
+  this.F.ln(this);
+  this.setVisible(this.Db, !0);
+  var b = this.eA ? gvjs_4h : gvjs_Mz;
+  this.hc().o(this, "enter", this.VZ).o(this, gvjs_3u, this.DI).o(this, gvjs_yx, this.c_).o(this, "open", this.Cqa).o(this, gvjs_Yt, this.OZ).o(a, b.ux, this.Cf).o(gvjs_5g(a), [b.wx, b.mB], this.Tpa).o(a, [b.ux, b.wx, b.mB, gvjs_ld, gvjs_kd, gvjs_3t], this.Hpa);
+  this.eA && this.hc().o(a, gvjs_Ou, this.nS);
+  this.Gq() && gvjs_$D(this, !0)
+}
+;
+gvjs_.nS = function(a) {
+  var b = a.target;
+  b.releasePointerCapture && b.releasePointerCapture(a.pointerId)
+}
+;
+function gvjs_$D(a, b) {
+  var c = a.hc()
+    , d = a.Kg();
+  b ? c.o(d, gvjs_xu, a.Iv).o(d, gvjs_Yo, a.$y).o(a.rP(), gvjs_kv, a.gj) : c.Ab(d, gvjs_xu, a.Iv).Ab(d, gvjs_Yo, a.$y).Ab(a.rP(), gvjs_kv, a.gj)
+}
+gvjs_.Le = function() {
+  this.Tg(-1);
+  this.Pg && this.Pg.Kd(!1);
+  this.Uq = !1;
+  gvjs_8D.G.Le.call(this)
+}
+;
+gvjs_.M = function() {
+  gvjs_8D.G.M.call(this);
+  this.Gf && (this.Gf.pa(),
+    this.Gf = null);
+  this.F = this.Pg = this.os = this.b0 = null
+}
+;
+gvjs_.VZ = function() {
+  return !0
+}
+;
+gvjs_.DI = function(a) {
+  var b = gvjs_QC(this, a.target);
+  if (-1 < b && b != this.fe) {
+    var c = gvjs_aE(this);
+    c && c.ci(!1);
+    this.fe = b;
+    c = gvjs_aE(this);
+    this.Uq && c.setActive(!0);
+    this.Eua && this.Pg && c != this.Pg && (gvjs_ED(c, 64) ? c.Kd(!0) : this.Pg.Kd(!1))
+  }
+  b = this.j();
+  null != a.target.j() && gvjs_WB(b, gvjs_Ts, a.target.j().id)
+}
+;
+gvjs_.c_ = function(a) {
+  a.target == gvjs_aE(this) && (this.fe = -1);
+  this.j().removeAttribute(gvjs_ct)
+}
+;
+gvjs_.Cqa = function(a) {
+  (a = a.target) && a != this.Pg && a.getParent() == this && (this.Pg && this.Pg.Kd(!1),
+    this.Pg = a)
+}
+;
+gvjs_.OZ = function(a) {
+  a.target == this.Pg && (this.Pg = null);
+  var b = this.j()
+    , c = a.target.j();
+  b && gvjs_FD(a.target, 2) && c && gvjs_ZB(b, c)
+}
+;
+gvjs_.Cf = function(a) {
+  this.kg && (this.Uq = !0);
+  var b = this.Kg();
+  b && gvjs_Sx(b) ? b.focus() : a.preventDefault()
+}
+;
+gvjs_.Tpa = function() {
+  this.Uq = !1
+}
+;
+gvjs_.Hpa = function(a) {
+  var b = this.eA ? gvjs_4h : gvjs_Mz;
+  a: {
+    var c = a.target;
+    if (this.os)
+      for (var d = this.j(); c && c !== d; ) {
+        var e = c.id;
+        if (e in this.os) {
+          c = this.os[e];
+          break a
+        }
+        c = c.parentNode
+      }
+    c = null
+  }
+  if (c)
+    switch (a.type) {
+      case b.ux:
+        c.Cf(a);
+        break;
+      case b.wx:
+      case b.mB:
+        c.Mo(a);
+        break;
+      case gvjs_ld:
+        c.Lo(a);
+        break;
+      case gvjs_kd:
+        c.PP(a);
+        break;
+      case gvjs_3t:
+        c.CI(a)
+    }
+}
+;
+gvjs_.Iv = function() {}
+;
+gvjs_.$y = function() {
+  this.Tg(-1);
+  this.Uq = !1;
+  this.Pg && this.Pg.Kd(!1)
+}
+;
+gvjs_.gj = function(a) {
+  return this.isEnabled() && this.isVisible() && (0 != this.ze() || this.b0) && this.Wj(a) ? (a.preventDefault(),
+    a.stopPropagation(),
+    !0) : !1
+}
+;
+gvjs_.Wj = function(a) {
+  var b = gvjs_aE(this);
+  if (b && typeof b.gj == gvjs_d && b.gj(a) || this.Pg && this.Pg != b && typeof this.Pg.gj == gvjs_d && this.Pg.gj(a))
+    return !0;
+  if (a.shiftKey || a.ctrlKey || a.metaKey || a.altKey)
+    return !1;
+  switch (a.keyCode) {
+    case 27:
+      if (this.Gq())
+        this.Kg().blur();
+      else
+        return !1;
+      break;
+    case 36:
+      gvjs_bE(this);
+      break;
+    case 35:
+      gvjs_rea(this);
+      break;
+    case 38:
+      if (this.tb == gvjs_U)
+        gvjs_cE(this);
+      else
+        return !1;
+      break;
+    case 37:
+      if (this.tb == gvjs_S)
+        this.gh() ? gvjs_dE(this) : gvjs_cE(this);
+      else
+        return !1;
+      break;
+    case 40:
+      if (this.tb == gvjs_U)
+        gvjs_dE(this);
+      else
+        return !1;
+      break;
+    case 39:
+      if (this.tb == gvjs_S)
+        this.gh() ? gvjs_cE(this) : gvjs_dE(this);
+      else
+        return !1;
+      break;
+    default:
+      return !1
+  }
+  return !0
+}
+;
+function gvjs_9D(a, b) {
+  var c = b.j();
+  c = c.id || (c.id = b.getId());
+  a.os || (a.os = {});
+  a.os[c] = b
+}
+gvjs_.addChild = function(a, b) {
+  gvjs_8D.G.addChild.call(this, a, b)
+}
+;
+gvjs_.zx = function(a, b, c) {
+  a.ju |= 2;
+  a.ju |= 64;
+  !this.Gq() && this.oka || a.eg(32, !1);
+  gvjs_MD(a, !1);
+  var d = a.getParent() == this ? gvjs_QC(this, a) : -1;
+  gvjs_8D.G.zx.call(this, a, b, c);
+  a.Bb && this.Bb && gvjs_9D(this, a);
+  a = d;
+  -1 == a && (a = this.ze());
+  a == this.fe ? this.fe = Math.min(this.ze() - 1, b) : a > this.fe && b <= this.fe ? this.fe++ : a < this.fe && b > this.fe && this.fe--
+}
+;
+gvjs_.removeChild = function(a, b) {
+  if (a = typeof a === gvjs_l ? this.CC(a) : a) {
+    var c = gvjs_QC(this, a);
+    -1 != c && (c == this.fe ? (a.ci(!1),
+      this.fe = -1) : c < this.fe && this.fe--);
+    (c = a.j()) && c.id && this.os && gvjs_Qy(this.os, c.id)
+  }
+  a = gvjs_8D.G.removeChild.call(this, a, b);
+  gvjs_MD(a, !0);
+  return a
+}
+;
+gvjs_.vi = function() {
+  return this.tb
+}
+;
+gvjs_.setOrientation = function(a) {
+  if (this.j())
+    throw Error(gvjs_8r);
+  this.tb = a
+}
+;
+gvjs_.isVisible = function() {
+  return this.Db
+}
+;
+gvjs_.setVisible = function(a, b) {
+  if (b || this.Db != a && this.dispatchEvent(a ? gvjs_Sw : gvjs_1u)) {
+    this.Db = a;
+    var c = this.j();
+    c && (gvjs_6(c, a),
+    this.Gq() && gvjs_6D(this.Kg(), this.kg && this.Db),
+    b || this.dispatchEvent(this.Db ? "aftershow" : "afterhide"));
+    return !0
+  }
+  return !1
+}
+;
+gvjs_.isEnabled = function() {
+  return this.kg
+}
+;
+gvjs_.Gb = function(a) {
+  this.kg != a && this.dispatchEvent(a ? gvjs_qu : gvjs_ju) && (a ? (this.kg = !0,
+    gvjs_PC(this, function(b) {
+      b.tha ? delete b.tha : b.Gb(!0)
+    })) : (gvjs_PC(this, function(b) {
+    b.isEnabled() ? b.Gb(!1) : b.tha = !0
+  }),
+    this.Uq = this.kg = !1),
+  this.Gq() && gvjs_6D(this.Kg(), a && this.Db))
+}
+;
+gvjs_.Gq = function() {
+  return this.MY
+}
+;
+gvjs_.jp = function(a) {
+  a != this.MY && this.Bb && gvjs_$D(this, a);
+  this.MY = a;
+  this.kg && this.Db && gvjs_6D(this.Kg(), a)
+}
+;
+gvjs_.Tg = function(a) {
+  (a = this.Ye(a)) ? a.ci(!0) : -1 < this.fe && gvjs_aE(this).ci(!1)
+}
+;
+gvjs_.ci = function(a) {
+  this.Tg(gvjs_QC(this, a))
+}
+;
+function gvjs_aE(a) {
+  return a.Ye(a.fe)
+}
+function gvjs_bE(a) {
+  gvjs_eE(a, function(b, c) {
+    return (b + 1) % c
+  }, a.ze() - 1)
+}
+function gvjs_rea(a) {
+  gvjs_eE(a, function(b, c) {
+    b--;
+    return 0 > b ? c - 1 : b
+  }, 0)
+}
+function gvjs_dE(a) {
+  gvjs_eE(a, function(b, c) {
+    return (b + 1) % c
+  }, a.fe)
+}
+function gvjs_cE(a) {
+  gvjs_eE(a, function(b, c) {
+    b--;
+    return 0 > b ? c - 1 : b
+  }, a.fe)
+}
+function gvjs_eE(a, b, c) {
+  c = 0 > c ? gvjs_QC(a, a.Pg) : c;
+  var d = a.ze();
+  c = b.call(a, c, d);
+  for (var e = 0; e <= d; ) {
+    var f = a.Ye(c);
+    if (f && a.a8(f)) {
+      a.N3(c);
+      break
+    }
+    e++;
+    c = b.call(a, c, d)
+  }
+}
+gvjs_.a8 = function(a) {
+  return a.isVisible() && a.isEnabled() && gvjs_ED(a, 2)
+}
+;
+gvjs_.N3 = function(a) {
+  this.Tg(a)
+}
+;
+function gvjs_fE() {}
+gvjs_t(gvjs_fE, gvjs_zD);
+gvjs_le(gvjs_fE);
+gvjs_fE.prototype.sa = function() {
+  return gvjs_Ks
+}
+;
+function gvjs_gE(a, b, c) {
+  gvjs_LD.call(this, a, c || gvjs_fE.Lc(), b);
+  this.eg(1, !1);
+  this.eg(2, !1);
+  this.eg(4, !1);
+  this.eg(32, !1);
+  this.K = 1
+}
+gvjs_t(gvjs_gE, gvjs_LD);
+gvjs_HD(gvjs_Ks, function() {
+  return new gvjs_gE(null)
+});
+function gvjs_hE() {}
+gvjs_t(gvjs_hE, gvjs_zD);
+gvjs_le(gvjs_hE);
+gvjs_hE.prototype.J = function(a) {
+  return a.wa().J(gvjs_b, this.sa())
+}
+;
+gvjs_hE.prototype.fb = function(a, b) {
+  b.id && a.lL(b.id);
+  if ("HR" == b.tagName) {
+    var c = b;
+    b = this.J(a);
+    gvjs_ih(b, c);
+    gvjs_kh(c)
+  } else
+    gvjs_VC(b, this.sa());
+  return b
+}
+;
+gvjs_hE.prototype.setContent = function() {}
+;
+gvjs_hE.prototype.sa = function() {
+  return gvjs_Ls
+}
+;
+function gvjs_iE(a, b) {
+  gvjs_LD.call(this, null, a || gvjs_hE.Lc(), b);
+  this.eg(1, !1);
+  this.eg(2, !1);
+  this.eg(4, !1);
+  this.eg(32, !1);
+  this.K = 1
+}
+gvjs_t(gvjs_iE, gvjs_LD);
+gvjs_iE.prototype.Nb = function() {
+  gvjs_iE.G.Nb.call(this);
+  var a = this.j();
+  gvjs_VB(a, gvjs_Lw)
+}
+;
+gvjs_HD(gvjs_Ls, function() {
+  return new gvjs_iE
+});
+function gvjs_jE(a) {
+  this.dN = a || "menu"
+}
+gvjs_t(gvjs_jE, gvjs_5D);
+gvjs_le(gvjs_jE);
+gvjs_ = gvjs_jE.prototype;
+gvjs_.Fh = function(a) {
+  return "UL" == a.tagName || gvjs_jE.G.Fh.call(this, a)
+}
+;
+gvjs_.lZ = function(a) {
+  return "HR" == a.tagName ? new gvjs_iE : gvjs_jE.G.lZ.call(this, a)
+}
+;
+gvjs_.vs = function(a, b) {
+  return gvjs_rh(a.j(), b)
+}
+;
+gvjs_.sa = function() {
+  return gvjs_Z
+}
+;
+gvjs_.ln = function(a) {
+  gvjs_jE.G.ln.call(this, a);
+  a = a.j();
+  gvjs_WB(a, gvjs_Yu, gvjs_Rd)
+}
+;
+gvjs_HD(gvjs_Ls, function() {
+  return new gvjs_iE
+});
+function gvjs_kE(a, b) {
+  gvjs_8D.call(this, gvjs_U, b || gvjs_jE.Lc(), a);
+  this.jp(!1)
+}
+gvjs_t(gvjs_kE, gvjs_8D);
+gvjs_ = gvjs_kE.prototype;
+gvjs_.kG = !0;
+gvjs_.Z6 = !1;
+gvjs_.sa = function() {
+  return this.Oa().sa()
+}
+;
+gvjs_.vs = function(a) {
+  if (this.Oa().vs(this, a))
+    return !0;
+  for (var b = 0, c = this.ze(); b < c; b++) {
+    var d = this.Ye(b);
+    if (typeof d.vs == gvjs_d && d.vs(a))
+      return !0
+  }
+  return !1
+}
+;
+gvjs_.Bj = function(a) {
+  this.addChild(a, !0)
+}
+;
+gvjs_.Bu = function(a, b) {
+  this.zx(a, b, !0)
+}
+;
+gvjs_.removeItem = function(a) {
+  (a = this.removeChild(a, !0)) && a.pa()
+}
+;
+gvjs_.od = function(a) {
+  return this.Ye(a)
+}
+;
+gvjs_.bh = function() {
+  return this.ze()
+}
+;
+gvjs_.Qy = function() {
+  var a = [];
+  gvjs_PC(this, function(b) {
+    a.push(b)
+  });
+  return a
+}
+;
+gvjs_.setPosition = function(a, b) {
+  var c = this.isVisible();
+  c || gvjs_6(this.j(), !0);
+  var d = this.j()
+    , e = gvjs_vz(d);
+  a instanceof gvjs_z && (b = a.y,
+    a = a.x);
+  gvjs_sz(d, d.offsetLeft + (a - e.x), d.offsetTop + (Number(b) - e.y));
+  c || gvjs_6(this.j(), !1)
+}
+;
+gvjs_.getPosition = function() {
+  return this.isVisible() ? gvjs_vz(this.j()) : null
+}
+;
+gvjs_.setVisible = function(a, b, c) {
+  (b = gvjs_kE.G.setVisible.call(this, a, b)) && a && this.Bb && this.kG && this.Kg().focus();
+  this.Nda = a && c && typeof c.clientX === gvjs_g ? new gvjs_z(c.clientX,c.clientY) : null;
+  return b
+}
+;
+gvjs_.VZ = function(a) {
+  this.kG && this.Kg().focus();
+  return gvjs_kE.G.VZ.call(this, a)
+}
+;
+gvjs_.a8 = function(a) {
+  return (this.Z6 || a.isEnabled()) && a.isVisible() && gvjs_ED(a, 2)
+}
+;
+gvjs_.vf = function(a) {
+  for (var b = this.Oa(), c = gvjs_zh(this.wa(), gvjs_b, b.sa() + gvjs_Er, a), d = c.length, e = 0; e < d; e++)
+    gvjs_7D(b, this, c[e]);
+  gvjs_kE.G.vf.call(this, a)
+}
+;
+gvjs_.Wj = function(a) {
+  var b = gvjs_kE.G.Wj.call(this, a);
+  b || gvjs_PC(this, function(c) {
+    !b && c.Soa && c.g1 == a.keyCode && (this.isEnabled() && this.ci(c),
+      b = c.gj(a))
+  }, this);
+  return b
+}
+;
+gvjs_.Tg = function(a) {
+  gvjs_kE.G.Tg.call(this, a);
+  (a = this.Ye(a)) && gvjs_Iz(a.j(), this.j())
+}
+;
+function gvjs_lE() {}
+gvjs_t(gvjs_lE, gvjs_2D);
+gvjs_le(gvjs_lE);
+gvjs_ = gvjs_lE.prototype;
+gvjs_.J = function(a) {
+  var b = this.Rl(a);
+  b = a.wa().J(gvjs_b, gvjs_Is + b.join(" "), this.aO(a.getContent(), a.wa()));
+  this.il(b, a.en());
+  return b
+}
+;
+gvjs_.Qk = function() {
+  return gvjs_Bt
+}
+;
+gvjs_.ib = function(a) {
+  return a && a.firstChild && a.firstChild.firstChild
+}
+;
+gvjs_.aO = function(a, b) {
+  return b.J(gvjs_b, gvjs_Is + (this.sa() + gvjs_Jr), b.J(gvjs_b, gvjs_Is + (this.sa() + gvjs_Ir), a))
+}
+;
+gvjs_.Fh = function(a) {
+  return a.tagName == gvjs_b
+}
+;
+gvjs_.fb = function(a, b) {
+  gvjs_mE(b, !0);
+  gvjs_mE(b, !1);
+  a: {
+    var c = a.wa().O$(b);
+    var d = this.sa() + gvjs_Jr;
+    if (c && gvjs_UC(c, d) && (c = a.wa().O$(c),
+      d = this.sa() + gvjs_Ir,
+    c && gvjs_UC(c, d))) {
+      c = !0;
+      break a
+    }
+    c = !1
+  }
+  c || b.appendChild(this.aO(b.childNodes, a.wa()));
+  gvjs_WC(b, [gvjs_Y, this.sa()]);
+  return gvjs_lE.G.fb.call(this, a, b)
+}
+;
+gvjs_.sa = function() {
+  return gvjs_Hs
+}
+;
+function gvjs_mE(a, b) {
+  if (a)
+    for (var c = b ? a.firstChild : a.lastChild, d; c && c.parentNode == a; ) {
+      d = b ? c.nextSibling : c.previousSibling;
+      if (3 == c.nodeType) {
+        var e = c.nodeValue;
+        if ("" == gvjs_kf(e))
+          a.removeChild(c);
+        else {
+          c.nodeValue = b ? e.replace(/^[\s\xa0]+/, "") : e.replace(/[\s\xa0]+$/, "");
+          break
+        }
+      } else
+        break;
+      c = d
+    }
+}
+;function gvjs_nE() {}
+gvjs_t(gvjs_nE, gvjs_lE);
+gvjs_le(gvjs_nE);
+gvjs_ = gvjs_nE.prototype;
+gvjs_.ib = function(a) {
+  return gvjs_nE.G.ib.call(this, a && a.firstChild)
+}
+;
+gvjs_.fb = function(a, b) {
+  var c = gvjs_gz("*", gvjs_Z, b)[0];
+  if (c) {
+    gvjs_6(c, !1);
+    gvjs_5g(c).body.appendChild(c);
+    var d = new gvjs_kE;
+    d.fb(c);
+    a.lp(d)
+  }
+  return gvjs_nE.G.fb.call(this, a, b)
+}
+;
+gvjs_.aO = function(a, b) {
+  return gvjs_nE.G.aO.call(this, [this.createCaption(a, b), this.cO(b)], b)
+}
+;
+gvjs_.createCaption = function(a, b) {
+  return gvjs_oE(a, this.sa(), b)
+}
+;
+function gvjs_oE(a, b, c) {
+  return c.J(gvjs_b, gvjs_Is + (b + gvjs_Dr), a)
+}
+gvjs_.cO = function(a) {
+  return a.J(gvjs_b, gvjs_Is + (this.sa() + gvjs_Hr), "\u00a0")
+}
+;
+gvjs_.sa = function() {
+  return gvjs_Js
+}
+;
+function gvjs_pE() {
+  this.SW = []
+}
+gvjs_t(gvjs_pE, gvjs_UD);
+gvjs_le(gvjs_pE);
+gvjs_pE.prototype.J = function(a) {
+  var b = gvjs_pE.G.J.call(this, a);
+  gvjs_VC(b, gvjs_Ps);
+  gvjs_qE(this, a, b);
+  return b
+}
+;
+gvjs_pE.prototype.fb = function(a, b) {
+  b = gvjs_pE.G.fb.call(this, a, b);
+  gvjs_VC(b, gvjs_Ps);
+  gvjs_qE(this, a, b);
+  var c = gvjs_gz(gvjs_b, gvjs_Z, b);
+  if (c.length) {
+    var d = new gvjs_kE(a.wa());
+    c = c[0];
+    gvjs_6(c, !1);
+    a.wa().kc().body.appendChild(c);
+    d.fb(c);
+    a.lp(d, !0)
+  }
+  return b
+}
+;
+gvjs_pE.prototype.setContent = function(a, b) {
+  var c = this.ib(a)
+    , d = c && c.lastChild;
+  gvjs_pE.G.setContent.call(this, a, b);
+  d && c.lastChild != d && gvjs_UC(d, gvjs_Qs) && c.appendChild(d)
+}
+;
+gvjs_pE.prototype.ln = function(a) {
+  gvjs_pE.G.ln.call(this, a);
+  var b = a.ib()
+    , c = gvjs_zh(a.wa(), gvjs_6a, gvjs_Qs, b)[0];
+  gvjs_rE(a, c);
+  c != b.lastChild && b.appendChild(c);
+  a = a.j();
+  gvjs_WB(a, gvjs_Yu, gvjs_Rd)
+}
+;
+function gvjs_qE(a, b, c) {
+  var d = b.wa().J(gvjs_6a);
+  d.className = gvjs_Qs;
+  gvjs_rE(b, d);
+  a.ib(c).appendChild(d)
+}
+function gvjs_rE(a, b) {
+  a.gh() ? (gvjs_VC(b, gvjs_Rs),
+    gvjs_th(b, a.VM ? "\u25c4" : "\u25ba")) : (gvjs_XC(b, gvjs_Rs),
+    gvjs_th(b, a.VM ? "\u25ba" : "\u25c4"))
+}
+;function gvjs_sE(a, b, c, d) {
+  gvjs_ZD.call(this, a, b, c, d || gvjs_pE.Lc())
+}
+gvjs_t(gvjs_sE, gvjs_ZD);
+gvjs_ = gvjs_sE.prototype;
+gvjs_.kq = null;
+gvjs_.g4 = null;
+gvjs_.S0 = !1;
+gvjs_.Ah = null;
+gvjs_.UO = !1;
+gvjs_.VM = !0;
+gvjs_.msa = !1;
+gvjs_.Nb = function() {
+  gvjs_sE.G.Nb.call(this);
+  this.hc().o(this.getParent(), gvjs_1u, this.Ida);
+  this.Ah && gvjs_tE(this, this.Ah, !0)
+}
+;
+gvjs_.Le = function() {
+  this.hc().Ab(this.getParent(), gvjs_1u, this.Ida);
+  this.Ah && (gvjs_tE(this, this.Ah, !1),
+  this.UO || (this.Ah.Le(),
+    gvjs_kh(this.Ah.j())));
+  gvjs_sE.G.Le.call(this)
+}
+;
+gvjs_.M = function() {
+  this.Ah && !this.UO && this.Ah.pa();
+  this.Ah = null;
+  gvjs_sE.G.M.call(this)
+}
+;
+gvjs_.ci = function(a) {
+  gvjs_sE.G.ci.call(this, a);
+  a || (this.kq && gvjs_ql(this.kq),
+    this.kq = gvjs_pl(this.Hs, 218, this))
+}
+;
+gvjs_.LT = function() {
+  var a = this.getParent();
+  a && gvjs_aE(a) == this && (gvjs_uE(this, !0),
+    gvjs_vE(this))
+}
+;
+gvjs_.Hs = function() {
+  var a = this.Ah;
+  a && a.getParent() == this && (gvjs_uE(this, !1),
+    gvjs_PC(a, function(b) {
+      typeof b.Hs == gvjs_d && b.Hs()
+    }))
+}
+;
+function gvjs_wE(a) {
+  a.kq && gvjs_ql(a.kq);
+  a.g4 && gvjs_ql(a.g4)
+}
+gvjs_.setVisible = function(a, b) {
+  (a = gvjs_sE.G.setVisible.call(this, a, b)) && !this.isVisible() && this.Hs();
+  return a
+}
+;
+function gvjs_vE(a) {
+  gvjs_PC(a.getParent(), function(b) {
+    b != this && typeof b.Hs == gvjs_d && (b.Hs(),
+      gvjs_wE(b))
+  }, a)
+}
+gvjs_.gj = function(a) {
+  var b = a.keyCode
+    , c = this.gh() ? 37 : 39
+    , d = this.gh() ? 39 : 37;
+  if (!this.S0) {
+    if (!this.isEnabled() || b != c && 13 != b && b != this.g1)
+      return !1;
+    this.LT();
+    gvjs_bE(this.Td());
+    gvjs_wE(this)
+  } else if (!this.Td().gj(a))
+    if (b == d)
+      this.Hs();
+    else
+      return !1;
+  a.preventDefault();
+  return !0
+}
+;
+gvjs_.jua = function() {
+  this.Ah.getParent() == this && (gvjs_wE(this),
+    this.GC().ci(this),
+    gvjs_vE(this))
+}
+;
+gvjs_.Ida = function(a) {
+  a.target == this.GC() && (this.Hs(),
+    gvjs_wE(this))
+}
+;
+gvjs_.Lo = function(a) {
+  this.isEnabled() && (gvjs_wE(this),
+    this.g4 = gvjs_pl(this.LT, 218, this));
+  gvjs_sE.G.Lo.call(this, a)
+}
+;
+gvjs_.$h = function(a) {
+  gvjs_wE(this);
+  if (gvjs_ED(this, 8) || gvjs_ED(this, 16))
+    return gvjs_sE.G.$h.call(this, a);
+  this.LT();
+  return !0
+}
+;
+function gvjs_uE(a, b) {
+  !b && a.Td() && a.Td().Tg(-1);
+  a.dispatchEvent(gvjs_NC(64, b));
+  var c = a.Td();
+  b != a.S0 && gvjs_ZC(a.j(), "goog-submenu-open", b);
+  if (b != c.isVisible() && (b && (c.Bb || c.R(),
+    c.Tg(-1)),
+    c.setVisible(b),
+    b)) {
+    c = new gvjs__D(a.j(),a.VM ? 12 : 8,a.msa);
+    var d = a.Td()
+      , e = d.j();
+    d.isVisible() || (e.style.visibility = gvjs_0u,
+      gvjs_6(e, !0));
+    c.Mf(e, a.VM ? 8 : 12);
+    d.isVisible() || (gvjs_6(e, !1),
+      e.style.visibility = gvjs_Mx)
+  }
+  a.S0 = b
+}
+function gvjs_tE(a, b, c) {
+  var d = a.hc();
+  (c ? d.o : d.Ab).call(d, b, "enter", a.jua)
+}
+gvjs_.Bj = function(a) {
+  this.Td().addChild(a, !0)
+}
+;
+gvjs_.Bu = function(a, b) {
+  this.Td().zx(a, b, !0)
+}
+;
+gvjs_.removeItem = function(a) {
+  (a = this.Td().removeChild(a, !0)) && a.pa()
+}
+;
+gvjs_.od = function(a) {
+  return this.Td().Ye(a)
+}
+;
+gvjs_.bh = function() {
+  return this.Td().ze()
+}
+;
+gvjs_.Qy = function() {
+  return this.Td().Qy()
+}
+;
+gvjs_.Td = function() {
+  this.Ah ? this.UO && this.Ah.getParent() != this && gvjs_OC(this.Ah, this) : this.lp(new gvjs_kE(this.wa()), !0);
+  this.Ah.j() || this.Ah.J();
+  return this.Ah
+}
+;
+gvjs_.lp = function(a, b) {
+  var c = this.Ah;
+  a != c && (c && (this.Hs(),
+  this.Bb && gvjs_tE(this, c, !1)),
+    this.Ah = a,
+    this.UO = !b,
+  a && (gvjs_OC(a, this),
+    a.setVisible(!1, !0),
+    a.kG = !1,
+    a.jp(!1),
+  this.Bb && gvjs_tE(this, a, !0)))
+}
+;
+gvjs_.vs = function(a) {
+  return this.Td().vs(a)
+}
+;
+gvjs_HD(gvjs_Ps, function() {
+  return new gvjs_sE(null)
+});
+function gvjs_xE(a, b, c, d, e) {
+  gvjs_4D.call(this, a, c || gvjs_nE.Lc(), d);
+  this.eg(64, !0);
+  this.lR = new gvjs_1D(null,9);
+  b && this.lp(b);
+  this.lta = null;
+  this.Hc = new gvjs_IA(500);
+  !gvjs_Ig && !gvjs_Jg || gvjs_Eg("533.17.9") || (this.iD = !0);
+  this.Gla = !0;
+  this.mta = e || gvjs_jE.Lc()
+}
+gvjs_t(gvjs_xE, gvjs_4D);
+gvjs_ = gvjs_xE.prototype;
+gvjs_.iD = !1;
+gvjs_.Bva = !1;
+gvjs_.kwa = !1;
+gvjs_.Nb = function() {
+  gvjs_xE.G.Nb.call(this);
+  gvjs_yE(this, !0);
+  this.la && gvjs_zE(this, this.la, !0);
+  gvjs_WB(this.H, gvjs_Yu, !!this.la)
+}
+;
+gvjs_.Le = function() {
+  gvjs_xE.G.Le.call(this);
+  gvjs_yE(this, !1);
+  if (this.la) {
+    this.Kd(!1);
+    this.la.Le();
+    gvjs_zE(this, this.la, !1);
+    var a = this.la.j();
+    a && gvjs_kh(a)
+  }
+}
+;
+gvjs_.M = function() {
+  gvjs_xE.G.M.call(this);
+  this.la && (this.la.pa(),
+    delete this.la);
+  delete this.cva;
+  this.Hc.pa()
+}
+;
+gvjs_.Cf = function(a) {
+  gvjs_xE.G.Cf.call(this, a);
+  this.ak() && (this.Kd(!gvjs_FD(this, 64), a),
+  this.la && (this.la.Uq = gvjs_FD(this, 64)))
+}
+;
+gvjs_.Mo = function(a) {
+  gvjs_xE.G.Mo.call(this, a);
+  this.la && !this.ak() && (this.la.Uq = !1)
+}
+;
+gvjs_.$h = function() {
+  this.setActive(!1);
+  return !0
+}
+;
+gvjs_.Rpa = function(a) {
+  this.la && this.la.isVisible() && !this.vs(a.target) && this.Kd(!1)
+}
+;
+gvjs_.vs = function(a) {
+  return a && gvjs_rh(this.j(), a) || this.la && this.la.vs(a) || !1
+}
+;
+gvjs_.Wj = function(a) {
+  if (32 == a.keyCode) {
+    if (a.preventDefault(),
+    a.type != gvjs_mv)
+      return !0
+  } else if (a.type != gvjs_kv)
+    return !1;
+  if (this.la && this.la.isVisible()) {
+    var b = 13 == a.keyCode || 32 == a.keyCode
+      , c = this.la.gj(a);
+    return c && this.la && this.la.Pg instanceof gvjs_sE || !(27 == a.keyCode || b && this.Gla) ? c : (this.Kd(!1),
+      !0)
+  }
+  return 40 == a.keyCode || 38 == a.keyCode || 32 == a.keyCode || 13 == a.keyCode ? (this.Kd(!0, a),
+    !0) : !1
+}
+;
+gvjs_.az = function() {
+  this.Kd(!1)
+}
+;
+gvjs_.uqa = function() {
+  this.ak() || this.Kd(!1)
+}
+;
+gvjs_.$y = function(a) {
+  this.iD || this.Kd(!1);
+  gvjs_xE.G.$y.call(this, a)
+}
+;
+gvjs_.Td = function() {
+  this.la || this.lp(new gvjs_kE(this.wa(),this.mta));
+  return this.la || null
+}
+;
+gvjs_.lp = function(a) {
+  var b = this.la;
+  if (a != b && (b && (this.Kd(!1),
+  this.Bb && gvjs_zE(this, b, !1),
+    delete this.la),
+  this.Bb && gvjs_WB(this.H, gvjs_Yu, !!a),
+    a)) {
+    this.la = a;
+    gvjs_OC(a, this);
+    a.setVisible(!1);
+    var c = this.iD;
+    (a.kG = c) && a.jp(!0);
+    this.Bb && gvjs_zE(this, a, !0)
+  }
+  return b
+}
+;
+gvjs_.Bj = function(a) {
+  this.Td().addChild(a, !0)
+}
+;
+gvjs_.Bu = function(a, b) {
+  this.Td().zx(a, b, !0)
+}
+;
+gvjs_.removeItem = function(a) {
+  (a = this.Td().removeChild(a, !0)) && a.pa()
+}
+;
+gvjs_.od = function(a) {
+  return this.la ? this.la.Ye(a) : null
+}
+;
+gvjs_.bh = function() {
+  return this.la ? this.la.ze() : 0
+}
+;
+gvjs_.setVisible = function(a, b) {
+  (a = gvjs_xE.G.setVisible.call(this, a, b)) && !this.isVisible() && this.Kd(!1);
+  return a
+}
+;
+gvjs_.Gb = function(a) {
+  gvjs_xE.G.Gb.call(this, a);
+  this.isEnabled() || this.Kd(!1)
+}
+;
+gvjs_.c4 = gvjs_n(62);
+gvjs_.Ov = gvjs_n(63);
+gvjs_.Kd = function(a, b) {
+  gvjs_xE.G.Kd.call(this, a);
+  if (this.la && gvjs_FD(this, 64) == a) {
+    if (a) {
+      if (!this.la.Bb)
+        if (this.Bva) {
+          var c = gvjs_oh(this.j());
+          c ? this.la.sE(c.parentNode, c) : this.la.R(this.j().parentNode)
+        } else
+          this.la.R();
+      this.UU = gvjs_wz(this.j());
+      this.S7 = gvjs_Ez(this.j());
+      this.mS();
+      c = !!b && (13 == b.keyCode || 32 == b.keyCode);
+      b && (40 == b.keyCode || 38 == b.keyCode) || c && this.kwa ? gvjs_bE(this.la) : this.la.Tg(-1)
+    } else {
+      this.setActive(!1);
+      this.la.Uq = !1;
+      if (c = this.j())
+        gvjs_WB(c, gvjs_Ts, ""),
+          gvjs_WB(c, "owns", "");
+      null != this.bS && (this.bS = void 0,
+      (c = this.la.j()) && gvjs_Cz(c, "", ""))
+    }
+    this.la.setVisible(a, !1, b);
+    this.xf || (b = this.hc(),
+      c = a ? b.o : b.Ab,
+      c.call(b, this.wa().kc(), gvjs_gd, this.Rpa, !0),
+    this.iD && c.call(b, this.la, gvjs_Yo, this.uqa),
+      c.call(b, this.Hc, gvjs_dx, this.Cua),
+      a ? this.Hc.start() : this.Hc.stop())
+  }
+  this.la && this.la.j() && this.la.H.removeAttribute(gvjs_dt)
+}
+;
+gvjs_.mS = function() {
+  if (this.la.Bb) {
+    var a = this.cva || this.j()
+      , b = this.lR;
+    this.lR.element = a;
+    a = this.la.j();
+    this.la.isVisible() || (a.style.visibility = gvjs_0u,
+      gvjs_6(a, !0));
+    !this.bS && this.lR.Qoa && this.lR.MQ & 32 && (this.bS = gvjs_Dz(a));
+    b.Mf(a, b.lH ^ 1, this.lta, this.bS);
+    this.la.isVisible() || (gvjs_6(a, !1),
+      a.style.visibility = gvjs_Mx)
+  }
+}
+;
+gvjs_.Cua = function() {
+  var a = gvjs_Ez(this.j()), b = gvjs_wz(this.j()), c;
+  (c = !gvjs_nz(this.S7, a)) || (c = this.UU,
+    c = !(c == b || c && b && c.top == b.top && c.right == b.right && c.bottom == b.bottom && c.left == b.left));
+  c && (this.la.Bb && b && this.UU && b.La() < this.UU.La() && (c = this.la.j(),
+  this.la.isVisible() || (c.style.visibility = gvjs_0u,
+    gvjs_6(c, !0)),
+    gvjs_sz(c, new gvjs_z(0,0))),
+    this.S7 = a,
+    this.UU = b,
+    this.mS())
+}
+;
+function gvjs_zE(a, b, c) {
+  var d = a.hc();
+  c = c ? d.o : d.Ab;
+  c.call(d, b, gvjs_Ss, a.az);
+  c.call(d, b, gvjs_Yt, a.OZ);
+  c.call(d, b, gvjs_3u, a.DI);
+  c.call(d, b, gvjs_yx, a.c_)
+}
+function gvjs_yE(a, b) {
+  var c = a.hc();
+  (b ? c.o : c.Ab).call(c, a.j(), gvjs_lv, a.iqa)
+}
+gvjs_.DI = function(a) {
+  (a = a.target.j()) && gvjs_AE(this, a)
+}
+;
+gvjs_.iqa = function(a) {
+  gvjs_ED(this, 32) && this.Kg() && this.la && this.la.isVisible() && a.stopPropagation()
+}
+;
+gvjs_.c_ = function() {
+  if (!gvjs_aE(this.la)) {
+    var a = this.j();
+    gvjs_WB(a, gvjs_Ts, "");
+    gvjs_WB(a, "owns", "")
+  }
+}
+;
+gvjs_.OZ = function(a) {
+  if (gvjs_FD(this, 64) && a.target instanceof gvjs_ZD) {
+    a = a.target;
+    var b = a.j();
+    a.isVisible() && gvjs_FD(a, 2) && null != b && gvjs_AE(this, b)
+  }
+}
+;
+function gvjs_AE(a, b) {
+  a = a.j();
+  b = gvjs_YB(b) || b;
+  if (!b.id) {
+    var c = gvjs_KC.Lc();
+    b.id = gvjs_LC(c)
+  }
+  gvjs_ZB(a, b);
+  gvjs_WB(a, "owns", b.id)
+}
+gvjs_HD(gvjs_Js, function() {
+  return new gvjs_xE(null)
+});
+function gvjs_BE(a) {
+  gvjs_H.call(this);
+  this.Iq = [];
+  gvjs_CE(this, a)
+}
+gvjs_t(gvjs_BE, gvjs_H);
+gvjs_ = gvjs_BE.prototype;
+gvjs_.Wt = null;
+gvjs_.bT = null;
+gvjs_.bh = function() {
+  return this.Iq.length
+}
+;
+gvjs_.od = function(a) {
+  return this.Iq[a] || null
+}
+;
+function gvjs_CE(a, b) {
+  b && (b.forEach(function(c) {
+    this.BE(c, !1)
+  }, a),
+    gvjs_Me(a.Iq, b))
+}
+gvjs_.Bj = function(a) {
+  this.Bu(a, this.bh())
+}
+;
+gvjs_.Bu = function(a, b) {
+  a && (this.BE(a, !1),
+    gvjs_fq(this.Iq, a, b))
+}
+;
+gvjs_.removeItem = function(a) {
+  a && gvjs_Ie(this.Iq, a) && a == this.Wt && (this.Wt = null,
+    this.dispatchEvent(gvjs_k))
+}
+;
+gvjs_.Be = function() {
+  return this.Wt
+}
+;
+gvjs_.Qy = function() {
+  return gvjs_Le(this.Iq)
+}
+;
+gvjs_.gl = function(a) {
+  a != this.Wt && (this.BE(this.Wt, !1),
+    this.Wt = a,
+    this.BE(a, !0));
+  this.dispatchEvent(gvjs_k)
+}
+;
+gvjs_.Vl = function() {
+  var a = this.Wt;
+  return a ? this.Iq.indexOf(a) : -1
+}
+;
+gvjs_.rk = function(a) {
+  this.gl(this.od(a))
+}
+;
+gvjs_.clear = function() {
+  gvjs_Fy(this.Iq);
+  this.Wt = null
+}
+;
+gvjs_.M = function() {
+  gvjs_BE.G.M.call(this);
+  delete this.Iq;
+  this.Wt = null
+}
+;
+gvjs_.BE = function(a, b) {
+  a && (typeof this.bT == gvjs_d ? this.bT(a, b) : typeof a.qp == gvjs_d && a.qp(b))
+}
+;
+function gvjs_DE(a, b, c, d, e) {
+  gvjs_xE.call(this, a, b, c, d, e || new gvjs_jE("listbox"));
+  this.rO = this.getContent();
+  this.A_ = null;
+  this.R3("listbox")
+}
+gvjs_t(gvjs_DE, gvjs_xE);
+gvjs_ = gvjs_DE.prototype;
+gvjs_.Ca = null;
+gvjs_.Nb = function() {
+  gvjs_DE.G.Nb.call(this);
+  gvjs_EE(this);
+  gvjs_FE(this)
+}
+;
+gvjs_.vf = function(a) {
+  gvjs_DE.G.vf.call(this, a);
+  (a = this.bj()) ? (this.rO = a,
+    gvjs_EE(this)) : this.Be() || this.rk(0)
+}
+;
+gvjs_.M = function() {
+  gvjs_DE.G.M.call(this);
+  this.Ca && (this.Ca.pa(),
+    this.Ca = null);
+  this.rO = null
+}
+;
+gvjs_.az = function(a) {
+  this.gl(a.target);
+  gvjs_DE.G.az.call(this, a);
+  a.stopPropagation();
+  this.dispatchEvent(gvjs_Ss)
+}
+;
+gvjs_.b_ = function() {
+  var a = this.Be();
+  gvjs_DE.G.Wa.call(this, a && a.getValue());
+  gvjs_EE(this)
+}
+;
+gvjs_.lp = function(a) {
+  var b = gvjs_DE.G.lp.call(this, a);
+  a != b && (this.Ca && this.Ca.clear(),
+  a && (this.Ca ? gvjs_PC(a, function(c) {
+    gvjs_GE(c);
+    this.Ca.Bj(c)
+  }, this) : gvjs_HE(this, a)));
+  return b
+}
+;
+gvjs_.Bj = function(a) {
+  gvjs_GE(a);
+  gvjs_DE.G.Bj.call(this, a);
+  this.Ca ? this.Ca.Bj(a) : gvjs_HE(this, this.Td());
+  gvjs_IE(this)
+}
+;
+gvjs_.Bu = function(a, b) {
+  gvjs_GE(a);
+  gvjs_DE.G.Bu.call(this, a, b);
+  this.Ca ? this.Ca.Bu(a, b) : gvjs_HE(this, this.Td())
+}
+;
+gvjs_.removeItem = function(a) {
+  gvjs_DE.G.removeItem.call(this, a);
+  this.Ca && this.Ca.removeItem(a)
+}
+;
+gvjs_.gl = function(a) {
+  if (this.Ca) {
+    var b = this.Be();
+    this.Ca.gl(a);
+    a != b && this.dispatchEvent(gvjs_Kt)
+  }
+}
+;
+gvjs_.rk = function(a) {
+  this.Ca && this.gl(this.Ca.od(a))
+}
+;
+gvjs_.Wa = function(a) {
+  if (null != a && this.Ca)
+    for (var b = 0, c; c = this.Ca.od(b); b++)
+      if (c && typeof c.getValue == gvjs_d && c.getValue() == a) {
+        this.gl(c);
+        return
+      }
+  this.gl(null)
+}
+;
+gvjs_.getValue = function() {
+  var a = this.Be();
+  return a ? a.getValue() : null
+}
+;
+gvjs_.Be = function() {
+  return this.Ca ? this.Ca.Be() : null
+}
+;
+gvjs_.Vl = function() {
+  return this.Ca ? this.Ca.Vl() : -1
+}
+;
+function gvjs_HE(a, b) {
+  a.Ca = new gvjs_BE;
+  b && gvjs_PC(b, function(c) {
+    gvjs_GE(c);
+    this.Ca.Bj(c)
+  }, a);
+  gvjs_FE(a)
+}
+function gvjs_FE(a) {
+  a.Ca && a.hc().o(a.Ca, gvjs_k, a.b_)
+}
+function gvjs_EE(a) {
+  var b = a.Be();
+  a.setContent(b ? b.bj() : a.rO);
+  var c = a.Oa().ib(a.j());
+  c && a.wa().O_(c) && (null == a.A_ && (a.A_ = gvjs__B(c)),
+    b = b ? b.j() : null,
+    gvjs_0B(c, b ? gvjs__B(b) : a.A_),
+    gvjs_IE(a))
+}
+function gvjs_IE(a) {
+  var b = a.Oa();
+  if (b && (b = b.ib(a.j()))) {
+    var c = a.H;
+    b.id || (b.id = gvjs_LC(gvjs_KC.Lc()));
+    gvjs_VB(b, "option");
+    gvjs_WB(b, gvjs_Iw, !0);
+    gvjs_WB(c, gvjs_Ts, b.id);
+    a.Ca && (c = a.Ca.Qy(),
+      gvjs_WB(b, "setsize", gvjs_JE(c)),
+      a = a.Ca.Vl(),
+      gvjs_WB(b, "posinset", 0 <= a ? gvjs_JE(c.slice(0, a + 1)) : 0))
+  }
+}
+function gvjs_JE(a) {
+  return a.filter(function(b) {
+    return b instanceof gvjs_ZD
+  }).length
+}
+function gvjs_GE(a) {
+  a.R3(a instanceof gvjs_ZD ? "option" : gvjs_Lw)
+}
+gvjs_.Kd = function(a, b) {
+  gvjs_DE.G.Kd.call(this, a, b);
+  gvjs_FD(this, 64) ? this.Td().Tg(this.Vl()) : gvjs_IE(this)
+}
+;
+gvjs_HD(gvjs_Os, function() {
+  return new gvjs_DE(null)
+});
+function gvjs_KE(a, b) {
+  this.D = gvjs_Oh();
+  this.ma = a;
+  this.Z7 = [];
+  this.Mj(b)
+}
+function gvjs_LE(a, b) {
+  var c = gvjs_Oh()
+    , d = gvjs_9f
+    , e = null;
+  switch (a) {
+    case 2:
+      var f = new gvjs_fD("google-visualization-toolbar-small-dialog");
+      e = gvjs_sw + f.getId();
+      d = gvjs_$f(gvjs_5f(gvjs_Ob, {
+        "class": gvjs_Mu
+      }, gvjs_9r), gvjs_bg, gvjs_5f("pre", {}, gvjs_5f(gvjs_Ob, {
+        id: e
+      }, b.message)));
+      break;
+    case 3:
+      f = new gvjs_fD("google-visualization-toolbar-big-dialog"),
+        d = gvjs_$f(gvjs_5f(gvjs_Ob, {
+          "class": gvjs_Mu
+        }, gvjs_9r), gvjs_bg, gvjs_5f(gvjs_Ob, {}, gvjs_5f("pre", {}, b.message)))
+  }
+  gvjs_jD(f, d);
+  a = f;
+  gvjs_kD(a);
+  gvjs_th(a.tk, "Google Visualization");
+  a = f;
+  gvjs_kD(a);
+  gvjs_hh(a.Dh);
+  f.setVisible(!0);
+  e && (c = f = c.j(e),
+    e = 0,
+    a = 1,
+    b = new gvjs_IC,
+    b.kj = gvjs_fea(c, e, f, a),
+  gvjs_ph(c) && !gvjs_fh(c) && (d = c.parentNode,
+    e = Array.prototype.indexOf.call(d.childNodes, c),
+    c = d),
+  gvjs_ph(f) && !gvjs_fh(f) && (d = f.parentNode,
+    a = Array.prototype.indexOf.call(d.childNodes, f),
+    f = d),
+    b.kj ? (b.sd = f,
+      b.td = a,
+      b.fd = c,
+      b.Ad = e) : (b.sd = c,
+      b.td = e,
+      b.fd = f,
+      b.Ad = a),
+    b.select())
+}
+gvjs_KE.prototype.Mj = function(a) {
+  a = a || [];
+  var b = this.ma
+    , c = this.D;
+  c.qc(b);
+  if (!b)
+    throw Error(gvjs_za);
+  var d = c.J(gvjs_6a, null)
+    , e = [c.J(gvjs_6a, null, "Chart options")];
+  this.zE = new gvjs_DE(e);
+  if (a)
+    for (e = 0; e < a.length; e++) {
+      var f = null;
+      f = a[e];
+      var g = f.datasource
+        , h = f.gadget
+        , k = f.userprefs
+        , l = f.visualization
+        , m = f["package"]
+        , n = f.style || "width: 700px; height: 500px;";
+      switch (f.type) {
+        case "csv":
+          f = gvjs_ME(this, e, gvjs_re(function(p) {
+            gvjs_Xy((new gvjs_Xm(p)).Ld("tqx", "out:csv;").toString(), window, gvjs_9e(gvjs_ds))
+          }, g), "Export data as CSV");
+          break;
+        case "htmlcode":
+          f = gvjs_ME(this, e, gvjs_re(function(p, q) {
+            p = '<iframe style="' + n + '" src="http://www.google.com/ig/ifr?url=' + encodeURIComponent(p) + gvjs_Cr + encodeURIComponent(q) + gvjs_NE(k) + '" />';
+            gvjs_LE(2, {
+              message: p
+            })
+          }, h, g), "Publish to web page");
+          break;
+        case "jscode":
+          f = gvjs_ME(this, e, gvjs_re(function(p, q, r) {
+            p = '<html>\n <head>\n  <title>Google Visualization API</title>\n  <script type="text/javascript" src="https://www.google.com/jsapi">\x3c/script>\n  <script type="text/javascript">\n   google.load(\'visualization\', \'1\', {packages: [\'' + encodeURIComponent(q) + "']});\n\n   function drawVisualization() {\n    new google.visualization.Query('" + p + "').send(\n     function(response) {\n      new " + encodeURIComponent(r) + '(\n       document.getElementById(\'visualization\')).\n        draw(response.getDataTable(), null);\n      });\n   }\n\n   google.setOnLoadCallback(drawVisualization);\n  \x3c/script>\n </head>\n <body>\n  <div id="visualization" style="width: 500px; height: 500px;"></div>\n </body>\n</html>';
+            gvjs_LE(3, {
+              message: p
+            })
+          }, g, m, l), "Javascript code");
+          break;
+        case gvjs_av:
+          f = gvjs_ME(this, e, gvjs_re(function(p) {
+            gvjs_Xy((new gvjs_Xm(p)).Ld("tqx", "out:html;").toString(), window, gvjs_9e(gvjs_ds))
+          }, g), "Export data as HTML");
+          break;
+        case "igoogle":
+          f = gvjs_ME(this, e, gvjs_re(function(p, q, r) {
+            gvjs_Xy("http://www.google.com/ig/adde?moduleurl=" + encodeURIComponent(p) + gvjs_Cr + encodeURIComponent(q) + gvjs_NE(r))
+          }, h, g, k), "Add to iGoogle");
+          break;
+        default:
+          throw Error("No such toolbar component as: " + f.toSource());
+      }
+      f && this.zE.Bj(f)
+    }
+  gvjs_G(this.zE, gvjs_Ss, gvjs_s(this.Xqa, this));
+  this.zE.R(d);
+  c.appendChild(b, d)
+}
+;
+gvjs_KE.prototype.Xqa = function() {
+  var a = this.zE.Vl();
+  this.Z7[a]();
+  this.zE.rk(-1)
+}
+;
+function gvjs_ME(a, b, c, d) {
+  d = new gvjs_ZD(d);
+  a.Z7[b] = c;
+  return d
+}
+function gvjs_NE(a) {
+  if (!a)
+    return "";
+  var b = "", c;
+  for (c in a)
+    b += "&up_" + c + "=" + encodeURIComponent(a[c]);
+  return b
+}
+gvjs_KE.prototype.zE = null;
+function gvjs_OE() {}
+gvjs_t(gvjs_OE, gvjs_zD);
+gvjs_le(gvjs_OE);
+gvjs_OE.prototype.J = function(a) {
+  var b = a.wa().J(gvjs_6a, this.Rl(a).join(" "));
+  a = a.jZ();
+  gvjs_PE(this, b, a);
+  return b
+}
+;
+gvjs_OE.prototype.fb = function(a, b) {
+  b = gvjs_OE.G.fb.call(this, a, b);
+  var c = gvjs_SC(b)
+    , d = !1;
+  gvjs_He(c, gvjs_QE(this, null)) ? d = null : gvjs_He(c, gvjs_QE(this, !0)) ? d = !0 : gvjs_He(c, gvjs_QE(this, !1)) && (d = !1);
+  a.ns = d;
+  gvjs_WB(b, gvjs_Vt, null == d ? "mixed" : 1 == d ? gvjs_Rd : gvjs_Sb);
+  return b
+}
+;
+gvjs_OE.prototype.Qk = function() {
+  return gvjs_Ut
+}
+;
+function gvjs_PE(a, b, c) {
+  if (b) {
+    var d = gvjs_QE(a, c);
+    gvjs_UC(b, d) || (gvjs_w(gvjs_sea, function(e) {
+      e = gvjs_QE(this, e);
+      gvjs_ZC(b, e, e == d)
+    }, a),
+      gvjs_WB(b, gvjs_Vt, null == c ? "mixed" : 1 == c ? gvjs_Rd : gvjs_Sb))
+  }
+}
+gvjs_OE.prototype.sa = function() {
+  return gvjs_Fs
+}
+;
+function gvjs_QE(a, b) {
+  a = a.sa();
+  if (1 == b)
+    return a + "-checked";
+  if (0 == b)
+    return a + "-unchecked";
+  if (null == b)
+    return a + "-undetermined";
+  throw Error("Invalid checkbox state: " + b);
+}
+;function gvjs_RE(a, b, c) {
+  c = c || gvjs_OE.Lc();
+  gvjs_LD.call(this, null, c, b);
+  this.ns = void 0 !== a ? a : !1
+}
+gvjs_t(gvjs_RE, gvjs_LD);
+var gvjs_sea = {
+  Rza: !0,
+  QBa: !1,
+  RBa: null
+};
+gvjs_ = gvjs_RE.prototype;
+gvjs_.Qb = null;
+gvjs_.jZ = function() {
+  return this.ns
+}
+;
+gvjs_.nn = function() {
+  return 1 == this.ns
+}
+;
+gvjs_.bi = function(a) {
+  a != this.ns && (this.ns = a,
+    gvjs_PE(this.Oa(), this.j(), this.ns))
+}
+;
+gvjs_.In = function(a) {
+  if (this.Bb) {
+    var b = gvjs_FD(this, 32);
+    this.Le();
+    this.Qb = a;
+    this.Nb();
+    b && this.H.focus()
+  } else
+    this.Qb = a
+}
+;
+gvjs_.toggle = function() {
+  this.bi(this.ns ? !1 : !0)
+}
+;
+gvjs_.Nb = function() {
+  gvjs_RE.G.Nb.call(this);
+  if (this.OP) {
+    var a = this.hc();
+    this.Qb && a.o(this.Qb, gvjs_Wt, this.NZ).o(this.Qb, gvjs_ld, this.Lo).o(this.Qb, gvjs_kd, this.PP).o(this.Qb, gvjs_gd, this.Cf).o(this.Qb, gvjs_md, this.Mo);
+    a.o(this.j(), gvjs_Wt, this.NZ)
+  }
+  a = this.H;
+  this.Qb && a != this.Qb && gvjs_jf(gvjs__B(a)) && (this.Qb.id || (this.Qb.id = this.getId() + ".lbl"),
+    gvjs_WB(a, gvjs_pv, this.Qb.id))
+}
+;
+gvjs_.NZ = function(a) {
+  a.stopPropagation();
+  var b = this.ns ? "uncheck" : "check";
+  this.isEnabled() && !a.target.href && this.dispatchEvent(b) && (a.preventDefault(),
+    this.toggle(),
+    this.dispatchEvent(gvjs_Kt))
+}
+;
+gvjs_.Wj = function(a) {
+  32 == a.keyCode && (this.$h(a),
+    this.NZ(a));
+  return !1
+}
+;
+gvjs_HD(gvjs_Fs, function() {
+  return new gvjs_RE
+});
+function gvjs_SE(a, b, c) {
+  gvjs_F.call(this);
+  this.Bt = a;
+  this.Zv = b || 0;
+  this.pd = c;
+  this.KG = gvjs_s(this.gC, this)
+}
+gvjs_t(gvjs_SE, gvjs_F);
+gvjs_ = gvjs_SE.prototype;
+gvjs_.ac = 0;
+gvjs_.M = function() {
+  gvjs_SE.G.M.call(this);
+  this.stop();
+  delete this.Bt;
+  delete this.pd
+}
+;
+gvjs_.start = function(a) {
+  this.stop();
+  this.ac = gvjs_pl(this.KG, void 0 !== a ? a : this.Zv)
+}
+;
+gvjs_.stop = function() {
+  this.ak() && gvjs_ql(this.ac);
+  this.ac = 0
+}
+;
+gvjs_.fI = gvjs_n(64);
+gvjs_.ak = function() {
+  return 0 != this.ac
+}
+;
+gvjs_.gC = function() {
+  this.ac = 0;
+  this.Bt && this.Bt.call(this.pd)
+}
+;
+function gvjs_TE(a, b) {
+  gvjs_H.call(this);
+  this.H = a;
+  a = gvjs_ph(this.H) ? this.H : this.H ? this.H.body : null;
+  this.AQ = !!a && gvjs_Gz(a);
+  this.mca = gvjs_G(this.H, gvjs_sg ? "DOMMouseScroll" : gvjs_Wv, this, b)
+}
+gvjs_t(gvjs_TE, gvjs_H);
+gvjs_TE.prototype.handleEvent = function(a) {
+  var b = 0
+    , c = 0
+    , d = a.$i;
+  d.type == gvjs_Wv ? (a = gvjs_UE(-d.wheelDelta),
+    void 0 !== d.wheelDeltaX ? (b = gvjs_UE(-d.wheelDeltaX),
+      c = gvjs_UE(-d.wheelDeltaY)) : c = a) : (a = d.detail,
+    100 < a ? a = 3 : -100 > a && (a = -3),
+    void 0 !== d.axis && d.axis === d.HORIZONTAL_AXIS ? b = a : c = a);
+  typeof this.Eca === gvjs_g && (b = gvjs_0g(b, -this.Eca, this.Eca));
+  typeof this.Fca === gvjs_g && (c = gvjs_0g(c, -this.Fca, this.Fca));
+  this.AQ && (b = -b);
+  b = new gvjs_VE(a,d,b,c);
+  this.dispatchEvent(b)
+}
+;
+function gvjs_UE(a) {
+  return gvjs_tg && (gvjs_ug || gvjs_wg) && 0 != a % 40 ? a : a / 40
+}
+gvjs_TE.prototype.M = function() {
+  gvjs_TE.G.M.call(this);
+  gvjs_ki(this.mca);
+  this.mca = null
+}
+;
+function gvjs_VE(a, b, c, d) {
+  gvjs_5h.call(this, b);
+  this.type = gvjs_Wv;
+  this.detail = a;
+  this.deltaX = c;
+  this.deltaY = d
+}
+gvjs_t(gvjs_VE, gvjs_5h);
+var gvjs_WE = {}
+  , gvjs_XE = null;
+function gvjs_YE(a) {
+  a = gvjs_pe(a);
+  delete gvjs_WE[a];
+  gvjs_Py(gvjs_WE) && gvjs_XE && gvjs_XE.stop()
+}
+function gvjs_ZE() {
+  gvjs_XE || (gvjs_XE = new gvjs_SE(function() {
+      gvjs_tea()
+    }
+    ,20));
+  var a = gvjs_XE;
+  a.ak() || a.start()
+}
+function gvjs_tea() {
+  var a = gvjs_se();
+  gvjs_w(gvjs_WE, function(b) {
+    gvjs__E(b, a)
+  });
+  gvjs_Py(gvjs_WE) || gvjs_ZE()
+}
+;function gvjs_0E() {
+  gvjs_H.call(this);
+  this.K = 0;
+  this.endTime = this.startTime = null
+}
+gvjs_t(gvjs_0E, gvjs_H);
+gvjs_ = gvjs_0E.prototype;
+gvjs_.So = function() {
+  return 1 == this.K
+}
+;
+gvjs_.Ef = function() {
+  return 0 == this.K
+}
+;
+gvjs_.jK = function() {
+  this.Jh("begin")
+}
+;
+gvjs_.Xz = function() {
+  this.Jh(gvjs_R)
+}
+;
+gvjs_.Jh = function(a) {
+  this.dispatchEvent(a)
+}
+;
+function gvjs_1E(a, b, c, d) {
+  gvjs_0E.call(this);
+  if (!Array.isArray(a) || !Array.isArray(b))
+    throw Error("Start and end parameters must be arrays");
+  if (a.length != b.length)
+    throw Error("Start and end points must be the same length");
+  this.wp = a;
+  this.YH = b;
+  this.duration = c;
+  this.N6 = d;
+  this.coords = [];
+  this.bB = !1;
+  this.progress = 0
+}
+gvjs_t(gvjs_1E, gvjs_0E);
+gvjs_ = gvjs_1E.prototype;
+gvjs_.pq = gvjs_n(57);
+gvjs_.play = function(a) {
+  if (a || this.Ef())
+    this.progress = 0,
+      this.coords = this.wp;
+  else if (this.So())
+    return !1;
+  gvjs_YE(this);
+  this.startTime = a = gvjs_se();
+  -1 == this.K && (this.startTime -= this.duration * this.progress);
+  this.endTime = this.startTime + this.duration;
+  this.progress || this.jK();
+  this.Jh("play");
+  -1 == this.K && this.Jh("resume");
+  this.K = 1;
+  var b = gvjs_pe(this);
+  b in gvjs_WE || (gvjs_WE[b] = this);
+  gvjs_ZE();
+  gvjs__E(this, a);
+  return !0
+}
+;
+gvjs_.stop = function(a) {
+  gvjs_YE(this);
+  this.K = 0;
+  a && (this.progress = 1);
+  gvjs_2E(this, this.progress);
+  this.Jh(gvjs__p);
+  this.Xz()
+}
+;
+gvjs_.pause = function() {
+  this.So() && (gvjs_YE(this),
+    this.K = -1,
+    this.Jh("pause"))
+}
+;
+gvjs_.M = function() {
+  this.Ef() || this.stop(!1);
+  this.Jh("destroy");
+  gvjs_1E.G.M.call(this)
+}
+;
+gvjs_.destroy = function() {
+  this.pa()
+}
+;
+function gvjs__E(a, b) {
+  b < a.startTime && (a.endTime = b + a.endTime - a.startTime,
+    a.startTime = b);
+  a.progress = (b - a.startTime) / (a.endTime - a.startTime);
+  1 < a.progress && (a.progress = 1);
+  gvjs_2E(a, a.progress);
+  1 == a.progress ? (a.K = 0,
+    gvjs_YE(a),
+    a.Jh(gvjs_vu),
+    a.Xz()) : a.So() && a.M1()
+}
+function gvjs_2E(a, b) {
+  typeof a.N6 === gvjs_d && (b = a.N6(b));
+  a.coords = Array(a.wp.length);
+  for (var c = 0; c < a.wp.length; c++)
+    a.coords[c] = (a.YH[c] - a.wp[c]) * b + a.wp[c]
+}
+gvjs_.M1 = function() {
+  this.Jh("animate")
+}
+;
+gvjs_.Jh = function(a) {
+  this.dispatchEvent(new gvjs_3E(a,this))
+}
+;
+function gvjs_3E(a, b) {
+  gvjs_1h.call(this, a);
+  this.coords = b.coords;
+  this.x = b.coords[0];
+  this.y = b.coords[1];
+  this.z = b.coords[2];
+  this.duration = b.duration;
+  this.progress = b.progress;
+  this.state = b.K
+}
+gvjs_t(gvjs_3E, gvjs_1h);
+gvjs_q("google.visualization.drawToolbar", function(a, b) {
+  new gvjs_KE(a,b)
+}, void 0);
+function gvjs_4E(a) {
+  return a.join("#")
+}
+var gvjs_5E = ["minorgridline", "gridline", gvjs_at, gvjs_Jt, gvjs_5w, gvjs_wb, "pathinterval", gvjs_Xo, gvjs_iv, gvjs_e, gvjs_Ct, gvjs_yt, gvjs_Zs, gvjs_ow, gvjs_Np, gvjs_fx, "axistick", "axistitle", gvjs_$s, gvjs_rv, gvjs_Av, gvjs_zv, "colorbar", gvjs_Pd, gvjs_Ss];
+function gvjs_6E(a, b, c, d, e) {
+  this.iq = b;
+  this.JB = e;
+  a = gvjs_7E(this, a);
+  this.ny = (d - c) / (gvjs_7E(this, b) - a);
+  this.YK = this.ny * a - c
+}
+gvjs_6E.prototype.Ya = function(a) {
+  return gvjs_7E(this, a) * this.ny - this.YK
+}
+;
+gvjs_6E.prototype.Ae = function(a) {
+  a: switch (a = (a + this.YK) / this.ny,
+    this.JB) {
+    case 0:
+      a = Math.pow(Math.E, a);
+      break a;
+    case 1:
+      break a;
+    default:
+      a = Math.pow(a * this.JB + 1, 1 / this.JB)
+  }
+  return isFinite(a) ? a : this.iq
+}
+;
+function gvjs_7E(a, b) {
+  switch (a.JB) {
+    case 0:
+      return Math.log(b);
+    case 1:
+      return b;
+    default:
+      return (Math.pow(b, a.JB) - 1) / a.JB
+  }
+}
+;function gvjs_8E(a, b) {
+  return 0 > b ? a / Math.pow(10, -b) : a * Math.pow(10, b)
+}
+function gvjs_9E(a) {
+  return Math.floor(.4342944819032518 * Math.log(a))
+}
+function gvjs_$E(a) {
+  return Math.ceil(.4342944819032518 * Math.log(a))
+}
+;function gvjs_aF(a, b, c, d, e, f) {
+  this.iy = a;
+  this.zH = b;
+  this.ZK = c;
+  this.XK = d;
+  this.Ku = e;
+  this.U9 = f;
+  this.ym = this.iy == this.zH ? this.iy / 2 : isNaN(this.U9) ? gvjs_8E(1, gvjs_9E(this.zH - this.iy)) / 1E3 : this.U9 / 2;
+  a >= this.ym ? (this.Zk = new gvjs_6E(a,b,c,d,this.Ku),
+    this.Ki = Math.round(this.Zk.Ya(this.ym))) : b <= -this.ym ? (this.Zk = new gvjs_6E(-b,-a,d,c,this.Ku),
+    this.Ki = Math.round(this.Zk.Ya(this.ym)),
+    f = 2 * this.Ki - d,
+    e = 2 * this.Ki - c,
+    this.Zk = new gvjs_6E(-b,-a,f,e,this.Ku)) : a >= -this.ym ? (this.Ki = Math.round(c),
+    this.Zk = new gvjs_6E(this.ym,b,this.Ki,d,this.Ku)) : b <= this.ym ? (this.Ki = Math.round(d),
+    e = 2 * this.Ki - c,
+    this.Zk = new gvjs_6E(this.ym,-a,this.Ki,e,this.Ku)) : (this.Zk = new gvjs_6E(this.ym,b,0,1,this.Ku),
+    e = this.Zk.Ya(-a),
+    this.Ki = Math.round(c + e / (e + 1) * (d - c)),
+    b >= -a ? this.Zk = new gvjs_6E(this.ym,b,this.Ki,d,this.Ku) : (e = 2 * this.Ki - c,
+      this.Zk = new gvjs_6E(this.ym,-a,this.Ki,e,this.Ku)));
+  this.Sg = d < c
+}
+gvjs_ = gvjs_aF.prototype;
+gvjs_.Yb = function() {
+  return this.iy
+}
+;
+gvjs_.$b = function() {
+  return this.zH
+}
+;
+gvjs_.Ho = function() {
+  return this.ZK
+}
+;
+gvjs_.an = function() {
+  return this.XK
+}
+;
+gvjs_.Ae = function(a) {
+  if (this.iy == this.zH)
+    return this.iy;
+  var b = this.Sg ? -1 : 1;
+  return a * b > this.Ki * b ? this.Zk.Ae(a) : a * b < this.Ki * b ? -this.Zk.Ae(2 * this.Ki - a) : 0
+}
+;
+gvjs_.Ya = function(a) {
+  return this.iy == this.zH ? Math.abs(this.ZK - this.XK) / 2 : a > this.ym ? this.Zk.Ya(a) : a < -this.ym ? 2 * this.Ki - this.Zk.Ya(-a) : this.Ki
+}
+;
+var gvjs_uea = {
+  aBa: gvjs_iw,
+  LOG: "log",
+  OAa: gvjs_Vv
+};
+function gvjs_bF() {
+  return {
+    transform: function(a) {
+      return a
+    },
+    inverse: function(a) {
+      return a
+    }
+  }
+}
+function gvjs_vea(a) {
+  var b = gvjs_wea(a);
+  return {
+    transform: function(c) {
+      var d = gvjs_cF(b, c, function(e) {
+        return e.source
+      });
+      return null === d ? c : d.target + (c - d.source) * d.xC
+    },
+    inverse: function(c) {
+      var d = gvjs_cF(b, c, function(e) {
+        return e.target
+      });
+      return null === d ? c : 0 == d.xC ? d.source : d.source + (c - d.target) / d.xC
+    }
+  }
+}
+function gvjs_wea(a) {
+  for (var b = [], c = 0, d = null, e = 0; e < a.length; e++) {
+    var f = a[e]
+      , g = f.voa
+      , h = f.start;
+    f = f.end;
+    var k = g / (f - h);
+    null === d || d != h ? b.push({
+      source: h,
+      target: h + c,
+      xC: k
+    }) : b[b.length - 1].xC = k;
+    b.push({
+      source: f,
+      target: h + c + g,
+      xC: 1
+    });
+    c += g - (f - h);
+    d = f
+  }
+  return b
+}
+function gvjs_cF(a, b, c) {
+  b = gvjs_Iy(a, {
+    source: b,
+    target: b,
+    xC: 0
+  }, function(d, e) {
+    d = c(d);
+    e = c(e);
+    return d < e ? -1 : d > e ? 1 : 0
+  });
+  0 > b && (b = -b - 2);
+  return 0 > b ? null : a[b]
+}
+function gvjs_xea(a) {
+  var b = new gvjs_aF(.5 * a,a,0,1,0);
+  return {
+    transform: function(c) {
+      return null == c ? c : b.Ya(c)
+    },
+    inverse: function(c) {
+      return null == c ? c : b.Ae(c)
+    }
+  }
+}
+function gvjs_yea(a) {
+  var b = new gvjs_aF(-a,a,-1,1,0,a);
+  return {
+    transform: function(c) {
+      return null == c ? c : b.Ya(c)
+    },
+    inverse: function(c) {
+      return null == c ? c : b.Ae(c)
+    }
+  }
+}
+function gvjs_dF(a, b, c) {
+  return (c = a.cb(c, gvjs_uea)) ? c : gvjs_K(a, b) ? "log" : gvjs_iw
+}
+function gvjs_eF(a, b, c) {
+  switch (a) {
+    case gvjs_iw:
+      return 0 == c.length ? gvjs_bF() : gvjs_vea(c);
+    case "log":
+      return gvjs_xea(b);
+    case gvjs_Vv:
+      return gvjs_yea(b);
+    default:
+      return gvjs_bF()
+  }
+}
+;function gvjs_fF(a, b, c) {
+  this.ra = [];
+  this.Lca = a;
+  this.Jha = b;
+  this.hC = c || gvjs_bF()
+}
+function gvjs_gF(a, b) {
+  if (0 < a.ra.length) {
+    var c = a.ra[a.ra.length - 1][0]
+      , d = b - c;
+    if (d > a.Lca && (d = Math.round(d / a.Lca),
+    1 < d))
+      for (var e = 1; e < d; e++) {
+        var f = e / d * (b - c) + c;
+        a.ra.push([f, a.Jha(f)])
+      }
+  }
+  a.ra.push([b, a.Jha(b)])
+}
+gvjs_fF.prototype.cd = function() {
+  return this.ra
+}
+;
+function gvjs_hF() {}
+gvjs_hF.prototype.qm = function() {
+  return this
+}
+;
+gvjs_hF.prototype.vz = function() {
+  return !1
+}
+;
+gvjs_hF.prototype.isNumber = function() {
+  return !1
+}
+;
+function gvjs_iF() {}
+gvjs_iF.prototype.zq = function() {
+  return ")"
+}
+;
+function gvjs_jF() {}
+gvjs_jF.prototype.zq = function() {
+  return "("
+}
+;
+function gvjs_kF(a) {
+  this.Eg = a
+}
+gvjs_o(gvjs_kF, gvjs_hF);
+gvjs_kF.prototype.join = function(a) {
+  var b = [];
+  gvjs_u(this.Eg, function(c, d) {
+    0 < d && b.push(a);
+    d = !1;
+    c instanceof gvjs_kF && 1 < c.Eg.length && this.HC() > c.HC() && (d = !0);
+    d && b.push(new gvjs_jF);
+    gvjs_Me(b, c.Im());
+    d && b.push(new gvjs_iF)
+  }, this);
+  return b
+}
+;
+gvjs_kF.prototype.qm = function() {
+  if (1 === this.Eg.length)
+    return this.Eg[0];
+  var a = [];
+  gvjs_u(this.Eg, function(b) {
+    a.push(b.qm())
+  });
+  this.Eg = a;
+  return this
+}
+;
+function gvjs_lF(a) {
+  this.value = a
+}
+gvjs_lF.prototype.zq = function() {
+  return gvjs_g
+}
+;
+function gvjs_mF(a) {
+  this.value = a
+}
+gvjs_o(gvjs_mF, gvjs_hF);
+gvjs_mF.prototype.Im = function() {
+  return [new gvjs_lF(this.value)]
+}
+;
+gvjs_mF.prototype.vz = function() {
+  return 0 > this.value
+}
+;
+gvjs_mF.prototype.getValue = function() {
+  return this.value
+}
+;
+gvjs_mF.prototype.isNumber = function() {
+  return !0
+}
+;
+function gvjs_nF() {}
+gvjs_nF.prototype.zq = function() {
+  return "--"
+}
+;
+function gvjs_oF(a) {
+  this.Eg = [a]
+}
+gvjs_o(gvjs_oF, gvjs_kF);
+function gvjs_pF(a) {
+  this.Eg = [a]
+}
+gvjs_o(gvjs_pF, gvjs_oF);
+gvjs_pF.prototype.qm = function() {
+  var a = this.Eg[0].qm();
+  if (a.vz()) {
+    if (a instanceof gvjs_pF)
+      return a.Eg[0];
+    if (a instanceof gvjs_mF)
+      return new gvjs_mF(-a.getValue());
+    throw Error("Unknown type of negative.");
+  }
+  return new gvjs_pF(a)
+}
+;
+gvjs_pF.prototype.Im = function() {
+  return gvjs_Ke([new gvjs_nF], this.Eg[0].Im())
+}
+;
+gvjs_pF.prototype.vz = function() {
+  return this.qm()instanceof gvjs_pF
+}
+;
+gvjs_pF.prototype.HC = function() {
+  return -1
+}
+;
+function gvjs_qF() {}
+gvjs_qF.prototype.zq = function() {
+  return "-"
+}
+;
+function gvjs_rF() {}
+gvjs_rF.prototype.zq = function() {
+  return "+"
+}
+;
+function gvjs_sF(a) {
+  this.Eg = a
+}
+gvjs_o(gvjs_sF, gvjs_kF);
+gvjs_sF.prototype.HC = function() {
+  return 1
+}
+;
+gvjs_sF.prototype.Im = function() {
+  for (var a = [], b = 0; b < this.Eg.length; b++) {
+    var c = this.Eg[b];
+    0 < a.length && c.vz() ? (a.push(new gvjs_qF),
+      c = (new gvjs_pF(c)).qm()) : 0 < a.length && a.push(new gvjs_rF);
+    a = gvjs_Ke(a, c.Im())
+  }
+  return a
+}
+;
+function gvjs_tF() {}
+gvjs_tF.prototype.zq = function() {
+  return "="
+}
+;
+function gvjs_uF(a) {
+  this.Eg = a
+}
+gvjs_o(gvjs_uF, gvjs_kF);
+gvjs_uF.prototype.HC = function() {
+  return 0
+}
+;
+gvjs_uF.prototype.Im = function() {
+  return this.join(new gvjs_tF)
+}
+;
+function gvjs_vF() {}
+gvjs_vF.prototype.zq = function() {
+  return "*"
+}
+;
+function gvjs_wF(a, b) {
+  this.Eg = a;
+  this.r8 = null != b ? b : !1
+}
+gvjs_o(gvjs_wF, gvjs_kF);
+gvjs_wF.prototype.HC = function() {
+  return 2
+}
+;
+gvjs_wF.prototype.qm = function() {
+  gvjs_kF.prototype.qm.call(this);
+  var a = 0
+    , b = []
+    , c = 1;
+  gvjs_u(this.Eg, function(e) {
+    e.vz() && (e = (new gvjs_pF(e)).qm(),
+      a++);
+    e.isNumber() && (c *= e.getValue(),
+      e = null);
+    e && b.push(e)
+  });
+  1 !== c && gvjs_Ne(b, 0, 0, new gvjs_mF(c));
+  var d = new gvjs_wF(b,this.r8);
+  a % 2 && (d = new gvjs_pF(d));
+  return d
+}
+;
+gvjs_wF.prototype.Im = function() {
+  return this.r8 ? gvjs_Ke.apply(null, gvjs_v(this.Eg, function(a) {
+    return a.Im()
+  })) : this.join(new gvjs_vF)
+}
+;
+gvjs_wF.prototype.vz = function() {
+  var a = 0;
+  gvjs_u(this.Eg, function(b) {
+    b.vz() && a++
+  });
+  return !!(a % 2)
+}
+;
+function gvjs_xF() {}
+gvjs_xF.prototype.zq = function() {
+  return "^"
+}
+;
+function gvjs_yF(a) {
+  this.Eg = a
+}
+gvjs_o(gvjs_yF, gvjs_kF);
+gvjs_yF.prototype.HC = function() {
+  return 3
+}
+;
+gvjs_yF.prototype.Im = function() {
+  return this.join(new gvjs_xF)
+}
+;
+function gvjs_zF(a) {
+  this.name = a
+}
+gvjs_zF.prototype.zq = function() {
+  return "identifier"
+}
+;
+function gvjs_AF(a) {
+  this.name = a
+}
+gvjs_o(gvjs_AF, gvjs_hF);
+gvjs_AF.prototype.Im = function() {
+  return [new gvjs_zF(this.name)]
+}
+;
+gvjs_AF.prototype.getName = function() {
+  return this.name
+}
+;
+function gvjs_BF(a, b) {
+  if (a instanceof gvjs_BF)
+    this.yd = a.um();
+  else {
+    var c;
+    if (c = gvjs_ne(a))
+      a: {
+        for (var d = c = 0; d < a.length; d++) {
+          if (!gvjs_ne(a[d]) || 0 < c && a[d].length != c) {
+            c = !1;
+            break a
+          }
+          for (var e = 0; e < a[d].length; e++)
+            if (typeof a[d][e] !== gvjs_g) {
+              c = !1;
+              break a
+            }
+          0 == c && (c = a[d].length)
+        }
+        c = 0 != c
+      }
+    if (c)
+      this.yd = gvjs_Le(a);
+    else if (a instanceof gvjs_A)
+      this.yd = gvjs_CF(a.height, a.width);
+    else if (typeof a === gvjs_g && typeof b === gvjs_g && 0 < a && 0 < b)
+      this.yd = gvjs_CF(a, b);
+    else
+      throw Error("Invalid argument(s) for Matrix contructor");
+  }
+  this.ya = new gvjs_A(this.yd[0].length,this.yd.length)
+}
+function gvjs_DF(a, b, c) {
+  for (var d = 0; d < a.Tb().height; d++)
+    for (var e = 0; e < a.Tb().width; e++)
+      b.call(c, a.yd[d][e], d, e, a)
+}
+function gvjs_EF(a, b) {
+  var c = new gvjs_BF(a.Tb());
+  gvjs_DF(a, function(d, e, f) {
+    c.yd[e][f] = b.call(void 0, d, e, f, a)
+  });
+  return c
+}
+function gvjs_CF(a, b) {
+  for (var c = [], d = 0; d < a; d++) {
+    c[d] = [];
+    for (var e = 0; e < b; e++)
+      c[d][e] = 0
+  }
+  return c
+}
+gvjs_ = gvjs_BF.prototype;
+gvjs_.add = function(a) {
+  if (!gvjs_fz(this.ya, a.Tb()))
+    throw Error("Matrix summation is only supported on arrays of equal size");
+  return gvjs_EF(this, function(b, c, d) {
+    return b + a.yd[c][d]
+  })
+}
+;
+function gvjs_zea(a, b) {
+  if (a.ya.height != b.Tb().height)
+    throw Error("The given matrix has height " + b.ya.height + ", but  needs to have height " + a.ya.height + ".");
+  var c = new gvjs_BF(a.ya.height,a.ya.width + b.ya.width);
+  gvjs_DF(a, function(d, e, f) {
+    c.yd[e][f] = d
+  });
+  gvjs_DF(b, function(d, e, f) {
+    c.yd[e][this.ya.width + f] = d
+  }, a);
+  return c
+}
+gvjs_.equals = function(a, b) {
+  if (this.ya.width != a.ya.width || this.ya.height != a.ya.height)
+    return !1;
+  b = b || 0;
+  for (var c = 0; c < this.ya.height; c++)
+    for (var d = 0; d < this.ya.width; d++)
+      if (!(Math.abs(this.yd[c][d] - a.yd[c][d]) <= (b || 1E-6)))
+        return !1;
+  return !0
+}
+;
+gvjs_.uZ = gvjs_n(65);
+function gvjs_FF(a) {
+  for (var b = new gvjs_BF(a), c = 0, d = 0; d < b.ya.height && !(c >= b.ya.width); d++) {
+    for (var e = d; 0 == b.yd[e][c]; )
+      if (e++,
+      e == b.ya.height && (e = d,
+        c++,
+      c == b.ya.width))
+        return b;
+    var f = a
+      , g = d
+      , h = f.yd[e];
+    f.yd[e] = f.yd[g];
+    f.yd[g] = h;
+    e = b.yd[d][c];
+    for (f = c; f < b.ya.width; f++)
+      b.yd[d][f] /= e;
+    for (e = 0; e < b.ya.height; e++)
+      if (e != d)
+        for (g = b.yd[e][c],
+               f = c; f < b.ya.width; f++)
+          b.yd[e][f] -= g * b.yd[d][f];
+    c++
+  }
+  return b
+}
+gvjs_.Tb = function() {
+  return this.ya
+}
+;
+function gvjs_GF(a, b, c) {
+  return 0 <= b && b < a.ya.height && 0 <= c && c < a.ya.width ? a.yd[b][c] : null
+}
+gvjs_.multiply = function(a) {
+  if (a instanceof gvjs_BF) {
+    if (this.ya.width != a.Tb().height)
+      throw Error("Invalid matrices for multiplication. Second matrix should have the same number of rows as the first has columns.");
+    return gvjs_Aea(this, a)
+  }
+  if (typeof a === gvjs_g)
+    return gvjs_Bea(this, a);
+  throw Error("A matrix can only be multiplied by a number or another matrix.");
+}
+;
+gvjs_.aU = function(a) {
+  if (!gvjs_fz(this.ya, a.Tb()))
+    throw Error("Matrix subtraction is only supported on arrays of equal size.");
+  return gvjs_EF(this, function(b, c, d) {
+    return b - a.yd[c][d]
+  })
+}
+;
+gvjs_.um = function() {
+  return this.yd
+}
+;
+function gvjs_HF(a, b, c, d) {
+  var e = new gvjs_BF((c ? c : a.ya.height - 1) - 0 + 1,(d ? d : a.ya.width - 1) - b + 1);
+  gvjs_DF(e, function(f, g, h) {
+    e.yd[g][h] = this.yd[0 + g][b + h]
+  }, a);
+  return e
+}
+function gvjs_Aea(a, b) {
+  var c = new gvjs_BF(a.ya.height,b.Tb().width);
+  gvjs_DF(c, function(d, e, f) {
+    for (var g = d = 0; g < this.ya.width; g++)
+      d += gvjs_GF(this, e, g) * gvjs_GF(b, g, f);
+    if (!(0 <= e && e < c.ya.height && 0 <= f && f < c.ya.width))
+      throw Error("Index out of bounds when setting matrix value, (" + e + "," + f + ") in size (" + c.ya.height + "," + c.ya.width + ")");
+    c.yd[e][f] = d
+  }, a);
+  return c
+}
+function gvjs_Bea(a, b) {
+  return gvjs_EF(a, function(c) {
+    return c * b
+  })
+}
+;function gvjs_IF(a) {
+  this.tO = a.fv + 1;
+  this.Ua = a.range;
+  this.dta = a.Gca;
+  this.ZY = 0;
+  this.hC = a.$X || gvjs_bF();
+  this.h6 = 0;
+  this.ra = []
+}
+gvjs_IF.prototype.add = function(a, b) {
+  if (isFinite(this.hC.transform(a))) {
+    if (0 < this.ra.length) {
+      var c = a - this.ra[this.ra.length - 1].x;
+      0 < c && (this.ZY += c)
+    }
+    this.h6 += b;
+    this.ra.push({
+      x: a,
+      y: b
+    })
+  }
+}
+;
+function gvjs_Cea(a) {
+  var b = a.dta;
+  b || (b = null != a.Ua && null != a.Ua.min && isFinite(a.Ua.min) && null != a.Ua.max && isFinite(a.Ua.max) ? (a.Ua.max - a.Ua.min) / 100 : void 0);
+  null != b && isFinite(b) || (b = a.ZY / (a.ra.length - 1));
+  return b
+}
+function gvjs_Dea(a, b) {
+  return gvjs_Ee(a.ra, function(c, d) {
+    return c + Math.pow(this.hC.inverse(d.x), b)
+  }, 0, a)
+}
+function gvjs_Eea(a, b) {
+  return gvjs_Ee(a.ra, function(c, d) {
+    return c + Math.pow(this.hC.inverse(d.x), b) * d.y
+  }, 0, a)
+}
+function gvjs_Fea(a) {
+  for (var b = [], c = a.tO, d = 0; d < c; d++) {
+    for (var e = Array(c + 1), f = 0; f <= c; f++)
+      e[f] = f < c ? gvjs_Dea(a, d + f) : gvjs_Eea(a, d);
+    b.push(e)
+  }
+  return new gvjs_BF(b)
+}
+function gvjs_Gea(a) {
+  var b = gvjs_FF(gvjs_Fea(a));
+  return gvjs_v(gvjs_Ky(a.tO), function(c) {
+    return gvjs_GF(b, c, this.tO)
+  }, a)
+}
+function gvjs_Hea(a, b) {
+  var c = a.tO;
+  return gvjs_s(function(d) {
+    d = this.hC.inverse(d);
+    for (var e = 0, f = 0; f < c; f++)
+      e += b[f] * Math.pow(d, f);
+    return e
+  }, a)
+}
+function gvjs_Iea(a, b) {
+  b = gvjs_Hea(a, b);
+  var c = gvjs_Cea(a);
+  if (null == c || isNaN(c) || !isFinite(c) || 0 === c)
+    return null;
+  c = new gvjs_fF(c,b,a.hC);
+  var d = a.ra;
+  gvjs_Qe(d, function(q, r) {
+    return q.x > r.x ? 1 : q.x < r.x ? -1 : 0
+  });
+  var e = a.h6 / d.length
+    , f = a.Ua;
+  null != a.Ua && null != a.Ua.min && isFinite(a.Ua.min) && 0 < d.length && f.min < d[0].x && gvjs_gF(c, f.min);
+  for (var g = 0, h = 0, k = !0, l = 0; l < d.length; l++) {
+    var m = d[l].x
+      , n = d[l].y
+      , p = b(m);
+    k = k && p === n;
+    gvjs_gF(c, m);
+    g += Math.pow(n - p, 2);
+    h += Math.pow(n - e, 2)
+  }
+  b = k ? 1 : 1 - g / h;
+  null != a.Ua && null != a.Ua.max && isFinite(a.Ua.max) && 1 < d.length && f.max > d[d.length - 1].x && gvjs_gF(c, f.max);
+  return {
+    data: c.cd(),
+    r2: b
+  }
+}
+function gvjs_Jea(a) {
+  function b(d, e) {
+    for (var f = [], g = c.length - 1; 0 <= g; g--) {
+      var h = c[g];
+      if (null != h && 0 !== h) {
+        h = new gvjs_mF(h);
+        if (0 < g) {
+          var k = new gvjs_AF(d || "x");
+          1 < g && (k = new gvjs_yF([k, new gvjs_mF(g)]));
+          h = new gvjs_wF([h, k],!0)
+        }
+        f.push(h)
+      }
+    }
+    return new gvjs_uF([new gvjs_AF(e || "y"), new gvjs_sF(f)])
+  }
+  var c = gvjs_Gea(a);
+  a = gvjs_Iea(a, c);
+  return null == a || 0 === a.data.length ? null : {
+    $p: c,
+    data: a.data,
+    r2: a.r2,
+    rv: b().qm(),
+    bR: b
+  }
+}
+;function gvjs_JF(a, b, c, d) {
+  var e = new gvjs_IF(d);
+  gvjs_Pz(gvjs_Qz(a), function(f) {
+    var g = b(f);
+    f = c(f);
+    null != g && isFinite(g) && null != f && isFinite(f) && e.add(g, f)
+  });
+  return gvjs_Jea(e)
+}
+;function gvjs_KF(a, b, c, d) {
+  a = gvjs_JF(a, b, c, {
+    range: d.range,
+    Gca: d.Gca,
+    fv: 1,
+    $X: d.$X
+  });
+  return null === a || isNaN(a.r2) ? null : {
+    data: a.data,
+    r2: a.r2,
+    rv: {
+      offset: a.$p[0],
+      slope: a.$p[1]
+    }
+  }
+}
+;var gvjs_LF = {
+  linear: function(a, b, c, d) {
+    function e(g, h) {
+      return new gvjs_uF([new gvjs_AF(h || "y"), new gvjs_sF([new gvjs_wF([new gvjs_mF(f.rv.slope), new gvjs_AF(g || "x")]), new gvjs_mF(f.rv.offset)])])
+    }
+    var f = gvjs_KF(a, b, c, d);
+    return null === f ? null : {
+      data: f.data,
+      r2: f.r2,
+      rv: e().qm(),
+      bR: e
+    }
+  },
+  exponential: function(a, b, c, d) {
+    function e(m, n) {
+      m = new gvjs_wF([new gvjs_mF(Math.exp(l.rv.offset)), new gvjs_yF([new gvjs_AF("e"), new gvjs_wF([new gvjs_mF(l.rv.slope), new gvjs_AF(m || "x")])])],!0);
+      null !== f && (m = new gvjs_sF([m, new gvjs_mF(f)]));
+      return m = new gvjs_uF([new gvjs_AF(n || "y"), m])
+    }
+    for (var f = Infinity, g = 0; g < a; g++) {
+      var h = b(g)
+        , k = c(g);
+      null != k && k < f && (f = k)
+    }
+    f = 0 < f ? null : f - 1;
+    var l = gvjs_KF(a, b, function(m) {
+      m = c(m);
+      if (null == m)
+        return null;
+      null != f && (m -= f);
+      return Math.log(m)
+    }, d);
+    if (null === l)
+      return null;
+    a = [];
+    for (g = 0; g < l.data.length; g++)
+      h = l.data[g][0],
+        k = Math.exp(l.data[g][1]),
+      null != f && (k += f),
+        a.push([h, k]);
+    return {
+      data: a,
+      r2: l.r2,
+      rv: e().qm(),
+      bR: e
+    }
+  }
+};
+gvjs_LF.polynomial = gvjs_JF;
+var gvjs_MF = [{
+  color: "#3366CC",
+  lighter: "#45AFE2"
+}, {
+  color: gvjs_vr,
+  lighter: "#FF3300"
+}, {
+  color: gvjs_wr,
+  lighter: "#FFCC00"
+}, {
+  color: gvjs_lr,
+  lighter: "#14C21D"
+}, {
+  color: "#990099",
+  lighter: "#DF51FD"
+}, {
+  color: "#0099C6",
+  lighter: "#15CBFF"
+}, {
+  color: "#DD4477",
+  lighter: "#FF97D2"
+}, {
+  color: "#66AA00",
+  lighter: "#97FB00"
+}, {
+  color: "#B82E2E",
+  lighter: "#DB6651"
+}, {
+  color: "#316395",
+  lighter: "#518BC6"
+}, {
+  color: gvjs_rr,
+  lighter: "#BD6CBD"
+}, {
+  color: "#22AA99",
+  lighter: "#35D7C2"
+}, {
+  color: "#AAAA11",
+  lighter: "#E9E91F"
+}, {
+  color: "#6633CC",
+  lighter: "#9877DD"
+}, {
+  color: "#E67300",
+  lighter: "#FF8F20"
+}, {
+  color: "#8B0707",
+  lighter: "#D20B0B"
+}, {
+  color: "#651067",
+  lighter: "#B61DBA"
+}, {
+  color: "#329262",
+  lighter: "#40BD7E"
+}, {
+  color: "#5574A6",
+  lighter: "#6AA7C4"
+}, {
+  color: "#3B3EAC",
+  lighter: "#6D70CD"
+}, {
+  color: "#B77322",
+  lighter: "#DA9136"
+}, {
+  color: "#16D620",
+  lighter: "#2DEA36"
+}, {
+  color: "#B91383",
+  lighter: "#E81EA6"
+}, {
+  color: "#F4359E",
+  lighter: "#F558AE"
+}, {
+  color: "#9C5935",
+  lighter: "#C07145"
+}, {
+  color: "#A9C413",
+  lighter: "#D7EE53"
+}, {
+  color: "#2A778D",
+  lighter: "#3EA7C6"
+}, {
+  color: "#668D1C",
+  lighter: "#97D129"
+}, {
+  color: "#BEA413",
+  lighter: "#E9CA1D"
+}, {
+  color: "#0C5922",
+  lighter: "#149638"
+}, {
+  color: "#743411",
+  lighter: "#C5571D"
+}]
+  , gvjs_NF = {
+  color: "#EEEEEE",
+  lighter: "#FEFEFE"
+}
+  , gvjs_Kea = {
+  milliseconds: {
+    format: ["ss.SSS", "SSS"],
+    interval: [1, 2, 5, 10, 20, 50, 100, 200, 500]
+  },
+  seconds: {
+    format: [gvjs_Ja, "ss.SSS"],
+    interval: [1, 2, 5, 10, 15, 30]
+  },
+  minutes: {
+    format: [gvjs_Ia, "mm"],
+    interval: [1, 2, 5, 10, 15, 30]
+  },
+  hours: {
+    format: [gvjs_Ia, "HH"],
+    interval: [1, 2, 3, 4, 6, 12]
+  },
+  days: {
+    format: ["d"],
+    interval: [1, 2, 7]
+  },
+  months: {
+    format: ["MM"],
+    interval: [1, 2, 3, 4, 6]
+  },
+  years: {
+    format: ["y"],
+    interval: [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1E3]
+  }
+}
+  , gvjs_Lea = {
+  milliseconds: {
+    format: [".SSS"],
+    interval: [50, 100, 200, 500]
+  },
+  seconds: {
+    format: [":ss"],
+    interval: [5, 10, 15, 30]
+  },
+  minutes: {
+    format: [":mm"],
+    interval: [5, 10, 15, 30]
+  },
+  hours: {
+    format: ["HH"],
+    interval: [1, 2, 3, 4, 6, 12]
+  },
+  days: {
+    format: ["d"],
+    interval: [1, 2, 7]
+  },
+  months: {
+    format: ["MM"],
+    interval: [1, 2, 3, 4, 6, 12]
+  },
+  years: {
+    format: ["y"],
+    interval: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1E3]
+  }
+}
+  , gvjs_OF = {
+  titleTextStyle: {
+    color: gvjs_mr,
+    italic: !0
+  },
+  viewWindow: {
+    maxPadding: "50%"
+  },
+  minTextSpacing: 10,
+  gridlines: {
+    baseline: gvjs_ub,
+    minorTextOpacity: .7,
+    minorGridlineOpacity: .4,
+    allowMinor: !0,
+    minStrongLineDistance: 40,
+    minWeakLineDistance: 20,
+    minStrongToWeakLineDistance: 0,
+    minNotchDistance: 5,
+    minMajorTextDistance: 20,
+    minMinorTextDistance: 20,
+    unitThreshold: 2.2,
+    units: {
+      milliseconds: {
+        format: [gvjs_Ka],
+        interval: [1, 2, 5, 10, 20, 50, 100, 200, 500]
+      },
+      seconds: {
+        format: [5, 6],
+        interval: [1, 2, 5, 10, 15, 30]
+      },
+      minutes: {
+        format: [7],
+        interval: [1, 2, 5, 10, 15, 30]
+      },
+      hours: {
+        format: [7],
+        interval: [1, 2, 3, 4, 6, 12]
+      },
+      days: {
+        format: [1, 2, 3, gvjs_Vj.MONTH_DAY_YEAR_MEDIUM, gvjs_Vj.MONTH_DAY_FULL, gvjs_Vj.MONTH_DAY_MEDIUM, gvjs_Vj.MONTH_DAY_SHORT, gvjs_Vj.MONTH_DAY_ABBR, gvjs_Vj.DAY_ABBR],
+        interval: [1, 2, 7]
+      },
+      months: {
+        format: [gvjs_Vj.YEAR_MONTH_FULL, gvjs_Vj.YEAR_MONTH_ABBR, "MMM"],
+        interval: [1, 2, 3, 4, 6]
+      },
+      years: {
+        format: [gvjs_Vj.YEAR_FULL],
+        interval: [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1E3]
+      }
+    }
+  },
+  minorGridlines: {
+    count: 1,
+    units: {
+      milliseconds: {
+        format: [".SSS"],
+        interval: [50, 100, 200, 250, 500]
+      },
+      seconds: {
+        format: [":ss"],
+        interval: [5, 10, 15, 30]
+      },
+      minutes: {
+        format: [":mm"],
+        interval: [5, 10, 15, 30]
+      },
+      hours: {
+        format: [7],
+        interval: [1, 2, 3, 4, 6, 12]
+      },
+      days: {
+        format: ["d"],
+        interval: [1, 2, 7]
+      },
+      months: {
+        format: ["MMMMM", "MMM", "MM"],
+        interval: [1, 2, 3, 4, 6, 12]
+      },
+      years: {
+        format: ["y"],
+        interval: [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1E3]
+      }
+    }
+  }
+}
+  , gvjs_PF = {
+  histogram: {
+    bar: {
+      gap: 1,
+      group: {
+        gap: 2
+      }
+    },
+    histogram: {
+      lastBucketPercentile: 0,
+      hideBucketItems: !1,
+      bucketSize: null,
+      numBucketsRule: "rice",
+      minSpacing: 1
+    },
+    domainAxis: {
+      baselineColor: gvjs_f,
+      gridlines: {
+        color: gvjs_f
+      },
+      showTextEvery: 0,
+      maxAlternation: 2
+    },
+    targetAxis: {
+      format: "#",
+      gridlines: {
+        multiple: 1
+      }
+    }
+  }
+}
+  , gvjs_QF = {
+  vAxis: gvjs_OF,
+  hAxis: gvjs_OF,
+  domainAxis: {
+    maxPadding: "5%"
+  },
+  sizeAxis: {
+    minSize: 5,
+    maxSize: 30
+  },
+  fontName: gvjs_2r,
+  titleTextStyle: {
+    color: gvjs_ca,
+    bold: !0
+  },
+  bubble: {
+    textStyle: {
+      color: gvjs_ca
+    }
+  },
+  candlestick: {
+    hollowIsRising: !1
+  },
+  annotations: {
+    datum: {
+      textStyle: {
+        color: gvjs_Nw
+      },
+      stemColor: gvjs_tr
+    },
+    domain: {
+      textStyle: {
+        color: gvjs_mr
+      },
+      stemColor: gvjs_tr
+    }
+  },
+  majorAxisTextColor: gvjs_mr,
+  minorAxisTextColor: gvjs_or,
+  backgroundColor: {
+    fill: gvjs_Br,
+    stroke: gvjs_pr,
+    strokeWidth: 0
+  },
+  chartArea: {
+    backgroundColor: {
+      fill: gvjs_f
+    }
+  },
+  baselineColor: gvjs_nr,
+  gridlineColor: gvjs_zr,
+  pieSliceBorderColor: gvjs_ea,
+  pieResidueSliceColor: gvjs_zr,
+  pieSliceTextStyle: {
+    color: gvjs_ea
+  },
+  areaOpacity: .3,
+  intervals: {
+    style: gvjs_lt,
+    color: gvjs_Ow,
+    lineWidth: 1,
+    fillOpacity: .3,
+    barWidth: .25,
+    shortBarWidth: .1,
+    boxWidth: .25,
+    dataOpacity: 1,
+    pointSize: 6
+  },
+  actionsMenu: {
+    textStyle: {
+      color: gvjs_ca
+    },
+    disabledTextStyle: {
+      color: "#c0c0c0"
+    }
+  },
+  legend: {
+    newLegend: !0,
+    textStyle: {
+      color: gvjs_mr
+    },
+    pagingTextStyle: {
+      color: "#0011cc"
+    },
+    scrollArrows: {
+      activeColor: "#0011cc",
+      inactiveColor: gvjs_zr
+    }
+  },
+  tooltip: {
+    textStyle: {
+      color: gvjs_ca
+    },
+    boxStyle: {
+      stroke: gvjs_zr,
+      strokeOpacity: 1,
+      strokeWidth: 1,
+      fill: gvjs_Ox,
+      fillOpacity: 1,
+      shadow: {
+        radius: 2,
+        opacity: .1,
+        xOffset: 1,
+        yOffset: 1
+      }
+    }
+  },
+  aggregationTarget: gvjs_ub,
+  colorAxis: {
+    legend: {
+      textStyle: {
+        color: gvjs_ca
+      }
+    }
+  }
+};
+function gvjs_RF(a) {
+  var b = gvjs_v(a.lines, function(c) {
+    var d = a.anchor ? a.anchor : {
+      x: 0,
+      y: 0
+    }
+      , e = gvjs_VA(c.x + d.x, c.length, a.ld);
+    c = gvjs_VA(c.y + d.y, a.ja.fontSize, a.Pc);
+    return e.start == e.end || c.start == c.end ? null : new gvjs_B(c.start,e.end,c.end,e.start)
+  });
+  b = gvjs_De(b, function(c) {
+    return null != c
+  });
+  return gvjs_$B(b)
+}
+;/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+*/
+var gvjs_SF = {
+  100: "#c6dafc",
+  500: "#5e97f6",
+  800: "#2a56c6"
+}
+  , gvjs_TF = {
+  100: "#f4c7c3",
+  500: "#db4437",
+  900: "#a52714"
+}
+  , gvjs_UF = {
+  100: "#fce8b2",
+  600: "#f2a600",
+  700: "#f09300",
+  800: "#ee8100"
+}
+  , gvjs_VF = {
+  100: "#b7e1cd",
+  500: "#0f9d58",
+  700: "#0b8043"
+}
+  , gvjs_WF = {
+  100: "#e1bee7",
+  400: "#ab47bc",
+  800: "#6a1b9a"
+}
+  , gvjs_XF = {
+  100: "#b2ebf2",
+  600: "#00acc1",
+  800: "#00838f"
+}
+  , gvjs_YF = {
+  100: "#ffccbc",
+  400: "#ff7043",
+  700: "#e64a19"
+}
+  , gvjs_ZF = {
+  100: "#f0f4c3",
+  800: "#9e9d24",
+  900: "#827717"
+}
+  , gvjs__F = {
+  100: "#c5cae9",
+  400: "#5c6bc0",
+  600: "#3949ab"
+}
+  , gvjs_0F = {
+  100: "#f8bbd0",
+  200: "#f48fb1",
+  300: "#f06292",
+  500: "#e91e63",
+  700: "#c2185b",
+  900: "#880e4f"
+}
+  , gvjs_1F = {
+  100: "#b2dfdb",
+  700: "#00796b",
+  900: "#004d40"
+};
+var gvjs_2F = {}
+  , gvjs_3F = !1;
+function gvjs_4F(a) {
+  if (!gvjs_3F) {
+    var b = {
+      colors: [{
+        color: "#dea19b",
+        dark: "#ad7d79",
+        light: "#ffd1c9"
+      }, {
+        color: "#cdc785",
+        dark: "#aea971",
+        light: "#eeeeac"
+      }, {
+        color: "#d6b9db",
+        dark: "#a992ad",
+        light: "#fff0db"
+      }, {
+        color: "#a2c488",
+        dark: "#7f9a6b",
+        light: "#d2feb0"
+      }, {
+        color: "#ffbc46",
+        dark: "#ce9839",
+        light: "#eeee5b"
+      }, {
+        color: "#9bbdde",
+        dark: "#7993ad",
+        light: "#c991ff"
+      }],
+      backgroundColor: {
+        gradient: {
+          color1: "#8080ff",
+          color2: "#000020",
+          x1: gvjs_Ro,
+          y1: gvjs_Ro,
+          x2: gvjs_So,
+          y2: gvjs_So
+        }
+      },
+      titleTextStyle: {
+        color: gvjs_Ox
+      },
+      hAxis: {
+        textStyle: {
+          color: gvjs_Ox
+        },
+        titleTextStyle: {
+          color: gvjs_Ox
+        }
+      },
+      vAxis: {
+        textStyle: {
+          color: gvjs_Ox
+        },
+        titleTextStyle: {
+          color: gvjs_Ox
+        }
+      },
+      legend: {
+        textStyle: {
+          color: gvjs_Ox
+        }
+      },
+      chartArea: {
+        backgroundColor: {
+          stroke: gvjs_Ar,
+          fill: gvjs_f
+        }
+      },
+      areaOpacity: .8
+    };
+    gvjs_2F.classic = b;
+    b = {
+      titlePosition: gvjs_Fp,
+      axisTitlesPosition: gvjs_Fp,
+      legend: {
+        position: gvjs_Fp
+      },
+      chartArea: {
+        width: gvjs_So,
+        height: gvjs_So
+      },
+      vAxis: {
+        textPosition: gvjs_Fp
+      },
+      hAxis: {
+        textPosition: gvjs_Fp
+      }
+    };
+    gvjs_2F.maximized = b;
+    b = {
+      enableInteractivity: !1,
+      legend: {
+        position: gvjs_f
+      },
+      seriesType: gvjs_at,
+      lineWidth: 1.6,
+      chartArea: {
+        width: gvjs_So,
+        height: gvjs_So
+      },
+      vAxis: {
+        textPosition: gvjs_f,
+        gridlines: {
+          color: gvjs_f
+        },
+        baselineColor: gvjs_f
+      },
+      hAxis: {
+        textPosition: gvjs_f,
+        gridlines: {
+          color: gvjs_f
+        },
+        baselineColor: gvjs_f
+      }
+    };
+    gvjs_2F.sparkline = b;
+    b = {
+      bar: {
+        groupWidth: "65%"
+      },
+      textStyle: {
+        color: gvjs_qr,
+        fontName: gvjs_qs
+      },
+      annotations: {
+        textStyle: {
+          color: gvjs_qr,
+          fontName: gvjs_qs
+        }
+      },
+      bubble: {
+        highContrast: !0,
+        textStyle: {
+          auraColor: gvjs_f,
+          color: "#636363",
+          fontName: gvjs_qs
+        }
+      },
+      tooltip: {
+        textStyle: {
+          color: gvjs_qr,
+          fontName: gvjs_qs
+        },
+        boxStyle: {
+          stroke: "#b2b2b2",
+          strokeOpacity: 1,
+          strokeWidth: 1.5,
+          fill: gvjs_Ox,
+          fillOpacity: 1,
+          shadow: {
+            radius: 1,
+            opacity: .2,
+            xOffset: 0,
+            yOffset: 2
+          }
+        }
+      },
+      vAxis: {
+        textStyle: {
+          color: gvjs_qr,
+          fontName: gvjs_qs,
+          fontSize: 12
+        },
+        gridlines: {
+          color: gvjs_Ar
+        },
+        baselineColor: "#9e9e9e"
+      },
+      legend: {
+        newLegend: !0,
+        pagingTextStyle: {
+          fontName: gvjs_qs
+        },
+        textStyle: {
+          auraColor: gvjs_f,
+          color: gvjs_qr,
+          fontName: gvjs_qs,
+          fontSize: 12
+        }
+      },
+      hAxis: {
+        textStyle: {
+          color: gvjs_qr,
+          fontName: gvjs_qs,
+          fontSize: 12
+        },
+        gridlines: {
+          color: gvjs_Ar
+        },
+        baselineColor: "#9e9e9e"
+      },
+      pieSliceTextStyle: {
+        color: gvjs_ea,
+        fontName: gvjs_qs,
+        fontSize: 14
+      },
+      pieResidueSliceColor: gvjs_qr,
+      titleTextStyle: {
+        color: gvjs_qr,
+        fontName: gvjs_qs,
+        fontSize: 16,
+        bold: gvjs_Sb
+      },
+      scatter: {
+        dataOpacity: .6
+      },
+      colorAxis: {
+        colors: [],
+        "one-sided-colors": [gvjs_ea, gvjs_SF[gvjs_Sr]],
+        "two-sided-colors": [gvjs_SF[gvjs_Sr], gvjs_ea, gvjs_UF[gvjs_Tr]],
+        legend: {
+          textStyle: {
+            color: gvjs_qr,
+            fontName: gvjs_qs,
+            fontSize: 12
+          }
+        }
+      },
+      colors: [{
+        color: gvjs_SF[gvjs_Sr],
+        dark: gvjs_SF[gvjs_Vr],
+        light: gvjs_SF[gvjs_Or]
+      }, {
+        color: gvjs_TF[gvjs_Sr],
+        dark: gvjs_TF[gvjs_Wr],
+        light: gvjs_TF[gvjs_Or]
+      }, {
+        color: gvjs_UF[gvjs_Tr],
+        dark: gvjs_UF[gvjs_Vr],
+        light: gvjs_UF[gvjs_Or]
+      }, {
+        color: gvjs_VF[gvjs_Sr],
+        dark: gvjs_VF[gvjs_Ur],
+        light: gvjs_VF[gvjs_Or]
+      }, {
+        color: gvjs_WF[gvjs_Rr],
+        dark: gvjs_WF[gvjs_Vr],
+        light: gvjs_WF[gvjs_Or]
+      }, {
+        color: gvjs_XF[gvjs_Tr],
+        dark: gvjs_XF[gvjs_Vr],
+        light: gvjs_XF[gvjs_Or]
+      }, {
+        color: gvjs_YF[gvjs_Rr],
+        dark: gvjs_YF[gvjs_Ur],
+        light: gvjs_YF[gvjs_Or]
+      }, {
+        color: gvjs_ZF[gvjs_Vr],
+        dark: gvjs_ZF[gvjs_Wr],
+        light: gvjs_ZF[gvjs_Or]
+      }, {
+        color: gvjs__F[gvjs_Rr],
+        dark: gvjs__F[gvjs_Tr],
+        light: gvjs__F[gvjs_Or]
+      }, {
+        color: gvjs_0F["300"],
+        dark: gvjs_0F[gvjs_Sr],
+        light: gvjs_0F[gvjs_Or]
+      }, {
+        color: gvjs_1F[gvjs_Ur],
+        dark: gvjs_1F[gvjs_Wr],
+        light: gvjs_1F[gvjs_Or]
+      }, {
+        color: gvjs_0F[gvjs_Ur],
+        dark: gvjs_0F[gvjs_Wr],
+        light: gvjs_0F["200"]
+      }]
+    };
+    gvjs_2F.material = b;
+    gvjs_3F = !0
+  }
+  return gvjs_2F[a]
+}
+function gvjs_5F(a) {
+  var b = {};
+  b.color = a.color || a;
+  var c = gvjs_yj(b.color);
+  c == gvjs_f ? (b.qb = a.darker || c,
+    b.jh = a.lighter || c) : (c = gvjs_vj(c),
+    b.qb = a.darker || gvjs_uj(gvjs_1z(c, .25)),
+    b.jh = a.lighter || gvjs_uj(gvjs_2z(c, .25)));
+  return b
+}
+;var gvjs_Mea = {
+  NONE: gvjs_f,
+  rza: gvjs_c,
+  hBa: gvjs_zd,
+  PERCENT: gvjs_ud
+};
+function gvjs_6F() {}
+function gvjs_7F(a, b, c) {
+  b = a.C[b];
+  return b.ag && void 0 !== b.Sda ? (a = a.C[b.Sda].points[c],
+    a = null != a ? a.Kf.d : a,
+    null != a ? gvjs_Iy(b.points, a, function(d, e) {
+      return d - e.Kf.d
+    }) : c) : c
+}
+gvjs_ = gvjs_6F.prototype;
+gvjs_.iP = function(a) {
+  var b = a.Hb;
+  a = a.Eb;
+  var c = gvjs_7F(this, b, a);
+  return this.C[b].points[c].wd.Mx || (this.$a[c] ? this.$a[a].$w[0] : null)
+}
+;
+function gvjs_8F(a, b) {
+  var c = b.Hb;
+  b = gvjs_7F(a, c, b.Eb);
+  a = a.C[c].points[b].wd.En || a.C[c].title;
+  return null == a ? null : a
+}
+gvjs_.dZ = function(a) {
+  return a.Eb
+}
+;
+gvjs_.eZ = function(a) {
+  return {
+    row: a.Eb,
+    column: this.C[a.Hb].Cs
+  }
+}
+;
+gvjs_.lP = function(a) {
+  var b = this.Jk[a.column].Vb;
+  return null == b ? null : {
+    Hb: b,
+    Eb: this.Ds[a.row]
+  }
+}
+;
+gvjs_.xI = function(a, b) {
+  return this.C[a].points[b].wd
+}
+;
+/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+
+*/
+function gvjs_9F(a) {
+  this.Gd = gvjs_Te({}, a);
+  this.fX = gvjs_Te({}, a)
+}
+function gvjs_$F(a, b, c) {
+  var d = a.Gd.length;
+  for (a.Gd[b] = c; b < d; ++b)
+    a.fX[b] = gvjs_aG(a, 0 === b ? {} : a.fX[b - 1], a.Gd[b])
+}
+gvjs_9F.prototype.$v = function(a) {
+  var b = gvjs_me(a);
+  return b !== gvjs_h && b !== gvjs_sb || b === gvjs_h && typeof a.clone === gvjs_d || gvjs_oe(a)
+}
+;
+function gvjs_aG(a, b, c) {
+  if (a.$v(c) || a.$v(b) || Array.isArray(c))
+    return c;
+  if (gvjs_me(b) === gvjs_h) {
+    var d = gvjs_x(b);
+    gvjs_w(c, function(f, g) {
+      d[g] = gvjs_Ze(b, g) && null != b[g] ? gvjs_aG(this, b[g], f) : f
+    }, a);
+    return d
+  }
+  var e = gvjs_Le(b);
+  gvjs_w(c, function(f, g) {
+    e[g] = gvjs_aG(this, b[g], f)
+  }, a);
+  return e
+}
+gvjs_9F.prototype.compact = function() {
+  return gvjs_Ae(this.fX)
+}
+;
+function gvjs_bG(a) {
+  this.focused = {
+    Hb: null,
+    datum: null,
+    Eb: null
+  };
+  this.annotations = {
+    focused: null,
+    dI: null
+  };
+  this.legend = {
+    focused: {
+      Xc: null
+    },
+    Xi: null,
+    xF: null
+  };
+  this.gi = {
+    focused: {
+      wy: null
+    }
+  };
+  this.cursor = {
+    position: null,
+    p2: null
+  };
+  this.Ii = this.gm = null;
+  this.selected = new gvjs_$n;
+  a && (this.selected.setSelection(a.selected),
+  a.focused && (this.focused = gvjs_cG(this.focused, a.focused)),
+  a.annotations && (this.annotations = gvjs_cG(this.annotations, a.annotations)),
+  a.legend && (this.legend = gvjs_cG(this.legend, a.legend)),
+  a.gi && (this.gi = gvjs_cG(this.gi, a.gi)),
+  a.gm && (this.gm = gvjs_cG(this.gm, a.gm)),
+  a.Ii && gvjs_cG(this.Ii, a.Ii))
+}
+gvjs_bG.prototype.clone = function() {
+  var a = new gvjs_bG;
+  a.selected = this.selected.clone();
+  a.focused = gvjs_jj(this.focused);
+  a.annotations = gvjs_jj(this.annotations);
+  a.legend = gvjs_jj(this.legend);
+  a.gi = gvjs_jj(this.gi);
+  a.cursor = gvjs_jj(this.cursor);
+  a.gm = gvjs_jj(this.gm);
+  a.Ii = gvjs_jj(this.Ii);
+  return a
+}
+;
+gvjs_bG.prototype.equals = function(a, b) {
+  b = void 0 === b ? !1 : b;
+  return this.selected.equals(a.selected) && gvjs_Uz(this.focused, a.focused) && gvjs_Uz(this.annotations, a.annotations) && gvjs_Uz(this.legend, a.legend) && gvjs_Uz(this.gi, a.gi) && (b || gvjs_Uz(this.cursor, a.cursor)) && gvjs_Uz(this.gm, a.gm) && gvjs_Uz(this.Ii, a.Ii)
+}
+;
+function gvjs_cG(a, b) {
+  var c = new gvjs_9F(2);
+  gvjs_$F(c, 0, a);
+  gvjs_$F(c, 1, b);
+  return c.compact()
+}
+;function gvjs_Nea(a) {
+  if (0 == a.entries.length)
+    return gvjs_5f(gvjs_Ob, {
+      "class": gvjs_Nu
+    });
+  var b = a.entries.findIndex(function(d) {
+    return d.type == gvjs_Lw
+  })
+    , c = [];
+  -1 == b ? c.push(gvjs_dG(a.entries)) : (c.push(gvjs_dG(a.entries.slice(0, b))),
+    c.push(gvjs_5f(gvjs_Ob, {
+      "class": "google-visualization-tooltip-separator"
+    })),
+    c.push(gvjs_Oea(a.entries.slice(b + 1))));
+  return gvjs_5f(gvjs_Ob, {
+    "class": gvjs_Nu
+  }, gvjs_$f(c))
+}
+function gvjs_dG(a) {
+  a = a.map(function(b) {
+    return gvjs_5f("li", {
+      "class": "google-visualization-tooltip-item"
+    }, gvjs_$f(gvjs_eG(b.data)))
+  });
+  return gvjs_5f("ul", {
+    "class": "google-visualization-tooltip-item-list"
+  }, gvjs_$f(a))
+}
+function gvjs_Oea(a) {
+  a = a.map(function(b) {
+    return gvjs_5f("li", {
+      "data-logicalname": gvjs_4E([gvjs_Ss, b.data.id]),
+      "class": "google-visualization-tooltip-action"
+    }, gvjs_$f(gvjs_eG(b.data)))
+  });
+  return gvjs_5f("ul", {
+    "class": "google-visualization-tooltip-action-list"
+  }, gvjs_$f(a))
+}
+function gvjs_eG(a) {
+  return a.items.map(function(b, c) {
+    switch (b.type) {
+      case gvjs_m:
+        var d = b.html ? gvjs_OA(b.data.text) : gvjs_2f(b.data.text);
+        b = b.data.style;
+        var e = {
+          "font-family": b.bb,
+          "font-size": b.fontSize + gvjs_T,
+          color: b.color,
+          opacity: b.opacity,
+          margin: gvjs_9e("0"),
+          "font-style": b.Nc ? gvjs_9e(gvjs_Gp) : gvjs_9e(gvjs_f),
+          "text-decoration": b.Ue ? gvjs_9e(gvjs_bq) : gvjs_9e(gvjs_f),
+          "font-weight": b.bold ? gvjs_9e(gvjs_st) : gvjs_9e(gvjs_f)
+        };
+        b.Nc && (e["padding-right"] = gvjs_9e("0.04em"));
+        b = gvjs_Hf(e);
+        return gvjs_5f(gvjs_0w, {
+          style: b
+        }, gvjs_$f(0 == c ? "" : " ", d));
+      case gvjs_1w:
+        return gvjs_5f(gvjs_Ob, {
+          "class": "google-visualization-tooltip-square",
+          style: {
+            "background-color": b.data.brush && b.data.brush.fill
+          }
+        })
+    }
+  })
+}
+;function gvjs_fG(a, b, c, d, e) {
+  var f = b.left + d;
+  b = b.right - d;
+  if (!(a.box.left >= f && a.box.right <= b)) {
+    d = gvjs_0e(a);
+    var g = d.box.left;
+    d.box.left = gvjs_4y(c.x, d.box.right, -1);
+    d.box.right = gvjs_4y(c.x, g, -1);
+    if (g = d.hj) {
+      var h = g[0];
+      g[0] = g[2];
+      g[2] = h;
+      g[0].x = gvjs_4y(c.x, g[0].x, -1);
+      g[1].x = gvjs_4y(c.x, g[1].x, -1);
+      g[2].x = gvjs_4y(c.x, g[2].x, -1)
+    }
+    d.box.left >= f && d.box.right <= b ? (a.box = d.box,
+      a.hj = d.hj) : (a.hj && (c = new gvjs_O(f + e,b - e),
+      e = new gvjs_O(d.hj[0].x,d.hj[2].x),
+      g = new gvjs_O(a.hj[0].x,a.hj[2].x),
+    !(c.start <= g.start && c.end >= g.end) && c.start <= e.start && c.end >= e.end && (a.box = d.box,
+      a.hj = d.hj)),
+    a.box.right > b && (a.box.left -= a.box.right - b,
+      a.box.right = b),
+    a.box.left < f && (a.box.right += f - a.box.left,
+      a.box.left = f))
+  }
+}
+function gvjs_gG(a, b, c, d) {
+  var e = b.top + d;
+  b = b.bottom - d;
+  if (!(a.box.top >= e && a.box.bottom <= b)) {
+    d = gvjs_0e(a);
+    var f = d.box.top;
+    d.box.top = gvjs_4y(c.y, d.box.bottom, -1);
+    d.box.bottom = gvjs_4y(c.y, f, -1);
+    if (f = d.hj) {
+      var g = f[0];
+      f[0] = f[2];
+      f[2] = g;
+      f[0].y = gvjs_4y(c.y, f[0].y, -1);
+      f[1].y = gvjs_4y(c.y, f[1].y, -1);
+      f[2].y = gvjs_4y(c.y, f[2].y, -1)
+    }
+    d.box.top >= e && d.box.bottom <= b ? (a.box = d.box,
+      a.hj = d.hj) : (a.box.bottom > b && (a.box.top -= a.box.bottom - b,
+      a.box.bottom = b),
+    a.box.top < e && (a.box.bottom += e - a.box.top,
+      a.box.top = e),
+      delete a.hj)
+  }
+}
+;function gvjs_hG(a, b, c, d, e, f, g, h, k) {
+  var l = {
+    items: []
+  };
+  null != e && (e = gvjs_8z(e, f),
+    l.items.push({
+      type: gvjs_1w,
+      data: {
+        size: b.fontSize / 2,
+        brush: e
+      }
+    }));
+  null != g && l.items.push(gvjs_iG(g, b));
+  if (null != c && "" !== c) {
+    if (null == d)
+      throw Error("Line title is specified without a text style.");
+    l.items.push(gvjs_iG(c + ":", d))
+  }
+  l.items.push(gvjs_iG(a, b, h));
+  null != k && (l.id = k,
+    l.background = {
+      brush: new gvjs_3(gvjs_iy)
+    });
+  return {
+    type: gvjs_e,
+    data: l
+  }
+}
+function gvjs_jG() {
+  return {
+    type: gvjs_Lw,
+    data: {
+      brush: gvjs_9z("#eee", 1)
+    }
+  }
+}
+function gvjs_iG(a, b, c) {
+  a = {
+    type: gvjs_m,
+    data: {
+      text: a || "",
+      style: b
+    }
+  };
+  c && (a.html = !0);
+  return a
+}
+function gvjs_kG(a, b, c, d, e, f, g, h, k, l) {
+  if (h)
+    return {
+      html: gvjs_Nea(a),
+      hO: !1,
+      pivot: f,
+      anchor: d,
+      HG: e,
+      spacing: 20,
+      margin: 5
+    };
+  for (var m = h = 0; m < a.entries.length; m++) {
+    var n = a.entries[m];
+    if (n.type == gvjs_e) {
+      n = n.data;
+      for (var p = 0; p < n.items.length; p++) {
+        var q = n.items[p];
+        q.type == gvjs_m && (h = Math.max(h, q.data.style.fontSize))
+      }
+    }
+  }
+  g = 0 == h ? g || 0 : h;
+  for (n = m = h = 0; n < a.entries.length; n++)
+    switch (p = a.entries[n],
+      p.type) {
+      case gvjs_e:
+        p = gvjs_lG(p.data, b);
+        m += p.height + (0 < n ? p.bx : 0);
+        h = Math.max(h, p.width);
+        break;
+      case gvjs_Lw:
+        m += 1.5 * g + p.data.brush.strokeWidth
+    }
+  h = Math.max(h, 2 * g);
+  var r = new gvjs_A(Math.round(h + 2 * g / 1.618),Math.round(m + 2 * g / 1.618));
+  m = gvjs_$y(d.x - f.x);
+  n = gvjs_$y(d.y - f.y);
+  var t = c ? new gvjs_z(d.x + m * g,d.y + n * (g + r.height / 2)) : new gvjs_z(d.x + m * r.width / 2,d.y + n * r.height / 2);
+  p = t.x - r.width / 2;
+  q = p + r.width;
+  var u = t.y - r.height / 2
+    , v = u + r.height;
+  h = {};
+  c && (c = new gvjs_z(t.x,gvjs_4y(d.y, t.y, g / (g + r.height / 2))),
+    t = new gvjs_z(gvjs_4y(t.x, d.x, -1),c.y),
+    c.x = Math.round(c.x),
+    c.y = Math.round(c.y),
+    t.x = Math.round(t.x),
+    t.y = Math.round(t.y),
+    h.hj = 1 == m * n ? [c, d, t] : [t, d, c]);
+  h.box = new gvjs_B(Math.round(u),Math.round(q),Math.round(v),Math.round(p));
+  gvjs_fG(h, e, f, 5, 4);
+  gvjs_gG(h, e, f, 5);
+  d = {};
+  e = g / 1.618;
+  e = new gvjs_B(h.box.top + e,h.box.right - e,h.box.bottom - e,h.box.left + e);
+  f = [];
+  v = e.top;
+  c = a.entries.length;
+  r = !1;
+  for (m = 0; m < c; m++)
+    if (a.entries[m].gG) {
+      r = !0;
+      break
+    }
+  t = [];
+  n = [];
+  for (m = 0; m < c; m++)
+    if (p = a.entries[m],
+    p.type === gvjs_e) {
+      q = p.data;
+      u = [];
+      n.push(u);
+      for (var w = 0, x = q.items.length; w < x; w++) {
+        var y = gvjs_mG(q.items[w], b);
+        u.push(y);
+        p.gG && (w > t.length - 1 ? t.push(y.width) : t[w] = Math.max(t[w], y.width))
+      }
+    }
+  p = [];
+  q = [];
+  u = 0;
+  if (r)
+    for (m = 0; m < c; m++)
+      if (y = a.entries[m],
+      y.type == gvjs_e) {
+        r = [];
+        q.push(r);
+        w = 0;
+        if (y.gG)
+          for (x = 0,
+                 y = y.data.items.length; x < y; x++) {
+            var z = t[x] - n[u][x].width;
+            r.push(z);
+            w += z
+          }
+        p.push(w);
+        u++
+      }
+  for (m = u = 0; m < c; m++) {
+    r = a.entries[m];
+    t = {
+      Xc: r,
+      data: {}
+    };
+    switch (r.type) {
+      case gvjs_e:
+        var A = r.data;
+        w = t.data;
+        x = gvjs_lG(A, b);
+        r.gG && (x.width += p[u]);
+        0 < m && (v += x.bx);
+        A.background && (w.background = {
+          box: new gvjs_B(v - x.bx / 2,h.box.right,v + x.height + x.bx,h.box.left)
+        });
+        y = [];
+        z = e.left;
+        var B = 0;
+        for (A = A.items.length; B < A; B++) {
+          var D = {}
+            , C = n[u][B];
+          r.gG && (C.width += q[u][B]);
+          0 < B && (z += C.RQ);
+          var G = v + (x.height - C.height) / 2;
+          D.box = new gvjs_B(Math.round(G),Math.round(z + C.width),Math.round(G + C.height),Math.round(z));
+          k && (G = e.right - (D.box.left - e.left) - D.box.left - C.width,
+            D.box.left += G,
+            D.box.right += G);
+          y.push(D);
+          z += C.width
+        }
+        w.items = y;
+        v += x.height;
+        u++;
+        break;
+      case gvjs_Lw:
+        r = r.data,
+          w = v + g + r.brush.strokeWidth / 2,
+          t.data.line = new gvjs_bA(h.box.left,w,h.box.right,w),
+          v += 1.5 * g + r.brush.strokeWidth / 2
+    }
+    f.push(t)
+  }
+  d.entries = f;
+  d.Xea = !!k;
+  l = l || new gvjs_3({
+    fill: gvjs_Ox,
+    stroke: gvjs_yr,
+    strokeWidth: 1
+  });
+  return {
+    vl: l,
+    outline: h,
+    EG: d
+  }
+}
+function gvjs_lG(a, b) {
+  for (var c = 0, d = 0, e = 0, f = 0; f < a.items.length; f++) {
+    var g = gvjs_mG(a.items[f], b);
+    c += g.width + (0 < f ? g.RQ : 0);
+    d = Math.max(d, g.height);
+    e = Math.max(e, g.height / 2 + g.bx)
+  }
+  return {
+    width: c,
+    height: d,
+    bx: e - d / 2
+  }
+}
+function gvjs_mG(a, b) {
+  switch (a.type) {
+    case gvjs_m:
+      var c = a.data.style;
+      return {
+        width: b ? b(String(a.data.text), c).width : 0,
+        height: c.fontSize,
+        bx: c.fontSize / 3.236,
+        RQ: c.fontSize / 3.236
+      };
+    case gvjs_1w:
+      return a = a.data.size,
+        {
+          width: a,
+          height: a,
+          bx: a,
+          RQ: a
+        };
+    default:
+      return a = a.data.size,
+        {
+          width: a,
+          height: a,
+          bx: a,
+          RQ: a
+        }
+  }
+}
+;function gvjs_nG(a, b) {
+  this.qv = {};
+  this.yu = {};
+  this.qB = [];
+  this.updateOptions(a, b)
+}
+function gvjs_Pea(a) {
+  gvjs_u(a.qB, function(b) {
+    gvjs_oG(this, this.yu[b])
+  }, a)
+}
+gvjs_ = gvjs_nG.prototype;
+gvjs_.updateOptions = function(a, b) {
+  this.Za = gvjs_ry(a, "actionsMenu.textStyle", b);
+  this.Uma = gvjs_ry(a, "actionsMenu.disabledTextStyle", b);
+  gvjs_Pea(this)
+}
+;
+gvjs_.getEntries = function() {
+  for (var a = [], b = 0, c = this.qB.length; b < c; b++) {
+    var d = this.qB[b]
+      , e = this.yu[d];
+    if (!e.visible || e.visible())
+      d = e.enabled && !e.enabled() ? gvjs_hG(e.text || "", this.Uma, null, null, null, null, null, !1, null) : gvjs_0e(this.qv[d]),
+        a.push(d)
+  }
+  return a
+}
+;
+function gvjs_oG(a, b) {
+  if (!b.id)
+    throw Error("Missing mandatory ID for action.");
+  if (a.yu[b.id])
+    var c = a.yu[b.id];
+  else
+    c = a.yu[b.id] = {
+      id: b.id,
+      text: void 0,
+      visible: void 0,
+      enabled: void 0,
+      action: void 0
+    },
+      a.qB.push(b.id);
+  gvjs_2e(c, b);
+  a.qv[b.id] = gvjs_hG(c.text || "", a.Za, null, null, null, null, null, !1, c.id)
+}
+gvjs_.ng = function(a) {
+  (a = this.yu[a]) && (a = gvjs_0e(a));
+  return a
+}
+;
+gvjs_.removeEntry = function(a) {
+  a in this.qv && delete this.qv[a];
+  a in this.yu && delete this.yu[a];
+  a = gvjs_Be(this.qB, a);
+  0 <= a && this.qB.splice(a, 1)
+}
+;
+function gvjs_Qea(a, b) {
+  a.EG = a.EG || {};
+  a = a.EG;
+  a.entries = a.entries || {};
+  a = a.entries;
+  a[b] = a[b] || {};
+  b = a[b];
+  b.Xc = b.Xc || {};
+  return b.Xc
+}
+gvjs_.Us = function(a, b, c) {
+  if (!a.html) {
+    var d = b.focused.wy;
+    null != d && (a = gvjs_Xx(a.EG.entries, function(e) {
+      return e.Xc.data.id == d
+    }),
+    -1 !== a && (c = gvjs_Qea(c, a),
+      c.data = c.data || {},
+      c.data.background = c.data.background || {},
+      c.data.background.brush = gvjs_8z("#DDD")))
+  }
+}
+;
+function gvjs_pG(a, b, c, d) {
+  var e = gvjs_ry(a, gvjs_px, {
+    bb: b.bb,
+    fontSize: b.fontSize
+  });
+  this.fu = gvjs_K(a, gvjs_ox, c.has(gvjs_Ht));
+  this.bxa = gvjs_K(a, gvjs_ox, !0);
+  this.cxa = gvjs_K(a, "tooltip.showEmpty", !0);
+  this.Za = e;
+  this.FG = gvjs_ry(a, gvjs_px, {
+    bb: b.bb,
+    fontSize: b.fontSize,
+    bold: !0
+  });
+  this.le = d || null;
+  this.r9 = gvjs_J(a, "diff.newData.tooltip.prefix", "Current: ");
+  this.s9 = gvjs_J(a, "diff.oldData.tooltip.prefix", "Previous: ")
+}
+gvjs_pG.prototype.ov = function() {}
+;
+function gvjs_qG(a) {
+  this.Ea = a
+}
+gvjs_qG.prototype.aggregate = function(a) {
+  var b = this
+    , c = {
+    index: {},
+    order: [],
+    $w: {}
+  };
+  gvjs_u(a, function(d) {
+    var e = b.getKey(d);
+    if (null != e) {
+      typeof e !== gvjs_l && (e = e.toString());
+      if (!c.$w.hasOwnProperty(e)) {
+        var f = b.getTitle(d);
+        f && (c.$w[e] = f)
+      }
+      c.index.hasOwnProperty(e) || (c.index[e] = [],
+        c.order.push(e));
+      c.index[e].push(d)
+    }
+  });
+  return c
+}
+;
+function gvjs_rG() {
+  this.Ik = this.nf = null
+}
+gvjs_ = gvjs_rG.prototype;
+gvjs_.adoptText = function(a) {
+  this.nf = a
+}
+;
+gvjs_.first = function() {
+  return this.Ik = 0
+}
+;
+gvjs_.current = function() {
+  return this.Ik || 0
+}
+;
+gvjs_.next = function(a) {
+  a = this.peek(a);
+  return null == a ? a : this.Ik = a
+}
+;
+function gvjs_sG(a, b) {
+  b.lastIndex = a.Ik;
+  b = b.exec(a.nf);
+  return !b || 0 > b.index ? a.nf.length : b.index + b[0].length
+}
+gvjs_.peek = function(a) {
+  if (0 === a)
+    a = gvjs_sG(this, /(\r\n|\n|\r)/g);
+  else if (1 === a)
+    a = gvjs_sG(this, /([`~!@#$%^&*()_+\-=\[\]\\{}|;':",\.\/<>?]|[ \t\u2009\u200b]+)/g);
+  else if (2 === a)
+    a = gvjs_sG(this, /[\u00ad]/g);
+  else if (3 === a)
+    a: {
+      a = this.Ik + 1;
+      for (var b = this.nf.length; a < b; a++)
+        if (gvjs_Uda(this.nf.charCodeAt(a - 1), this.nf.charCodeAt(a)))
+          break a;
+      a = this.nf.length
+    }
+  else
+    a = this.nf.length;
+  return a
+}
+;
+function gvjs_tG() {
+  this.At = {}
+}
+gvjs_tG.prototype.add = function(a, b, c, d) {
+  null == b ? this.At[a] = d ? {
+    Rx: d,
+    levels: c
+  } : c : (a in this.At || (this.At[a] = {}),
+    this.At[a][b] = d ? {
+      Rx: d,
+      levels: c
+    } : c)
+}
+;
+function gvjs_uG(a, b) {
+  if (null == b)
+    return Object.keys(a.At);
+  var c = [], d;
+  for (d in a.At) {
+    var e = a.At[d];
+    if (typeof e === gvjs_g)
+      e === b && c.push(d);
+    else if (e.Rx)
+      0 <= e.levels.indexOf(b) && c.push(d);
+    else
+      for (var f in e) {
+        var g = e[f];
+        if (typeof g === gvjs_g)
+          g === b && c.push(d);
+        else if (g.Rx)
+          0 <= g.levels.indexOf(b) && c.push(d);
+        else
+          throw Error("Unknown type");
+      }
+  }
+  return c
+}
+gvjs_tG.prototype.VG = function(a, b, c) {
+  if (!(a in this.At))
+    throw Error("Error: unknown iterator type " + a);
+  a = this.At[a];
+  if (typeof a === gvjs_g)
+    return a;
+  if (a.Rx)
+    return a.Rx(c);
+  if (b in a) {
+    a = a[b];
+    if (typeof a === gvjs_g)
+      return a;
+    if (a.Rx)
+      return a.Rx(c)
+  }
+  return null
+}
+;
+function gvjs_vG(a) {
+  this.Vsa = a;
+  this.pJ = {};
+  this.IN = new gvjs_tG;
+  this.Lt = {};
+  this.nf = this.Ik = null;
+  this.VG(gvjs_e, gvjs_g, 0);
+  this.VG(gvjs_e, gvjs_f, [1, 2], gvjs_s(function(b) {
+    return "\u00ad" === this.nf[b - 1] ? 2 : 1
+  }, this));
+  this.VG(gvjs_Lt, null, 3)
+}
+gvjs_ = gvjs_vG.prototype;
+gvjs_.adoptText = function(a) {
+  this.nf = a;
+  for (var b in this.pJ)
+    this.pJ[b].adoptText(a)
+}
+;
+function gvjs_wG(a, b) {
+  var c = a.pJ[b];
+  c || (c = a.pJ[b] = new window.Intl.v8BreakIterator(a.Vsa,{
+    type: b
+  }),
+  null != a.nf && c.adoptText(a.nf),
+  null != a.Ik && c.first());
+  return c
+}
+gvjs_.VG = function(a, b, c, d) {
+  this.IN.add(a, b, c, d)
+}
+;
+function gvjs_xG(a, b, c) {
+  c.next();
+  if (c.current() >= a.nf.length)
+    return !0;
+  if (c.current() > a.Ik) {
+    var d = c.breakType();
+    c = c.current();
+    var e = a.IN.VG(b, d, c);
+    if (null == e)
+      throw Error("Break type " + d + " in " + b + " iterator was classified as null.");
+    e in a.Lt || (a.Lt[e] = []);
+    a.Lt[e].push(c)
+  }
+  return !1
+}
+function gvjs_yG(a, b) {
+  for (var c = a.Lt[b]; c && 0 < c.length && c[0] <= a.Ik; )
+    c.shift();
+  c = gvjs_uG(a.IN, b);
+  for (var d = {}, e = !1; !(e || a.Lt[b] && 0 !== a.Lt[b].length); ) {
+    e = !0;
+    for (var f = 0, g = c.length; f < g; f++) {
+      var h = c[f]
+        , k = gvjs_wG(a, h);
+      d[h] || (e = !1,
+      gvjs_xG(a, h, k) && (d[h] = !0))
+    }
+  }
+}
+gvjs_.first = function() {
+  for (var a = gvjs_uG(this.IN, void 0), b = 0, c = a.length; b < c; b++)
+    gvjs_wG(this, a[b]).first();
+  this.Lt = {};
+  return this.Ik = 0
+}
+;
+gvjs_.current = function() {
+  return this.Ik || 0
+}
+;
+gvjs_.next = function(a) {
+  gvjs_yG(this, a);
+  a = this.Lt[a];
+  if (null != a && 0 < a.length) {
+    a = this.Ik = a.shift();
+    for (var b in this.pJ)
+      for (var c = gvjs_wG(this, b); c.current() <= a; )
+        gvjs_xG(this, b, c);
+    return this.Ik
+  }
+  return this.nf.length
+}
+;
+gvjs_.peek = function(a) {
+  gvjs_yG(this, a);
+  a = this.Lt[a];
+  return null != a && 0 < a.length ? a[0] : this.nf.length
+}
+;
+function gvjs_zG(a) {
+  if (a.pz && a.hasOwnProperty("pz"))
+    return a.pz;
+  var b = new a;
+  return a.pz = b
+}
+;function gvjs_Rea() {
+  this.Tya = window.Intl && !!window.Intl.v8BreakIterator
+}
+function gvjs_AG() {
+  var a = ["en"];
+  return gvjs_zG(gvjs_Rea).Tya ? new gvjs_vG(a) : new gvjs_rG
+}
+;function gvjs_Sea(a, b, c, d, e, f) {
+  var g = null;
+  f = f ? 2 : 3;
+  for (var h = 0; h <= f; h++) {
+    var k = c.peek(h);
+    if (null == g || k < g.position)
+      g = {
+        position: k,
+        level: h
+      };
+    if (a(b(d, k)) <= e)
+      return h
+  }
+  return g && g.level || f
+}
+function gvjs_Tea(a) {
+  return function(b, c) {
+    b = gvjs_kf(a.slice(b, c));
+    "\u00ad" === b[b.length - 1] && (b = b.slice(0, b.length - 1) + "-");
+    return b
+  }
+}
+function gvjs_BG(a, b) {
+  b = null == b ? a.length : b;
+  return 0 <= b ? gvjs_kf(a.slice(0, b)) + "\u2026" : gvjs_Kr.slice(0, b)
+}
+function gvjs_Uea(a, b, c, d) {
+  if (a(gvjs_BG(b)) <= c)
+    return gvjs_BG(b);
+  var e = gvjs_AG();
+  e.adoptText(b);
+  e.first();
+  var f = e.next(3)
+    , g = a(b.slice(0, f)) <= c;
+  if (d && !g || !d && a(gvjs_BG(b, f)) > c)
+    for (d = 0; -3 <= d && !(b = gvjs_BG(b, d),
+    a(b) <= c); d--)
+      ;
+  else {
+    for (; a(gvjs_BG(b, e.peek(3))) <= c; )
+      f = e.next(3);
+    if (d && a(gvjs_BG(b, f)) > c)
+      for (e = b.slice(0, f),
+             d = 0; -3 <= d && !(b = e + gvjs_BG(b, d),
+      a(b) <= c); d--)
+        ;
+    else
+      b = gvjs_BG(b, f)
+  }
+  return b
+}
+var gvjs_CG = gvjs_Tz(function(a, b, c, d, e, f) {
+  if ("" === b)
+    return {
+      lines: [],
+      hx: !1
+    };
+  var g = null == f || null == f.truncate ? !0 : f.truncate
+    , h = null == f || null == f.Nea ? !1 : f.Nea;
+  f = null == f || null == f.y9 ? !1 : f.y9;
+  var k = a;
+  a = function(w) {
+    return k(w, c).width
+  }
+  ;
+  var l = gvjs_AG();
+  l.adoptText(b);
+  l.first();
+  for (var m = !1, n = gvjs_Tea(b), p = !1, q = [], r = 0; ; ) {
+    var t = gvjs_Sea(a, n, l, r, d, f)
+      , u = l.next(t);
+    if (0 !== t)
+      for (; u < b.length && a(n(r, l.peek(t))) <= d; )
+        u = l.next(t);
+    q.push(n(r, u));
+    var v = a(q[q.length - 1]) <= d;
+    if (u >= b.length || q.length >= e || !v) {
+      (u < b.length || !v) && g ? (0 !== t && (q[q.length - 1] = n(r, l.peek(t))),
+        p = !0) : u < b.length && (m = !0);
+      break
+    }
+    r = u
+  }
+  p && (q[q.length - 1] = gvjs_Uea(a, q[q.length - 1], d, h && 1 === q.length),
+    m = !0);
+  1 === q.length && "" === q[0] && (q = []);
+  return {
+    lines: q,
+    hx: m
+  }
+}, {
+  gT: function(a, b) {
+    a = [a];
+    for (var c = 1, d = b.length; c < d; c++)
+      a.push(b[c]);
+    return gvjs_Hi(a)
+  }
+});
+function gvjs_DG(a, b, c, d, e, f) {
+  function g(h) {
+    return a(h, c)
+  }
+  e = null != e ? Math.floor(e) : 1;
+  if (0 >= d)
+    return {
+      lines: [],
+      oe: 0 < b.length,
+      Oq: 0
+    };
+  if (0 == e)
+    return {
+      lines: [],
+      oe: !1,
+      Oq: 0
+    };
+  b = gvjs_CG(g, b, c, d, e, {
+    truncate: !0,
+    Nea: null != f ? f : !1,
+    y9: !0
+  });
+  return {
+    lines: b.lines,
+    oe: b.hx,
+    Oq: 0 < b.lines.length ? Math.max.apply(null, gvjs_v(gvjs_v(b.lines, g), function(h) {
+      return h.width
+    })) : 0
+  }
+}
+function gvjs_Vea(a) {
+  var b = {
+    background: gvjs_dv,
+    padding: gvjs_Pr,
+    border: gvjs_Qr
+  };
+  null != a.fontSize && (b.fontSize = a.fontSize + gvjs_T,
+    b.margin = a.fontSize + gvjs_T);
+  null != a.bb && (b.fontFamily = a.bb);
+  return b
+}
+;function gvjs_EG(a, b, c) {
+  for (var d = 0; d < a.length; ++d)
+    b.yb(a[d].sh.left, a[d].sh.top, a[d].sh.width, a[d].sh.height, a[d].brush, c)
+}
+function gvjs_FG(a, b, c) {
+  for (var d = 0; d < a.length; ++d) {
+    var e = new gvjs_SA;
+    e.move(a[d].path[0], a[d].path[1]);
+    e.va(a[d].path[2], a[d].path[3]);
+    e.va(a[d].path[4], a[d].path[5]);
+    e.close();
+    b.Ia(e, a[d].brush, c)
+  }
+}
+function gvjs_GG(a, b, c) {
+  for (var d = 0; d < a.length; ++d)
+    b.ce(a[d].text, a[d].x, a[d].y, 1, gvjs_2, gvjs_2, a[d].style, c)
+}
+;function gvjs_HG(a, b) {
+  this.x = void 0 === a ? 0 : a;
+  this.y = void 0 === b ? 0 : b
+}
+gvjs_HG.prototype.clone = function() {
+  return new gvjs_HG(this.x,this.y)
+}
+;
+function gvjs_IG(a, b) {
+  var c = a.html
+    , d = gvjs_3g(b);
+  c = gvjs_Bda(d, c);
+  b.appendChild(c);
+  var e = a.anchor;
+  b = a.pivot;
+  d = a.HG;
+  var f = a.spacing;
+  a = a.margin;
+  var g = new gvjs_A(c.clientWidth,c.clientHeight)
+    , h = d.right - e.x >= g.width + a
+    , k = e.x - d.left >= g.width + a
+    , l = d.bottom - e.y >= g.height + a
+    , m = e.y - d.top >= g.height + a
+    , n = gvjs_$y(e.x - b.x)
+    , p = gvjs_$y(e.y - b.y);
+  0 === n && n === p && (n = !k || h || l || m ? 1 : -1,
+    p = m || h ? -1 : 1);
+  h = e.x + (f + g.width / 2) * n;
+  e = e.y + (f + g.height / 2) * p;
+  e = {
+    box: new gvjs_B(e - g.height / 2,h + g.width / 2,e + g.height / 2,h - g.width / 2),
+    hj: null
+  };
+  gvjs_fG(e, d, b, a, 0);
+  gvjs_gG(e, d, b, a);
+  b = new gvjs_z(e.box.left,e.box.top);
+  c.style.width = c.clientWidth + 1 + gvjs_T;
+  c.style.height = c.clientHeight + gvjs_T;
+  c.style.left = b.x + gvjs_T;
+  c.style.top = b.y + gvjs_T;
+  return c
+}
+;function gvjs_JG(a, b, c) {
+  a = gvjs_KG(a, b);
+  b.appendChild(c, a);
+  return a
+}
+function gvjs_KG(a, b) {
+  var c = b.Sa();
+  c.j().setAttribute(gvjs_Cb, gvjs_Nu);
+  var d = a.outline
+    , e = new gvjs_SA
+    , f = new gvjs_B(d.box.top + .5,d.box.right + .5,d.box.bottom + .5,d.box.left + .5)
+    , g = d.hj;
+  e.move(f.left + 1, f.bottom);
+  e.Sf(f.left + 1, f.bottom - 1, 1, 1, 180, 270, !0);
+  e.va(f.left, f.top + 1);
+  e.Sf(f.left + 1, f.top + 1, 1, 1, 270, 0, !0);
+  if (null != g && g[0].y == d.box.top)
+    for (var h = 0; 3 > h; ++h)
+      e.va(g[h].x + .5, g[h].y + .5);
+  e.va(f.right - 1, f.top);
+  e.Sf(f.right - 1, f.top + 1, 1, 1, 0, 90, !0);
+  e.va(f.right, f.bottom - 1);
+  e.Sf(f.right - 1, f.bottom - 1, 1, 1, 90, 180, !0);
+  if (null != g && g[0].y == d.box.bottom)
+    for (d = 0; 3 > d; ++d)
+      e.va(g[d].x + .5, g[d].y + .5);
+  e.close();
+  b.Ia(e, a.vl, c);
+  a = a.EG;
+  for (e = 0; e < a.entries.length; e++)
+    switch (f = a.entries[e],
+      d = f.Xc,
+      g = b.Sa(),
+      b.appendChild(c, g),
+      d.type) {
+      case gvjs_e:
+        d = d.data;
+        f = f.data;
+        f.background && b.yb(f.background.box.left, f.background.box.top, f.background.box.right - f.background.box.left, f.background.box.bottom - f.background.box.top, d.background.brush, g);
+        for (h = 0; h < f.items.length; h++) {
+          var k = d.items[h]
+            , l = f.items[h];
+          switch (k.type) {
+            case gvjs_m:
+              b.ce(k.data.text, a.Xea ? l.box.right : l.box.left, l.box.top, 1, gvjs_2, gvjs_2, k.data.style, g, a.Xea);
+              break;
+            case gvjs_1w:
+              b.yb(l.box.left, l.box.top, l.box.right - l.box.left, l.box.bottom - l.box.top, k.data.brush, g)
+          }
+        }
+        null != d.id && (d = gvjs_4E([gvjs_Ss, d.id]),
+          b.kp(g, d));
+        break;
+      case gvjs_Lw:
+        d = d.data,
+          f = f.data,
+          h = new gvjs_SA,
+          h.move(f.line.x0, f.line.y0),
+          h.va(f.line.x1, f.line.y1),
+          b.Ia(h, d.brush, g)
+    }
+  return c
+}
+;function gvjs_LG(a, b) {
+  this.renderer = b;
+  this.zw = a;
+  this.Ms = null;
+  this.Fd = {};
+  this.Wy = {};
+  this.Hh = this.yt = this.n5 = this.Ea = null
+}
+gvjs_ = gvjs_LG.prototype;
+gvjs_.Fl = function(a, b) {
+  this.Fd = {};
+  this.Wy = {};
+  this.renderer.clear();
+  this.zw.clear();
+  gvjs_MG(this, a, b);
+  a = this.Ea;
+  a = this.renderer.Lm(a.width, a.height);
+  gvjs_NG(this, b, a)
+}
+;
+function gvjs_OG(a, b, c) {
+  a.Fd = {};
+  a.Wy = {};
+  gvjs_MG(a, b, c);
+  a.renderer.deleteContents(!0);
+  gvjs_NG(a, c, a.renderer.kw);
+  a.renderer.flush()
+}
+function gvjs_MG(a, b, c) {
+  var d = new gvjs_9F(2);
+  gvjs_$F(d, 0, b);
+  gvjs_$F(d, 1, c);
+  a.Ea = d.compact()
+}
+function gvjs_NG(a, b, c) {
+  a.registerElement(c.j(), gvjs_Bb);
+  var d = a.Ea
+    , e = a.renderer
+    , f = d.xG;
+  !gvjs_gy(f) && !gvjs_ey(f) || e.yb(0, 0, d.width, d.height, f, c);
+  d.oF == gvjs_aw && (f = a.mv(d.title, c, !0),
+    a.registerElement(f, gvjs_fx));
+  a.yt = e.Sa(!0);
+  f = d.legend;
+  a.PH(f);
+  f && (e.appendChild(c, a.yt),
+    a.registerElement(a.yt.j(), gvjs_rv));
+  a.Hh = e.Sa(!0);
+  f = d.Vi;
+  a.OH(f);
+  f && f.position != gvjs_Fp && (e.appendChild(c, a.Hh),
+    a.Fd.colorbar = a.Hh.j());
+  a.n5 = e.Sa(!1);
+  a.C9(d, c) || a.gY(d, c);
+  e.appendChild(c, a.n5);
+  a.Ms = b
+}
+function gvjs_PG(a, b, c) {
+  var d = gvjs_Ye({
+    C: null,
+    $a: null,
+    legend: null,
+    Jq: null,
+    Vi: null,
+    Ii: null
+  });
+  gvjs_tA(c, d) && gvjs_tA(a.Ms, d) ? (gvjs_Uz(c.legend, a.Ms.legend) || (a.renderer.qc(a.yt),
+    d = new gvjs_9F(2),
+    gvjs_$F(d, 0, b.legend || {}),
+    gvjs_$F(d, 1, c.legend || {}),
+    d = d.compact(),
+    a.PH(d)),
+  gvjs_Uz(c.Vi, a.Ms.Vi) || (a.renderer.qc(a.Hh),
+    d = new gvjs_9F(2),
+    gvjs_$F(d, 0, b.Vi || {}),
+    gvjs_$F(d, 1, c.Vi || {}),
+    d = d.compact(),
+    a.OH(d)),
+    a.Dea(b, c),
+  gvjs_Uz(c.Ii, a.Ms.Ii) || (gvjs_QG(a, "overlaybox"),
+    b = c.Ii,
+    d = new gvjs_3,
+    d.Te(b.color),
+    d.mf(b.opacity),
+    b = a.renderer.yb(b.left, b.top, b.width, b.height, d, a.renderer.kw),
+    a.registerElement(b, "overlaybox")),
+    a.Ms = c) : a.Fl(b, c)
+}
+gvjs_.gY = function(a, b) {
+  var c = {
+    color: gvjs_rt,
+    bb: a.Hj,
+    fontSize: a.Dl,
+    bold: !1,
+    Nc: !1,
+    Ue: !1
+  };
+  this.Oj(gvjs_ms, c, a.O.width);
+  var d = a.O.top + Math.round(a.O.height / 2);
+  this.renderer.Zi(gvjs_ms, a.O.left, d, a.O.left + a.O.width, d, gvjs_0, gvjs_0, c, b)
+}
+;
+gvjs_.PH = function(a) {
+  if (a) {
+    var b = a.ev;
+    if (b) {
+      var c = a.Xi || 0
+        , d = a.Pe.length;
+      if (a.$K)
+        var e = a.area;
+      else
+        e = gvjs_v(b, function(f) {
+          return gvjs_RG(f)
+        }, this),
+          e = gvjs_$B(e);
+      e && (e = gvjs_pz(e),
+        this.renderer.yb(e.left, e.top, e.width, e.height, new gvjs_3(gvjs_iy), this.yt));
+      for (e = 0; e < b.length; e++)
+        gvjs_Wea(this, b[e]);
+      gvjs_Xea(this, a.$K, c, d)
+    }
+  }
+}
+;
+function gvjs_RG(a) {
+  var b = [];
+  if (a.Da) {
+    var c = gvjs_RF(a.Da);
+    c && b.push(c)
+  }
+  a.square && b.push(gvjs_oz(a.square.coordinates));
+  return gvjs_$B(b)
+}
+function gvjs_SG(a, b, c, d, e, f, g) {
+  var h = a.renderer.HH()
+    , k = f.type
+    , l = Number(f.sides);
+  null != l && isFinite(l) || (l = 5);
+  var m = Number(f.rotation);
+  null != m && isFinite(m) || (m = 0);
+  m = m / 180 * Math.PI - Math.PI / 2;
+  "triangle" === k ? (k = gvjs_pw,
+    l = 3) : k === gvjs_1w ? (k = gvjs_pw,
+    l = 4,
+    m += Math.PI / 4) : "diamond" === k && (k = gvjs_pw,
+    l = 4);
+  var n = k === gvjs_3w;
+  500 < l && (k === gvjs_pw || k === gvjs_3w) && (k = gvjs_4o);
+  if (k === gvjs_pw || k === gvjs_3w) {
+    f = Number(f.dent);
+    null != f && isFinite(f) || (5 <= l ? (f = Math.cos(Math.PI / l),
+      f -= Math.pow(Math.sin(Math.PI / l), 2) / Math.sin(Math.PI / 2 - Math.PI / l)) : f = .3);
+    f *= d;
+    k === gvjs_3w && (l *= 2);
+    k = new gvjs_SA;
+    for (var p = 0; p < l; p++) {
+      var q = d;
+      n && p % 2 && (q = f);
+      var r = 2 * Math.PI / l * p + m
+        , t = Math.cos(r) * q + b;
+      q = Math.sin(r) * q + c;
+      0 < p ? k.va(t, q) : k.move(t, q)
+    }
+    k.close();
+    b = a.renderer.Dc(k, e)
+  } else
+    b = a.renderer.$x(b, c, d, e);
+  b && g && a.renderer.appendChild(g, b);
+  a.renderer.dC(h);
+  return b
+}
+gvjs_.iY = function(a, b) {
+  var c = this.Ea.C[a.index];
+  if (this.Ea.O5 && c && !c.Ih && c.hE) {
+    var d = a.square.coordinates.left
+      , e = a.square.coordinates.width
+      , f = a.square.coordinates.height
+      , g = d + e / 2;
+    a = a.square.coordinates.top + f / 2;
+    c.$r && this.renderer.yb(d, a, e, f / 2, c.$r, b);
+    var h = .5 * f
+      , k = c.Oc;
+    k && (k.strokeWidth > h && (k = k.clone(),
+      k.hl(h)),
+      this.renderer.jY(d, a, d + e, a, k, b));
+    c.Qg && c.rM && ((d = c.hE) || (d = {
+      type: gvjs_4o
+    }),
+      gvjs_SG(this, g, a, Math.min(c.pointRadius, f / 2, e / 2), c.Qg, d, b))
+  } else
+    this.renderer.yb(a.square.coordinates.left, a.square.coordinates.top, a.square.coordinates.width, a.square.coordinates.height, a.square.brush, b)
+}
+;
+function gvjs_Wea(a, b) {
+  if (b.isVisible) {
+    var c = a.renderer.Sa(!1)
+      , d = c.j();
+    b.id && d.setAttribute("column-id", b.id);
+    var e = gvjs_4E([gvjs_zv, b.index]);
+    a.registerElement(d, e, gvjs_zv);
+    if (d = gvjs_RG(b))
+      d = gvjs_pz(d),
+        a.renderer.yb(d.left, d.top, d.width, d.height, new gvjs_3(gvjs_iy), c);
+    b.Da && a.mv(b.Da, c);
+    b.square && a.iY(b, c);
+    if (b.Rg && b.Rg.isVisible) {
+      var f = b.Rg.coordinates.x
+        , g = b.Rg.coordinates.y
+        , h = b.Rg.brush;
+      d = a.renderer;
+      e = d.Sa();
+      d.yb(f, g, 12, 12, h, e);
+      d.appendChild(c, e);
+      h = new gvjs_SA;
+      h.move(f + 2, g + 2);
+      h.va(f + 12 - 2, g + 12 - 2);
+      h.move(f + 12 - 2, g + 2);
+      h.va(f + 2, g + 12 - 2);
+      f = new gvjs_3;
+      f.rd(gvjs_ea);
+      f.hl(2);
+      d.Ia(h, f, e);
+      d = e.j();
+      b = gvjs_4E([gvjs_uw, b.index]);
+      a.registerElement(d, b)
+    }
+    a.renderer.appendChild(a.yt, c)
+  }
+}
+function gvjs_Xea(a, b, c, d) {
+  b && (gvjs_TG(a, b.w2, c, d, -1),
+  b.a2 && a.mv(b.a2, a.yt),
+    gvjs_TG(a, b.s1, c, d, 1))
+}
+function gvjs_TG(a, b, c, d, e) {
+  if (b) {
+    var f = gvjs_UA(b.path);
+    f = a.renderer.Ia(f, b.brush, a.yt);
+    b.active && (b = gvjs_4E([gvjs_Av, e, c, d]),
+      a.registerElement(f, b))
+  }
+}
+gvjs_.OH = function(a) {
+  if (a) {
+    var b = a.definition
+      , c = this.renderer
+      , d = this.Hh;
+    gvjs_EG(b.XW, c, d);
+    gvjs_FG(b.G0, c, d);
+    gvjs_GG(b.V4, c, d);
+    a = this.renderer.yb(a.SH.left, a.SH.top, a.SH.width, a.SH.height, new gvjs_3(gvjs_iy), this.Hh);
+    this.registerElement(a, "colorbar")
+  }
+}
+;
+gvjs_.Oj = function(a, b, c) {
+  var d = b.fontSize;
+  a = this.renderer.Wl(a, b);
+  a > c && (d = Math.max(1, Math.floor(d * c / a)));
+  return d
+}
+;
+function gvjs_UG(a, b) {
+  var c = a.Fd[b];
+  c && (a.renderer.Re(c),
+    delete a.Fd[b])
+}
+gvjs_.nK = function(a, b) {
+  a = a.html ? gvjs_IG(a, this.zw.getContainer()) : gvjs_JG(a, this.renderer, this.n5).j();
+  this.registerElement(a, b)
+}
+;
+gvjs_.mv = function(a, b, c) {
+  (a = gvjs_VG(this, a, c)) && this.renderer.appendChild(b, a);
+  return a
+}
+;
+function gvjs_VG(a, b, c) {
+  var d = b.lines;
+  if (!d || 0 == d.length)
+    return null;
+  a = a.renderer;
+  var e = b.ja
+    , f = b.vl
+    , g = null != b.angle ? b.angle : 0
+    , h = b.anchor ? b.anchor : {
+    x: 0,
+    y: 0
+  }
+    , k = b.tooltip
+    , l = !!k || c || !1;
+  c = a.Sa();
+  if (0 === g && f) {
+    var m = gvjs_RF(b);
+    if (m) {
+      var n = Math.ceil(m.left - 3) + .5
+        , p = Math.floor(m.top - 1) + .5;
+      a.yb(n, p, Math.floor(m.right + 3) + .5 - n, Math.floor(m.bottom + 1) + .5 - p, f, c)
+    }
+  }
+  for (f = 0; f < d.length; f++)
+    m = d[f],
+      0 === g ? a.ce(m.text, m.x + h.x, m.y + h.y, m.length, b.ld, b.Pc, e, c) : gvjs_Qda(a, m.text, m.x + h.x, m.y + h.y, m.length, g, b.ld, b.Pc, e, c);
+  if (l) {
+    l = null;
+    if (0 === g)
+      (d = gvjs_RF(b)) && (l = a.yb(d.left, d.top, d.right - d.left, d.bottom - d.top, new gvjs_3(gvjs_iy), c));
+    else {
+      var q = gvjs_6y(g);
+      b = gvjs_0e(b);
+      b.angle = 0;
+      h = (new gvjs_ok(h.x,h.y)).rotate(-q);
+      b.anchor = new gvjs_HG(h.x,h.y);
+      for (f = 0; f < d.length; f++)
+        h = (new gvjs_ok(d[f].x,d[f].y)).rotate(-q),
+          b.lines[f].x = h.x,
+          b.lines[f].y = h.y;
+      if (d = gvjs_RF(b))
+        d = [new gvjs_ok(d.left,d.top), new gvjs_ok(d.right,d.top), new gvjs_ok(d.right,d.bottom), new gvjs_ok(d.left,d.bottom)],
+          gvjs_u(d, function(r) {
+            r.rotate(q)
+          }),
+          d = gvjs_UA(d, !1),
+          l = a.Ia(d, new gvjs_3(gvjs_iy), c)
+    }
+    k && l && gvjs_Sda(a, l, k, gvjs_Vea(e))
+  }
+  return c.j()
+}
+gvjs_.we = function(a, b, c) {
+  var d = this.Fd[b];
+  null == d ? this.renderer.appendChild(a, c) : this.renderer.replaceChild(a, c, d);
+  this.registerElement(c, b)
+}
+;
+gvjs_.registerElement = function(a, b, c) {
+  a && (this.renderer.kp(a, b),
+    this.Fd[b] = a,
+  c && (this.Wy[c] || (this.Wy[c] = []),
+  gvjs_He(this.Wy[c], b) || this.Wy[c].push(b)))
+}
+;
+function gvjs_QG(a, b) {
+  var c = a.Fd[b];
+  c && (a.renderer.Re(c),
+    delete a.Fd[b])
+}
+gvjs_.Qj = function(a) {
+  var b = [];
+  if (this.Fd[a]) {
+    var c = this.renderer.Qj(this.Fd[a]);
+    c && b.push(c)
+  }
+  a = this.Wy[a] || [];
+  for (var d = 0; d < a.length; ++d)
+    (c = this.renderer.Qj(this.Fd[a[d]])) && b.push(c);
+  return gvjs_$B(b)
+}
+;
+function gvjs_WG(a, b) {
+  return a.ia && a.ia.brush || a.brush || b.Qg
+}
+function gvjs_XG(a) {
+  return !a || a.$l
+}
+function gvjs_YG(a) {
+  return a.type == gvjs_e || a.type == gvjs_at || a.type == gvjs_Dd
+}
+function gvjs_ZG(a, b) {
+  return null != a.visible ? a.visible : b.rM
+}
+function gvjs__G(a, b) {
+  var c = a.points[b]
+    , d = a.points[b - 1];
+  a = a.points[b + 1];
+  d = !d || !d.ia || d.$l;
+  a = !a || !a.ia || a.$l;
+  return !(!c || !c.ia || c.$l) && d && a
+}
+function gvjs_0G(a, b) {
+  return a.ia && null != a.ia.radius ? a.ia.radius : null != a.radius ? a.radius : b.pointRadius
+}
+function gvjs_1G(a, b) {
+  return gvjs_0G(a, b) + gvjs_fy(gvjs_WG(a, b)) / 2
+}
+function gvjs_2G(a) {
+  return a.vp !== gvjs_f && a.Fa == gvjs_d && a.orientation == gvjs_S
+}
+function gvjs_3G(a, b) {
+  for (var c = new gvjs_6B, d = !0, e = !0, f = null, g = null, h = 0; h < a.points.length; h++) {
+    var k = a.points[h];
+    if (k && k.ia && null != k.ia.x && null != k.ia.y) {
+      d && (f = h,
+        d = !1);
+      var l = k.ia
+        , m = k && k.jt || a.Oc;
+      if (e || null === m)
+        c.move(l.x, l.y),
+          e = !1;
+      else {
+        var n = a.points[g];
+        a.N_ && n.fr ? c.Jp(m, a.points[g].fr.x, a.points[g].fr.y, k.wt.x, k.wt.y, l.x, l.y) : c.va(m, l.x, l.y)
+      }
+      g = h
+    } else
+      e = !b || d
+  }
+  !d & a.Zra && (d = b ? g : a.points.length - 1,
+    f = b ? f : 0,
+    b = a.points[f],
+  null != d && null != f && a.points[d] && !gvjs_XG(b) && (f = b && b.jt || a.Oc,
+    a.N_ ? c.Jp(f, a.points[d].fr.x, a.points[d].fr.y, b.wt.x, b.wt.y, b.ia.x, b.ia.y) : c.close(f)));
+  return c
+}
+function gvjs_4G(a) {
+  for (var b = new gvjs_6B, c = !0, d = 0; d < a.points.length; d++) {
+    var e = a.points[d]
+      , f = e && e.ia;
+    gvjs_XG(e) || !f || null == f.x || null == f.y ? c = !0 : (c || b.va(e && e.jt || a.Oc, f.WN, f.XN),
+    (c || f.WN != f.UN || f.XN != f.VN) && b.move(f.UN, f.VN),
+      c = !1)
+  }
+  return b
+}
+function gvjs_5G(a, b, c) {
+  return (c = (a = a.jd) && a[c || 0]) && c.position.hf(b)
+}
+function gvjs_6G(a, b, c) {
+  return (c = (a = a.wc) && a[c || 0]) && c.position.hf(b)
+}
+function gvjs_7G(a, b, c) {
+  return (c = (a = a.jd) && a[c || 0]) && c.position.ol(b)
+}
+function gvjs_8G(a, b, c) {
+  return (c = (a = a.wc) && a[c || 0]) && c.position.ol(b)
+}
+function gvjs_9G(a, b, c, d) {
+  for (var e = a.C, f = null, g = Infinity, h, k = new gvjs_z(b,c), l = 0, m = e.length; l < m; l++) {
+    var n = e[l];
+    if (!n.ag) {
+      var p = n;
+      if (a.Fa === gvjs_fw) {
+        n = p.fD.x - b;
+        var q = p.fD.y - c;
+        h = 0 < -n * (p.fD.y - p.gf.y) + q * (p.fD.x - p.gf.x);
+        if (0 < -(p.Uv.x - p.ei.x) * q + (p.Uv.y - p.ei.y) * n && h && Math.sqrt(Math.pow(p.Uv.x - b, 2) + Math.pow(p.Uv.y - c, 2)) < Math.sqrt(Math.pow(p.Uv.x - p.ei.x, 2) + Math.pow(p.Uv.y - p.ei.y, 2)) + d)
+          return {
+            row: l
+          }
+      } else {
+        p = 0;
+        for (q = n.points.length; p < q; p++)
+          if ((h = n.points[p]) && null != h.ia)
+            switch (h = h.ia,
+              n.type) {
+              case gvjs_e:
+              case gvjs_At:
+              case gvjs_Dd:
+                h = gvjs_cz(k, h);
+                h < d && h < g && (f = {
+                  $G: p,
+                  row: l
+                },
+                  g = h);
+                break;
+              case gvjs_Ft:
+              case gvjs_lt:
+                var r = null;
+                if (n.type === gvjs_lt)
+                  r = new gvjs_5(h.left,h.top,h.width,h.height);
+                else if (n.type === gvjs_Ft) {
+                  r = h.line;
+                  var t = Math.min(h.rect.top, r.top);
+                  r = new gvjs_5(h.rect.left,t,h.rect.width,Math.max(h.rect.top + h.rect.height, r.top + r.height) - t)
+                }
+                h = d;
+                r = r.distance(k);
+                (h = r > h ? null : r) && h < g && (f = {
+                  $G: p,
+                  row: l
+                },
+                  g = h);
+                break;
+              default:
+                throw Error("Unknown chart type for getPointDatum.");
+            }
+        if (0 === g)
+          break
+      }
+    }
+  }
+  return f
+}
+function gvjs_$G(a, b) {
+  b = b || {};
+  switch (a) {
+    case gvjs_Ow:
+      return b.qb;
+    case gvjs_Pw:
+      return b.jh;
+    case gvjs_Nw:
+      return b.color;
+    default:
+      return a
+  }
+}
+;function gvjs_aH(a, b) {
+  gvjs_LG.call(this, a, b);
+  this.df = null;
+  this.o5 = []
+}
+gvjs_o(gvjs_aH, gvjs_LG);
+function gvjs_bH(a, b, c) {
+  a.o5.push({
+    definition: b,
+    id: c
+  })
+}
+function gvjs_cH(a) {
+  var b = a.renderer.HH();
+  gvjs_u(a.o5, function(c) {
+    a.nK(c.definition, c.id)
+  });
+  a.renderer.dC(b);
+  a.o5 = []
+}
+gvjs_ = gvjs_aH.prototype;
+gvjs_.C9 = function(a, b) {
+  function c(m) {
+    m = a.C[m];
+    return !a.kd || m.type !== gvjs_Dd || m.rM
+  }
+  var d = this;
+  gvjs_Yea(this, a);
+  var e = this.renderer.Sa(!1);
+  this.renderer.appendChild(b, e);
+  this.registerElement(e.j(), gvjs_Tt);
+  gvjs_w(this.df, function(m) {
+    m.Kc || (m.Kc = d.renderer.Sa(!(void 0 !== m.a7 && !m.a7)))
+  });
+  this.renderer.yb(a.O.left, a.O.top, a.O.width, a.O.height, a.h8, e);
+  a.oF == gvjs_Fp && this.mv(a.title, this.df.title.Kc, !0);
+  a.cJ && this.mv(a.cJ, this.df.axistitle.Kc, !0);
+  gvjs_u(a.$a, function(m, n) {
+    m.Bc && gvjs_dH(d, m.Bc, null, n)
+  });
+  gvjs_w(a.jd, function(m) {
+    gvjs_Zea(d, a, m)
+  });
+  gvjs_w(a.wc, function(m) {
+    gvjs__ea(d, a, m)
+  });
+  var f = new gvjs_5(a.O.left,a.O.top,a.O.width,a.O.height);
+  this.renderer.dC(f);
+  for (var g = [], h = 0; h < a.C.length; h++)
+    c(h) && g.push({
+      wM: a.C[h].wM,
+      index: h
+    });
+  gvjs_Se(g, function(m, n) {
+    return gvjs_Re(m.wM, n.wM)
+  });
+  for (h = 0; h < g.length; h++) {
+    var k = g[h].index;
+    gvjs_eH(this, a.C[k], k)
+  }
+  a.kd && a.C[0].type === gvjs_Dd && gvjs_0ea(this, a, b);
+  for (g = 0; g < a.$a.length; g++)
+    a.$a[g].tooltip && (h = gvjs_4E([gvjs_Pd, g]),
+      gvjs_bH(this, a.$a[g].tooltip, h));
+  g = this.renderer.HH();
+  gvjs_w(a.jd, function(m) {
+    gvjs_fH(d, m)
+  });
+  gvjs_w(a.wc, function(m) {
+    gvjs_fH(d, m)
+  });
+  this.renderer.dC(g);
+  gvjs_cH(this);
+  var l = this.renderer.Sa(!1);
+  f = this.renderer.ZG(l, f);
+  this.renderer.appendChild(e, f);
+  gvjs_u(gvjs_5E, function(m) {
+    var n = d.df[m].Kc;
+    if (n) {
+      switch (d.df[m].position) {
+        case gvjs_Xt:
+          var p = l;
+          break;
+        case gvjs_gv:
+          p = e;
+          break;
+        case gvjs_bw:
+          p = b
+      }
+      d.renderer.appendChild(p, n)
+    }
+  });
+  return !0
+}
+;
+function gvjs_Yea(a, b) {
+  a.df = {};
+  var c = a.df;
+  c.action = {
+    position: gvjs_bw
+  };
+  c.annotation = {
+    position: gvjs_Xt
+  };
+  c.annotationtext = {
+    position: gvjs_gv
+  };
+  c.area = {
+    position: gvjs_Xt
+  };
+  c.bar = {
+    position: gvjs_Xt
+  };
+  c.baseline = {
+    position: gvjs_Xt
+  };
+  c.bubble = {
+    position: gvjs_Xt
+  };
+  c.categorysensitivityarea = {
+    position: gvjs_Xt
+  };
+  c.candlestick = {
+    position: gvjs_Xt
+  };
+  c.histogram = {
+    position: gvjs_Xt
+  };
+  c.gridline = {
+    position: gvjs_Xt
+  };
+  c.interval = {
+    position: gvjs_Xt
+  };
+  c.line = {
+    position: gvjs_Xt
+  };
+  c.minorgridline = {
+    position: gvjs_Xt
+  };
+  c.overlaybox = {
+    position: gvjs_Xt
+  };
+  c.pathinterval = {
+    position: gvjs_Xt
+  };
+  c.point = {
+    position: gvjs_gv,
+    a7: !1
+  };
+  c.pointsensitivityarea = {
+    position: gvjs_gv
+  };
+  c.steppedareabar = {
+    position: gvjs_Xt
+  };
+  c.tooltip = {
+    position: gvjs_bw
+  };
+  c.title = {
+    position: b.oF == gvjs_Fp ? gvjs_gv : gvjs_bw
+  };
+  c.axistick = {
+    position: gvjs_gv
+  };
+  c.axistitle = {
+    position: b.DB == gvjs_Fp ? gvjs_gv : gvjs_bw
+  };
+  var d = b.legend && b.legend.position == gvjs_Fp
+    , e = d ? a.yt : null;
+  d = d ? gvjs_gv : gvjs_bw;
+  c.legend = {
+    Kc: e,
+    position: d
+  };
+  c.legendscrollbutton = {
+    Kc: e,
+    position: d
+  };
+  c.legendentry = {
+    Kc: e,
+    position: d
+  };
+  b = b.Vi && b.Vi.position == gvjs_Fp;
+  c.colorbar = {
+    Kc: b ? a.Hh : null,
+    position: b ? gvjs_gv : gvjs_bw
+  }
+}
+function gvjs_eH(a, b, c) {
+  if (b.type == gvjs_At)
+    gvjs_1ea(a, b, c);
+  else if (b.type == gvjs_lt)
+    gvjs_gH(a, b, c);
+  else if (b.type == gvjs_4w)
+    gvjs_gH(a, b, c);
+  else if (b.type == gvjs_Ft)
+    for (var d = 0; d < b.points.length; d++)
+      gvjs_hH(a, c, b.points[d], d);
+  else if (b.type == gvjs_at) {
+    d = a.Ea.vp !== gvjs_f;
+    var e = a.Ea.Zj;
+    if (0 != b.points.length) {
+      e = e && !d;
+      for (var f = [], g = {
+        start: null,
+        end: null,
+        brush: null
+      }, h = 0; h <= b.points.length; h++) {
+        var k = b.points[h];
+        gvjs_XG(k) ? e && h !== b.points.length || (null !== g.start && null !== g.end && f.push(g),
+        h < b.points.length && (g = {
+          start: null,
+          end: null,
+          brush: null
+        })) : null === g.start ? g.start = h : (k = k && k.nQ || b.$r,
+          null === g.brush || gvjs_$z(g.brush, k) ? (g.end = h,
+            g.brush = k) : (f.push(g),
+            g = {
+              start: h - 1,
+              end: h,
+              brush: k
+            }))
+      }
+      h = a.renderer.Sa();
+      for (k = 0; k < f.length; k++) {
+        g = f[k];
+        var l = g.brush
+          , m = new gvjs_SA
+          , n = m
+          , p = b
+          , q = d
+          , r = g.start;
+        g = g.end;
+        var t = !0
+          , u = null;
+        n.move(p.points[r].ia.kW, p.points[r].ia.lW);
+        for (var v = r; v <= g; v++) {
+          var w = p.points[v];
+          gvjs_XG(w) || (w = w.ia,
+            n.va(w.WN, w.XN),
+          w.UN == w.WN && w.VN == w.XN || n.va(w.UN, w.VN),
+          null != w.x && null != w.y && (t = !1,
+            u = v))
+        }
+        if (!t)
+          if (q)
+            for (q = g; q >= r; q--)
+              g = p.points[q].ia,
+                n.va(g.mW, g.nW),
+              g.kW == g.mW && g.lW == g.nW || n.va(g.kW, g.lW);
+          else
+            p = p.points[u].ia,
+              n.va(p.mW, p.nW),
+              n.close();
+        a.renderer.Ia(m, l, h)
+      }
+      f = gvjs_4E([gvjs_at, c]);
+      a.we(a.df.area.Kc, f, h.j());
+      if (d) {
+        e = gvjs_4G(b);
+        d = gvjs_4E([gvjs_e, c]);
+        e = e.Dc(a.renderer);
+        f = gvjs_iH(a, b);
+        if (e) {
+          h = b.Ko;
+          k = b.nj;
+          if (h || k) {
+            f = f || a.renderer.Sa();
+            if (h)
+              for (l = 0; l < h.levels.length; l++)
+                a.renderer.Ia(h.levels[l].path, h.levels[l].brush, f);
+            k && a.renderer.Ia(k.path, k.brush, f)
+          }
+          f && a.renderer.appendChild(f, e)
+        }
+        e = f ? f.j() : e;
+        null != e && a.we(a.df.line.Kc, d, e);
+        gvjs_jH(a, b, c)
+      } else
+        gvjs_kH(a, b, c, e)
+    }
+  } else
+    gvjs_kH(a, b, c, a.Ea.Zj);
+  if (b.Df && b.Df.paths)
+    for (b = b.Df.paths,
+           d = 0; e = b[d]; ++d)
+      0 != e.line.length && (f = new gvjs_SA,
+        gvjs_TA(f, e.line, e.kX),
+      e.bottom && gvjs_TA(f, e.bottom, e.Pka),
+        h = a.renderer.Sa(),
+        a.renderer.Ia(f, e.brush, h),
+        e = h.j(),
+        f = gvjs_4E(["pathinterval", c, d]),
+        a.we(a.df.pathinterval.Kc, f, e))
+}
+function gvjs_lH(a, b, c, d, e) {
+  b.type == gvjs_lt || b.type == gvjs_4w ? a.Je(b, c, d, e) : b.type == gvjs_Ft ? gvjs_hH(a, c, d, e) : b.type == gvjs_At ? gvjs_mH(a, b, c, d, e, a.df.bubble.Kc) : gvjs_mH(a, b, c, d, e, a.df.point.Kc)
+}
+function gvjs_1ea(a, b, c) {
+  var d = a.df.bubble.Kc
+    , e = gvjs_lA(b.points.length, function(l) {
+    return l
+  });
+  b.wxa && gvjs_Qe(e, function(l, m) {
+    l = b.points[l];
+    m = b.points[m];
+    return (m ? m.ia.radius : 0) - (l ? l.ia.radius : 0)
+  });
+  for (var f = 0; f < e.length; f++) {
+    var g = e[f]
+      , h = b.points[g];
+    if (h) {
+      gvjs_mH(a, b, c, h, g, a.df.bubble.Kc);
+      var k = a.renderer.me(h.text, h.ja);
+      if (k.width < 2 * h.ia.radius || k.height < 2 * h.ia.radius)
+        h = a.renderer.ce(h.text, h.ia.x, h.ia.y, h.textLength, gvjs_0, gvjs_0, h.ja, d),
+          g = gvjs_4E([gvjs_yt, c, g]),
+          a.renderer.kp(h, g)
+    }
+  }
+}
+function gvjs_gH(a, b, c) {
+  for (var d = 0; d < b.points.length; d++)
+    a.Je(b, c, b.points[d], d)
+}
+gvjs_.Je = function(a, b, c, d) {
+  if (!gvjs_XG(c) && c.ia) {
+    var e = c.brush || gvjs_WG(c, a)
+      , f = a.type == gvjs_lt ? gvjs_wb : gvjs_5w
+      , g = gvjs_4E([f, b, d])
+      , h = c.ia.bar || c.ia;
+    e = this.renderer.Bl(h.left, h.top, h.width, h.height, e);
+    h = null;
+    var k = c.ia.outline
+      , l = c.Ko
+      , m = c.nj;
+    if (k || l || m) {
+      h = this.renderer.Sa();
+      this.renderer.appendChild(h, e);
+      if (k) {
+        var n = c.Oc || a.Oc;
+        k = gvjs_UA(k, !0);
+        this.renderer.Ia(k, n, h)
+      }
+      if (l)
+        for (n = 0; n < l.levels.length; n++)
+          k = l.levels[n].rect,
+            this.renderer.yb(k.left, k.top, k.width, k.height, l.levels[n].brush, h);
+      m && this.renderer.yb(m.rect.left, m.rect.top, m.rect.width, m.rect.height, m.brush, h)
+    }
+    e = h ? h.j() : e;
+    this.we(this.df[f].Kc, g, e);
+    c.tooltip && (f = gvjs_4E([gvjs_Pd, b, d]),
+      gvjs_bH(this, c.tooltip, f));
+    c.Bc && gvjs_dH(this, c.Bc, b, d);
+    c.ia.mt && gvjs_nH(this, a, b, d, c.ia.mt)
+  }
+}
+;
+function gvjs_iH(a, b) {
+  var c = null
+    , d = null;
+  gvjs_u(b.points, function(e, f) {
+    gvjs__G(b, f) && (c || (c = a.renderer.Sa()),
+    d || (d = gvjs_8z(b.Oc.Uj(), b.Oc.strokeOpacity)),
+    e && !gvjs_ZG(e, b) && a.renderer.Ke(e.ia.x, e.ia.y, b.lineWidth, d, c))
+  }, a);
+  return c
+}
+function gvjs_kH(a, b, c, d) {
+  var e = gvjs_4E([gvjs_e, c]);
+  if (0 >= b.lineWidth)
+    gvjs_QG(a, e),
+      gvjs_jH(a, b, c);
+  else {
+    var f = gvjs_3G(b, d);
+    if (0 != f.vc.length) {
+      d = (f = f.Dc(a.renderer)) && d ? null : gvjs_iH(a, b);
+      if (f) {
+        var g = b.Ko
+          , h = b.nj;
+        if (g || h) {
+          d || (d = a.renderer.Sa());
+          if (g)
+            for (var k = 0; k < g.levels.length; k++)
+              a.renderer.Ia(g.levels[k].path, g.levels[k].brush, d);
+          h && a.renderer.Ia(h.path, h.brush, d)
+        }
+        d && a.renderer.appendChild(d, f)
+      }
+      f = d ? d.j() : f;
+      null != f && a.we(a.df.line.Kc, e, f);
+      gvjs_jH(a, b, c)
+    }
+  }
+}
+function gvjs_0ea(a, b, c) {
+  for (var d = 0, e = b.C.length; d < e; d += 2) {
+    var f = b.C[d]
+      , g = b.C[d + 1]
+      , h = f.points.length;
+    if (0 != h)
+      for (var k = new gvjs_3({
+        stroke: f.Qg.fill,
+        strokeOpacity: f.Qg.fillOpacity,
+        strokeWidth: 1
+      }), l = 0; l < h; l++) {
+        var m = f.points[l]
+          , n = g.points[l];
+        !gvjs_XG(m) && m.ia && a.renderer.jY(m.ia.x, m.ia.y, n.ia.x, n.ia.y, k, c)
+      }
+  }
+}
+function gvjs_jH(a, b, c) {
+  for (var d = 0; d < b.points.length; d++)
+    gvjs_mH(a, b, c, b.points[d], d, a.df.point.Kc)
+}
+function gvjs_mH(a, b, c, d, e, f) {
+  var g;
+  if (g = !gvjs_XG(d) && d.ia)
+    a: {
+      var h = d.ia;
+      g = gvjs_1G(d, b);
+      var k = a.Ea.O;
+      if (h.x - g >= k.right || h.x + g <= k.left || h.y - g >= k.bottom || h.y + g <= k.top)
+        g = !1;
+      else {
+        if ((h.x >= k.right || h.x <= k.left) && (h.y >= k.bottom || h.y <= k.top)) {
+          g *= g;
+          var l = h.x - k.right
+            , m = h.x - k.left
+            , n = h.y - k.bottom;
+          h = h.y - k.top;
+          k = l * l;
+          m *= m;
+          n *= n;
+          h *= h;
+          if (k + n >= g && k + h >= g && m + h >= g && m + n >= g) {
+            g = !1;
+            break a
+          }
+        }
+        g = !0
+      }
+    }
+  if (g) {
+    g = gvjs_4E([b.type == gvjs_At ? gvjs_yt : gvjs_Np, c, e]);
+    if (gvjs_ZG(d, b)) {
+      n = a.we;
+      h = gvjs_0G(d, b);
+      k = gvjs_WG(d, b);
+      m = null;
+      var p = d.nj;
+      l = d.Ko;
+      var q = d.P8;
+      if (p || l || q)
+        m = a.renderer.Sa();
+      q && a.renderer.Ia(q.path, q.brush, m);
+      (q = d.shape) && q.type || (q = {
+        type: gvjs_4o
+      });
+      p && gvjs_SG(a, p.x, p.y, p.radius + .5, p.brush, q, m);
+      if (l)
+        for (p = 0; p < l.levels.length; p++)
+          gvjs_SG(a, l.x, l.y, l.levels[p].radius, l.levels[p].brush, q, m);
+      h = gvjs_SG(a, d.ia.x, d.ia.y, h, k, q);
+      m && a.renderer.appendChild(m, h);
+      m = m ? m.j() : h;
+      n.call(a, f, g, m)
+    } else
+      gvjs_QG(a, g);
+    d.tooltip && (f = gvjs_4E([gvjs_Pd, c, e]),
+      gvjs_bH(a, d.tooltip, f));
+    d.Bc && gvjs_dH(a, d.Bc, c, e);
+    d.ia.mt && gvjs_nH(a, b, c, e, d.ia.mt)
+  }
+}
+function gvjs_hH(a, b, c, d) {
+  if (c && c.ia) {
+    var e = a.renderer.Bl(c.ia.line.left, c.ia.line.top, c.ia.line.width, c.ia.line.height, c.Oc)
+      , f = a.renderer.Bl(c.ia.rect.left, c.ia.rect.top, c.ia.rect.width, c.ia.rect.height, c.yG)
+      , g = a.renderer.Sa();
+    a.renderer.appendChild(g, e);
+    a.renderer.appendChild(g, f);
+    if (e = c.Ko)
+      for (f = 0; f < e.levels.length; f++) {
+        var h = e.levels[f].rect;
+        a.renderer.yb(h.left, h.top, h.width, h.height, e.levels[f].brush, g)
+      }
+    (e = c.nj) && a.renderer.yb(e.rect.left, e.rect.top, e.rect.width, e.rect.height, e.brush, g);
+    e = gvjs_4E([gvjs_Ct, b, d]);
+    a.we(a.df.candlestick.Kc, e, g.j());
+    c.tooltip && (b = gvjs_4E([gvjs_Pd, b, d]),
+      gvjs_bH(a, c.tooltip, b))
+  }
+}
+function gvjs_dH(a, b, c, d) {
+  if (b) {
+    var e = b.kga
+      , f = a.Ea.O;
+    if (!(!e || e.x < f.left || e.x > f.right) && (f = b.labels) && 0 != f.length) {
+      var g = [gvjs_Zs, d];
+      gvjs_fq(g, c, 1);
+      g = gvjs_4E(g);
+      var h = e.x
+        , k = e.y
+        , l = e.length;
+      l = e.orientation == gvjs_S ? [l, 1] : [1, l];
+      e = a.renderer.Bl(Math.min(h, h + l[0]), Math.min(k, k + l[1]), Math.abs(l[0]), Math.abs(l[1]), new gvjs_3({
+        fill: e.color
+      }));
+      a.we(a.df.annotation.Kc, g, e);
+      e = a.renderer.Sa();
+      g = [gvjs_$s, d];
+      gvjs_fq(g, c, 1);
+      h = null;
+      b.Rp && !b.Rp.Eba && (f = [b.Rp.label],
+        h = -1);
+      b = a.renderer.HH();
+      for (k = 0; k < f.length; k++) {
+        var m = f[k];
+        if (l = gvjs_VG(a, m, !0)) {
+          if (m.xa) {
+            var n = gvjs_4E([gvjs_Pd, c, d, k]);
+            gvjs_bH(a, m.xa, n)
+          }
+          a.renderer.appendChild(e, l);
+          m = gvjs_Le(g);
+          m.push(h || k);
+          m = gvjs_4E(m);
+          a.registerElement(l, m)
+        }
+      }
+      a.renderer.dC(b);
+      c = gvjs_4E(g);
+      a.we(a.df.annotationtext.Kc, c, e.j())
+    }
+  }
+}
+function gvjs_nH(a, b, c, d, e) {
+  if (null != b.Df) {
+    var f = a.renderer.Sa();
+    b = b.Df.eu;
+    for (var g = 0; g < e.length; g++) {
+      var h = e[g].rect
+        , k = b[e[g].ss];
+      if (k && k.style != gvjs_at && k.style != gvjs_e) {
+        var l = e[g].brush;
+        0 == h.width && 0 == h.height ? (k = k.ava / 2,
+        0 < k && (h = a.renderer.$x(h.left, h.top, k, l),
+          a.renderer.appendChild(f, h))) : 0 == h.width || 0 == h.height ? (k = new gvjs_SA,
+          k.move(h.left, h.top),
+          k.va(h.left + h.width, h.top + h.height),
+          a.renderer.Ia(k, l, f)) : a.renderer.appendChild(f, a.renderer.Bl(h.left, h.top, h.width, h.height, l))
+      }
+    }
+    f.H && (c = gvjs_4E([gvjs_iv, c, d]),
+      f = f.j(),
+      a.we(a.df.interval.Kc, c, f))
+  }
+}
+function gvjs_Zea(a, b, c) {
+  gvjs_oH(a, c, function(d, e) {
+    var f = null != d.length ? d.length : b.O.height
+      , g = c.zp.Na;
+    return a.renderer.yb(Math.floor(d.Na), Math.min(g, g + c.zp.direction * f), 1, f, d.brush, e)
+  })
+}
+function gvjs__ea(a, b, c) {
+  gvjs_oH(a, c, function(d, e) {
+    var f = null != d.length ? d.length : b.O.width
+      , g = c.zp.Na;
+    return a.renderer.yb(Math.min(g, g + c.zp.direction * f), Math.floor(d.Na), f, 1, d.brush, e)
+  })
+}
+function gvjs_oH(a, b, c) {
+  (function(f, g, h) {
+      if (f) {
+        var k = a.df[g].Kc
+          , l = gvjs_4E([b.name, g]);
+        gvjs_u(f, function(m, n) {
+          n = gvjs_4E([b.name, g, n]);
+          gvjs_pH(a, m, h, k, n, l)
+        })
+      }
+    }
+  )(b.Ja, "gridline", c);
+  var d = a.df.baseline.Kc
+    , e = gvjs_4E([b.name, gvjs_Xo]);
+  b.baseline && b.baseline.isVisible && null != b.baseline.za && Infinity != b.baseline.Na && gvjs_pH(a, b.baseline, c, d, e)
+}
+function gvjs_pH(a, b, c, d, e, f) {
+  var g;
+  if (g = b && b.isVisible)
+    g = b.brush,
+      g = !(!gvjs_gy(g) && !gvjs_ey(g));
+  g && (b = c(b, d),
+    a.registerElement(b, e, f))
+}
+function gvjs_fH(a, b) {
+  var c = a.df
+    , d = a.mv(b.title, c.axistitle.Kc, !0)
+    , e = gvjs_4E([b.name, gvjs_fx]);
+  a.registerElement(d, e);
+  if (b.text) {
+    var f = c.axistick.Kc
+      , g = gvjs_4E([b.name, gvjs_8c]);
+    gvjs_u(b.text, function(h, k) {
+      h.isVisible && (h = a.mv(h.Da, f),
+        k = gvjs_4E([b.name, gvjs_8c, k]),
+        a.registerElement(h, k, g))
+    })
+  }
+}
+gvjs_.Dea = function(a, b) {
+  this.VK(a);
+  this.TV(a, b)
+}
+;
+gvjs_.VK = function(a) {
+  var b = this.Ms;
+  if (b) {
+    for (var c in b.C) {
+      var d = Number(c)
+        , e = a.C[d];
+      if (gvjs_tA(b.C[d], gvjs_Ye({
+        points: null
+      }))) {
+        var f = b.C[d].points, g;
+        for (g in f) {
+          var h = Number(g)
+            , k = f[h];
+          if (k.tooltip) {
+            var l = gvjs_4E([gvjs_Pd, Number(d), Number(h)]);
+            gvjs_UG(this, l)
+          }
+          if (k = k.Bc)
+            for (var m in k.labels)
+              k.labels[m].xa && (l = gvjs_4E([gvjs_Pd, Number(d), Number(h), Number(m)]),
+                gvjs_UG(this, l));
+          gvjs_lH(this, e, Number(d), e.points[h], Number(h))
+        }
+      } else {
+        for (var n in b.C[d].points)
+          b.C[d].points[n].tooltip && (f = gvjs_4E([gvjs_Pd, Number(d), Number(n)]),
+            gvjs_UG(this, f));
+        gvjs_eH(this, e, Number(d))
+      }
+    }
+    for (var p in b.$a)
+      if (c = Number(p),
+        d = b.$a[c],
+      d.tooltip && (e = gvjs_4E([gvjs_Pd, Number(c)]),
+        gvjs_UG(this, e)),
+        d = d.Bc) {
+        for (var q in d.labels)
+          d.labels[q].xa && (e = gvjs_4E([gvjs_Pd, null, Number(c), Number(q)]),
+            gvjs_UG(this, e));
+        gvjs_dH(this, a.$a[c].Bc, null, Number(c))
+      }
+    gvjs_cH(this)
+  }
+}
+;
+gvjs_.TV = function(a, b) {
+  for (var c in b.C) {
+    var d = Number(c)
+      , e = a.C[d];
+    if (gvjs_tA(b.C[d], gvjs_Ye({
+      points: null
+    })))
+      for (var f in b.C[d].points) {
+        var g = Number(f)
+          , h = new gvjs_9F(2);
+        gvjs_$F(h, 0, e.points[g]);
+        gvjs_$F(h, 1, b.C[d].points[g]);
+        h = h.compact();
+        gvjs_lH(this, e, Number(d), h, Number(g))
+      }
+    else
+      g = new gvjs_9F(2),
+        gvjs_$F(g, 0, e),
+        gvjs_$F(g, 1, b.C[d]),
+        e = g.compact(),
+        gvjs_eH(this, e, Number(d))
+  }
+  for (var k in b.$a)
+    c = Number(k),
+    b.$a[c].tooltip && (d = gvjs_4E([gvjs_Pd, Number(c)]),
+      gvjs_bH(this, b.$a[c].tooltip, d)),
+    b.$a[c].Bc && (d = new gvjs_9F(2),
+      gvjs_$F(d, 0, a.$a[c].Bc),
+      gvjs_$F(d, 1, b.$a[c].Bc),
+      d = d.compact(),
+      gvjs_dH(this, d, null, Number(c)));
+  gvjs_cH(this)
+}
+;
+function gvjs_qH(a, b, c, d, e, f) {
+  this.$d = a;
+  this.Qa = b;
+  this.dz = c;
+  this.Lv = d;
+  this.ssa = e;
+  this.Qb = f
+}
+function gvjs_rH(a, b, c) {
+  return new gvjs_qH(a,b,!1,!1,!1,c)
+}
+gvjs_qH.prototype.getPosition = function() {
+  return Math.round(this.Qa)
+}
+;
+gvjs_qH.prototype.getValue = function() {
+  return this.$d
+}
+;
+gvjs_qH.prototype.Dd = function() {
+  return this.Qb
+}
+;
+gvjs_qH.prototype.In = function(a) {
+  this.Qb = a
+}
+;
+function gvjs_sH() {}
+gvjs_sH.prototype.floor = function() {}
+;
+gvjs_sH.prototype.ceil = function() {}
+;
+gvjs_sH.prototype.round = function() {}
+;
+function gvjs_tH() {}
+gvjs_tH.prototype.La = function() {}
+;
+gvjs_tH.prototype.getHeight = function() {}
+;
+gvjs_tH.prototype.bt = function() {}
+;
+function gvjs_uH(a, b) {
+  this.WT = a;
+  this.UR = void 0 === b ? 0 : b;
+  this.Qa = 0
+}
+gvjs_o(gvjs_uH, gvjs_sH);
+gvjs_ = gvjs_uH.prototype;
+gvjs_.next = function() {
+  this.Qa++;
+  return this.getValue()
+}
+;
+gvjs_.he = function() {
+  this.Qa--;
+  return this.getValue()
+}
+;
+gvjs_.getValue = function() {
+  return gvjs_qA(15, this.Qa * this.WT + this.UR)
+}
+;
+gvjs_.floor = function(a) {
+  this.Qa = Math.floor((a - this.UR) / this.WT);
+  return this.getValue()
+}
+;
+gvjs_.ceil = function(a) {
+  this.Qa = Math.ceil((a - this.UR) / this.WT);
+  return this.getValue()
+}
+;
+gvjs_.round = function(a) {
+  this.Qa = Math.round((a - this.UR) / this.WT);
+  return this.getValue()
+}
+;
+function gvjs_vH(a) {
+  this.Gta = a.concat();
+  this.DJ = a.length;
+  this.Qa = 0
+}
+gvjs_o(gvjs_vH, gvjs_sH);
+gvjs_ = gvjs_vH.prototype;
+gvjs_.next = function() {
+  this.Qa++;
+  return this.getValue()
+}
+;
+gvjs_.he = function() {
+  this.Qa--;
+  return this.getValue()
+}
+;
+gvjs_.getValue = function() {
+  var a = Math.floor(this.Qa / this.DJ);
+  return gvjs_8E(this.Gta[this.Qa - a * this.DJ], a)
+}
+;
+gvjs_.floor = function(a) {
+  this.Qa = this.DJ * gvjs_$E(a);
+  if (this.getValue() != a)
+    for (; this.he() > a; )
+      ;
+  return this.getValue()
+}
+;
+gvjs_.ceil = function(a) {
+  this.Qa = this.DJ * gvjs_9E(a);
+  if (this.getValue() != a)
+    for (; this.next() < a; )
+      ;
+  return this.getValue()
+}
+;
+gvjs_.round = function(a) {
+  this.Qa = this.DJ * gvjs_$E(a);
+  if (this.getValue() != a) {
+    for (; this.he() > a; )
+      ;
+    if (a - this.getValue() < this.next() - a)
+      return this.he()
+  }
+  return this.getValue()
+}
+;
+function gvjs_wH(a) {
+  var b = 0;
+  gvjs_u(a, function(c) {
+    b = Math.max(b, gvjs_pA(c))
+  });
+  return b
+}
+;function gvjs_xH(a, b, c, d) {
+  this.aR = b;
+  this.Yc = new gvjs_gk({
+    pattern: a
+  });
+  this.lxa = c;
+  this.$ua = d
+}
+gvjs_xH.prototype.format = function(a) {
+  a /= this.aR;
+  return this.Yc.Ob(a) + " " + (2 > Math.abs(a) ? this.lxa : this.$ua)
+}
+;
+gvjs_Xi.prototype.format = gvjs_Xi.prototype.format;
+gvjs_Xi.Format = {
+  FULL_DATE: 0,
+  LONG_DATE: 1,
+  MEDIUM_DATE: 2,
+  SHORT_DATE: 3,
+  FULL_TIME: 4,
+  LONG_TIME: 5,
+  MEDIUM_TIME: 6,
+  SHORT_TIME: 7,
+  FULL_DATETIME: 8,
+  LONG_DATETIME: 9,
+  MEDIUM_DATETIME: 10,
+  SHORT_DATETIME: 11
+};
+var gvjs_yH = gvjs_2i;
+gvjs_1j.Format = {
+  DECIMAL: 1,
+  SCIENTIFIC: 2,
+  PERCENT: 3,
+  CURRENCY: 4,
+  COMPACT_SHORT: 5,
+  COMPACT_LONG: 6
+};
+gvjs_1j.prototype.format = gvjs_1j.prototype.format;
+gvjs_1j.prototype.setMinimumFractionDigits = gvjs_1j.prototype.setMinimumFractionDigits;
+gvjs_1j.prototype.setMaximumFractionDigits = gvjs_1j.prototype.setMaximumFractionDigits;
+gvjs_1j.prototype.setSignificantDigits = gvjs_1j.prototype.setSignificantDigits;
+gvjs_1j.setEnforceAsciiDigits = function(a) {
+  gvjs_3j = a
+}
+;
+gvjs_1j.isEnforceAsciiDigits = function() {
+  return gvjs_3j
+}
+;
+gvjs_Ui.createTimeZone = gvjs_Vi;
+function gvjs_zH() {
+  this.jR = this.RJ = null;
+  this.ZD = [];
+  this.y$ = this.$A = this.hK = null;
+  this.DF = !0
+}
+gvjs_ = gvjs_zH.prototype;
+gvjs_.yR = function(a) {
+  this.RJ = a;
+  this.DF = !0;
+  return this
+}
+;
+gvjs_.nw = function(a) {
+  this.jR = a;
+  this.DF = !0;
+  return this
+}
+;
+gvjs_.gK = function(a) {
+  this.hK = a;
+  this.DF = !0;
+  return this
+}
+;
+gvjs_.unit = function(a) {
+  this.$A = a;
+  this.DF = !0;
+  return this
+}
+;
+gvjs_.M5 = function(a) {
+  a = gvjs_aA(0, typeof a === gvjs_g ? a : 3);
+  this.ZD = [new gvjs_xH(a,Math.pow(10, 15),"Quadrillion","Quadrillion"), new gvjs_xH(a,Math.pow(10, 12),"Trillion","Trillion"), new gvjs_xH(a,Math.pow(10, 9),"Billion","Billion"), new gvjs_xH(a,Math.pow(10, 6),"Million","Million")];
+  return this
+}
+;
+gvjs_.P5 = function(a) {
+  a = gvjs_aA(0, typeof a === gvjs_g ? a : 3);
+  this.ZD = [new gvjs_xH(a,Math.pow(10, 15),"Q","Q"), new gvjs_xH(a,Math.pow(10, 12),"T","T"), new gvjs_xH(a,Math.pow(10, 9),"B","B"), new gvjs_xH(a,Math.pow(10, 6),"M","M")];
+  return this
+}
+;
+gvjs_.cd = function() {
+  var a = gvjs_x(this.y$);
+  if (this.DF && null == a.pattern)
+    if (typeof this.RJ === gvjs_g || typeof this.jR === gvjs_g) {
+      var b = typeof this.RJ === gvjs_g ? this.RJ : 0;
+      a.pattern = gvjs_aA(b, typeof this.jR === gvjs_g ? this.jR : typeof this.RJ === gvjs_g ? b : 15)
+    } else
+      a.pattern = gvjs_Nb,
+      null == a.significantDigits && (a.significantDigits = this.hK);
+  return new gvjs_AH(new gvjs_gk(a),this.ZD,this.hK,this.$A)
+}
+;
+function gvjs_AH(a, b, c, d) {
+  this.o9 = a;
+  this.ZD = b || [];
+  this.hK = c || null;
+  this.$A = d || null
+}
+gvjs_AH.prototype.format = function(a) {
+  var b = 0 > a;
+  a = Math.abs(a);
+  a = gvjs_qA(this.hK || 15, a);
+  for (var c = null, d = 0; d < this.ZD.length; d++) {
+    var e = this.ZD[d];
+    if (a >= e.aR) {
+      c = e.format(a);
+      break
+    }
+  }
+  null == c && (c = this.o9.Ob(a));
+  this.$A && (a = this.$A.symbol,
+    d = this.$A.usePadding ? " " : "",
+    c = this.$A.position == gvjs_j ? c + d + a : a + d + c);
+  return b ? "-" + c : c
+}
+;
+gvjs_AH.prototype.Ob = function(a) {
+  return this.format(a)
+}
+;
+gvjs_AH.prototype.parse = function(a) {
+  return this.o9.parse(a)
+}
+;
+function gvjs_BH(a, b, c, d) {
+  this.na = a;
+  this.Qf = b;
+  this.tb = c;
+  this.uq = d;
+  this.Jt = this.Yc = null
+}
+function gvjs_CH(a) {
+  a.uq && (a.uq.gK(15),
+    a.Yc = a.uq.cd())
+}
+function gvjs_2ea(a, b) {
+  a.uq && (b = gvjs_wH(b),
+    a.uq.yR(b),
+    a.uq.nw(b))
+}
+function gvjs_DH(a, b, c) {
+  var d;
+  return gvjs_Ge(b, function(e, f) {
+    f = 0 == f ? !0 : Math.abs(a.na.Ya(e) - a.na.Ya(d)) >= c;
+    d = e;
+    return f
+  })
+}
+function gvjs_EH(a, b, c) {
+  if (null == c)
+    return !0;
+  a.Jt && a.Jt.multiple === c || (a.Jt = {},
+    a.Jt.multiple = c,
+    a.Jt.gda = Math.pow(10, gvjs_pA(c || 1)),
+    a.Jt.xta = Math.round(c * a.Jt.gda));
+  return 1E-15 > Math.abs(gvjs_qA(15, b * a.Jt.gda) % a.Jt.xta)
+}
+function gvjs_FH(a, b) {
+  if (!a.Yc)
+    return !0;
+  var c = {};
+  return gvjs_Ge(b, function(d) {
+    var e = a.Yc.Ob(d);
+    return null == c[e] ? (c[e] = d,
+      !0) : !1
+  })
+}
+function gvjs_GH(a, b) {
+  if (!a.Yc)
+    return !0;
+  var c = b.length;
+  if (0 < c) {
+    if (gvjs_HH(a, b[0], b[1]))
+      return !1;
+    for (; 1 < --c; )
+      if (gvjs_HH(a, b[c - 1], b[c]))
+        return !1
+  }
+  return !0
+}
+function gvjs_HH(a, b, c) {
+  var d = gvjs_IH(a, b)
+    , e = gvjs_IH(a, c);
+  return Math.abs(a.na.Ya(b) - a.na.Ya(c)) < (d + e) / 2
+}
+function gvjs_IH(a, b) {
+  b = a.Yc.Ob(b);
+  return a.Qf.bt(b, a.tb)
+}
+function gvjs_JH(a, b, c) {
+  b = a.na.Ae(b);
+  a = a.na.Ae(c);
+  return Math.abs(a - b)
+}
+function gvjs_KH(a, b) {
+  return gvjs_v(b, function(c) {
+    c = gvjs_qA(15, c);
+    var d = a.na.Ya(c)
+      , e = a.Yc ? a.Yc.Ob(c) : "";
+    return new gvjs_qH(c,d,!0,!0,!0,e)
+  })
+}
+function gvjs_LH(a, b) {
+  for (var c = [], d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = c
+      , g = f.push
+      , h = a.na.Ya(e);
+    g.call(f, new gvjs_qH(e,h,!0,!0,!1,null))
+  }
+  return c
+}
+function gvjs_MH(a, b, c, d, e, f) {
+  if (c == d)
+    return [c];
+  if (!isFinite(c))
+    return [d];
+  var g = []
+    , h = b.floor(c);
+  c = null;
+  do
+    (null == e || gvjs_EH(a, h, e)) && (0 === h || null == f || Math.abs(h) >= f) && (g.push(h),
+      c = h),
+      h = b.next();
+  while (null == c || c < d);
+  return g
+}
+;function gvjs_NH(a, b, c, d, e, f) {
+  var g = this;
+  this.na = a;
+  this.m = f;
+  this.Gt = gvjs_L(this.m, gvjs_Vu);
+  this.a1 = gvjs_L(this.m, gvjs_Tv, this.Gt / 2);
+  this.Pd = new gvjs_BH(a,c,e,b);
+  this.PA = d;
+  a = this.m.fa(gvjs_Uu, gvjs_3ea);
+  a = typeof a === gvjs_g ? [a] : Array.isArray(a) ? a : [];
+  b = this.m.fa(gvjs_Sv, gvjs_4ea);
+  var h = typeof b === gvjs_g ? [b] : Array.isArray(b) ? b : [];
+  this.JR = this.m.Aa(gvjs_Wu);
+  this.OD = this.m.Aa(gvjs_Uv);
+  this.GA = new gvjs_vH(a);
+  this.zL = {};
+  gvjs_u(a, function(k) {
+    var l = [];
+    gvjs_u(h, function(m) {
+      Number.isInteger(10 * k / m) && l.push(m)
+    });
+    g.zL[k.toString()] = l
+  })
+}
+gvjs_NH.prototype.mP = function(a, b) {
+  function c(n) {
+    return d.PA ? (n = gvjs_KH(d.Pd, n),
+      d.PA(n)) : gvjs_GH(d.Pd, n)
+  }
+  var d = this;
+  a = null != a ? a : this.na.Yb();
+  b = null != b ? b : this.na.$b();
+  var e = b - a
+    , f = Math.min(e, gvjs_5ea(this));
+  if (0 === f)
+    return {
+      dk: [],
+      DR: []
+    };
+  this.GA.floor(f);
+  var g = !1
+    , h = null
+    , k = null
+    , l = null;
+  do {
+    var m = new gvjs_uH(f);
+    h = [];
+    gvjs_EH(this.Pd, f, this.JR) && (h = gvjs_MH(this.Pd, m, a, b, this.JR, null));
+    if (h.length)
+      if (gvjs_2ea(this.Pd, h),
+        gvjs_CH(this.Pd),
+      gvjs_DH(this.Pd, h, this.Gt) && gvjs_FH(this.Pd, h) && c(h)) {
+        g = !0;
+        break
+      } else if (g)
+        break;
+    f = this.GA.next()
+  } while (f <= e);
+  return function() {
+    k || (k = h,
+      l = f);
+    var n = gvjs_KH(d.Pd, k)
+      , p = d.EZ(l);
+    return {
+      dk: n,
+      DR: p
+    }
+  }()
+}
+;
+gvjs_NH.prototype.EZ = function(a) {
+  var b = this.na.Yb()
+    , c = this.na.$b()
+    , d = []
+    , e = gvjs_qA(15, a / Math.pow(10, Math.floor(Math.log10(a))));
+  e = this.zL[e.toString()] || [];
+  if (0 === e.length)
+    return d;
+  var f = new gvjs_vH(e);
+  f.floor(a / 20);
+  e = f.getValue();
+  do {
+    if (Number.isInteger(a / e)) {
+      var g = new gvjs_uH(e)
+        , h = [];
+      gvjs_EH(this.Pd, e, this.OD) && (h = gvjs_MH(this.Pd, g, b, c, this.OD, null));
+      if (h.length && gvjs_DH(this.Pd, h, this.a1)) {
+        d = gvjs_LH(this.Pd, h);
+        break
+      }
+    }
+    e = f.next()
+  } while (e < a);
+  return d
+}
+;
+function gvjs_5ea(a) {
+  var b = a.na.Ho()
+    , c = a.na.an()
+    , d = gvjs_JH(a.Pd, c, c - a.Gt)
+    , e = gvjs_JH(a.Pd, b, b + a.Gt);
+  d = Math.max(e, d);
+  e = a.na.Ya(0);
+  b <= e === e <= c && (b = a.na.Ae(e + a.Gt),
+    d = Math.max(d, b));
+  return 0 === d ? 0 : a.GA.ceil(d)
+}
+var gvjs_3ea = [1, 2, 2.5, 5]
+  , gvjs_4ea = [1, 1.5, 2, 2.5, 5];
+function gvjs_OH(a, b, c, d) {
+  this.so = a;
+  this.iq = b;
+  this.o3 = c;
+  this.hfa = d;
+  this.ny = (this.hfa - this.o3) / (this.iq - this.so);
+  this.YK = this.ny * this.so - this.o3
+}
+gvjs_ = gvjs_OH.prototype;
+gvjs_.Ae = function(a) {
+  return (a + this.YK) / this.ny
+}
+;
+gvjs_.Ya = function(a) {
+  return a * this.ny - this.YK
+}
+;
+gvjs_.Ho = function() {
+  return this.o3
+}
+;
+gvjs_.an = function() {
+  return this.hfa
+}
+;
+gvjs_.Yb = function() {
+  return this.so
+}
+;
+gvjs_.$b = function() {
+  return this.iq
+}
+;
+function gvjs_PH(a, b) {
+  this.PR = a;
+  this.eK = Math.floor(a / 10);
+  this.Wr = a - this.eK;
+  this.lc = 0;
+  this.uR = gvjs_9E(Math.abs(b));
+  this.jB = this.Wr * this.uR;
+  this.Qa = 0
+}
+gvjs_o(gvjs_PH, gvjs_sH);
+function gvjs_QH(a) {
+  var b = Math.floor(a.Qa / a.Wr);
+  a = 10 * (a.Qa + a.eK - b * a.Wr) / a.PR;
+  0 == a && (a = 1);
+  return gvjs_8E(a, b)
+}
+gvjs_ = gvjs_PH.prototype;
+gvjs_.getValue = function() {
+  this.Qa = Math.abs(this.lc) + this.jB;
+  return 0 < this.lc ? gvjs_QH(this) : 0 > this.lc ? -gvjs_QH(this) : 0
+}
+;
+gvjs_.next = function() {
+  this.lc++;
+  return this.getValue()
+}
+;
+gvjs_.he = function() {
+  this.lc--;
+  return this.getValue()
+}
+;
+gvjs_.floor = function(a) {
+  var b = this.eK
+    , c = gvjs_9E(Math.abs(a));
+  if (Math.abs(a) <= Math.pow(10, this.uR))
+    return this.lc = 0 > a ? -1 : 0,
+      this.getValue();
+  0 < a ? this.lc = this.Wr * c - this.jB : 0 > a && (this.lc = this.jB - this.Wr * c,
+    b = -b);
+  this.getValue() != a && (c = this.PR * a / gvjs_8E(1, gvjs_$E(Math.abs(a))),
+    this.lc += Math.floor(c) - b);
+  return this.getValue()
+}
+;
+gvjs_.ceil = function(a) {
+  var b = this.eK
+    , c = gvjs_9E(Math.abs(a));
+  if (Math.abs(a) <= Math.pow(10, this.uR))
+    return this.lc = 0 < a ? 1 : 0,
+      this.getValue();
+  0 < a ? this.lc = this.Wr * c - this.jB : 0 > a && (this.lc = this.jB - this.Wr * c,
+    b = -b);
+  this.getValue() != a && (c = this.PR * a / gvjs_8E(1, gvjs_$E(Math.abs(a))),
+    this.lc += Math.ceil(c) - b);
+  return this.getValue()
+}
+;
+gvjs_.round = function(a) {
+  var b = gvjs_9E(Math.abs(a));
+  if (Math.abs(a) <= Math.pow(10, this.uR))
+    return this.lc = 0;
+  if (0 < a) {
+    this.lc = this.Wr * b - this.jB;
+    if (this.next() > a)
+      return a - this.getValue() >= this.he() - a ? this.next() : this.getValue();
+    this.he()
+  } else if (0 > a) {
+    this.lc = this.jB - this.Wr * b;
+    if (this.he() < a)
+      return a - this.getValue() < this.next() - a ? this.he() : this.getValue();
+    this.next()
+  }
+  this.getValue() != a && (b = this.PR * a / gvjs_8E(1, gvjs_$E(Math.abs(a))),
+    this.lc += Math.round(b) - this.eK);
+  return this.getValue()
+}
+;
+function gvjs_RH(a, b, c, d, e, f, g) {
+  var h = this;
+  this.na = a;
+  this.Yf = Math.abs(g) || 1;
+  this.m = f;
+  this.Gt = gvjs_L(this.m, gvjs_Vu);
+  this.a1 = gvjs_L(this.m, gvjs_Tv, this.Gt / 5);
+  this.Pd = new gvjs_BH(a,c,e,b);
+  this.PA = d;
+  a = this.m.fa(gvjs_Uu, gvjs_6ea);
+  a = typeof a === gvjs_g ? [a] : Array.isArray(a) ? a : [];
+  b = this.m.fa(gvjs_Sv, gvjs_7ea);
+  var k = typeof b === gvjs_g ? [b] : Array.isArray(b) ? b : [];
+  this.GA = new gvjs_vH(a);
+  b = gvjs_v(a, function(l) {
+    for (l = 10 / l; 10 <= l; )
+      l /= 10;
+    return l
+  }).sort();
+  this.bF = new gvjs_vH(b);
+  this.zL = {};
+  gvjs_u(a, function(l) {
+    var m = [];
+    gvjs_u(k, function(n) {
+      Number.isInteger(10 * l / n) && m.push(n)
+    });
+    h.zL[l.toString()] = m
+  });
+  this.JR = this.m.Aa(gvjs_Wu);
+  this.OD = this.m.Aa(gvjs_Uv)
+}
+gvjs_RH.prototype.mP = function(a, b) {
+  function c(q) {
+    return 0 < q.length && (q[0] > a || q[q.length - 1] < b) || !gvjs_DH(e.Pd, q, e.Gt) || !gvjs_FH(e.Pd, q) ? !1 : e.PA ? (q = gvjs_KH(e.Pd, q),
+      e.PA(q)) : gvjs_GH(e.Pd, q)
+  }
+  function d(q, r) {
+    var t = e.Pd
+      , u = []
+      , v = q.length
+      , w = t.na.Ya(0);
+    if (w != t.na.Ya(q[0]) && w != t.na.Ya(q[v - 1])) {
+      for (var x = 0; x < v; x++)
+        0 !== q[x] && w == t.na.Ya(q[x]) || u.push(q[x]);
+      q = u
+    }
+    t = gvjs_KH(e.Pd, q);
+    r = e.EZ(r);
+    return {
+      dk: t,
+      DR: r
+    }
+  }
+  var e = this;
+  a = null != a ? a : this.na.Yb();
+  b = null != b ? b : this.na.$b();
+  var f = b - a
+    , g = this.Yf
+    , h = gvjs_8ea(this)
+    , k = gvjs_MH(this.Pd, new gvjs_PH(h,g), a, b, null, this.Yf)
+    , l = Math.min(f, 10 / h)
+    , m = k
+    , n = l;
+  gvjs_CH(this.Pd);
+  if (2 > k.length)
+    return d(k, l);
+  var p = !1;
+  if (c(k))
+    p = !0;
+  else {
+    l = k[0] || g;
+    k = k[1];
+    l === k && (l /= 10);
+    this.bF.ceil(Math.max(1, gvjs_8E(1, gvjs_$E(Math.abs(l))) / Math.abs(k - l)));
+    h = this.bF.getValue();
+    this.GA.floor(10 / h);
+    l = this.GA.getValue();
+    do {
+      h = 10 / l;
+      h = new gvjs_PH(h,g);
+      k = [];
+      gvjs_EH(this.Pd, l, this.OD) && (k = gvjs_MH(this.Pd, h, a, b, this.JR, this.Yf));
+      if (c(k)) {
+        p = !0;
+        break
+      }
+      l = this.GA.next()
+    } while (l < f);
+    p || (k = m,
+      l = n)
+  }
+  return d(k, l)
+}
+;
+gvjs_RH.prototype.EZ = function(a) {
+  var b = this.na.Yb()
+    , c = this.na.$b()
+    , d = []
+    , e = gvjs_qA(15, a / Math.pow(10, Math.floor(Math.log10(a))));
+  e = this.zL[e.toString()] || [];
+  if (0 === e.length)
+    return d;
+  var f = new gvjs_vH(e);
+  f.floor(a / 20);
+  e = f.getValue();
+  do {
+    if (Number.isInteger(a / e)) {
+      var g = new gvjs_PH(gvjs_qA(15, 10 / e),this.Yf)
+        , h = [];
+      gvjs_EH(this.Pd, e, this.OD) && (h = gvjs_MH(this.Pd, g, b, c, this.OD, this.Yf));
+      if (h.length && gvjs_DH(this.Pd, h, this.a1)) {
+        d = gvjs_LH(this.Pd, h);
+        break
+      }
+    }
+    e = f.next()
+  } while (e < a);
+  return d
+}
+;
+function gvjs_8ea(a) {
+  var b = a.na.Ya(10 * a.Yf);
+  a.bF.floor(1);
+  do {
+    var c = a.bF.next();
+    c = a.na.Ya(10 * a.Yf * (c - 1) / c)
+  } while (Math.abs(b - c) >= a.Gt);
+  c = a.bF.he();
+  1 > c && (c = a.bF.next());
+  return c
+}
+var gvjs_6ea = [1, 2, 5]
+  , gvjs_7ea = [1, 2, 5];
+function gvjs_SH(a, b, c, d, e, f, g, h, k, l, m, n, p) {
+  e && (e = c,
+    c = d,
+    d = e);
+  this.so = a;
+  this.iq = b;
+  this.Jw = c;
+  this.xE = d;
+  this.d0 = f;
+  this.Yf = g;
+  this.tb = h;
+  this.m = k;
+  this.Qf = l;
+  this.uq = m;
+  this.PA = n;
+  this.xca = p;
+  gvjs_TH(this)
+}
+function gvjs_TH(a) {
+  a.na = 1 == a.d0 ? new gvjs_OH(a.so,a.iq,a.Jw,a.xE) : new gvjs_aF(a.so,a.iq,a.Jw,a.xE,a.d0,a.Yf);
+  a.xca && a.xca(a.na)
+}
+function gvjs_UH(a, b, c) {
+  if (a.so == a.iq)
+    return b = a.Jw + (a.xE - a.Jw) / 2,
+      c = "",
+    a.uq && (c = a.uq.cd().format(a.so)),
+      {
+        dk: [gvjs_rH(a.so, b, c)]
+      };
+  var d = a.na
+    , e = a.m
+    , f = a.Yf
+    , g = a.d0
+    , h = a.tb
+    , k = a.Qf
+    , l = a.uq;
+  a = a.PA;
+  return (.65 < gvjs_9ea(d) && .5 < g ? new gvjs_NH(d,l,k,a,h,e) : new gvjs_RH(d,l,k,a,h,e,f)).mP(b, c)
+}
+function gvjs_VH(a, b, c, d, e) {
+  var f = 100;
+  do {
+    if (0 > f--)
+      break;
+    a.so = b;
+    a.iq = c;
+    gvjs_TH(a);
+    var g = b;
+    var h = c;
+    var k = gvjs_UH(a, b, c);
+    var l = k.dk;
+    1 < l.length && (null != d && (b = l[0].getValue()),
+    null != e && (c = l[l.length - 1].getValue()));
+    g = b != g || c != h;
+    if (isNaN(b) || isNaN(c))
+      g = !1,
+        b = null != d ? d : b,
+        c = null != e ? e : c
+  } while (g);
+  k.min = b;
+  k.max = c;
+  return k
+}
+function gvjs_$ea(a, b, c, d, e) {
+  var f = .005 * (b - a);
+  return gvjs_VH(new gvjs_SH(a - f,b + f,c,d,!1,1,0,gvjs_S,e,null,null,null,null), a, b, null, null).dk
+}
+function gvjs_9ea(a) {
+  function b(l, m) {
+    var n = m.Ae(l);
+    l = m.Ae(l + 10);
+    return Math.abs(l - n)
+  }
+  if (a.Yb() == a.$b())
+    return 1;
+  var c = Math.min(a.Ho(), a.an())
+    , d = Math.max(a.Ho(), a.an())
+    , e = a.Ya(0)
+    , f = Math.abs(a.Ae(c))
+    , g = Math.abs(a.Ae(d))
+    , h = Math.max(f, g)
+    , k = 0;
+  if (c > e || e > d)
+    k = Math.min(f, g);
+  c = a.Ya(k);
+  h = a.Ya(h);
+  return b(c, a) / b(h, a)
+}
+;function gvjs_WH(a, b) {
+  this.Ww = a;
+  this.Za = b
+}
+gvjs_o(gvjs_WH, gvjs_tH);
+gvjs_WH.prototype.La = function(a) {
+  return this.Ww(a, this.Za).width
+}
+;
+gvjs_WH.prototype.getHeight = function(a) {
+  return this.Ww(a, this.Za).height
+}
+;
+gvjs_WH.prototype.bt = function(a, b) {
+  return b == gvjs_S ? this.La(a) : this.getHeight(a)
+}
+;
+function gvjs_afa(a, b) {
+  if (a) {
+    if (b.length != a.length)
+      throw Error("colorsScale and valuesScale must be of the same length");
+  } else if (1 !== b.length)
+    throw Error("colorsScale must contain exactly one element when no valueScale is provided");
+  this.pl = a;
+  this.Zu = gvjs_v(b, function(c) {
+    return gvjs_qj(c).hex
+  })
+}
+function gvjs_XH(a, b) {
+  if (!a.pl)
+    return a.Zu[0];
+  if (b >= a.pl[a.pl.length - 1])
+    return a.Zu[a.Zu.length - 1];
+  if (b <= a.pl[0])
+    return a.Zu[0];
+  var c = gvjs_Iy(a.pl, b);
+  if (0 <= c)
+    return a.Zu[c];
+  var d = -c - 2;
+  c = -c - 1;
+  return gvjs_7z(a.Zu[c], a.Zu[d], (b - a.pl[d]) / (a.pl[c] - a.pl[d]))
+}
+function gvjs_bfa(a, b) {
+  b && 0 !== b.length ? 1 === b.length && (b = [gvjs_YH[0], b[0]]) : b = a && 3 === a.length ? gvjs_ZH : gvjs_YH;
+  if (!a || 2 > a.length)
+    return {
+      values: null,
+      dX: [gvjs_Ae(b)]
+    };
+  var c = a[0]
+    , d = a[a.length - 1]
+    , e = d - c;
+  if (0 === e)
+    return {
+      values: [d],
+      dX: [gvjs_Ae(b)]
+    };
+  if (2 === a.length)
+    for (a = [],
+           d = e / (b.length - 1),
+           e = 0; e < b.length; e++)
+      a.push(c + d * e);
+  return {
+    values: a,
+    dX: b
+  }
+}
+function gvjs__H(a, b) {
+  var c = a.view("colorAxis")
+    , d = null
+    , e = c.$I("values");
+  if (e && 0 < e.length) {
+    1 === e.length && (e = [e[0], e[0]]);
+    b && (null == e[0] && (e[0] = b.start),
+    null == e[e.length - 1] && (e[e.length - 1] = b.end));
+    if (null == e[0])
+      throw Error(gvjs_0t);
+    for (d = 1; d < e.length; d++) {
+      if (null == e[d])
+        throw Error(gvjs_0t);
+      if (e[d] < e[d - 1])
+        throw Error("colorAxis.values must be a monotonically increasing series");
+    }
+    d = e
+  } else {
+    e = c.Aa(gvjs_ed);
+    var f = c.Aa(gvjs_cd);
+    if (null != e && null != f && e > f)
+      throw Error("colorAxis.minValue (" + e + ") must be at most colorAxis.maxValue (" + f + ")");
+    (b = gvjs_9B(b, e, f)) && (d = [b.start, b.end])
+  }
+  a = gvjs_Fj(a, gvjs_Ij, [], gvjs_2t, void 0, void 0);
+  a = gvjs_Fj(c, gvjs_Ij, [], gvjs_2t, a, void 0);
+  b = c.fa("one-sided-colors", gvjs_YH);
+  c = c.fa("two-sided-colors", gvjs_ZH);
+  a && 0 !== a.length ? 1 === a.length && (a = [b[0], a[0]]) : a = d && 3 === d.length ? c : b;
+  c = gvjs_bfa(d, a);
+  return new gvjs_afa(c.values,c.dX)
+}
+var gvjs_YH = ["#EFE6DC", gvjs_lr]
+  , gvjs_ZH = [gvjs_vr, "#EFE6DC", gvjs_lr];
+function gvjs_0H(a, b, c, d) {
+  var e = {}
+    , f = b.numberFormat || gvjs_mk;
+  if (b.orientation == gvjs_S) {
+    e = b.ja;
+    var g = a.pl[0];
+    var h = a.pl[a.pl.length - 1];
+    f = new gvjs_gk({
+      pattern: f
+    });
+    g = f.Ob(g);
+    h = f.Ob(h);
+    e = {
+      minValue: {
+        text: g,
+        width: d ? d(g, e).width : 0,
+        height: e.fontSize
+      },
+      maxValue: {
+        text: h,
+        width: d ? d(h, e).width : 0,
+        height: e.fontSize
+      }
+    };
+    d = e.minValue.height / 4;
+    g = new gvjs_5(e.minValue.width + d,0,b.width - (e.minValue.width + e.maxValue.width + 2 * d),b.height)
+  } else
+    g = new gvjs_5(0,0,b.width,b.height);
+  d = .33 * g.height;
+  h = d / Math.sqrt(3) * 2;
+  f = new gvjs_5(g.left + h / 2,g.top + d + 1,g.width - h,g.height - d - 1);
+  var k = a.Zu
+    , l = a.pl
+    , m = l[l.length - 1] - l[0];
+  if (0 == m)
+    var n = [{
+      sh: new gvjs_5(f.left,f.top,f.width,f.height),
+      brush: new gvjs_3({
+        fill: k[0]
+      })
+    }];
+  else {
+    n = [];
+    m = f.width / m;
+    for (var p = f.left, q, r = 0; r < l.length - 1; ++r)
+      q = p + (l[r + 1] - l[r]) * m,
+        n[r] = {
+          sh: new gvjs_5(p,f.top,q - p,f.height),
+          brush: new gvjs_3({
+            gradient: {
+              x1: p,
+              y1: 0,
+              x2: q,
+              y2: 0,
+              Vf: k[r],
+              sf: k[r + 1]
+            }
+          })
+        },
+        p = q
+  }
+  f = n;
+  if (null != f && 0 < f.length && (0 > f[0].sh.width || 0 > f[0].sh.height))
+    return null;
+  k = g;
+  l = b.zca;
+  g = [];
+  for (n = 0; n < c.length; ++n)
+    m = c[n].value,
+      p = a.pl,
+      m < p[0] ? m = 0 : (q = k.width - h,
+        m > p[p.length - 1] ? m = q : (r = p[p.length - 1] - p[0],
+          m = 0 == r ? .5 * q : (m - p[0]) / r * q)),
+      m = k.left + m + h / 2,
+      m = [m - h / 2, k.top, m + h / 2, k.top, m, k.top + d],
+      p = new gvjs_3({
+        fill: l,
+        stroke: l
+      }),
+      g[n] = {
+        path: m,
+        brush: p
+      };
+  a = [];
+  b.orientation == gvjs_S && (a = e,
+    c = [],
+    c[0] = {
+      x: 0,
+      y: b.height - a.minValue.height,
+      text: a.minValue.text,
+      style: b.ja
+    },
+    c[1] = {
+      x: b.width - a.maxValue.width,
+      y: b.height - a.maxValue.height,
+      text: a.maxValue.text,
+      style: b.ja
+    },
+    a = c);
+  a = {
+    XW: f,
+    G0: g,
+    V4: a
+  };
+  e = a.XW;
+  for (c = 0; c < e.length; ++c)
+    d = e[c],
+    b.orientation == gvjs_U && (h = d.sh.left,
+      d.sh.left = d.sh.top,
+      d.sh.top = h,
+      h = d.sh.width,
+      d.sh.width = d.sh.height,
+      d.sh.height = h),
+      d.sh.left += b.left,
+      d.sh.top += b.top,
+      h = d.brush.clone(),
+      d.brush = h,
+      d = h.gradient,
+    b.orientation == gvjs_U && (d.y1 = d.x1,
+      d.x1 = 0,
+      d.y2 = d.x2,
+      d.x2 = 0),
+    null != d && (d.x1 += b.left,
+      d.y1 += b.top,
+      d.x2 += b.left,
+      d.y2 += b.top);
+  e = a.G0;
+  for (c = 0; c < e.length; ++c)
+    for (d = 0; 3 > d; ++d)
+      b.orientation == gvjs_U && (h = e[c].path[2 * d],
+        e[c].path[2 * d] = e[c].path[2 * d + 1],
+        e[c].path[2 * d + 1] = h),
+        e[c].path[2 * d] += b.left,
+        e[c].path[2 * d + 1] += b.top;
+  e = a.V4;
+  for (c = 0; c < e.length; ++c)
+    e[c].x += b.left,
+      e[c].y += b.top;
+  return a
+}
+;function gvjs_1H(a, b, c) {
+  this.xl = a;
+  this.Qa = c ? gvjs_J(b, "colorAxis.legend.position", c, gvjs_5da) : gvjs_f;
+  this.Za = gvjs_ry(b, "colorAxis.legend.textStyle", {
+    bb: a.Hj,
+    fontSize: a.Dl,
+    Lb: this.Qa == gvjs_Fp ? a.oz : gvjs_f
+  });
+  this.G1 = b.cb("colorAxis.legend.numberFormat");
+  this.qe = this.fc = null
+}
+gvjs_ = gvjs_1H.prototype;
+gvjs_.getPosition = function() {
+  return this.Qa
+}
+;
+gvjs_.getHeight = function() {
+  return 1.5 * this.Za.fontSize
+}
+;
+gvjs_.getArea = function() {
+  return this.fc
+}
+;
+gvjs_.qr = function(a) {
+  this.fc = a
+}
+;
+gvjs_.setScale = function(a) {
+  this.qe = a
+}
+;
+gvjs_.define = function() {
+  if (!this.fc || !this.qe)
+    return null;
+  var a = {
+    top: this.fc.top,
+    left: this.fc.left,
+    width: this.fc.right - this.fc.left,
+    height: this.fc.bottom - this.fc.top,
+    orientation: gvjs_S,
+    ja: this.Za,
+    zca: gvjs_rt,
+    numberFormat: this.G1
+  }
+    , b = gvjs_0H(this.qe, a, [], this.xl.sc);
+  return null == b ? null : {
+    position: this.Qa,
+    scale: this.qe,
+    SH: a,
+    definition: b
+  }
+}
+;
+function gvjs_2H(a, b, c, d, e) {
+  var f = gvjs_cfa;
+  this.Wea = gvjs_dfa;
+  this.mY = f;
+  this.m = a;
+  f = a.fa(gvjs_Fu);
+  this.Xe = null == f ? null : typeof f === gvjs_l ? {
+    pattern: f
+  } : {
+    pattern: f.pattern,
+    formatType: f.formatType,
+    timeZone: f.timeZone
+  };
+  this.sta = gvjs_Oj(a, [gvjs_Vu, "gridlines.minStrongLineDistance"]);
+  this.vta = gvjs_Oj(a, [gvjs_Tv, "gridlines.minWeakLineDistance"]);
+  this.tta = gvjs_Oj(a, "gridlines.minStrongToWeakLineDistance");
+  this.rta = gvjs_Oj(a, "gridlines.minNotchDistance");
+  this.pta = gvjs_Oj(a, "gridlines.minMajorTextDistance");
+  this.qta = gvjs_Oj(a, "gridlines.minMinorTextDistance");
+  this.Hya = gvjs_Oj(a, "gridlines.unitThreshold");
+  this.b7 = gvjs_K(a, "gridlines.allowMinor");
+  0 === a.Aa(gvjs_Rv) && (this.b7 = !1);
+  this.Ff = b;
+  this.QA = c;
+  this.RR = d;
+  this.jta = e;
+  this.Yca = this.qca = null
+}
+function gvjs_3H(a, b, c, d, e) {
+  return new gvjs_2H(a,b,c,d,e)
+}
+gvjs_2H.prototype.generate = function gvjs_efa(a, b, c, d) {
+  var f = this, g, h, k, l, m, n, p, q, r, t, u, v, w, x, y, z, A, B, D, C, G, J, I, M, H, Q;
+  return gvjs_Dy(gvjs_efa, function(R) {
+    switch (R.Fi) {
+      case 1:
+        g = gvjs_ffa(f, a, b, c),
+          h = f.m.pb("gridlines.units." + g.unit),
+          k = gvjs_sk[g.unit],
+          l = gvjs_HA[k],
+          m = [],
+          n = {
+            minValue: g.minValue,
+            maxValue: g.maxValue,
+            unitName: g.unit,
+            Yga: k,
+            Wga: l,
+            Xga: h.format,
+            z5: h.interval,
+            Rca: f.sta,
+            dt: d.dt,
+            ud: d.ud,
+            uta: f.pta,
+            LZ: m,
+            Qca: 0
+          },
+          f.qca = n,
+          p = gvjs_4H(f, n),
+          q = null;
+      case 2:
+        if (!(q = p.next().value)) {
+          R.hh(3);
+          break
+        }
+        if (0 == q.Ja.length) {
+          R.hh(2);
+          break
+        }
+        r = d.W6;
+        if (!(f.b7 && 1 == q.multiple && 0 < k))
+          return I = 1 != q.multiple ? 0 : r,
+            M = gvjs_5H(d.ud, I, q.Ja, q.KL),
+            H = void 0,
+            1 < q.multiple ? (Q = gvjs_gfa(f, g, q, l, d),
+              H = gvjs_Ke(q.Ja, Q)) : H = q.Ja,
+            gvjs_zy(R, {
+              Ja: H,
+              ec: M
+            }, 2);
+        t = k - 1;
+        u = gvjs_rk[t];
+        v = f.m.pb("minorGridlines.units." + u);
+        w = gvjs_HA[t];
+        x = {
+          minValue: g.minValue,
+          maxValue: g.maxValue,
+          unitName: u,
+          Yga: t,
+          Wga: w,
+          Xga: v.format,
+          z5: v.interval,
+          Rca: f.vta,
+          dt: d.CR,
+          ud: d.UJ,
+          uta: f.qta,
+          LZ: q.Ja,
+          Qca: f.tta
+        };
+        f.Yca = x;
+        y = gvjs_4H(f, x);
+        z = null;
+        A = !1;
+      case 6:
+        if (A) {
+          R.hh(2);
+          break
+        }
+        z = y.next().value;
+        A = null == z;
+        if (null == z || !z.Ja.length)
+          return J = gvjs_5H(d.ud, 2, q.Ja, q.KL),
+            gvjs_zy(R, {
+              Ja: q.Ja,
+              ec: J
+            }, 6);
+        B = gvjs_5H(d.ud, r, q.Ja, q.KL);
+        D = gvjs_5H(d.UJ, r, z.Ja, z.KL);
+        gvjs_u(D, function(T) {
+          T.optional = !0
+        });
+        C = gvjs_Ke(z.Ja, q.Ja);
+        G = gvjs_Ke(B, D);
+        return gvjs_zy(R, {
+          Ja: C,
+          ec: G
+        }, 6);
+      case 3:
+        return R.return({
+          Ja: [],
+          ec: []
+        })
+    }
+  })
+}
+;
+function gvjs_ffa(a, b, c, d) {
+  gvjs_FA(d, gvjs_hfa, a.mY);
+  a = gvjs_FA((c - b) / a.Hya, a.Wea, a.mY);
+  var e = gvjs_ifa(a);
+  a = gvjs_Xx(gvjs_HA, function(f) {
+    return gvjs_Jy(f, e)
+  });
+  return {
+    minValue: b,
+    maxValue: c,
+    unit: gvjs_rk[a]
+  }
+}
+var gvjs_4H = function gvjs_jfa(a, b) {
+  var d, e, f, g, h, k, l, m, n, p, q, r, t, u, v, w, x, y, z, A, B;
+  return gvjs_Dy(gvjs_jfa, function(D) {
+    switch (D.Fi) {
+      case 1:
+        d = b.z5.length,
+          e = 0;
+      case 2:
+        if (!(e < d)) {
+          D.hh(4);
+          break
+        }
+        f = b.z5[e];
+        g = 0;
+        h = gvjs_Pda(b.Wga, f);
+        k = gvjs_yA(new Date(b.minValue + a.QA), h);
+        if ("days" === b.unitName) {
+          var C = k;
+          C = gvjs_yA(C, [0, 0, 0, 0, 1]);
+          k = C = gvjs_zA(C, [0, 0, 0, 0, (7 + C.getDay() - 1) % 7])
+        }
+        l = new gvjs_AA(k,new Date(b.maxValue + a.QA),b.Yga,f);
+        m = [];
+        n = !0;
+        p = a.RR(b.minValue);
+        for (q = -1; l.Qz <= l.tY; )
+          if (r = l.next(),
+            t = a.RR(r.getTime() - a.QA),
+            !(t < p)) {
+            -1 == q && t >= p && (q = m.length);
+            u = l.peek();
+            if (null != u && (v = a.RR(u.getTime() - a.QA),
+            Math.abs(v - t) < b.Rca)) {
+              n = !1;
+              break
+            }
+            for (w = !1; g < b.LZ.length; ) {
+              x = b.LZ[g];
+              if (Math.abs(x.Na - t) < b.Qca) {
+                w = !0;
+                break
+              }
+              if (x.Na > t) {
+                g = Math.max(0, g - 1);
+                break
+              }
+              g++
+            }
+            w || m.push({
+              za: r,
+              Na: t,
+              isVisible: !0,
+              brush: b.dt,
+              length: null,
+              S_: !1
+            })
+          }
+        if (!n) {
+          D.hh(3);
+          break
+        }
+        y = gvjs_6H(a, m, b);
+        z = null;
+      case 5:
+        if (!(z = y.next().value)) {
+          D.hh(6);
+          break
+        }
+        if (null == z) {
+          D.hh(5);
+          break
+        }
+        A = Infinity;
+        for (B = 0; B < m.length - 1; ++B)
+          A = Math.min(A, m[B + 1].Na - m[B].Na);
+        return gvjs_zy(D, {
+          Ja: m,
+          KL: z,
+          multiple: f,
+          Xca: A
+        }, 5);
+      case 6:
+        m = [];
+      case 3:
+        ++e;
+        D.hh(2);
+        break;
+      case 4:
+        return D.return({
+          Ja: [],
+          KL: [],
+          multiple: 1,
+          Xca: Infinity
+        })
+    }
+  })
+}
+  , gvjs_6H = function gvjs_kfa(a, b, c) {
+  var e, f, g, h, k, l, m, n, p, q, r;
+  return gvjs_Dy(gvjs_kfa, function(t) {
+    1 == t.Fi && (e = c.Xga,
+    Array.isArray(e) || (e = [e]),
+      f = [],
+      null != a.Xe && null != a.Xe.pattern ? f = [new gvjs_Tj(a.Xe)] : (g = a.Xe || {},
+        f = gvjs_v(e, function(u) {
+          g.pattern = u;
+          return new gvjs_Tj(g)
+        })),
+      h = 0);
+    if (3 != t.Fi) {
+      if (!(h < f.length))
+        return t.hh(0);
+      k = f[h];
+      l = [];
+      for (m = 0; m < b.length; ++m)
+        n = b[m],
+          p = n.Me || k.Ob(n.za),
+          q = a.jta(p, c.ud),
+          r = a.Ff ? q.height : q.width,
+          l.push({
+            text: p,
+            size: r
+          });
+      return gvjs_zy(t, l, 3)
+    }
+    ++h;
+    return t.hh(2)
+  })
+};
+function gvjs_gfa(a, b, c, d, e) {
+  if (c.Xca / c.multiple < a.rta)
+    return [];
+  e = e.dt;
+  var f = []
+    , g = new Date(b.maxValue + a.QA);
+  d = gvjs_yA(new Date(b.minValue + a.QA), d);
+  b = new gvjs_AA(d,g,gvjs_sk[b.unit],1);
+  for (d = 0; b.Qz <= b.tY; ) {
+    if (0 != d % c.multiple) {
+      g = b.next();
+      var h = a.RR(g.getTime() - a.QA);
+      f.push({
+        za: g,
+        Na: h,
+        isVisible: !0,
+        brush: e,
+        length: 5,
+        S_: !0
+      })
+    }
+    d++
+  }
+  return f
+}
+function gvjs_5H(a, b, c, d) {
+  for (var e = [], f = 1 == b ? gvjs_2 : 3 == b ? gvjs_R : gvjs_0, g = 0, h = [], k = 1 < c.length ? c[1].Na - c[0].Na : 0, l = 0; l < c.length; ++l) {
+    var m = c[l]
+      , n = Math.round(b == k)
+      , p = d[l].size;
+    if (f == gvjs_2) {
+      var q = n;
+      var r = n + p
+    } else
+      f == gvjs_R ? (q = n - p,
+        r = n) : (q = Math.round(n - p / 2),
+        r = Math.round(n + p / 2));
+    for (r = new gvjs_O(q - 0,r + 0); g < e.length; )
+      e[g].start > r.end && (g = Math.max(0, g - 1)),
+        g++;
+    h.push({
+      za: m.za,
+      isVisible: !0,
+      Na: n,
+      Da: {
+        text: d[l].text,
+        ja: a,
+        lines: [{
+          x: n,
+          y: 0,
+          text: d[l].text,
+          length: p
+        }],
+        ld: f,
+        Pc: gvjs_R,
+        BEa: d[l].text,
+        anchor: null,
+        angle: 0
+      }
+    })
+  }
+  return h
+}
+function gvjs_ifa(a) {
+  return gvjs_v(a, function(b) {
+    return 0 < b ? 1 : 0
+  })
+}
+var gvjs_hfa = [[1], [50], [500], [0, 1], [0, 15], [0, 30], [0, 0, 1], [0, 0, 15], [0, 0, 30], [0, 0, 0, 1], [0, 0, 0, 6], [0, 0, 0, 12], [0, 0, 0, 0, 1], [0, 0, 0, 0, 7], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 3], [0, 0, 0, 0, 0, 6], [0, 0, 0, 0, 0, 0, 1]]
+  , gvjs_dfa = [[1], [2], [5], [10], [20], [50], [100], [200], [500], [0, 1], [0, 2], [0, 5], [0, 10], [0, 15], [0, 30], [0, 0, 1], [0, 0, 2], [0, 0, 5], [0, 0, 10], [0, 0, 15], [0, 0, 30], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 4], [0, 0, 0, 6], [0, 0, 0, 12], [0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 7], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 3], [0, 0, 0, 0, 0, 6], [0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 10], [0, 0, 0, 0, 0, 0, 50], [0, 0, 0, 0, 0, 0, 100]]
+  , gvjs_cfa = 3;
+function gvjs_7H(a) {
+  switch (a) {
+    case gvjs_Lb:
+    case gvjs_Mb:
+      return {
+        toNumber: gvjs_8H,
+        Hy: gvjs_9H
+      };
+    case gvjs_Od:
+      return {
+        toNumber: gvjs_lfa,
+        Hy: gvjs_mfa
+      };
+    case gvjs_g:
+    case gvjs_l:
+      return {
+        toNumber: gvjs_$H,
+        Hy: gvjs_aI
+      };
+    default:
+      return {
+        toNumber: gvjs_$H,
+        Hy: gvjs_aI
+      }
+  }
+}
+function gvjs_$H(a) {
+  return Number(a)
+}
+function gvjs_aI(a) {
+  return a
+}
+function gvjs_8H(a) {
+  return a.getTime()
+}
+function gvjs_9H(a) {
+  return new Date(a)
+}
+function gvjs_lfa(a) {
+  return gvjs_GA(a)
+}
+function gvjs_mfa(a) {
+  return gvjs_DA(a).reverse()
+}
+;function gvjs_bI() {}
+gvjs_ = gvjs_bI.prototype;
+gvjs_.init = function(a) {
+  this.options = a;
+  this.ticks = [];
+  this.sn = Infinity;
+  this.rn = -Infinity;
+  this.wda = null;
+  this.Xe = a.cb(gvjs_Fu);
+  a.fa("valueFormatter", function(b, c) {
+    return c
+  });
+  this.gd = this.Vz = null
+}
+;
+gvjs_.dD = function(a, b, c) {
+  if (0 != c.length && a != gvjs_iw)
+    throw Error("Non-linear scale with gaps is not supported.");
+  for (var d = [], e = 0; e < c.length; e++) {
+    a: {
+      var f = c[e];
+      var g = this.$Y(f.woa);
+      var h = this.oM(f.Gc);
+      f = this.oM(f.xe);
+      if (0 < g)
+        if (h + g < f)
+          h += g;
+        else {
+          g = null;
+          break a
+        }
+      g = {
+        voa: 0,
+        start: h,
+        end: f
+      }
+    }
+    g && d.push(g)
+  }
+  this.Vz = gvjs_eF(a, gvjs_8E(1, gvjs_9E(b)), d)
+}
+;
+gvjs_.OE = gvjs_n(67);
+function gvjs_cI(a, b) {
+  a.Xe || (a.Xe = b)
+}
+function gvjs_dI(a) {
+  a.gd || a.dv();
+  return a.gd
+}
+gvjs_.zc = function(a) {
+  a = gvjs_eI(this, a);
+  if (null == a)
+    return null;
+  a = gvjs_fI(this, a);
+  return isFinite(a) ? a : null
+}
+;
+function gvjs_eI(a, b) {
+  return null == b ? null : a.oM(b)
+}
+gvjs_.Xq = function(a) {
+  return this.QR(this.Vz.inverse(a))
+}
+;
+function gvjs_fI(a, b) {
+  return a.Vz.transform(b)
+}
+gvjs_.gX = function(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+;
+gvjs_.oc = function(a) {
+  null != a && (a < this.sn && null != a && (this.sn = a),
+  a > this.rn && null != a && (this.rn = a))
+}
+;
+function gvjs_gI(a, b, c) {
+  this.Wea = a;
+  this.mY = b;
+  this.JX = c
+}
+gvjs_o(gvjs_gI, gvjs_bI);
+gvjs_ = gvjs_gI.prototype;
+gvjs_.mZ = function() {
+  return null
+}
+;
+gvjs_.init = function(a, b) {
+  gvjs_bI.prototype.init.call(this, a, b);
+  a = a.pb("formatOptions");
+  b = [];
+  b.push(a.millisecond);
+  b.push(a.second);
+  b.push(a.minute);
+  b.push(a.hour);
+  b.push(a.day);
+  b.push(a.month);
+  b.push(a.year);
+  this.JX = gvjs_nfa([b, gvjs_Te(this.Xe, b.length), this.JX])
+}
+;
+function gvjs_nfa(a) {
+  a = gvjs_My.apply(null, a);
+  return gvjs_v(a, function(b) {
+    return gvjs_Yx(b, function(c) {
+      return c
+    })
+  })
+}
+gvjs_.fa = function(a, b) {
+  return a.fa(b)
+}
+;
+gvjs_.oM = function(a) {
+  return gvjs_8H(a)
+}
+;
+gvjs_.QR = function(a) {
+  return gvjs_9H(a)
+}
+;
+gvjs_.$Y = function(a) {
+  return a
+}
+;
+gvjs_.dv = function() {
+  var a = gvjs_BA(this.xEa);
+  a = this.JX[a];
+  this.gd = typeof a === gvjs_h ? new gvjs_Tj(a) : new gvjs_Tj({
+    pattern: a
+  })
+}
+;
+var gvjs_ofa = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 7], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 3], [0, 0, 0, 0, 0, 6], [0, 0, 0, 0, 0, 12], [0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 5], [0, 0, 0, 0, 0, 0, 10], [0, 0, 0, 0, 0, 0, 25], [0, 0, 0, 0, 0, 0, 50], [0, 0, 0, 0, 0, 0, 100]]
+  , gvjs_pfa = [2, 2, 2, 2, 2, gvjs_Vj.YEAR_MONTH_ABBR, "y"]
+  , gvjs_qfa = [[1], [2], [5], [10], [20], [50], [100], [200], [500], [0, 1], [0, 2], [0, 5], [0, 10], [0, 15], [0, 30], [0, 0, 1], [0, 0, 2], [0, 0, 5], [0, 0, 10], [0, 0, 15], [0, 0, 30], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 4], [0, 0, 0, 6], [0, 0, 0, 12], [0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 7], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 3], [0, 0, 0, 0, 0, 6], [0, 0, 0, 0, 0, 12], [0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, 5], [0, 0, 0, 0, 0, 0, 10], [0, 0, 0, 0, 0, 0, 25], [0, 0, 0, 0, 0, 0, 50], [0, 0, 0, 0, 0, 0, 100]]
+  , gvjs_rfa = [6, 6, 7, {
+  pattern: 7,
+  clearMinutes: !0
+}, 2, gvjs_Vj.YEAR_MONTH_ABBR, "y"];
+function gvjs_hI(a, b, c) {
+  this.GX = a;
+  this.Pa = b;
+  this.JQ = a - b / 2;
+  this.Asa = c;
+  this.index = 0
+}
+gvjs_hI.prototype.Ev = function() {
+  return this.JQ
+}
+;
+gvjs_hI.prototype.Kn = function(a) {
+  this.JQ = a
+}
+;
+gvjs_hI.prototype.getCenter = function() {
+  return this.JQ + this.Pa / 2
+}
+;
+gvjs_hI.prototype.getHeight = function() {
+  return this.Pa
+}
+;
+function gvjs_sfa(a, b) {
+  this.wF = a;
+  this.yz = b;
+  a = 0;
+  for (var c = b.length; a < c; a++)
+    b[a].index = a
+}
+function gvjs_tfa(a) {
+  for (var b = 0, c = 0, d = a.yz.length; c < d; c++)
+    b += a.yz[c].getHeight();
+  if (b > a.wF)
+    throw Error("Not enough space for labels. Need: " + b + " got: " + a.wF);
+  a.yz.sort(function(f, g) {
+    var h = f.GX
+      , k = g.GX;
+    return h == k ? f.index > g.index ? 1 : 0 : h > k ? 1 : -1
+  });
+  c = 0;
+  for (d = a.yz.length; c < d; c++) {
+    b = a.yz[c];
+    var e = gvjs_iI(a, b.Ev(), b.getHeight());
+    b.Kn(e)
+  }
+  c = [];
+  b = 0;
+  for (d = a.yz.length; b < d; b++)
+    c.push([a.yz[b]]);
+  for (; gvjs_ufa(a, c); )
+    ;
+}
+function gvjs_ufa(a, b) {
+  for (var c = 0; c < b.length - 1; c++) {
+    var d = b[c]
+      , e = b[c + 1]
+      , f = d[d.length - 1];
+    if (f.JQ + f.Pa > e[0].Ev()) {
+      f = e;
+      for (e = 0; e < f.length; e++)
+        d.push(f[e]);
+      var g = 0;
+      for (e = f = 0; e < d.length; e++)
+        g += d[e].GX,
+          f += d[e].getHeight();
+      g = g / d.length - f / 2;
+      g = gvjs_iI(a, g, f);
+      for (e = 0; e < d.length; e++)
+        a = d[e],
+          a.Kn(g),
+          g += a.getHeight();
+      b.splice(c + 1, 1);
+      return !0
+    }
+  }
+  return !1
+}
+function gvjs_iI(a, b, c) {
+  return gvjs_0g(b, 0, a.wF - c)
+}
+;function gvjs_jI(a, b, c, d) {
+  this.xl = a;
+  this.Qa = c ? gvjs_J(b, gvjs_uv, c, gvjs_4da) : gvjs_f;
+  this.WM = gvjs_J(b, gvjs_sv, this.Qa == gvjs_vt ? gvjs_0 : gvjs_2, gvjs_6da);
+  c = gvjs_S;
+  if (this.Qa == gvjs_$c || this.Qa == gvjs_j || this.Qa == gvjs_ov || this.Qa == gvjs_xt)
+    c = gvjs_U;
+  this.tb = c;
+  this.Za = gvjs_ry(b, gvjs_vv, {
+    bb: a.Hj,
+    fontSize: a.Dl,
+    Lb: this.Qa == gvjs_Fp ? a.oz : gvjs_f
+  });
+  this.gu = !1;
+  this.Xda = gvjs_ry(b, "legend.pagingTextStyle", this.Za);
+  this.Zd = gvjs_Tz(a.sc, {
+    size: 1E4
+  });
+  this.hQ = this.Za.fontSize;
+  d = d ? gvjs_0g(d, 1, 4) : 1;
+  this.kz = this.hQ * d;
+  this.Jy = Math.round(this.Za.fontSize / (1.618 * 1.618));
+  this.iG = this.fc = null;
+  this.d4 = gvjs_K(b, "legend.showPageIndex", !0);
+  this.gwa = gvjs_J(b, "legend.scrollArrows.orientation", this.tb, gvjs_iC);
+  this.ewa = gvjs_qy(b, "legend.scrollArrows.activeColor");
+  this.fwa = gvjs_qy(b, "legend.scrollArrows.inactiveColor");
+  this.Xi = gvjs_Oj(b, "legend.pageIndex", 0);
+  this.Pe = null;
+  this.mI = this.Jy;
+  this.oA = this.pA = this.r3 = 0;
+  this.Hca = this.Qa == gvjs_vx ? gvjs_Oj(b, gvjs_tv, 1) : 1;
+  this.eG = 0
+}
+gvjs_jI.prototype.getPosition = function() {
+  return this.Qa
+}
+;
+gvjs_jI.prototype.getArea = function() {
+  return this.fc
+}
+;
+gvjs_jI.prototype.qr = function(a) {
+  this.fc = a
+}
+;
+function gvjs_vfa(a) {
+  a.iG = gvjs_De(a.xl.Vo, function(b) {
+    return b.isVisible
+  })
+}
+gvjs_jI.prototype.define = function() {
+  if (!this.fc)
+    return null;
+  if (this.Qa != gvjs_f)
+    if (this.tb == gvjs_U)
+      gvjs_wfa(this);
+    else {
+      for (var a = [1, 9, 99, 0], b = 0; b < a.length; ++b) {
+        a: {
+          var c = a[b];
+          var d = this.fc.right - this.fc.left
+            , e = !1
+            , f = Math.round(1.618 * this.Za.fontSize);
+          1 != c && (d -= f + this.mI + 2 * this.Za.fontSize,
+            e = !0,
+          0 != c && (d -= gvjs_kI(this, c) + this.Jy));
+          f = gvjs_lI(this, this.iG, d);
+          if (0 == f.length)
+            this.gu = !1;
+          else {
+            this.Pe = [];
+            for (var g = this.iG; 0 < g.length; ) {
+              if (0 < c && this.Pe.length == c) {
+                c = !1;
+                break a
+              }
+              for (var h = [gvjs_mI(this, f, g, e)], k = 1; k < this.eG && g.length != f.length; k++)
+                g = gvjs_Oe(g, f.length),
+                  f = gvjs_lI(this, g, d),
+                  h.push(gvjs_mI(this, f, g, e));
+              h = gvjs_xfa(this, h);
+              this.Pe.push(h);
+              g = gvjs_Oe(g, f.length);
+              f = gvjs_lI(this, g, d)
+            }
+            this.gu = 1 < this.Pe.length
+          }
+          c = !0
+        }
+        if (c)
+          break
+      }
+      this.gu && (this.r3 = Math.round((this.fc.top + this.fc.bottom - this.Za.fontSize) / 2),
+        this.oA = this.fc.right - this.Za.fontSize,
+        this.pA = this.oA - this.mI - this.Za.fontSize,
+      this.d4 && (a = gvjs_kI(this, this.Pe.length),
+        this.pA -= a + this.mI))
+    }
+  a = 0;
+  c = b = null;
+  if (this.Pe && 0 < this.Pe.length)
+    if (1 < this.Pe.length && (a = this.Xi < this.Pe.length ? this.Xi : this.Pe.length - 1),
+      b = this.Pe[a],
+      this.gu) {
+      c = 0 < a;
+      d = a < this.Pe.length - 1;
+      e = this.r3;
+      f = null;
+      this.d4 && (f = a + 1 + "/" + this.Pe.length,
+        g = this.pA + this.Za.fontSize,
+        h = this.oA - g,
+        f = {
+          text: f,
+          ja: this.Xda,
+          vl: null,
+          lines: [{
+            x: g + h / 2,
+            y: e,
+            text: f,
+            length: h
+          }],
+          ld: gvjs_0,
+          Pc: gvjs_2,
+          tooltip: "",
+          anchor: null,
+          angle: 0
+        });
+      h = this.Za.fontSize;
+      k = Math.round(h / 2);
+      g = this.pA;
+      var l = this.oA;
+      this.gwa == gvjs_U ? (g = [{
+        x: g + h,
+        y: e + h
+      }, {
+        x: g + k,
+        y: e
+      }, {
+        x: g,
+        y: e + h
+      }],
+        e = [{
+          x: l,
+          y: e
+        }, {
+          x: l + h,
+          y: e
+        }, {
+          x: l + k,
+          y: e + h
+        }]) : (g = [{
+        x: g + h,
+        y: e + h
+      }, {
+        x: g + h,
+        y: e
+      }, {
+        x: g,
+        y: e + k
+      }],
+        e = [{
+          x: l,
+          y: e
+        }, {
+          x: l + h,
+          y: e + k
+        }, {
+          x: l,
+          y: e + h
+        }]);
+      h = {
+        active: this.ewa,
+        mQ: this.fwa
+      };
+      c = {
+        w2: {
+          path: g,
+          active: c,
+          Rb: h,
+          brush: c ? h.active : h.mQ
+        },
+        s1: {
+          path: e,
+          active: d,
+          Rb: h,
+          brush: d ? h.active : h.mQ
+        },
+        a2: f
+      }
+    } else
+      c = null;
+  return {
+    position: this.Qa,
+    area: this.fc,
+    Pe: this.Pe,
+    ev: b,
+    Xi: a,
+    $K: c
+  }
+}
+;
+function gvjs_wfa(a) {
+  var b = Math.max(a.fc.right - a.fc.left - (a.kz + a.Jy), 0)
+    , c = a.fc.bottom - a.fc.top
+    , d = Math.max(c - 2 * a.hQ, 0)
+    , e = a.iG
+    , f = a.xl;
+  gvjs_2G(f) && e.reverse();
+  var g = gvjs_v(e, function(h) {
+    h = gvjs_DG(this.Zd, h.text, this.Za, b, Infinity);
+    0 == h.lines.length && (h.lines = [""]);
+    return h
+  }, a);
+  if (a.Qa != gvjs_ov || f.DH != gvjs_e && f.DH != gvjs_at)
+    if (c = gvjs_nI(a, g, c),
+      a.gu = gvjs_yfa(e, c),
+      a.gu)
+      if (c = gvjs_nI(a, g, d),
+      void 0 === c[0] || 0 == c[0].length)
+        a.gu = !1;
+      else {
+        for (a.Pe = []; 0 < e.length; ) {
+          f = gvjs_oI(a, c, e);
+          a.Pe.push(f);
+          for (f = 0; void 0 !== c[f] && 0 != c[f].length; )
+            ++f;
+          g = gvjs_Oe(g, f);
+          c = gvjs_nI(a, g, d);
+          e = gvjs_Oe(e, f)
+        }
+        a.gu && (a.r3 = Math.round(a.fc.bottom - a.Za.fontSize),
+          a.pA = a.fc.left,
+          a.oA = a.pA + a.Za.fontSize + a.mI,
+        a.d4 && (d = gvjs_kI(a, a.Pe.length),
+          a.oA += d + a.mI))
+      }
+    else
+      f = gvjs_oI(a, c, e),
+        a.Pe = [f];
+  else
+    f = gvjs_zfa(a, g, c, e),
+      a.Pe = [f]
+}
+function gvjs_nI(a, b, c) {
+  var d = a.Za.fontSize;
+  a = gvjs_Afa(a, b, d + Math.round(d / 1.618), d + Math.round(d / 3.236));
+  return gvjs_oA(a, c)
+}
+function gvjs_Bfa(a, b) {
+  var c = gvjs_Oy(a.xl.jd);
+  b = a.xl.C[b];
+  a = gvjs_v(b.points, function(d) {
+    return gvjs_XG(d) ? null : new gvjs_z(d.ia.x,d.ia.y)
+  });
+  b = gvjs_wA(a, c.ef, b.Zj);
+  return null !== b ? b : gvjs_Cfa(a, c.ef)
+}
+function gvjs_Cfa(a, b) {
+  a = gvjs_De(a, function(c) {
+    return null != c
+  });
+  b = -(gvjs_Iy(a, b, function(c, d) {
+    return gvjs_Re(c, d.x)
+  }) + 1);
+  a = gvjs_Oe(a, 0, b);
+  return (a = gvjs_Ey(a, function(c) {
+    return null !== c.y
+  })) ? a.y : null
+}
+function gvjs_zfa(a, b, c, d) {
+  for (var e = a.fc.right - a.fc.left, f = Math.round(a.fc.left), g = [], h = [], k = a.xl.qz == gvjs_lu, l = 0; l < d.length; l++) {
+    var m = d[l]
+      , n = gvjs_DG(a.Zd, m.text, a.Za, e, b[l].lines.length)
+      , p = {};
+    p.id = m.id;
+    p.brush = m.brush.clone();
+    var q = gvjs_x(a.Za);
+    q.color = p.brush.fill;
+    p.Da = {
+      text: m.text,
+      ja: q,
+      vl: null,
+      lines: [],
+      ld: gvjs_2,
+      Pc: gvjs_2,
+      tooltip: n.oe ? m.text : "",
+      anchor: null,
+      angle: 0
+    };
+    q.Lb && p.brush.rd(q.Lb, 1);
+    p.isVisible = !0;
+    for (var r = 0; r < n.lines.length; r++)
+      p.Da.lines.push({
+        length: e,
+        text: n.lines[r]
+      });
+    k && (r = a.Zd(p.Da.lines[0].text, q).width,
+      p.Rg = {},
+      p.Rg.coordinates = {
+        x: f + r + 5
+      },
+      p.Rg.brush = p.brush,
+      p.Rg.isVisible = !1);
+    p.index = m.index;
+    r = gvjs_Bfa(a, p.index) || 0;
+    q = a.Zd(p.Da.lines[0], q).height;
+    m = new gvjs_hI(r,p.Da.lines.length * q,p);
+    g.push(m);
+    h.push(p)
+  }
+  gvjs_tfa(new gvjs_sfa(c,g));
+  for (r = 0; r < g.length; r++)
+    for (m = g[r],
+           a = m.Ev(),
+           p = m.Asa,
+           b = p.Da.lines,
+           l = 0; l < b.length; l++)
+      b[l].y = Math.round(l * q + a),
+        b[l].x = f,
+      k && (p.Rg.coordinates.y = b[l].y);
+  return h
+}
+function gvjs_oI(a, b, c) {
+  var d = a.kz + a.Jy
+    , e = a.fc.right - a.fc.left - d
+    , f = a.Za.fontSize
+    , g = Math.round(f / 1.618)
+    , h = f + g
+    , k = f + Math.round(f / 3.236);
+  f = [];
+  for (var l = 0, m = Math.round(a.fc.left), n = 0; n < c.length; n++) {
+    var p = c[n]
+      , q = b[n].length;
+    if (0 != q) {
+      var r = gvjs_DG(a.Zd, p.text, a.Za, e, q);
+      q = {};
+      q.id = p.id;
+      q.Da = {
+        text: p.text,
+        ja: a.Za,
+        vl: null,
+        lines: [],
+        anchor: new gvjs_HG(m,0),
+        ld: gvjs_2,
+        Pc: gvjs_2,
+        tooltip: r.oe ? p.text : "",
+        angle: 0
+      };
+      q.square = {};
+      q.square.coordinates = new gvjs_5(m,l,a.kz,a.hQ);
+      q.square.brush = p.brush.clone();
+      a.Za.Lb && q.square.brush.rd(a.Za.Lb, 1);
+      q.isVisible = !0;
+      for (var t = 0; t < r.lines.length; t++)
+        0 < t && (l += k),
+          q.Da.lines.push({
+            x: d,
+            y: l,
+            length: e,
+            text: r.lines[t]
+          });
+      q.index = p.index;
+      l += h;
+      f.push(q)
+    }
+  }
+  b = Math.round(a.fc.top);
+  a.gu || (g = l - g,
+    c = a.fc.bottom - a.fc.top,
+    a.WM == gvjs_R ? b += c - g : a.WM == gvjs_0 && (b += Math.floor((c - g) / 2)));
+  for (n = 0; n < f.length; n++)
+    q = f[n],
+      q.square.coordinates.top += b,
+      q.Da.anchor.y += b;
+  return f
+}
+function gvjs_Afa(a, b, c, d) {
+  for (var e = gvjs_Ee(b, function(k, l) {
+    return Math.max(k, l.lines.length)
+  }, 0), f = [], g = 0; g < e; g++) {
+    var h = 0 == g ? c : d;
+    gvjs_u(b, function(k, l) {
+      g < k.lines.length && f.push({
+        key: l,
+        min: 0 == g && 0 == l ? this.Za.fontSize : h,
+        extra: []
+      })
+    }, a)
+  }
+  return f
+}
+function gvjs_yfa(a, b) {
+  var c = a.length - 1;
+  return 1 < a.length && 1 > b[c].length
+}
+function gvjs_xfa(a, b) {
+  var c = a.fc.bottom - a.fc.top
+    , d = a.Za.fontSize
+    , e = c - a.eG * d
+    , f = 1 < a.eG ? e / (a.eG - 1) : 0
+    , g = (c - ((d + f) * b.length - f)) / 2
+    , h = [];
+  gvjs_u(b, function(k) {
+    var l = Math.round(g);
+    gvjs_u(k, function(m) {
+      m.Da.anchor.y += l;
+      m.square.coordinates.top += l
+    });
+    g += d + f;
+    gvjs_Me(h, k)
+  });
+  return h
+}
+function gvjs_lI(a, b, c) {
+  var d = Math.min(a.xl.width * (2 - 1.618) / 2, c);
+  if (d < a.kz + a.Jy)
+    return [];
+  a = gvjs_Dfa(a, d, b);
+  return gvjs_nA(a, c)
+}
+function gvjs_mI(a, b, c, d) {
+  for (var e = a.fc.right - a.fc.left, f = a.kz + a.Jy, g = Math.round(1.618 * a.Za.fontSize), h = [], k = 0, l = Math.round(a.fc.top), m = 0; m < b.length; m++) {
+    var n = c[m]
+      , p = gvjs_DG(a.Zd, n.text, a.Za, b[m] - f - (0 < m ? g : 0), 1)
+      , q = 0 < p.lines.length ? p.lines[0] : ""
+      , r = a.Zd(q, a.Za).width
+      , t = [{
+      x: k + f,
+      y: 0,
+      length: r,
+      text: q
+    }]
+      , u = {};
+    u.id = n.id;
+    u.Da = {
+      text: n.text,
+      ja: a.Za,
+      vl: null,
+      lines: q ? t : [],
+      anchor: new gvjs_HG(0,l),
+      ld: gvjs_2,
+      Pc: gvjs_2,
+      tooltip: p.oe ? n.text : "",
+      angle: 0
+    };
+    u.isVisible = !0;
+    u.square = {};
+    u.square.brush = n.brush.clone();
+    a.Za.Lb && u.square.brush.rd(a.Za.Lb, 1);
+    u.square.coordinates = new gvjs_5(k,l,a.kz,a.hQ);
+    u.index = n.index;
+    h.push(u);
+    k += r + f + g
+  }
+  b = a.fc.left;
+  d || (d = k - g,
+    a.WM == gvjs_R ? b += e - d : a.WM == gvjs_0 && (b += Math.floor((e - d) / 2)));
+  for (m = 0; m < h.length; m++)
+    u = h[m],
+      u.square.coordinates.left += b,
+      u.Da.anchor.x += b;
+  return h
+}
+function gvjs_Dfa(a, b, c) {
+  var d = a.kz + a.Jy
+    , e = Math.round(1.618 * a.Za.fontSize);
+  return gvjs_v(c, function(f, g) {
+    var h = this.Zd(f.text, this.Za).width + d;
+    f = Math.min(b, h);
+    h -= f;
+    0 < g && (f += e);
+    return {
+      min: f,
+      extra: [h]
+    }
+  }, a)
+}
+function gvjs_kI(a, b) {
+  for (var c = "0"; 10 <= b; )
+    c += "0",
+      b /= 10;
+  return a.Zd(c + "/" + c, a.Xda).width
+}
+;var gvjs_pI = null;
+function gvjs_qI() {
+  this.SK = {}
+}
+function gvjs_rI() {
+  return gvjs_pI ? gvjs_pI : gvjs_pI = new gvjs_qI
+}
+gvjs_qI.prototype.dh = function(a) {
+  return (a = this.SK[a]) ? a.apply(null, []) : null
+}
+;
+function gvjs_sI() {
+  this.Y$ = 1
+}
+gvjs_o(gvjs_sI, gvjs_bI);
+gvjs_ = gvjs_sI.prototype;
+gvjs_.mZ = function() {
+  return [0, 0, 0, 0]
+}
+;
+gvjs_.fa = function(a, b) {
+  return a.fa(b)
+}
+;
+gvjs_.gX = function(a, b) {
+  a = gvjs_GA(a);
+  b = gvjs_GA(b);
+  return a < b ? -1 : a > b ? 1 : 0
+}
+;
+gvjs_.oM = function(a) {
+  return gvjs_GA(a)
+}
+;
+gvjs_.QR = function(a) {
+  return gvjs_DA(a).reverse()
+}
+;
+gvjs_.$Y = function(a) {
+  return a
+}
+;
+gvjs_.dv = function() {
+  var a = new gvjs_Tj({
+    pattern: this.Xe || (1 < this.Y$ ? gvjs_Ia : 1 === this.Y$ ? gvjs_Ja : gvjs_Ka),
+    timeZone: 0
+  });
+  this.gd = {
+    Ob: function(b) {
+      b = gvjs_qk(b);
+      return a.Ob(b)
+    }
+  }
+}
+;
+function gvjs_tI(a, b, c, d, e, f) {
+  this.V = a;
+  this.Fka = c[0];
+  this.options = b.view(c);
+  this.index = d;
+  this.type = gvjs_J(this.options, gvjs_Sd, e, gvjs_2da);
+  this.maxValue = this.minValue = null;
+  this.hG = [];
+  this.pO = this.cB = null;
+  this.nka = 0 < a.wh.bars;
+  b = gvjs_J(this.options, gvjs_fx);
+  c = a.DB === gvjs_Fp ? a.oz : gvjs_f;
+  c = gvjs_ry(this.options, gvjs_ix, {
+    bb: a.Hj,
+    fontSize: a.Dl,
+    Lb: c
+  });
+  this.title = {
+    text: b,
+    ja: c,
+    vl: null,
+    lines: [],
+    ld: gvjs_0,
+    Pc: gvjs_2,
+    tooltip: "",
+    anchor: null,
+    angle: 0
+  };
+  this.ticks = [];
+  this.ec = this.yg = null;
+  this.uj = gvjs_J(this.options, "textPosition", gvjs_aw, gvjs_jC);
+  b = this.type != gvjs_Vd || a.Fa == gvjs_Dd ? gvjs_oy(this.options, "majorAxisTextColor", gvjs_QF.majorAxisTextColor) : gvjs_oy(this.options, "minorAxisTextColor", gvjs_QF.minorAxisTextColor);
+  c = this.uj === gvjs_Fp ? a.oz : gvjs_f;
+  b = {
+    color: b,
+    bb: a.Hj,
+    fontSize: a.Dl,
+    Lb: c
+  };
+  this.ud = gvjs_ry(this.options, gvjs_bx, b);
+  c = gvjs_Oj(this.options, "gridlines.minorTextOpacity");
+  c = gvjs_7z(this.ud.color, a.SM || gvjs_Br, c);
+  this.UJ = gvjs_ry(this.options, gvjs_bx, b);
+  this.UJ.color = c;
+  this.Xxa = gvjs_J(this.options, "outTextPosition", "unbound", gvjs_7da);
+  this.zga = gvjs_J(this.options, "inTextPosition", "low", gvjs_8da);
+  b = gvjs_oy(this.options, gvjs_mt, a.Kka);
+  this.Jka = new gvjs_3({
+    fill: b
+  });
+  b = gvjs_oy(this.options, gvjs_Su, a.baa);
+  this.dt = new gvjs_3({
+    fill: b
+  });
+  this.Gv = this.options.Aa(gvjs_Tu);
+  this.caa = this.options.Aa(gvjs_Vu);
+  this.wta = this.options.Aa(gvjs_Rv);
+  c = gvjs_Oj(this.options, "gridlines.minorGridlineOpacity");
+  a = b == gvjs_f ? gvjs_f : gvjs_7z(b, a.SM || gvjs_Br, c);
+  a = gvjs_oy(this.options, gvjs_Qv, a);
+  this.CR = new gvjs_3({
+    fill: a
+  });
+  this.Yo = 2;
+  this.D$ = Math.max(this.Yo, Math.round(this.title.ja.fontSize / 3.236));
+  this.vG = 0;
+  this.direction = this.ro = gvjs_L(this.options, gvjs_iu, 1);
+  this.ef = this.Pf = null;
+  this.nM = this.ww = 0;
+  this.nb = {
+    min: -Infinity,
+    max: Infinity
+  };
+  this.qM = this.Hma = f;
+  this.n3 = gvjs_dF(this.options, gvjs_Cv, gvjs_Ew);
+  this.mga = (this.gw = (this.Zca = this.n3 === gvjs_Vv) || "log" === this.n3) && !this.Zca;
+  this.type == gvjs_Vd && (this.baseline = this.ta = null,
+    this.eV = Infinity,
+    this.aca = this.o0 = null)
+}
+function gvjs_uI(a, b) {
+  typeof b !== gvjs_g || 0 === b || isNaN(b) || (b = Math.abs(b),
+    a.eV = Math.min(b - b / 10, a.eV))
+}
+gvjs_ = gvjs_tI.prototype;
+gvjs_.dD = function(a) {
+  this.yg && gvjs_u(this.yg, function(b) {
+    gvjs_uI(this, b.v)
+  }, this);
+  a = a || [];
+  this.ta.dD(this.n3, this.eV, a)
+}
+;
+gvjs_.initScale = function(a) {
+  var b = gvjs_rI().dh(a);
+  this.ta = b;
+  this.dataType = a;
+  gvjs_vI(this) && (a = {},
+    gvjs_gq(a, [gvjs_Iv], 1),
+    gvjs_gq(a, ["slantedText"], !1),
+    gvjs_hq(this.options, 1, a),
+    this.oS());
+  a = this.vi();
+  if (this.options.fa(gvjs_tu) && (!this.options.fa("explorer.axis") || this.options.cb("explorer.axis." + a)) || null != this.Gv && 0 > this.Gv)
+    this.Gv = -1;
+  b.init(this.options, this.Gv);
+  this.minValue = b.fa(this.options, gvjs_ed);
+  this.maxValue = b.fa(this.options, gvjs_cd);
+  this.cB = this.options.fa(gvjs_Xo, gvjs_QF.vAxis.gridlines.baseline);
+  this.pO = void 0 !== this.cB && this.cB !== gvjs_ub ? this.cB : this.pO || b.mZ();
+  gvjs_Efa(this)
+}
+;
+function gvjs_Efa(a) {
+  var b = a.options.fa(gvjs_ex);
+  Array.isArray(b) && (a.yg = b);
+  a.yg && (a.yg = gvjs_v(a.yg, function(c) {
+    var d = {};
+    d.v = void 0 !== c.v ? c.v : c;
+    typeof c.f === gvjs_l && (d.f = c.f);
+    return d
+  }),
+  0 < a.yg.length && (gvjs_Qe(a.yg, function(c, d) {
+    return a.ta.gX(c.v, d.v)
+  }),
+  null == a.minValue && (a.minValue = a.yg[0].v),
+  null == a.maxValue && (a.maxValue = gvjs_Ae(a.yg).v)))
+}
+function gvjs_wI(a) {
+  a.qM = gvjs_J(a.options, gvjs_Lx, a.qM, gvjs_3da);
+  var b = a.ta;
+  if (a.type == gvjs_Vd) {
+    var c = b.fa(a.options, "viewWindow.numericMin");
+    typeof c !== gvjs_g && (c = b.zc(b.fa(a.options, gvjs_Kx)));
+    var d = b.fa(a.options, "viewWindow.numericMax");
+    typeof d !== gvjs_g && (d = b.zc(b.fa(a.options, gvjs_Jx)));
+    null != c && (a.nb.min = c);
+    null != d && (a.nb.max = d)
+  } else
+    a.nb.min = gvjs_L(a.options, gvjs_Kx, a.nb.min),
+      a.nb.max = gvjs_L(a.options, gvjs_Jx, a.nb.max),
+      a.nb.max = Math.max(a.nb.min + 1, a.nb.max);
+  a.nb.min > a.nb.max && (c = a.nb.min,
+    a.nb.min = a.nb.max,
+    a.nb.max = c);
+  a.type == gvjs_Vd && (-Infinity != a.nb.min && (c = a.nb.min,
+  null != c && (b.sn = c)),
+  Infinity != a.nb.max && (c = a.nb.max,
+  null != c && (b.rn = c)),
+    gvjs_xI(a))
+}
+function gvjs_yI(a) {
+  if (a.type == gvjs_Vd && !a.ta)
+    throw Error("Axis type/data type mismatch for " + a.Fka);
+}
+function gvjs_zI(a, b, c, d, e) {
+  a.Pf = c + (1 == a.direction ? .5 : -.5);
+  a.vG = b - 1;
+  a.ef = c + b * a.direction;
+  b = a.Y7();
+  a.ne = d;
+  a.Dg = e;
+  a.type != gvjs_Vd ? d = gvjs_Ffa(a, a.vG + 1) : (null != a.cB && a.cB !== gvjs_ub && a.oc(a.ta.zc(a.cB)),
+  null != a.minValue && a.oc(a.ta.zc(a.minValue)),
+  null != a.maxValue && a.oc(a.ta.zc(a.maxValue)),
+    gvjs_Gfa(a),
+    d = gvjs_vI(a) ? gvjs_Hfa(a) : gvjs_Ifa(a));
+  return {
+    title: a.title,
+    name: a.H$(),
+    type: a.type,
+    Mq: a.gw,
+    dataType: a.dataType,
+    ro: a.ro,
+    Pf: a.Pf,
+    ef: a.ef,
+    number: {
+      hf: a.sda.bind(a),
+      ol: a.Xq.bind(a)
+    },
+    position: {
+      hf: a.vN.bind(a),
+      ol: a.U7.bind(a)
+    },
+    zp: b,
+    baseline: d.baseline,
+    Ja: d.Ja,
+    text: d.ec,
+    Tn: a.ta ? {
+      min: a.ta.sn,
+      max: a.ta.rn
+    } : {
+      min: a.nb.min,
+      max: a.nb.max
+    }
+  }
+}
+function gvjs_Ffa(a, b) {
+  var c = a.V.$a;
+  -Infinity == a.nb.min && (a.nb.min = Math.min(0, a.nb.max - 1));
+  Infinity == a.nb.max && (a.nb.max = Math.max(c.length, a.nb.min + 1));
+  a.nb.max = Math.max(a.nb.min + 1, a.nb.max);
+  var d = a.nb.max - a.nb.min;
+  a.nka && (d = Math.min(d, Math.floor((b + 1) / 2)));
+  a.type == gvjs_It && (d = Math.max(1, d - 1));
+  a.nM = gvjs_AI(a);
+  a.ww = a.vG / d;
+  var e = gvjs_Jfa(a);
+  b = gvjs_lA(c.length, function(f) {
+    var g = e.Ob(c[f].$w[0])
+      , h = f - a.nM;
+    return {
+      za: c[f].data,
+      Na: a.Jc(f),
+      text: g,
+      isVisible: 0 <= h && h <= d,
+      optional: !0
+    }
+  });
+  return {
+    Ja: [],
+    baseline: null,
+    ec: gvjs_BI(a, b),
+    ticks: []
+  }
+}
+function gvjs_Jfa(a) {
+  if (a.ta) {
+    if (gvjs_vI(a)) {
+      var b = gvjs_3H(a.options, a.XDa, a.AEa, a.qCa, a.V.sc);
+      gvjs_CI(a, b, 0);
+      return new gvjs_Tj({
+        pattern: gvjs_Xi.Format.FULL_DATETIME
+      })
+    }
+    b = gvjs_v(a.yg, function(c) {
+      return c.v
+    });
+    b = gvjs_wH(b);
+    a = gvjs_DI(a);
+    a.nw(b);
+    return a.cd()
+  }
+  return {
+    Ob: function(c) {
+      return c
+    }
+  }
+}
+function gvjs_Hfa(a) {
+  function b(C) {
+    C = c(C);
+    var G = gvjs_BI(a, C);
+    if (null == G)
+      return !1;
+    gvjs_Ce(G, function(J) {
+      var I = J.Da.anchor.x;
+      u && (I = J.Da.anchor.y);
+      J.isVisible && gvjs_EI(a, I) || gvjs_Ie(G, J)
+    });
+    return G
+  }
+  function c(C) {
+    a.yg ? C = gvjs_CI(a, w, v) : (C = C || [],
+      C = gvjs_v(C, function(G) {
+        var J = G.za;
+        J = (Array.isArray(J) ? d.zc(J) : J.getTime()) - v;
+        if (null != J && (J = a.Jc(J),
+        null != J && !isNaN(J)))
+          return {
+            za: G.za,
+            Na: J,
+            text: G.Da.text,
+            isVisible: G.isVisible,
+            optional: G.optional
+          }
+      }));
+    return C
+  }
+  var d = a.ta
+    , e = !0
+    , f = !0;
+  a.qM != gvjs_Lv && (e = isFinite(a.nb.min),
+    f = isFinite(a.nb.max));
+  var g = gvjs_FI(a)
+    , h = g
+    , k = h.min;
+  h = h.max;
+  gvjs_GI(a, g);
+  gvjs_xI(a);
+  var l = k
+    , m = h;
+  g = Math.abs(h - k);
+  var n = a.cZ()
+    , p = a.baseline.za
+    , q = null == p ? null : d.zc(p);
+  p = Math.abs(a.ef - a.Pf);
+  var r = a.options.Mg("viewWindow.maxPadding", p) / p;
+  r *= g;
+  e || (k = null != q && q <= k && k - g < q ? q : k - r);
+  f || (h = null != q && q >= h && h + g > q ? q : h + r);
+  g = {
+    min: k,
+    max: h
+  };
+  gvjs_GI(a, g);
+  gvjs_xI(a);
+  gvjs_Qe(a.hG);
+  var t = Infinity;
+  for (g = 1; g < a.hG.length; ++g)
+    (q = Math.abs(a.hG[g] - a.hG[g - 1])) && (t = Math.min(t, q));
+  Infinity === t && (t = 0);
+  var u = n.orientation === gvjs_U;
+  n = {};
+  var v = 0;
+  d instanceof gvjs_sI && (v = (new Date(1970,0,1)).getTime(),
+    n = {
+      gridlines: {
+        units: gvjs_Kea
+      },
+      minorGridlines: {
+        units: gvjs_Lea
+      }
+    });
+  g = null != a.Gv && 0 <= a.Gv ? a.Gv : -1;
+  q = a.caa;
+  0 <= g && (q = p / (g + 1));
+  null != q && gvjs_gq(n, [gvjs_Ru, "minStrongLineDistance"], q);
+  gvjs_hq(a.options, 1, n);
+  var w = gvjs_3H(a.options, u, v, function(C) {
+    return a.Jc(C)
+  }, a.V.sc)
+    , x = {
+    ud: a.ud,
+    dt: a.dt,
+    UJ: a.UJ,
+    CR: a.CR,
+    W6: 1 == a.direction ? 1 : 0
+  }
+    , y = a.direction;
+  p = function I(G, J) {
+    var M, H, Q, R;
+    return gvjs_Dy(I, function(T) {
+      1 == T.Fi && (M = w.generate(G, J, t, x),
+        H = null,
+        Q = function() {
+          a.direction = 1;
+          return H = M.next().value
+        }
+        ,
+        R = {});
+      if (4 != T.Fi) {
+        if (!Q())
+          return T.hh(0);
+        H.Ja = gvjs_Le(H.Ja);
+        H.ec = gvjs_Le(H.ec);
+        R.RF = function(O) {
+          return Math.round(100 * O) / 100
+        }
+        ;
+        -1 === y && (a.direction = y,
+          gvjs_u(H.Ja, function(O) {
+            return function(K, E) {
+              K = gvjs_x(K);
+              H.Ja[E] = K;
+              K.Na = O.RF(gvjs_HI(a, K.Na))
+            }
+          }(R)),
+          gvjs_u(H.ec, function(O) {
+            return function(K, E) {
+              K = gvjs_x(K);
+              H.ec[E] = K;
+              K.Na = O.RF(gvjs_HI(a, K.Na));
+              K.Da = gvjs_x(K.Da);
+              K.Da.lines[0] = gvjs_x(K.Da.lines[0]);
+              K.Da.lines[0].x = O.RF(gvjs_HI(a, K.Da.lines[0].x))
+            }
+          }(R)));
+        gvjs_Ce(H.ec, function(O) {
+          O.za = d.Xq(O.za.getTime());
+          O.Da = gvjs_x(O.Da);
+          var K = gvjs_x(O.Da.lines[0]);
+          O.Da.lines[0] = K;
+          u && (O = gvjs_8d([K.y, K.x]),
+            K.x = O.next().value,
+            K.y = O.next().value)
+        });
+        gvjs_Ce(H.Ja, function(O, K) {
+          O = gvjs_x(O);
+          H.Ja[K] = O;
+          gvjs_EI(a, O.Na) ? O.za = d.Xq(O.za.getTime() - v) : (O.isVisible = !1,
+            gvjs_Ie(H.Ja, O))
+        });
+        gvjs_Se(H.Ja, function(O, K) {
+          return d.gX(O.za, K.za)
+        });
+        return gvjs_zy(T, H, 4)
+      }
+      R = {
+        RF: R.RF
+      };
+      return T.hh(2)
+    })
+  }
+  ;
+  q = !0;
+  n = null;
+  for (var z, A; q; ) {
+    g = k;
+    q = h;
+    var B = p(k, h);
+    r = null;
+    for (var D = !1; !D && (r = B.next().value); )
+      if (n = r.Ja,
+        D = b(r.ec))
+        A = a.o0,
+          z = a.aca;
+    D && 1 < n.length && (e || (z = gvjs_Ee(r.Ja, function(G, J) {
+      var I = d.zc(J.za);
+      return J.S_ || I > l ? G : Math.max(G, I)
+    }, -Infinity),
+      k = Math.max(k, z)),
+    f || (r = gvjs_Ee(r.Ja, function(G, J) {
+      var I = d.zc(J.za);
+      return J.S_ || I < m ? G : Math.min(G, I)
+    }, Infinity),
+      h = Math.min(h, r)));
+    q = k != g || h != q;
+    g = {
+      min: k,
+      max: h
+    };
+    gvjs_GI(a, g);
+    gvjs_xI(a)
+  }
+  a.yg = null;
+  A = A || [];
+  z = c(A);
+  return {
+    Ja: n,
+    baseline: gvjs_II(a),
+    ec: A,
+    ticks: z
+  }
+}
+function gvjs_CI(a, b, c) {
+  var d = []
+    , e = gvjs_v(a.yg, function(g) {
+    var h = a.ta.zc(g.v);
+    return {
+      za: new Date(h + c),
+      Me: g.f,
+      brush: a.dt
+    }
+  })
+    , f = null;
+  if (f = gvjs_6H(b, e, b.Yca || b.qca).next().value)
+    if (null == f || 0 === f.length)
+      return [];
+  gvjs_u(e, function(g, h) {
+    var k = g.za
+      , l = k.getTime() - c;
+    null != l && (l = a.Jc(l),
+    null == l || isNaN(l) || (g.Na = l,
+      g.isVisible = !0,
+      d.push({
+        za: k,
+        Na: l,
+        text: f[h].text,
+        isVisible: !0
+      })))
+  });
+  return d
+}
+function gvjs_Ifa(a) {
+  function b(z) {
+    z = c({
+      dk: z
+    });
+    return gvjs_BI(a, z)
+  }
+  function c(z) {
+    return a.yg ? gvjs_Kfa(a, v) : gvjs_Lfa(a, z.dk)
+  }
+  var d = a.ta
+    , e = !0
+    , f = !0;
+  a.qM != gvjs_Lv && (e = isFinite(a.nb.min),
+    f = isFinite(a.nb.max));
+  var g = gvjs_FI(a)
+    , h = g
+    , k = h.min;
+  h = h.max;
+  gvjs_GI(a, g);
+  gvjs_xI(a);
+  var l = k
+    , m = h
+    , n = Math.abs(h - k);
+  isFinite(n) || (n = 1);
+  var p = a.baseline.za;
+  g = null == p ? null : d.zc(p);
+  var q = a.cZ();
+  p = d.Vz.inverse(d.sn);
+  var r = d.Vz.inverse(d.rn);
+  gvjs_uI(a, p);
+  gvjs_uI(a, r);
+  r = Math.abs(a.ef - a.Pf);
+  var t = a.gw ? 0 : 1
+    , u = new gvjs_WH(a.V.sc,a.ud);
+  gvjs_hq(a.options, 1, {
+    format: d.Xe
+  });
+  var v = gvjs_DI(a);
+  p = a.Gv;
+  -1 === p && (p = null);
+  var w = a.caa;
+  null != p && 2 < p && (a.gw && (p *= 2),
+    w = r / Math.max(1, p + 1));
+  null == w && (w = 40,
+  a.vi() === gvjs_S && (w *= 2));
+  a.gw && (w /= 2);
+  e || (null != g && g <= k && k - n < g && (k = g,
+    e = !0),
+  a.mga && 0 >= k && (k = .1 * l));
+  !f && null != g && g >= h && h + n < g && (h = g,
+    f = !0);
+  gvjs_hq(a.options, 0, {
+    gridlines: {
+      minSpacing: w
+    }
+  });
+  n = function(z, A) {
+    function B(I) {
+      return gvjs_qA(13, d.Vz.inverse(I))
+    }
+    var D = B(z)
+      , C = B(A)
+      , G = e ? null : B(l)
+      , J = f ? null : B(m);
+    if (isNaN(D) || isNaN(C))
+      return {
+        dk: [],
+        DR: [],
+        min: z,
+        max: A
+      };
+    z = q.ZK + .5;
+    A = q.XK - .5;
+    a.gw && (A -= .5);
+    return gvjs_VH(new gvjs_SH(D,C,z,A,q.Sg,t,a.eV || 1,q.orientation,a.options,u,v,b,function(I) {
+        a.Jc = function(M) {
+          if (null == M)
+            return null;
+          M = B(M);
+          return I.Ya(M)
+        }
+        ;
+        a.uN = function(M) {
+          if (null == M)
+            return null;
+          M = I.Ae(M);
+          return gvjs_fI(d, M)
+        }
+      }
+    ), D, C, G, J)
+  }(k, h);
+  k = gvjs_fI(d, n.min);
+  h = gvjs_fI(d, n.max);
+  g = {
+    min: k,
+    max: h
+  };
+  gvjs_GI(a, g);
+  gvjs_xI(a);
+  k = a.o0 || [];
+  if (0 === p || 1 === p)
+    n.dk = gvjs_Oe(n.dk, 0, p);
+  2 === p && (n.dk = [n.dk[0], n.dk[n.dk.length - 1]]);
+  h = c(n);
+  var x = [];
+  if (!a.yg) {
+    var y = {};
+    gvjs_u(h, function(z) {
+      y[(Math.round(1E4 * z.Na) / 1E4).toString()] = !0
+    });
+    a.wta && (null == p || 2 <= p) && gvjs_u(n.DR || [], function(z) {
+      z = z.getValue();
+      z = gvjs_fI(d, z);
+      z = a.Jc(z);
+      z = Math.round(1E4 * z) / 1E4;
+      y[z.toString()] || x.push(z)
+    })
+  }
+  p = gvjs_v(h, function(z) {
+    return {
+      tick: z,
+      za: z.za,
+      Na: z.Na,
+      isVisible: gvjs_EI(this, z.Na),
+      length: null,
+      brush: this.dt
+    }
+  }, a);
+  0 < x.length && (n = gvjs_v(x, function(z) {
+    return {
+      za: this.U7(z),
+      Na: z,
+      isVisible: !0,
+      length: null,
+      brush: this.CR
+    }
+  }, a),
+    gvjs_Me(p, n));
+  if (n = gvjs_II(a))
+    n.isVisible = gvjs_EI(a, n.Na);
+  return {
+    Ja: p,
+    baseline: n,
+    ec: k,
+    ticks: h
+  }
+}
+function gvjs_Lfa(a, b) {
+  var c = [];
+  gvjs_u(b, function(d) {
+    var e = d.Dd()
+      , f = d.getValue()
+      , g = null == f ? null : a.ta.QR(f);
+    f = gvjs_fI(a.ta, f);
+    f = a.Jc(f);
+    if (!isNaN(f)) {
+      f = Math.round(1E4 * f) / 1E4;
+      var h = gvjs_EI(a, f);
+      d.ssa && h && c.push({
+        za: g,
+        Na: f,
+        text: e || "",
+        isVisible: h
+      })
+    }
+  });
+  return c
+}
+function gvjs_Kfa(a, b) {
+  var c = gvjs_v(a.yg, function(f) {
+    return f.v
+  });
+  c = gvjs_wH(c);
+  b.nw(c);
+  var d = b.cd()
+    , e = [];
+  gvjs_u(a.yg, function(f) {
+    var g = f.v
+      , h = a.ta.zc(g);
+    null != h && (h = a.Jc(h),
+    null != h && !isNaN(h) && gvjs_EI(a, h) && (f = f.f,
+    typeof f !== gvjs_l && (f = d.Ob(g)),
+      e.push({
+        za: g,
+        Na: h,
+        text: f,
+        isVisible: !0
+      })))
+  });
+  return e
+}
+function gvjs_DI(a) {
+  var b = a.options;
+  a = new gvjs_zH;
+  var c = {
+    pattern: b.cb([gvjs_Fu, "format.pattern"]),
+    fractionDigits: b.Aa(["format.fractionDigits", "formatOptions.fractionDigits"]),
+    significantDigits: b.Aa(["format.significantDigits"]),
+    scaleFactor: b.Aa(["format.scaleFactor", gvjs_Hu, "formatter.scaleFactor"]),
+    prefix: b.cb(["format.prefix", gvjs_Gu, "formatter.prefix"]),
+    suffix: b.cb(["format.suffix", gvjs_Iu, "formatter.suffix"]),
+    decimalSymbol: b.cb(["format.decimalSymbol"]),
+    groupingSymbol: b.cb(["format.groupingSymbol"]),
+    negativeColor: b.cb(["format.negativeColor"]),
+    negativeParens: b.cb(["format.negativeParens"])
+  };
+  a.y$ = c;
+  a.DF = !1;
+  c = b.Aa(["format.numDecimals", "formatter.numDecimals", "formatOptions.numDecimals"]);
+  typeof c === gvjs_g && (a.yR(c),
+    a.nw(c));
+  c = b.Aa(["format.maxNumDecimals", "formatter.maxNumDecimals", "formatOptions.maxNumDecimals"]);
+  typeof c === gvjs_g && a.nw(c);
+  var d = b.Aa(["format.minNumDecimals", "formatter.minNumDecimals", "formatOptions.minNumDecimals"]);
+  typeof d === gvjs_g && a.yR(d);
+  d = b.Aa(["format.numSignificantDigits", "formatter.numSignificantDigits", "formatOptions.numSignificantDigits"]);
+  typeof d === gvjs_g && a.gK(d);
+  (d = b.fa(["format.unit", "formatter.unit", "formatOptions.unit"])) && a.unit({
+    symbol: d.symbol,
+    position: d.position,
+    usePadding: d.usePadding
+  });
+  b = b.fa(["format.useMagnitudes", "formatter.useMagnitudes", "formatOptions.useMagnitudes"]);
+  null != b && (d = a.P5.bind(a),
+  "long" === b && (d = a.M5.bind(a)),
+    d(typeof c === gvjs_g ? c : 5));
+  return a
+}
+function gvjs_II(a) {
+  var b = null;
+  a.type == gvjs_Vd && a.baseline && (b = {
+    za: a.baseline.za,
+    Na: a.baseline.Na,
+    isVisible: !0,
+    length: null,
+    brush: a.Jka
+  });
+  return b
+}
+function gvjs_Gfa(a) {
+  if (a.yg) {
+    var b = Infinity
+      , c = -Infinity;
+    gvjs_u(a.yg, function(e) {
+      e = this.ta.zc(e.v);
+      b = Math.min(b, e);
+      c = Math.max(c, e);
+      this.oc(e)
+    }, a);
+    if (1 < a.yg.length) {
+      var d = a.ta.rn;
+      b <= a.ta.sn && !isFinite(a.nb.min) && (a.nb.min = b);
+      c >= d && !isFinite(a.nb.max) && (a.nb.max = c)
+    }
+  }
+}
+function gvjs_FI(a) {
+  var b = isFinite(a.nb.min) ? a.nb.min : a.ta.sn;
+  isFinite(b) || (b = 0);
+  var c = isFinite(a.nb.max) ? a.nb.max : a.ta.rn;
+  isFinite(c) || (c = 1);
+  if (b === c) {
+    if (gvjs_vI(a)) {
+      a = new Date(b);
+      a = gvjs_BA([a.getMilliseconds(), a.getSeconds(), a.getMinutes(), a.getHours(), a.getDate() - 1, a.getMonth(), a.getFullYear()]);
+      var d = [1, 1E3, 6E4, 36E5, 864E5, 26784E5];
+      a = a < d.length ? d[a] : 316224E5
+    } else
+      a = 1;
+    b -= a;
+    c += a
+  }
+  return {
+    min: b,
+    max: c
+  }
+}
+function gvjs_GI(a, b) {
+  var c = b.min;
+  null != c && (a.ta.sn = c);
+  c = b.max;
+  null != c && (a.ta.rn = c);
+  a.nb = b;
+  a.ww = a.vG / Math.max(1, b.max - b.min);
+  Infinity !== b.min && (a.nM = b.min)
+}
+function gvjs_xI(a) {
+  var b = null == a.pO ? null : a.ta.zc(a.pO);
+  a.ta.wda = b;
+  if (null != b) {
+    var c = a.Jc(b);
+    isNaN(c) && (c = Infinity);
+    a.baseline = {
+      za: a.ta.Xq(b),
+      Na: c
+    }
+  } else
+    a.baseline = {
+      za: null,
+      Na: Infinity,
+      isVisible: !1
+    }
+}
+gvjs_.oc = function(a) {
+  this.type == gvjs_Vd && null != a && (!this.mga || 0 <= a) && (this.ta.oc(a),
+    this.hG.push(a))
+}
+;
+function gvjs_JI(a) {
+  if (a.type == gvjs_Vd) {
+    var b = a.ta
+      , c = b.sn
+      , d = b.rn
+      , e = .01 * (d - c);
+    0 < c && -Infinity == a.nb.min && (c = Math.max(c - e, 0),
+    null != c && (b.sn = c));
+    0 > d && Infinity == a.nb.max && (a = Math.min(d + e, 0),
+    null != a && (b.rn = a))
+  }
+}
+gvjs_.Jc = function(a) {
+  return null == a || 0 === this.ww ? null : this.Pf + (a - this.nM) * this.direction * this.ww
+}
+;
+gvjs_.uN = function(a) {
+  return null == a || 0 === this.ww ? null : (a - this.Pf) * this.direction / this.ww + this.nM
+}
+;
+gvjs_.U7 = function(a) {
+  a = this.uN(a);
+  return null == a ? null : this.Xq(a)
+}
+;
+gvjs_.vN = function(a) {
+  a = this.sda(a);
+  return null == a ? null : this.Jc(a)
+}
+;
+function gvjs_HI(a, b) {
+  return null == b ? null : 2 * a.Pf - b
+}
+function gvjs_KI(a, b) {
+  return isNaN(b) ? !0 : b * a.direction > a.ef * a.direction
+}
+function gvjs_EI(a, b) {
+  return !isNaN(b) && Infinity != b && !(isNaN(b) || b * a.direction < a.Pf * a.direction) && !gvjs_KI(a, b)
+}
+gvjs_.sda = function(a) {
+  return this.type == gvjs_Vd ? this.ta.zc(a) : a
+}
+;
+gvjs_.Xq = function(a) {
+  return null == a ? null : this.type == gvjs_Vd ? this.ta.Xq(a) : a
+}
+;
+function gvjs_AI(a) {
+  switch (a.type) {
+    case gvjs_Ht:
+      return a.nb.min - .5
+  }
+  return a.nb.min
+}
+function gvjs_LI(a, b) {
+  return null == b ? !1 : a.type == gvjs_Vd ? b >= a.nb.min && b <= a.nb.max : b >= Math.floor(a.nb.min) && b < Math.ceil(a.nb.max)
+}
+function gvjs_vI(a) {
+  return null != a.ta && (a.ta instanceof gvjs_gI || a.ta instanceof gvjs_sI)
+}
+function gvjs_BI(a, b) {
+  a.ticks = b;
+  a.ec = null;
+  b = a.uj;
+  b === gvjs_f && (a.uj = gvjs_Fp);
+  a.W7();
+  a.V7();
+  var c = null;
+  b === gvjs_f && (a.ec = []);
+  a.ec && a.o7() && (a.o0 = a.ec,
+    a.aca = a.ticks,
+    c = a.ec);
+  a.uj = b;
+  return c
+}
+;function gvjs_Mfa(a, b, c, d) {
+  this.Y0 = Math.pow(a, 2);
+  this.K0 = Math.pow(b, 2);
+  this.Fma = b;
+  this.M2 = (this.Or = c ? new gvjs_O(d.transform(c.start),d.transform(c.end)) : null) ? this.Or.end - this.Or.start : null;
+  this.vda = d
+}
+function gvjs_MI(a, b) {
+  var c = null;
+  null != b && null != a.vda && (b = a.vda.transform(b));
+  if (null != b && null != a.Or)
+    0 === a.M2 && b === a.Or.start ? c = (a.K0 + a.Y0) / 2 : b <= a.Or.start ? c = a.Y0 : b >= a.Or.end && (c = a.K0);
+  else if (!a.M2 || null == b)
+    return a.Fma;
+  null == c && (b = gvjs_0g(b, a.Or.start, a.Or.end),
+    c = gvjs_4y(a.Y0, a.K0, (b - a.Or.start) / a.M2));
+  return Math.round(Math.sqrt(c))
+}
+function gvjs_NI(a, b) {
+  var c = gvjs_Oj(a, "sizeAxis.minSize")
+    , d = gvjs_Oj(a, "sizeAxis.maxSize");
+  if (c > d)
+    throw Error("sizeAxis.minSize (" + c + ") must be at most sizeAxis.maxSize (" + d + ")");
+  var e = a.Aa("sizeAxis.minValue")
+    , f = a.Aa("sizeAxis.maxValue");
+  if (null != e && null != f && e > f)
+    throw Error("sizeAxis.minValue (" + e + ") must be at most sizeAxis.maxValue (" + f + ")");
+  b = gvjs_9B(b, e, f);
+  a = gvjs_dF(a, "sizeAxis.logScale", "sizeAxis.scaleType");
+  a = gvjs_eF(a, 1, []);
+  return new gvjs_Mfa(c,d,b,a)
+}
+;function gvjs_OI(a, b, c, d) {
+  this.Cl = a;
+  this.m = b;
+  this.xl = d;
+  this.Zd = c;
+  this.Za = gvjs_ry(this.m, "bubble.textStyle", {
+    bb: d.Hj,
+    fontSize: d.Dl,
+    Lb: d.oz
+  });
+  this.Qya = gvjs_K(this.m, "bubble.highContrast", !1);
+  this.$T = gvjs_oy(this.m, "bubble.stroke", gvjs_yr);
+  this.lK = gvjs_ny(this.m, gvjs_zt, .8);
+  this.gla = [[255, 255, 255], [97, 97, 97]];
+  this.m1 = 0;
+  this.tM = 1;
+  this.vM = 2;
+  this.qs = 3;
+  this.iu = 4;
+  this.aq = this.Wfa = this.t8 = this.Iha = this.Cha = "";
+  this.YX = this.m.fa(gvjs_2t, gvjs_MF);
+  this.sO = gvjs_5F(this.YX[0]).color;
+  this.tL = this.rs = this.t4 = this.aX = this.$D = this.TB = null;
+  this.Yj()
+}
+gvjs_OI.prototype.Yj = function() {
+  function a(k, l, m) {
+    if (c.$() <= k)
+      return "";
+    var n = c.W(k);
+    if (l && !gvjs_He(m, n))
+      throw Error(gvjs_wa + k + " must be of type " + m.join("/"));
+    if (!l && gvjs_He(m, n))
+      throw Error(gvjs_wa + k + " cannot be of type " + m.join("/"));
+    return n
+  }
+  var b = this.xl
+    , c = this.Cl
+    , d = c.$();
+  if (3 > d)
+    throw Error("Data table should have at least 3 columns");
+  a(this.m1, !0, [gvjs_l]);
+  var e = a(this.tM, !1, [gvjs_l])
+    , f = a(this.vM, !1, [gvjs_l]);
+  this.Cha = c.Ga(this.tM);
+  this.Iha = c.Ga(this.vM);
+  typeof this.qs === gvjs_g && this.qs < d ? (this.aq = a(this.qs, !0, [gvjs_g, gvjs_l]),
+  this.aq == gvjs_l && (this.TB = {},
+    this.$D = []),
+    this.t8 = c.Ga(this.qs)) : this.qs = null;
+  var g = !1;
+  typeof this.iu === gvjs_g && this.iu < d ? (a(this.iu, !0, [gvjs_g]),
+    this.Wfa = c.Ga(this.iu),
+    g = gvjs_K(this.m, "sortBubblesBySize", !0)) : this.iu = null;
+  b.$a = [];
+  b.Ds = {};
+  for (d = 0; d < c.ca(); d++) {
+    var h = c.fj(d);
+    b.Ds[h] = d
+  }
+  b.C = [{
+    type: gvjs_At,
+    Yg: gvjs_K(this.m, ["series.0.enableInteractivity", gvjs_ru], !0),
+    rM: !0,
+    NT: !0,
+    wxa: g,
+    points: [],
+    uCa: this.TB,
+    hEa: this.$D
+  }];
+  b.hv = e;
+  b.HL = [f];
+  b.wh = {};
+  b.wh.bubbles = 1;
+  b.Vo = []
+}
+;
+function gvjs_Nfa(a, b, c) {
+  for (var d = a.Cl, e = 0; e < d.ca(); e++) {
+    var f = d.getValue(e, a.tM)
+      , g = d.getValue(e, a.vM);
+    f = gvjs_eI(b.ta, f);
+    g = gvjs_eI(c.ta, g);
+    null != f && gvjs_uI(b, f);
+    null != g && gvjs_uI(c, g)
+  }
+}
+gvjs_OI.prototype.fka = function(a) {
+  if (a) {
+    var b = gvjs_vj(gvjs_PI(this, a.Kf))
+      , c = gvjs_x(a.ja);
+    b = gvjs_uj(gvjs_4z(b, this.gla));
+    c.color = b;
+    a.ja = c
+  }
+}
+;
+gvjs_OI.prototype.AW = function(a, b) {
+  var c = this.Cl
+    , d = c.Ha(a, this.tM)
+    , e = c.Ha(a, this.vM);
+  d = [{
+    title: this.Cha || "X",
+    value: d
+  }, {
+    title: this.Iha || "Y",
+    value: e
+  }];
+  null != this.qs && (e = c.Ha(a, this.qs),
+    d.push({
+      title: this.t8 || gvjs_7r,
+      value: e
+    }));
+  null != this.iu && (a = c.Ha(a, this.iu),
+    d.push({
+      title: this.Wfa || "Size",
+      value: a
+    }));
+  return {
+    title: b,
+    lines: d
+  }
+}
+;
+function gvjs_PI(a, b) {
+  return a.aq == gvjs_g ? gvjs_XH(a.rs, b.color) : a.aq == gvjs_l ? a.TB[b.color].color : a.sO
+}
+;function gvjs_QI(a, b, c, d, e) {
+  this.lb = this.Ta = a;
+  this.options = b;
+  this.sc = c;
+  this.Dg = this.ne = null;
+  a = this.V = this.B8();
+  a.sc = c;
+  a.width = d;
+  a.height = e;
+  a.Fa = gvjs_J(b, gvjs_Sd, gvjs_f, gvjs_eC);
+  a.Hj = gvjs_J(b, gvjs_yp);
+  a.Dl = gvjs_Oj(b, gvjs_zp, Math.round(Math.pow(2 * (a.width + a.height), 1 / 3)));
+  a.DH = gvjs_J(b, "seriesType", gvjs_e, gvjs_fC);
+  a.Yg = gvjs_K(b, gvjs_ru, !0);
+  a.$f = gvjs_K(b, gvjs_nx);
+  a.ax = gvjs_qy(b, "tooltip.boxStyle");
+  a.FE = gvjs_J(b, gvjs_Kw, gvjs_Ww, gvjs_lC);
+  a.O5 = gvjs_K(b, "legend.newLegend");
+  a.xG = gvjs_qy(b, gvjs_ht);
+  a.h8 = gvjs_qy(b, gvjs_Nt);
+  c = a.h8;
+  d = a.xG;
+  c = gvjs_hy(c) ? c.fill : gvjs_hy(d) ? gvjs_gy(c) ? gvjs_7z(c.fill, d.fill, c.fillOpacity) : d.fill : null;
+  a.SM = c;
+  a.Kka = gvjs_oy(b, gvjs_mt, "");
+  a.baa = gvjs_oy(b, gvjs_Qu, "");
+  a.oz = a.SM || "";
+  c = gvjs_J(b, gvjs_fx);
+  a.oF = gvjs_J(b, "titlePosition", gvjs_aw, gvjs_jC);
+  d = gvjs_ry(b, gvjs_ix, {
+    bb: a.Hj,
+    fontSize: a.Dl,
+    Lb: a.oF == gvjs_Fp ? a.oz : gvjs_f
+  });
+  a.title = {
+    text: c,
+    ja: d,
+    vl: null,
+    lines: [],
+    ld: gvjs_2,
+    Pc: gvjs_R,
+    tooltip: "",
+    anchor: null,
+    angle: 0
+  };
+  a.DB = gvjs_J(b, "axisTitlesPosition", gvjs_aw, gvjs_jC);
+  a.$c = gvjs_K(b, "is3D");
+  a.bw = gvjs_K(b, "isRtl", !1);
+  a.Mfa = gvjs_K(b, "shouldHighlightSelection", !0);
+  a.Zj = gvjs_K(b, gvjs_hv);
+  a.qz = gvjs_J(b, "interactivityModel", gvjs_eu, gvjs_aea);
+  this.M8()
+}
+gvjs_ = gvjs_QI.prototype;
+gvjs_.$g = function() {
+  return this.V
+}
+;
+gvjs_.B8 = function() {
+  return new gvjs_6F
+}
+;
+gvjs_.ti = function() {
+  return this.V
+}
+;
+gvjs_.init = function(a, b) {
+  var c = this
+    , d = Infinity;
+  if (null != b) {
+    var e = this.options.fa("async", null);
+    d = typeof e === gvjs_g ? e : (e = gvjs_K(this.options, "async", !1)) ? 100 : Infinity
+  }
+  var f = gvjs_Ke([this.ala.bind(this)], this.nz())
+    , g = a(function() {
+    for (var h = Date.now(), k = 0; 0 < f.length && k <= d; )
+      (k = f.shift()()) && (f = gvjs_Ke(k, f)),
+        k = Date.now() - h;
+    if (0 === f.length) {
+      if (c.V.qz == gvjs_lu && (!c.V.wh || c.V.wh.line != c.V.C.length))
+        throw Error("DIVE interactivity model is only supported when all series are of type line.");
+      b && b(c)
+    } else
+      setTimeout(g, 0)
+  });
+  g()
+}
+;
+gvjs_.nz = function() {
+  var a = this, b;
+  return [function() {
+    b = a.ti()
+  }
+    , function() {
+      var c = a.N$()
+        , d = a.M$()
+        , e = null
+        , f = b.Fa;
+      !b.kd || f !== gvjs_fw && f !== gvjs_Dd ? b.O5 && f !== gvjs_fw && f !== gvjs_yt && (e = 2) : e = 2;
+      e = a.options.Aa("legend.iconAspectRatio") || e;
+      a.ne = new gvjs_jI(b,a.options,c,e);
+      a.Dg = new gvjs_1H(b,a.options,d)
+    }
+    , this.tN.bind(this), function() {
+      gvjs_vfa(a.ne);
+      var c = a.V
+        , d = c.title.ja.fontSize
+        , e = a.ne.Za.fontSize
+        , f = a.ne.getPosition()
+        , g = a.Dg.Za.fontSize
+        , h = a.Dg.getPosition()
+        , k = c.oF == gvjs_aw ? c.title.text : ""
+        , l = gvjs_DG(a.sc, k, c.title.ja, c.O.width, Infinity)
+        , m = Math.max(2, Math.round(d / 3.236))
+        , n = Math.max(2, Math.round(e / 1.618))
+        , p = Math.max(2, Math.round(g / 1.618));
+      g = [];
+      g.push({
+        key: gvjs_wt,
+        min: 2,
+        extra: [Math.max(2, Math.round(1.618 * c.Dl)) - 2]
+      });
+      g.push({
+        key: gvjs_wx,
+        min: 0,
+        extra: [Infinity]
+      });
+      0 < l.lines.length && g.push({
+        key: gvjs_fx,
+        min: d + 2,
+        extra: []
+      });
+      if (f == gvjs_vx) {
+        f = a.ne;
+        for (var q = c.O.width, r = f.iG, t = gvjs_lI(f, r, q), u = 1; (0 == f.Hca || f.Hca > u) && t.length < r.length; )
+          ++u,
+            r = gvjs_Oe(r, t.length),
+            t = gvjs_lI(f, r, q);
+        f = u;
+        for (q = 0; q < f; ++q)
+          g.push({
+            key: gvjs_rv,
+            min: e + 2,
+            extra: [n - 2]
+          })
+      }
+      h == gvjs_vx && g.push({
+        key: gvjs_1t,
+        min: a.Dg.getHeight() + 2,
+        extra: [p - 2]
+      });
+      for (h = 1; h < l.lines.length; h++)
+        g.push({
+          key: gvjs_fx,
+          min: d + 2,
+          extra: [m - 2]
+        });
+      l = gvjs_oA(g, c.O.top);
+      d = l[gvjs_wx][0] || 0;
+      m = l.title || [];
+      h = gvjs_DG(a.sc, k, c.title.ja, c.O.width, m.length);
+      for (n = 0; n < h.lines.length; n++)
+        d += m[n],
+          c.title.lines.push({
+            text: h.lines[n],
+            x: c.O.left,
+            y: d,
+            length: c.O.width
+          });
+      c.title.tooltip = h.oe ? k : "";
+      k = l.legend || [];
+      0 < k.length && (a.ne.eG = k.length,
+        e = d + k[0] - e,
+        d += gvjs_az.apply(null, k),
+        a.ne.qr(new gvjs_B(e,c.O.right,d,c.O.left)));
+      e = l.colorBar || [];
+      0 < e.length && (d += e[0],
+        c = new gvjs_B(d - a.Dg.getHeight(),c.O.right,d,c.O.left),
+        a.Dg.qr(c));
+      b.legend = a.ne.define();
+      b.Vi = a.Dg.define()
+    }
+  ]
+}
+;
+gvjs_.M8 = function() {
+  this.lb = new gvjs_N(this.Ta);
+  if (2 > this.lb.$())
+    throw Error("Not enough columns given to draw the requested chart.");
+}
+;
+gvjs_.mea = function() {}
+;
+gvjs_.ala = function() {
+  var a = this.V
+    , b = {
+    width: this.options.Mg(gvjs_3o, a.width),
+    left: this.options.Mg(gvjs_0o, a.width),
+    right: this.options.Mg(gvjs_1o, a.width),
+    height: this.options.Mg(gvjs__o, a.height),
+    top: this.options.Mg(gvjs_2o, a.height),
+    bottom: this.options.Mg(gvjs_Zo, a.height)
+  };
+  a.O = gvjs_$q(a.width, a.height, b)
+}
+;
+function gvjs_RI(a, b, c, d, e, f, g, h, k, l) {
+  this.DU = a;
+  this.fg = b;
+  this.goa = c;
+  this.eta = d;
+  this.Cca = e;
+  this.bP = f;
+  this.rxa = g;
+  this.d1 = h;
+  this.mka = k;
+  this.X7 = l
+}
+function gvjs_SI(a, b, c, d) {
+  switch (d) {
+    case "attachToEnd":
+      return (b - 1 - a) % c;
+    default:
+      return a
+  }
+}
+function gvjs_TI(a, b, c) {
+  b = Math.ceil((a.fg.length - 0) / (b * c));
+  return 2 > a.fg.length || 2 > b
+}
+function gvjs_Ofa(a, b, c, d, e) {
+  b = gvjs_SI(b, a.fg.length, d, a.rxa);
+  for (var f = 1 >= a.fg.length ? a.DU : Math.max(0, Math.abs(a.fg[1].Na - a.fg[0].Na) * d - a.d1), g = []; b < a.fg.length; b += d) {
+    var h = a.fg[b]
+      , k = h.isVisible && !a.mka ? Math.min(f, 2 * h.Na, 2 * (a.DU - h.Na)) : f
+      , l = a.X7(h.text, k, e)
+      , m = l.oe;
+    k < f && (m = a.X7(h.text, f, e).oe);
+    g.push({
+      za: h.za,
+      isVisible: h.isVisible,
+      optional: h.optional,
+      Na: h.Na,
+      jca: c,
+      text: h.text,
+      width: l.Oq,
+      layout: l,
+      oe: m
+    })
+  }
+  return g
+}
+function gvjs_UI(a, b, c, d) {
+  var e = b * c;
+  d = 1 < b ? 1 : d;
+  for (var f = [], g = 0; g < b; g++) {
+    var h = gvjs_Ofa(a, a.goa + g * c, g * d, e, d);
+    gvjs_Me(f, h)
+  }
+  gvjs_Qe(f, function(k, l) {
+    return k.Na - l.Na
+  });
+  return f
+}
+function gvjs_VI(a, b, c) {
+  a = gvjs_UI(a, b, c, a.eta);
+  return gvjs_Ee(a, function(d, e) {
+    return {
+      vw: Math.max(d.vw, e.layout.lines.length),
+      oe: d.oe || e.oe
+    }
+  }, {
+    vw: 0,
+    oe: !1
+  })
+}
+function gvjs_WI(a) {
+  for (var b = 1, c = a.bP || 1, d = gvjs_VI(a, b, c), e = b; d.oe && b < a.Cca; ) {
+    b++;
+    if (gvjs_TI(a, b, c))
+      break;
+    e = b;
+    d = gvjs_VI(a, e, c)
+  }
+  b = c;
+  if (!a.bP) {
+    c = a.fg.length / e * a.d1 / a.DU;
+    if (isNaN(c) || !isFinite(c) || 1 > c)
+      c = 1;
+    var f = new gvjs_vH(gvjs_XI);
+    f.floor(c);
+    for (c = f.next(); d.oe && c < a.fg.length && !gvjs_TI(a, e, c); )
+      b = c,
+        d = gvjs_VI(a, e, b),
+        c = f.next()
+  }
+  return {
+    PV: e,
+    skip: b,
+    vw: d.vw * e
+  }
+}
+function gvjs_YI(a, b, c, d, e) {
+  a = gvjs_UI(a, b, c, d);
+  e = gvjs_Ee(a, function(f, g) {
+    var h = g.oe ? 1 : 0;
+    delete g.oe;
+    return f + h
+  }, 0) <= a.length * e;
+  return {
+    jU: a,
+    O6: e
+  }
+}
+function gvjs_ZI(a, b, c, d, e) {
+  var f = Math.min(a.Cca, d)
+    , g = Math.min(b, f)
+    , h = a.bP || c;
+  c = gvjs_YI(a, g, h, d, e);
+  for (b = g; !c.O6 && g < f; ) {
+    g++;
+    if (gvjs_TI(a, g, h))
+      break;
+    b = g;
+    c = gvjs_YI(a, b, h, d, e)
+  }
+  f = h;
+  if (!a.bP) {
+    h = a.fg.length / b * a.d1 / a.DU;
+    if (isNaN(h) || !isFinite(h) || 1 > h)
+      h = 1;
+    g = new gvjs_vH(gvjs_XI);
+    g.floor(h);
+    for (h = g.next(); !c.O6 && h < a.fg.length && !gvjs_TI(a, b, h); )
+      f = h,
+        c = gvjs_YI(a, b, f, d, e),
+        h = g.next()
+  }
+  return {
+    PV: b,
+    skip: f,
+    jU: c.jU
+  }
+}
+var gvjs_XI = [1, 2, 3, 4, 5];
+function gvjs__I(a, b, c, d, e, f) {
+  gvjs_tI.call(this, a, b, gvjs_Ke(["hAxes." + d, gvjs_Xu], c), d, e, f);
+  this.Y6 = !1;
+  this.oS()
+}
+gvjs_o(gvjs__I, gvjs_tI);
+gvjs_ = gvjs__I.prototype;
+gvjs_.oS = function() {
+  var a = this.options;
+  this.w4 = a.Dq("slantedText");
+  var b = gvjs_L(a, "slantedTextAngle", 30);
+  this.Yfa = b = gvjs_3y(b, 360);
+  this.PT = gvjs_6y(b);
+  this.Eka = gvjs_Oj(a, gvjs_Ev, .5 * this.ud.fontSize);
+  this.l$ = gvjs_Oj(a, "firstVisibleText");
+  this.kR = gvjs_Oj(a, "maxTextLines", Infinity);
+  this.J0 = gvjs_Oj(a, gvjs_Iv, 2);
+  this.aP = gvjs_Oj(a, "showTextEvery", 0);
+  this.v4 = gvjs_J(a, "showTextEveryMode", "attachToStart", gvjs_dea);
+  this.Vca = gvjs_Oj(a, "minTextSpacing", this.ud.fontSize);
+  gvjs_K(a, ["allowContainerBoundaryTextCutoff", "allowContainerBoundaryTextCufoff"], !1)
+}
+;
+gvjs_.H$ = function() {
+  return "hAxis#" + this.index
+}
+;
+gvjs_.wW = function(a, b) {
+  var c = this.V.O;
+  return gvjs_zI(this, c.width, 1 == this.direction ? c.left : c.right, a, b)
+}
+;
+gvjs_.W7 = function() {
+  var a = this
+    , b = null != this.ec;
+  if (0 == this.index) {
+    var c = this.V.sc
+      , d = this.ud.fontSize
+      , e = this.title.ja.fontSize
+      , f = this.V.DB == gvjs_aw ? this.title.text : ""
+      , g = new gvjs_RI(this.V.width,this.ticks,this.l$,this.kR,this.J0,this.aP,this.v4,this.Vca,this.Y6,function(y, z, A) {
+        return gvjs_DG(c, y, a.ud, z, A)
+      }
+    )
+      , h = this.aP || 1;
+    if (this.uj == gvjs_aw)
+      if (null == this.w4)
+        if (this.ticks.length * d / (this.J0 * h) <= this.V.width) {
+          var k = gvjs_WI(g);
+          if (k.skip > h || 0 == k.vw) {
+            var l = gvjs_0I(this, c);
+            k = null
+          }
+        } else
+          l = gvjs_0I(this, c);
+      else
+        this.w4 ? l = gvjs_0I(this, c) : k = gvjs_WI(g);
+    var m = gvjs_DG(c, f, this.title.ja, this.V.O.width, Infinity)
+      , n = this.Yo
+      , p = Math.max(n, Math.round(d / 1.618))
+      , q = Math.max(n, Math.round(d / 3.236));
+    f = function() {
+      return {
+        key: gvjs_ex,
+        min: l.minHeight + n,
+        max: l.maxHeight + n,
+        extra: [p - n]
+      }
+    }
+    ;
+    var r = [];
+    r.push({
+      key: gvjs_wt,
+      min: n,
+      extra: [Infinity]
+    });
+    0 < m.lines.length && r.push({
+      key: gvjs_fx,
+      min: e + n,
+      extra: [Infinity]
+    });
+    var t = this.ne.Za.fontSize;
+    this.ne.getPosition() == gvjs_vt && r.push({
+      key: gvjs_rv,
+      min: t + this.Yo,
+      extra: [Infinity]
+    });
+    this.Dg.getPosition() == gvjs_vt && r.push({
+      key: gvjs_1t,
+      min: this.Dg.getHeight() + n,
+      extra: [Infinity]
+    });
+    t = r.length;
+    k && 0 < k.vw ? r.push({
+      key: gvjs_ex,
+      min: d + n,
+      extra: [p - n]
+    }) : l && r.push(f());
+    var u = r.length;
+    if (k)
+      for (var v = 1; v < k.vw; v++)
+        r.push({
+          key: gvjs_ex,
+          min: d + n,
+          extra: [q - n]
+        });
+    d = r.length;
+    for (q = 1; q < m.lines.length; q++)
+      r.push({
+        key: gvjs_fx,
+        min: e + n,
+        extra: [this.D$ - n]
+      });
+    this.LV = e = gvjs_oA(r, this.V.height - this.V.O.bottom);
+    var w = e.ticks || [];
+    if (k) {
+      var x = gvjs_ZI(g, k.PV, k.skip, w.length, 0);
+      null == this.w4 && x.skip > h && (x = k = null,
+        l = gvjs_0I(this, c),
+        r[t] = f(),
+        r = gvjs_Ida(r, 0, u, d, void 0),
+        e = gvjs_oA(r, this.V.height - this.V.O.bottom))
+    }
+    this.ij = this.V.O.bottom;
+    w = e.ticks || [];
+    if (0 < w.length) {
+      for (g = 1; g < w.length; g++)
+        w[g] += w[g - 1];
+      if (b && 1 == w.length)
+        for (b = this.ij + w[0],
+               g = 0; g < this.ec.length; g++)
+          h = this.ec[g].Da,
+            h.anchor = h.anchor || new gvjs_HG(0,0),
+            h.anchor.y = b;
+      k ? this.ec = gvjs_v(x.jU, function(y, z) {
+        var A = gvjs_v(y.layout.lines, function(B, D) {
+          return {
+            x: 0,
+            y: w[y.jca + D],
+            length: y.width,
+            text: B
+          }
+        });
+        z = a.ec && a.ec[z] && a.ec[z].Da;
+        return {
+          za: y.za,
+          isVisible: y.isVisible,
+          optional: y.optional,
+          Da: {
+            text: y.text,
+            ja: a.ud,
+            lines: A,
+            ld: z ? z.ld : gvjs_0,
+            Pc: z ? z.Pc : gvjs_R,
+            tooltip: y.layout.oe ? y.text : "",
+            anchor: new gvjs_HG(y.Na,a.ij),
+            angle: 0
+          }
+        }
+      }) : l && (k = w[0],
+        x = Math.min(k - n, l.maxHeight),
+        this.ec = gvjs_Pfa(this, c, this.ij + k - x, x, l.skip));
+      this.ij += gvjs_Ae(w)
+    }
+    gvjs_Qfa(this);
+    gvjs_Rfa(this);
+    gvjs_Sfa(this)
+  }
+}
+;
+function gvjs_Qfa(a) {
+  var b = a.V.sc
+    , c = a.V.DB == gvjs_aw ? a.title.text : ""
+    , d = a.LV.title || [];
+  if (0 < d.length)
+    for (b = gvjs_DG(b, c, a.title.ja, a.V.O.width, d.length),
+           a.title.tooltip = b.oe ? c : "",
+           a.title.lines = [],
+           c = 0; c < d.length; c++)
+      a.ij += d[c],
+        a.title.Pc = gvjs_R,
+        a.title.lines.push({
+          x: a.V.O.left + a.V.O.width / 2,
+          y: a.ij,
+          length: a.V.O.width,
+          text: b.lines[c]
+        })
+}
+function gvjs_Rfa(a) {
+  var b = a.ne.Za.fontSize
+    , c = a.LV.legend || [];
+  0 < c.length && (a.ij += c[0],
+    a.ne.qr(new gvjs_B(a.ij - b,a.V.O.right,a.ij,a.V.O.left)))
+}
+function gvjs_Sfa(a) {
+  var b = a.LV.colorBar || [];
+  0 < b.length && (a.ij += b[0],
+    b = new gvjs_B(a.ij - a.Dg.getHeight(),a.V.O.right,a.ij,a.V.O.left),
+    a.Dg.qr(b))
+}
+function gvjs_0I(a, b) {
+  function c(m) {
+    m = b(m.text, d).width;
+    return Math.ceil(Math.abs(m * f) + Math.abs(e * g))
+  }
+  var d = a.ud
+    , e = d.fontSize
+    , f = Math.sin(a.PT % Math.PI)
+    , g = Math.cos(a.PT % Math.PI)
+    , h = a.aP;
+  h || (h = 2 > a.ticks.length ? 1 : Math.ceil((e + a.Yo) / f / Math.abs(a.ticks[1].Na - a.ticks[0].Na)));
+  for (var k = 0, l = 0; l < a.ticks.length; l += h)
+    k = Math.max(c(a.ticks[l]), k);
+  a = c({
+    text: gvjs_Kr
+  });
+  return {
+    minHeight: Math.min(k, a),
+    maxHeight: k,
+    skip: h
+  }
+}
+function gvjs_Pfa(a, b, c, d, e) {
+  var f = gvjs_SI(0, a.ticks.length, e, a.v4);
+  d = Math.floor((d - a.ud.fontSize * Math.cos(a.PT % Math.PI)) / Math.sin(a.PT % Math.PI));
+  var g = [];
+  for (c += a.Eka; f < a.ticks.length; f += e) {
+    var h = a.ticks[f]
+      , k = gvjs_DG(b, h.text, a.ud, d, 1)
+      , l = {
+      text: h.text,
+      ja: a.ud,
+      lines: [],
+      angle: -a.Yfa,
+      ld: 180 < a.Yfa ? gvjs_2 : gvjs_R,
+      Pc: gvjs_0,
+      tooltip: k.oe ? h.text : "",
+      anchor: new gvjs_HG(h.Na,c)
+    };
+    0 < k.lines.length && l.lines.push({
+      x: 0,
+      y: 0,
+      length: d,
+      text: k.lines[0]
+    });
+    g.push({
+      za: h.za,
+      isVisible: h.isVisible,
+      optional: h.optional,
+      Da: l
+    })
+  }
+  return g
+}
+gvjs_.V7 = function() {
+  var a = this;
+  if (0 == this.index) {
+    var b = this.V.sc, c = this.ud.fontSize, d = new gvjs_RI(this.V.width,this.ticks,this.l$,this.kR,this.J0,this.aP,this.v4,this.Vca,this.Y6,function(q, r, t) {
+        return gvjs_DG(b, q, a.ud, r, t)
+      }
+    ), e, f = this.zga;
+    this.uj == gvjs_Fp && (e = gvjs_WI(d));
+    var g = this.Yo
+      , h = Math.max(this.Yo, Math.round(c / 3.236))
+      , k = Math.max(this.Yo, Math.round(c / 1.618));
+    k = this.type == gvjs_Vd ? h : k;
+    var l = Math.max(g, Math.round(c / 3.236));
+    if (this.type == gvjs_Vd)
+      if ("high" === f) {
+        var m = gvjs_2;
+        var n = h
+      } else
+        m = gvjs_R,
+          n = -h;
+    else
+      m = gvjs_0,
+        n = 0;
+    f = [];
+    f.push({
+      key: gvjs_wx,
+      min: g,
+      extra: [Infinity]
+    });
+    if (e)
+      for (h = 0; h < e.vw; h++)
+        f.push({
+          key: gvjs_ex,
+          min: c + g,
+          extra: [(0 == h ? k : l) - g]
+        });
+    var p = gvjs_oA(f, Math.floor(this.V.O.height / 2)).ticks || [];
+    if (0 < p.length) {
+      for (c = 1; c < p.length; c++)
+        p[c] += p[c - 1];
+      d = gvjs_ZI(d, e.PV, e.skip, p.length, .5);
+      this.ec = gvjs_v(d.jU, function(q) {
+        var r = q.layout.lines;
+        r.reverse();
+        r = gvjs_v(r, function(t, u) {
+          return {
+            x: 0,
+            y: -p[q.jca + u],
+            length: q.width,
+            text: t
+          }
+        }, this);
+        return {
+          za: q.za,
+          isVisible: q.isVisible,
+          optional: q.optional,
+          Da: {
+            text: q.text,
+            ja: this.ud,
+            lines: r,
+            ld: m,
+            Pc: gvjs_2,
+            tooltip: q.layout.oe ? q.text : "",
+            anchor: new gvjs_HG(n + q.Na,this.V.O.bottom),
+            angle: 0
+          }
+        }
+      }, this)
+    }
+  }
+}
+;
+gvjs_.o7 = function() {
+  function a(h, k) {
+    var l = h[0].anchor;
+    gvjs_u(h, function(m) {
+      var n = m.anchor
+        , p = n.x;
+      n = n.y;
+      var q = l.x
+        , r = l.y
+        , t = k;
+      t = t * Math.PI / 180;
+      p -= q;
+      n -= r;
+      var u = Math.sin(t);
+      t = Math.cos(t);
+      m.anchor = new gvjs_HG(t * p - u * n + q,u * p + t * n + r);
+      m.angle = 0
+    })
+  }
+  var b = this;
+  if (this.uj == gvjs_f)
+    return !0;
+  var c = this.options.fa(gvjs_ex, null)
+    , d = null != c && Array.isArray(c);
+  gvjs_Se(this.ec, function(h, k) {
+    return h.optional && !k.optional ? 1 : k.optional && !h.optional ? -1 : 0
+  });
+  c = gvjs_v(this.ec, function(h) {
+    return gvjs_x(h.Da)
+  });
+  var e = 0 < c.length ? c[0].angle : 0;
+  e && (0 < e ? a(c, 360 - e) : a(c, -e));
+  var f = []
+    , g = [];
+  return gvjs_Ge(c, function(h, k) {
+    function l(n) {
+      return gvjs_lz(m, n)
+    }
+    var m = gvjs_RF(h);
+    if (!m)
+      return !0;
+    h = Math.round(h.ja.fontSize / 4);
+    m.expand(new gvjs_B(0,h,0,h));
+    if (gvjs_Yx(f, l))
+      return d || b.ec[k].optional ? (b.ec[k].isVisible = !1,
+        !0) : !1;
+    if (d || b.ec[k].optional) {
+      if (gvjs_Yx(g, l))
+        return b.ec[k].isVisible = !1,
+        0 === f.length;
+      g.push(m)
+    } else
+      f.push(m);
+    return !0
+  })
+}
+;
+gvjs_.cZ = function() {
+  var a = {};
+  a.Sg = -1 == this.direction;
+  a.ZK = this.V.O.left;
+  a.XK = this.V.O.right;
+  a.orientation = this.vi();
+  return a
+}
+;
+gvjs_.vi = function() {
+  return gvjs_S
+}
+;
+gvjs_.Y7 = function() {
+  return 0 == this.index ? {
+    Na: this.V.O.bottom,
+    direction: -1
+  } : {
+    Na: this.V.O.top,
+    direction: 1
+  }
+}
+;
+function gvjs_1I() {
+  this.h9 = 0
+}
+gvjs_o(gvjs_1I, gvjs_bI);
+gvjs_ = gvjs_1I.prototype;
+gvjs_.mZ = function() {
+  return 0
+}
+;
+gvjs_.init = function(a, b) {
+  gvjs_bI.prototype.init.call(this, a, b);
+  this.gd = null;
+  this.dfa = gvjs_L(a, gvjs_Hu, 1);
+  a.fa("tickScoringWeights", gvjs_x(gvjs_Tfa))
+}
+;
+gvjs_.OE = gvjs_n(66);
+gvjs_.dv = function() {
+  var a = this.Xe;
+  a = {
+    pattern: a,
+    fractionDigits: a ? null : this.h9,
+    scaleFactor: this.dfa,
+    prefix: this.options.cb(gvjs_Gu),
+    suffix: this.options.cb(gvjs_Iu),
+    significantDigits: this.options.bD("formatOptions.significantDigits")
+  };
+  this.gd = new gvjs_gk(a)
+}
+;
+gvjs_.fa = function(a, b) {
+  return a.Aa(b)
+}
+;
+gvjs_.oM = function(a) {
+  return Number(a)
+}
+;
+gvjs_.QR = function(a) {
+  return a
+}
+;
+gvjs_.$Y = function(a) {
+  return a
+}
+;
+var gvjs_Tfa = {
+  zEa: 10,
+  ODa: 10,
+  TDa: 10,
+  jEa: 10,
+  yEa: 10
+};
+gvjs_rI().SK.timeofday = function() {
+  return new gvjs_sI
+}
+;
+gvjs_rI().SK.date = function() {
+  return new gvjs_gI(gvjs_ofa,3,gvjs_pfa)
+}
+;
+gvjs_rI().SK.datetime = function() {
+  return new gvjs_gI(gvjs_qfa,3,gvjs_rfa)
+}
+;
+gvjs_rI().SK.number = function() {
+  return new gvjs_1I
+}
+;
+function gvjs_2I(a) {
+  return new gvjs_ok(Math.round(a.x),Math.round(a.y))
+}
+function gvjs_Ufa(a) {
+  return Array.prototype.reduce.call(arguments, gvjs_eA, new gvjs_ok(0,0))
+}
+function gvjs_Vfa(a) {
+  return Array.prototype.reduce.call(arguments, function(b, c) {
+    return new gvjs_A(b.width + c.width,b.height + c.height)
+  }, new gvjs_A(0,0))
+}
+function gvjs_3I(a, b, c) {
+  return new gvjs_ok(Math.cos(a) * b,Math.sin(a) * c)
+}
+function gvjs_Wfa(a) {
+  return new gvjs_ok(a[0],a[1])
+}
+function gvjs_4I(a, b) {
+  return gvjs_v([[a.x - b.width / 2, a.y - b.height / 2], [a.x + b.width / 2, a.y - b.height / 2], [a.x + b.width / 2, a.y + b.height / 2], [a.x - b.width / 2, a.y + b.height / 2]], gvjs_Wfa)
+}
+function gvjs_5I(a, b, c, d) {
+  return new gvjs_5(Math.min(a, c),Math.min(b, d),Math.abs(c - a),Math.abs(d - b))
+}
+;function gvjs_6I(a, b, c, d, e, f) {
+  gvjs_tI.call(this, a, b, gvjs_Ke(["vAxes." + d, gvjs_Ud], c), d, e, f);
+  this.type == gvjs_Vd && (this.direction = -this.direction);
+  this.oS()
+}
+gvjs_o(gvjs_6I, gvjs_tI);
+gvjs_ = gvjs_6I.prototype;
+gvjs_.oS = function() {
+  this.kR = gvjs_Oj(this.options, "maxTextLines", 3)
+}
+;
+gvjs_.H$ = function() {
+  return "vAxis#" + this.index
+}
+;
+gvjs_.wW = function(a, b) {
+  var c = this.V.O;
+  return gvjs_zI(this, c.height, 1 == this.direction ? c.top : c.bottom, a, b)
+}
+;
+function gvjs_7I(a) {
+  var b = a.V.sc;
+  return gvjs_Ee(a.ticks, function(c, d) {
+    return Math.max(c, b(d.text, this.ud).width)
+  }, 0, a)
+}
+function gvjs_Xfa(a) {
+  var b = a.V.sc
+    , c = gvjs_7I(a);
+  a = b(gvjs_Kr, a.ud).width;
+  return Math.min(a, c)
+}
+gvjs_.W7 = function() {
+  var a = this
+    , b = this.V.sc
+    , c = this.ud.fontSize
+    , d = this.title.ja.fontSize
+    , e = this.V.DB == gvjs_aw ? this.title.text : ""
+    , f = gvjs_DG(b, e, this.title.ja, this.V.O.height, Infinity)
+    , g = this.Yo
+    , h = gvjs_7I(this)
+    , k = gvjs_Xfa(this)
+    , l = [];
+  this.uj == gvjs_aw ? l.push({
+    key: gvjs_zw,
+    min: g,
+    extra: [c - g]
+  }) : l.push({
+    key: gvjs_zw,
+    min: 0,
+    extra: [Infinity]
+  });
+  0 < f.lines.length && l.push({
+    key: gvjs_fx,
+    min: d + g,
+    extra: [Infinity]
+  });
+  this.uj == gvjs_aw && l.push({
+    key: gvjs_ex,
+    min: k + g,
+    max: h + g,
+    extra: [Infinity]
+  });
+  for (c = 1; c < f.lines.length; c++)
+    l.push({
+      key: gvjs_fx,
+      min: d + g,
+      extra: [this.D$ - g]
+    });
+  d = this.V.O;
+  l = gvjs_oA(l, 0 == this.index ? d.left : this.V.width - d.right);
+  var m = 0 == this.index ? 0 : this.V.width;
+  f = l.title || [];
+  if (0 < f.length)
+    for (b = gvjs_DG(b, e, this.title.ja, d.height, f.length),
+         1 === this.index && b.lines.reverse(),
+           this.title.tooltip = b.oe ? e : "",
+           this.title.lines = [],
+           e = 0; e < f.length; e++)
+      m += f[e] * (0 == this.index ? 1 : -1),
+        this.title.angle = -90,
+        this.title.Pc = 0 == this.index ? gvjs_R : gvjs_2,
+        this.title.lines.push({
+          x: m,
+          y: d.top + d.height / 2,
+          length: d.height,
+          text: b.lines[e]
+        });
+  if (this.uj == gvjs_aw) {
+    e = l.ticks[0] || 0;
+    m += e * (0 == this.index ? 1 : -1);
+    var n = Math.min(h, e - g);
+    this.ec = n < k ? [] : gvjs_v(this.ticks, function(p, q) {
+      var r = 0 == a.index ? gvjs_R : gvjs_2
+        , t = gvjs_0;
+      "bound" == a.Xxa && (0 == q && (t = 1 == a.direction ? gvjs_2 : gvjs_R),
+      q == a.ticks.length - 1 && (t = 1 == a.direction ? gvjs_R : gvjs_2));
+      return gvjs_8I(a, p, m, n, r, t, 0)
+    })
+  }
+}
+;
+gvjs_.o7 = function() {
+  var a = this;
+  if (this.uj == gvjs_f)
+    return !0;
+  var b = gvjs_v(this.ec, function(g) {
+    return g.Da
+  })
+    , c = this.options.fa(gvjs_ex, null)
+    , d = null != c && Array.isArray(c)
+    , e = []
+    , f = [];
+  return gvjs_Ge(b, function(g, h) {
+    var k = gvjs_RF(g)
+      , l = g.ja.fontSize / 8;
+    if (!k)
+      return !0;
+    if (gvjs_Yx(e, function(m) {
+      return gvjs_mz(k, m, l)
+    }))
+      return d || a.ec[h].optional ? (a.ec[h].isVisible = !1,
+        !0) : !1;
+    if (d || a.ec[h].optional) {
+      if (gvjs_Yx(f, function(m) {
+        return gvjs_mz(k, m, l)
+      }))
+        return a.ec[h].isVisible = !1,
+        0 === e.length;
+      f.push(k)
+    } else
+      e.push(k);
+    return !0
+  })
+}
+;
+gvjs_.V7 = function() {
+  var a = this.V.sc
+    , b = this.ud.fontSize
+    , c = this.Yo
+    , d = Math.max(this.Yo, Math.round(b / 3.236));
+  b = Math.max(this.Yo, Math.round(b / 1.618));
+  b = this.type == gvjs_Vd ? d : b;
+  if (this.type == gvjs_Vd)
+    if ("high" == this.zga) {
+      var e = gvjs_R;
+      var f = d
+    } else
+      e = gvjs_2,
+        f = -d;
+  else
+    e = gvjs_0,
+      f = 0;
+  d = gvjs_Ee(this.ticks, function(m, n) {
+    return Math.max(m, a(n.text, this.ud).width)
+  }, 0, this);
+  var g = a(gvjs_Kr, this.ud).width;
+  g = Math.min(g, d);
+  var h = [];
+  h.push({
+    key: gvjs_zw,
+    min: c,
+    extra: [Infinity]
+  });
+  this.uj == gvjs_Fp && h.push({
+    key: gvjs_ex,
+    min: g + c,
+    max: d + b,
+    extra: []
+  });
+  b = gvjs_oA(h, this.V.O.width);
+  var k = 0 == this.index ? this.V.O.left : this.V.O.right;
+  if (this.uj == gvjs_Fp) {
+    b = b.ticks[0] || 0;
+    var l = Math.min(d, b - c);
+    k += (b - l) * (0 == this.index ? 1 : -1);
+    this.ec = gvjs_v(this.ticks, function(m) {
+      return gvjs_8I(this, m, k, l, 0 == this.index ? gvjs_2 : gvjs_R, e, f)
+    }, this)
+  }
+}
+;
+function gvjs_8I(a, b, c, d, e, f, g) {
+  var h = gvjs_DG(a.V.sc, b.text, a.ud, d, a.kR)
+    , k = a.ud.fontSize
+    , l = Math.max(2, Math.round(k / 3.236))
+    , m = h.lines.length
+    , n = gvjs_v(h.lines, function(p, q) {
+    return {
+      x: 0,
+      y: (k + l) * (q - (m - 1) / 2),
+      length: d,
+      text: p
+    }
+  });
+  return {
+    za: b.za,
+    isVisible: b.isVisible,
+    optional: b.optional,
+    text: b.text,
+    Da: {
+      text: b.text,
+      ja: a.ud,
+      vl: null,
+      lines: n,
+      ld: e,
+      Pc: f,
+      tooltip: h.oe ? b.text : "",
+      anchor: new gvjs_HG(c,b.Na - g),
+      angle: 0
+    }
+  }
+}
+gvjs_.cZ = function() {
+  var a = {};
+  a.Sg = -1 == this.direction;
+  a.ZK = this.V.O.top;
+  a.XK = this.V.O.bottom;
+  a.orientation = this.vi();
+  return a
+}
+;
+gvjs_.vi = function() {
+  return gvjs_U
+}
+;
+gvjs_.Y7 = function() {
+  return 0 == this.index ? {
+    Na: this.V.O.left,
+    direction: 1
+  } : {
+    Na: this.V.O.right,
+    direction: -1
+  }
+}
+;
+function gvjs_9I(a) {
+  this.gd = a = void 0 === a ? String : a;
+  this.tE = gvjs_Yfa()
+}
+function gvjs_Yfa() {
+  var a = new Map;
+  a.set(gvjs_g, function(b, c) {
+    return c.gd(b.value)
+  });
+  a.set("identifier", function(b) {
+    return b.name
+  });
+  a.set("+", function() {
+    return " + "
+  });
+  a.set("-", function() {
+    return gvjs_ar
+  });
+  a.set("--", function() {
+    return "-"
+  });
+  a.set("=", function() {
+    return " = "
+  });
+  a.set("*", function() {
+    return " * "
+  });
+  a.set("(", function() {
+    return "("
+  });
+  a.set(")", function() {
+    return ")"
+  });
+  a.set(",", function() {
+    return gvjs_ha
+  });
+  a.set("^", function() {
+    return "^"
+  });
+  return a
+}
+gvjs_9I.prototype.R = function(a) {
+  var b = this;
+  return gvjs_v(a, function(c) {
+    return b.tE.get(c.zq())(c, b)
+  }, this).join("")
+}
+;
+function gvjs_$I(a) {
+  a = gvjs_De(a.split("}"), function(g) {
+    return null != g && "" !== gvjs_kf(g)
+  });
+  for (var b = {}, c = {}, d = 0; d < a.length; c = {
+    CM: c.CM
+  },
+    d++) {
+    var e = a[d].split("{")
+      , f = gvjs_v(e[0].split(","), gvjs_kf);
+    c.CM = gvjs_Jz(gvjs_kf(e[1]));
+    0 === f.length ? Object.assign(b, c.CM) : gvjs_u(f, function(g) {
+      return function(h) {
+        b[h] = b[h] || {};
+        Object.assign(b[h], g.CM)
+      }
+    }(c))
+  }
+  return b
+}
+var gvjs_Zfa = [{
+  input: gvjs_1,
+  bg: [gvjs_pp, gvjs_3p]
+}, {
+  input: gvjs_Kp,
+  bg: [gvjs_qp, gvjs_4p]
+}, {
+  input: gvjs_rp,
+  bg: [gvjs_pp]
+}, {
+  input: gvjs_sp,
+  bg: [gvjs_qp]
+}, {
+  input: gvjs_6p,
+  bg: [gvjs_3p]
+}, {
+  input: gvjs_7p,
+  bg: [gvjs_4p]
+}, {
+  input: gvjs_8p,
+  bg: [gvjs_5p]
+}];
+function gvjs_aJ(a, b) {
+  var c = {
+    fill: {},
+    stroke: {}
+  };
+  a = new gvjs_Aj([a]);
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = e.bg;
+    e = a.fa(e.input);
+    if (null != e)
+      for (var g = 0; g < f.length; g++)
+        gvjs_q(f[g], e, c)
+  }
+  return c
+}
+function gvjs__fa(a) {
+  return gvjs_aJ(a, gvjs_Zfa)
+}
+function gvjs_bJ(a, b) {
+  b = void 0 === b ? gvjs__fa : b;
+  if (null == a)
+    return {};
+  a = gvjs_kf(a);
+  if (gvjs_0z(a))
+    var c = b({
+      color: a
+    });
+  else if ("{" === a.charAt(0))
+    try {
+      var d = gvjs_Gi(a);
+      null != d && (c = d)
+    } catch (e) {}
+  null == c && (gvjs_sf(a, "{") ? (c = gvjs_Ny(gvjs_$I(a), b),
+  gvjs_Ze(c, "") && (Object.assign(c, c[""]),
+    gvjs_Qy(c, "")),
+  gvjs_Ze(c, "*") && (Object.assign(c, c["*"]),
+    gvjs_Qy(c, "*"))) : c = b(gvjs_Jz(a)));
+  return c
+}
+;function gvjs_cJ(a) {
+  this.x = a.x || 0;
+  this.y = a.y || 0;
+  this.length = a.length;
+  this.text = a.text
+}
+;function gvjs_dJ(a) {
+  this.text = a.text;
+  this.ja = a.ja;
+  this.vl = a.vl;
+  this.lines = a.lines;
+  this.ld = a.ld;
+  this.Pc = a.Pc;
+  this.tooltip = void 0 !== a.tooltip ? a.tooltip : "";
+  this.wd = a.wd;
+  this.angle = null != a.angle ? a.angle : 0;
+  this.anchor = void 0 !== a.anchor ? a.anchor : null;
+  this.hx = !!a.hx
+}
+gvjs_dJ.prototype.xW = gvjs_n(68);
+function gvjs_eJ(a, b, c, d, e) {
+  gvjs_QI.call(this, a, b, c, d, e);
+  this.gs = this.S4 = this.hU = this.je = this.ed = this.ke = this.Bf = this.Kb = null;
+  this.Tz = 1;
+  this.jN = this.LH = null;
+  this.Pr = !1
+}
+gvjs_o(gvjs_eJ, gvjs_QI);
+gvjs_ = gvjs_eJ.prototype;
+gvjs_.nz = function() {
+  var a = this, b;
+  return [function() {
+    var c = a.options;
+    b = a.V;
+    b.kd = gvjs_K(c, "isDiff");
+    b.kd || b.Fa !== gvjs_Dd || (b.Fa = gvjs_d,
+      gvjs_hq(c, 1, {
+        pointSize: 7,
+        trendlines: {
+          pointsVisible: !1,
+          lineWidth: 2
+        },
+        lineWidth: 0,
+        orientation: gvjs_S,
+        domainAxis: {
+          viewWindowMode: gvjs_qw
+        }
+      }));
+    var d = c.cb(gvjs_qx, gvjs_mC);
+    a.wz = d != gvjs_f;
+    d = b;
+    var e = Set;
+    var f = gvjs_Fj(c, gvjs_Ij, [], gvjs_yu, [gvjs_gp], gvjs_bea);
+    d.Ig = new e(f);
+    if (b.Ig.has(gvjs_Ht) && b.Fa != gvjs_d)
+      throw Error("Focus target category is not supported for the chosen chart type, " + b.Fa);
+    b.Fa == gvjs_yt ? a.gs = new gvjs_OI(a.lb,a.options,a.sc,b) : (a.Kb = c.fa(gvjs_2t, gvjs_MF),
+      gvjs_fJ(a));
+    c = 0 < b.wh.bars || 0 < b.wh.area || 0 < b.wh.steppedArea;
+    d = a.options.cb(gvjs_jv, gvjs_Mea);
+    null == d && (d = gvjs_K(a.options, gvjs_jv) ? gvjs_c : gvjs_f);
+    b.vp = c && d || gvjs_f;
+    b.Ofa = gvjs_K(a.options, "showRemoveSeriesButton", !1)
+  }
+    , this.$la.bind(this), this.mea.bind(this), function() {
+      b.Fa === gvjs_4u && gvjs_fJ(a)
+    }
+    , this.Kra.bind(this), gvjs_QI.prototype.nz.bind(this)]
+}
+;
+function gvjs_fJ(a) {
+  var b = a.V
+    , c = a.lb
+    , d = b.Fa == gvjs_Dd ? function() {
+      return gvjs_Dd
+    }
+    : b.Fa === gvjs_4u ? function() {
+        return gvjs_lt
+      }
+      : function(l) {
+        return gvjs_J(a.options, gvjs_Qw + l + ".type", b.DH, gvjs_fC)
+      }
+  ;
+  d = b.kd ? gvjs_0fa(c, d, b.Fa) : gvjs_1fa(c, d);
+  a.jN = d.I7;
+  b.$a = [];
+  b.Ds = {};
+  for (var e = d.Mk, f = {
+    Tr: 0
+  }; f.Tr < c.ca(); f = {
+    Tr: f.Tr
+  },
+         f.Tr++) {
+    var g = c.fj(f.Tr)
+      , h = c.getValue(f.Tr, 0)
+      , k = gvjs_v(e, function(l) {
+      return function(m) {
+        return c.Ha(l.Tr, m.columns.domain[0]) || ""
+      }
+    }(f));
+    h = {
+      data: h,
+      $w: k,
+      Cs: g
+    };
+    if (k = e[0].columns.tooltip)
+      h.wd = gvjs_gJ(a, k[0], f.Tr);
+    b.$a.push(h);
+    b.Ds[g] = f.Tr
+  }
+  b.C = [];
+  for (e = 0; e < d.y3.length; e++)
+    f = gvjs_2fa(a, e, d.y3[e]),
+      b.C.push(f),
+    gvjs_Py(c.Rj(e)) || (b.C[e].properties = c.Rj(e));
+  b.Jk = d.y8;
+  b.Mk = d.Mk;
+  b.hv = d.hv;
+  b.HL = {};
+  b.wh = {};
+  a.hU = new Set;
+  a.S4 = [];
+  for (d = 0; d < b.C.length; ++d) {
+    e = b.C[d];
+    a.hU.add(e.Qc);
+    f = b.HL[e.Qc];
+    if (null == f)
+      b.HL[e.Qc] = e.dataType;
+    else if (f != e.dataType)
+      throw Error("All series on a given axis must be of the same data type");
+    b.wh[e.type] = (b.wh[e.type] || 0) + 1;
+    f = a.S4[e.Qc] || {};
+    a.S4[e.Qc] = f;
+    f[e.type] = (f[e.type] || 0) + 1
+  }
+}
+function gvjs_3fa(a) {
+  function b(e) {
+    var f = d.C[e];
+    if (d.kd && f.type === gvjs_Dd) {
+      var g = [a.options.fa(gvjs_hu, .5), a.options.fa(gvjs_gu, 1)]
+        , h = f.color.color;
+      d.Vo.push({
+        id: f.id,
+        text: f.mD,
+        brush: new gvjs_3({
+          gradient: {
+            Vf: h,
+            sf: h,
+            tn: g[0],
+            un: g[1],
+            x1: gvjs_So,
+            y1: gvjs_Ro,
+            x2: gvjs_Ro,
+            y2: gvjs_Ro,
+            Sn: !0,
+            sp: !0
+          }
+        }),
+        index: e,
+        isVisible: f.GF
+      })
+    } else
+      g = new gvjs_3({
+        fill: f.color.color
+      }),
+        f.dH ? g.mf(f.dH) : f.$r && g.mf(f.$r.fillOpacity),
+        d.Vo.push({
+          id: f.id,
+          text: f.mD,
+          brush: g,
+          index: e,
+          isVisible: f.GF
+        });
+    c[e] = !0
+  }
+  var c = {}
+    , d = a.V;
+  d.Vo = [];
+  gvjs_u(d.C, function(e, f) {
+    c[f] || (b(f),
+    null != e.XL && b(e.XL))
+  }, a);
+  d.kd && d.C[0].type === gvjs_lt && d.Vo.push({
+    id: -1,
+    text: "Previous data",
+    brush: new gvjs_3({
+      fill: gvjs_NF.color
+    }),
+    index: -1,
+    isVisible: !0
+  })
+}
+function gvjs_4fa(a, b) {
+  function c(H) {
+    return H = 864E5 * H + e
+  }
+  function d(H) {
+    H -= e;
+    return H / 864E5
+  }
+  for (var e = (new Date(1900,0,1,0,0,0)).getTime(), f = new gvjs_1j("0.###E0"), g = new gvjs_1j("#.###"), h = new gvjs_9I(function(H) {
+      return 0 !== H && (1E5 < Math.abs(H) || .01 > Math.abs(H)) ? f.format(H) : g.format(H)
+    }
+  ), k = a.V, l = 0, m = k.orientation === gvjs_U, n = k.C.length, p = {
+    wu: 0
+  }; p.wu < n; p = {
+    wu: p.wu,
+    vu: p.vu,
+    WF: p.WF,
+    tx: p.tx,
+    FM: p.FM,
+    xM: p.xM
+  },
+         p.wu++) {
+    var q = k.C[p.wu]
+      , r = function(H) {
+      return function(Q, R) {
+        return [gvjs_xx + H.wu + "." + Q, gvjs_xx + Q].concat(R || [])
+      }
+    }(p);
+    if (null != a.options.fa(gvjs_xx + p.wu)) {
+      l++;
+      var t = gvjs_J(a.options, r(gvjs_Sd), gvjs_Hp, gvjs_LF.Type)
+        , u = a.options.fa(r(gvjs_1), "<default>")
+        , v = "<default>" === u;
+      v && (u = q.Qg.fill);
+      v = gvjs_ny(a.options, r(gvjs_Kp, [gvjs_cu]), v ? .5 : 1);
+      var w = gvjs_Oj(a.options, r(gvjs_jw, [gvjs_jw]), 0)
+        , x = gvjs_K(a.options, r(gvjs_nw, [gvjs_nw]), 0 < w);
+      0 >= w && (w = 6);
+      w /= 2;
+      0 < w && (w += 1);
+      var y = {};
+      null != q.columns.data && (y.data = q.columns.data);
+      var z = gvjs_Oj(a.options, r(gvjs_Bv, [gvjs_Bv]), 2)
+        , A = gvjs_J(a.options, r(gvjs_8t), gvjs_f, gvjs_oC)
+        , B = gvjs_K(a.options, r(gvjs_Nx), !1);
+      u = gvjs_5F(u);
+      t = gvjs_LF[t];
+      var D = (m ? a.ke : a.Bf)[0]
+        , C = (m ? a.Bf : a.ke)[q.Qc];
+      if (D.type === gvjs_Vd) {
+        p.vu = D.ta;
+        p.FM = C.ta;
+        D = b.Ga(0);
+        p.xM = q.columns.data[0];
+        p.tx = gvjs_Wx;
+        p.WF = gvjs_Wx;
+        C = null;
+        0 < b.ca() && gvjs_oe(b.getValue(0, 0)) ? (p.tx = d,
+          p.WF = c) : C = {
+          transform: function(H) {
+            return function(Q) {
+              return gvjs_fI(H.vu, H.WF(Q))
+            }
+          }(p),
+          inverse: function(H) {
+            return function(Q) {
+              return H.tx(H.vu.Vz.inverse(Q))
+            }
+          }(p)
+        };
+        var G = {
+          min: p.tx(p.vu.sn),
+          max: p.tx(p.vu.rn)
+        };
+        t = t(b.ca(), function(H) {
+          return function(Q) {
+            Q = b.getValue(Q, 0);
+            Q = H.vu.zc(Q);
+            return H.tx(Q)
+          }
+        }(p), function(H) {
+          return function(Q) {
+            return H.FM.zc(b.getValue(Q, H.xM))
+          }
+        }(p), {
+          range: G,
+          $X: C,
+          fv: gvjs_L(a.options, r("degree"), 3)
+        });
+        if (null !== t) {
+          C = gvjs_J(a.options, r(gvjs_8c), b.Ga(p.xM));
+          D = t.bR ? t.bR(D, C).qm() : t.rv;
+          D = h.R(D.Im()) || "Trendline " + l;
+          D = gvjs_J(a.options, r(gvjs_fx), D);
+          C = gvjs_v(t.data, function(H) {
+            return function(Q) {
+              var R = H.WF(Q[0]);
+              return [H.vu.Xq(R), H.FM.Xq(Q[1])]
+            }
+          }(p));
+          q.XL = k.C.length;
+          G = gvjs_9z(u.color, z);
+          gvjs_ay(G, v);
+          var J = gvjs_8z(u.color);
+          J.mf(v);
+          var I = gvjs_J(a.options, r(gvjs_nv), D);
+          gvjs_K(a.options, r("showR2"), !1) && (I += "\n" + h.R((new gvjs_uF([new gvjs_yF([new gvjs_AF("r"), new gvjs_mF(2)]), new gvjs_mF(t.r2)])).Im()));
+          t = !1 !== a.options.fa(r(gvjs_Pd));
+          var M = a.options.fa(r(gvjs_Op), {
+            type: gvjs_4o
+          });
+          q = {
+            id: q.id + "_trendline",
+            title: D,
+            ag: !0,
+            data: C,
+            dataType: q.dataType,
+            Yg: gvjs_K(a.options, r(gvjs_ru, [gvjs_ru]), !0),
+            NT: t,
+            isVisible: !0,
+            Cs: 0,
+            columns: y,
+            Sda: p.wu,
+            We: q.We,
+            Df: null,
+            color: u,
+            dH: v,
+            Qg: J,
+            Oc: G,
+            $r: null,
+            NG: null,
+            type: gvjs_e,
+            wM: gvjs_L(a.options, r("zOrder"), 0),
+            lineWidth: z,
+            pointRadius: w,
+            hE: M,
+            jea: 12,
+            ey: A,
+            RT: gvjs_Oj(a.options, r(gvjs_Yw, [gvjs_Yw]), 1),
+            rM: x,
+            points: [],
+            kX: [],
+            Qc: q.Qc,
+            GF: B,
+            mD: I
+          };
+          k.C.push(q)
+        }
+      }
+    }
+  }
+}
+function gvjs_1fa(a, b) {
+  for (var c = [], d = [], e = null, f = null, g = 0, h = [], k = new Set, l = a.$(), m = !1, n, p = 0; p < l; ++p) {
+    var q = a.W(p)
+      , r = a.Bd(p, gvjs_Bd) || (0 == p ? gvjs_mu : gvjs_$t);
+    if (0 == p && r !== gvjs_mu)
+      throw Error(gvjs_cs);
+    if (r == gvjs_mu) {
+      if (m || 0 < g)
+        throw Error(gvjs_ys + p + ")");
+      m = !0;
+      e = {
+        columns: {},
+        dataType: q
+      };
+      f = {
+        Vb: null,
+        We: d.length
+      };
+      d.push(e)
+    } else if (r === gvjs_$t) {
+      0 === g && (f = c.length,
+        n = b(f),
+        e = {
+          type: n,
+          dataType: q,
+          columns: {}
+        },
+        f = {
+          Vb: f,
+          We: null
+        },
+        c.push(e),
+        g = n === gvjs_Ft ? 4 : 1);
+      g--;
+      if (q !== e.dataType)
+        throw Error(gvjs_0r + p + gvjs_fr + q + gvjs_cr + e.dataType);
+      n !== gvjs_lt && n !== gvjs_Ft || k.add(p)
+    } else if (r === gvjs_Pd && e.columns[r])
+      throw Error("Only one column with role 'tooltip' per series is allowed");
+    r !== gvjs_mu && (m = !1);
+    e.columns[r] = e.columns[r] || [];
+    h.push({
+      Vb: f.Vb,
+      We: f.We,
+      role: r,
+      wE: e.columns[r].length
+    });
+    e.columns[r].push(p)
+  }
+  if (0 < g)
+    throw Error(gvjs_js + g + ")");
+  a = 0;
+  b = d[0].dataType;
+  for (e = 0; e < c.length; ++e) {
+    if (d.length <= a)
+      throw Error("Series #" + e + gvjs_er);
+    l = d[a + 1];
+    m = c[e].columns.data;
+    if (l && l.columns.domain[0] <= m[0] && (++a,
+    b !== d[a].dataType))
+      throw Error(gvjs_1r);
+    c[e].We = a
+  }
+  return {
+    y3: c,
+    Mk: d,
+    hv: b,
+    y8: h,
+    I7: k
+  }
+}
+function gvjs_hJ(a, b) {
+  if (a !== b)
+    throw Error("Column types must be consistent: equal for domain columns and for columns in the same serie.");
+}
+function gvjs_0fa(a, b, c) {
+  var d = []
+    , e = []
+    , f = null
+    , g = []
+    , h = new Set;
+  if (c === gvjs_Dd) {
+    c = a.$() - 2;
+    var k = function(t) {
+      if (t !== gvjs_$t && t !== gvjs_3v)
+        throw Error("All columns must be either data or old-data columns");
+    }
+      , l = {
+      data: null,
+      "old-data": null
+    };
+    f = a.W(0);
+    for (var m = 0; 2 > m; ++m) {
+      var n = a.W(m)
+        , p = a.Bd(m, gvjs_Bd);
+      k(p);
+      gvjs_hJ(f, n);
+      n = {
+        columns: {},
+        dataType: n
+      };
+      n.columns.domain = [m];
+      e.push(n);
+      l[p] = m;
+      g.push({
+        We: m,
+        role: gvjs_mu,
+        wE: 0,
+        Vb: null
+      })
+    }
+    for (m = 0; m < c; ++m) {
+      p = 2 + m;
+      var q = a.W(m);
+      n = a.Bd(m, gvjs_Bd);
+      k(n);
+      m % 2 && gvjs_hJ(d[m - 1].dataType, q);
+      var r = l[n];
+      q = {
+        type: b(m),
+        dataType: q,
+        We: r,
+        columns: {}
+      };
+      q.columns[n] = [p];
+      d.push(q);
+      g.push({
+        We: r,
+        role: n,
+        wE: 0,
+        Vb: m
+      })
+    }
+  } else if (c === gvjs_d) {
+    n = f = null;
+    r = 0;
+    c = a.$();
+    for (k = 0; k < c; ++k) {
+      l = a.W(k);
+      m = a.Bd(k, gvjs_Bd) || (0 === k ? gvjs_mu : gvjs_$t);
+      if (0 === k && m !== gvjs_mu)
+        throw Error(gvjs_cs);
+      if (m === gvjs_mu) {
+        if (0 < r)
+          throw Error(gvjs_ys + k + ")");
+        f = {
+          columns: {},
+          dataType: l
+        };
+        n = {
+          Vb: null,
+          We: e.length
+        };
+        e.push(f)
+      }
+      0 !== r || m !== gvjs_$t && m !== gvjs_3v || (n = d.length,
+        p = b(n),
+        f = {
+          type: p,
+          dataType: l,
+          columns: {}
+        },
+        n = {
+          Vb: n,
+          We: null
+        },
+        d.push(f),
+        r = p === gvjs_Ft ? 4 : m === gvjs_3v ? 2 : 1,
+      p !== gvjs_lt && p !== gvjs_Ft || h.add(k));
+      if (m === gvjs_$t || m === gvjs_3v)
+        if (r--,
+        l !== f.dataType)
+          throw Error(gvjs_0r + k + gvjs_fr + l + gvjs_cr + f.dataType);
+      if (m === gvjs_Pd && f.columns[m])
+        throw Error("Only one data column with role 'tooltip' per series is allowed");
+      f.columns[m] = f.columns[m] || [];
+      g.push({
+        Vb: n.Vb,
+        We: n.We,
+        role: m,
+        wE: f.columns[m].length
+      });
+      f.columns[m].push(k)
+    }
+    if (0 < r)
+      throw Error(gvjs_js + r + ")");
+    a = 0;
+    f = e[0].dataType;
+    for (b = 0; b < d.length; ++b) {
+      if (e.length <= a)
+        throw Error("Series #" + b + gvjs_er);
+      c = e[a + 1];
+      k = d[b].columns[gvjs_3v] || d[b].columns.data;
+      if (c && c.columns.domain[0] <= k[0] && (++a,
+      f !== e[a].dataType))
+        throw Error(gvjs_1r);
+      d[b].We = a
+    }
+  }
+  return {
+    y3: d,
+    Mk: e,
+    hv: f,
+    y8: g,
+    I7: h
+  }
+}
+gvjs_.fL = function(a) {
+  a = a.columns[gvjs_3v];
+  return null != a && 0 < a.length
+}
+;
+function gvjs_2fa(a, b, c) {
+  var d = c.type
+    , e = c.columns
+    , f = c.We
+    , g = a.options
+    , h = gvjs_Qw + b + "."
+    , k = d + "."
+    , l = e.data || e[gvjs_3v]
+    , m = a.lb.jf(l[0])
+    , n = a.lb.Ga(l[0]) || ""
+    , p = d == gvjs_Dd ? 0 : 2
+    , q = gvjs_Oj(g, [h + gvjs_jw, gvjs_jw], d == gvjs_Dd ? 7 : 0);
+  var r = gvjs_K(g, [h + gvjs_nw, gvjs_nw], d == gvjs_e || d == gvjs_at || d == gvjs_Dd ? 0 < q : !0);
+  0 == q && (q = d == gvjs_Dd ? 7 : 6);
+  q /= 2;
+  0 < q && (q += 1);
+  b = g.fa(h + gvjs_1, a.Kb[(a.V.kd && d == gvjs_Dd ? Math.floor(b / 2) : b) % a.Kb.length]);
+  b = gvjs_5F(b);
+  var t = null;
+  if (d == gvjs_at || d == gvjs_4w)
+    t = gvjs_ny(g, [h + gvjs_bt, gvjs_bt]),
+      t = gvjs_8z(b.color, t);
+  var u = null;
+  if (d == gvjs_Ft) {
+    u = new gvjs_3({
+      stroke: b.color,
+      strokeWidth: 2,
+      fill: b.color
+    });
+    var v = new gvjs_3({
+      stroke: b.color,
+      strokeWidth: 2,
+      fill: gvjs_Br
+    })
+      , w = gvjs_K(g, "candlestick.hollowIsRising")
+      , x = w ? u : v;
+    u = {
+      Uea: gvjs_qy(g, [h + gvjs_Et, gvjs_Et], w ? v : u),
+      g$: gvjs_qy(g, [h + gvjs_Dt, gvjs_Dt], x)
+    }
+  }
+  p = gvjs_Oj(g, [h + gvjs_Bv, gvjs_Bv], p);
+  v = gvjs_9z(b.color, p);
+  (w = g.$I([h + "lineDashStyle", "lineDashStyle"])) && null != w && (v.Mi = w);
+  k = gvjs_Oj(g, [h + gvjs_cu, k + gvjs_cu, gvjs_cu], 1);
+  w = null;
+  if (d === gvjs_Dd || d === gvjs_e || d === gvjs_at)
+    w = g.fa([h + gvjs_Op, gvjs_Op], {
+      type: gvjs_4o
+    }),
+    typeof w === gvjs_l && (w = {
+      type: w
+    });
+  x = null;
+  if (a.V.kd && d === gvjs_Dd) {
+    var y = a.fL(c);
+    k = y ? a.options.fa(gvjs_hu, .5) : a.options.fa(gvjs_gu, 1);
+    y && (x = !1)
+  }
+  y = d == gvjs_4w ? t : gvjs_8z(b.color, k);
+  if (a.V.kd)
+    if (d === gvjs_lt) {
+      var z = g.fa("diff.oldData.color", gvjs_NF);
+      z = gvjs_5F(z);
+      z = {
+        background: {
+          Qg: gvjs_8z(z.color, k)
+        }
+      }
+    } else
+      d === gvjs_Dd && a.fL(c) && (r = !1);
+  else
+    d === gvjs_Dd && (d = gvjs_e);
+  var A = gvjs_5fa(a, e, g, h, b)
+    , B = !1 !== a.options.fa(h + gvjs_Pd);
+  return {
+    id: a.lb.Ne(l[0]),
+    title: n,
+    dataType: c.dataType,
+    isVisible: !0,
+    NT: B,
+    Cs: m,
+    columns: e,
+    We: f,
+    Yg: gvjs_K(g, [h + gvjs_ru, gvjs_ru], !0),
+    Df: A,
+    color: b,
+    dH: k,
+    Qg: y,
+    Oc: v,
+    $r: t,
+    hE: w,
+    Ih: z,
+    NG: u,
+    type: d,
+    wM: gvjs_L(g, h + "zOrder", 0),
+    lineWidth: p,
+    pointRadius: q,
+    jea: 12,
+    ey: gvjs_J(g, [h + gvjs_8t, gvjs_8t], gvjs_f, gvjs_oC),
+    RT: gvjs_Oj(g, [h + gvjs_Yw, gvjs_Yw], 1),
+    rM: r,
+    points: [],
+    kX: [],
+    Qc: gvjs_Oj(g, [h + gvjs_$w, gvjs_$w], 0),
+    GF: null != x ? x : gvjs_K(g, h + gvjs_Nx, !0),
+    mD: gvjs_J(g, h + gvjs_nv, n)
+  }
+}
+function gvjs_5fa(a, b, c, d, e) {
+  function f(v, w) {
+    return g(v, w).concat([d + w, w])
+  }
+  function g(v, w) {
+    return [d + "interval." + v + "." + w, d + "intervals." + w, "interval." + v + "." + w, "intervals." + w]
+  }
+  var h = b.interval;
+  if (!h)
+    return null;
+  b = {
+    Mb: [],
+    IA: [],
+    qN: [],
+    points: [],
+    areas: [],
+    lines: [],
+    eu: {}
+  };
+  for (var k = {}, l = 0; l < h.length; l++) {
+    var m = h[l]
+      , n = a.lb.Ne(m) || a.lb.Ga(m) || gvjs_eu
+      , p = c.cb(g(n, gvjs_Jd), gvjs_gC);
+    switch (p) {
+      case gvjs_lt:
+        b.Mb.push(m);
+        a.jN.add(m);
+        break;
+      case "sticks":
+        b.IA.push(m);
+        break;
+      case "boxes":
+        b.qN.push(m);
+        a.jN.add(m);
+        break;
+      case gvjs_mw:
+        b.points.push(m);
+        break;
+      case gvjs_at:
+        b.areas.push(m);
+        break;
+      case gvjs_e:
+        b.lines.push(m);
+        break;
+      case gvjs_f:
+        break;
+      default:
+        throw Error("Invalid interval style: " + p);
+    }
+    n in k ? k[n].push(m) : k[n] = [m]
+  }
+  1 < b.Mb.length && 0 == b.IA.length && (b.IA = [b.Mb[0], b.Mb[b.Mb.length - 1]]);
+  if (0 != b.IA.length % 2)
+    throw Error("Stick-intervals must be defined by an even number of columns");
+  if (0 != b.areas.length % 2)
+    throw Error("Area-intervals must be defined by an even number of columns");
+  for (var q in k) {
+    a = gvjs_Oj(c, g(q, gvjs_Bv));
+    h = gvjs_ny(c, g(q, gvjs_sp));
+    l = gvjs_oy(c, g(q, gvjs_1), "", gvjs_Xe(gvjs_hC));
+    l = gvjs_$G(l, e);
+    a = new gvjs_3({
+      stroke: l,
+      strokeWidth: a,
+      fill: l,
+      fillOpacity: h
+    });
+    h = gvjs_Oj(c, g(q, "barWidth"));
+    l = gvjs_Oj(c, g(q, "shortBarWidth"));
+    m = gvjs_Oj(c, g(q, "boxWidth"));
+    n = gvjs_Oj(c, g(q, gvjs_jw));
+    p = c.cb(g(q, gvjs_Jd), gvjs_gC);
+    var r = gvjs_K(c, f(q, gvjs_hv))
+      , t = gvjs_J(c, f(q, gvjs_8t), gvjs_f, gvjs_oC)
+      , u = gvjs_Oj(c, f(q, gvjs_Yw), 1);
+    a = {
+      style: p,
+      brush: a,
+      Ika: h,
+      Qwa: l,
+      Vka: m,
+      ava: n,
+      Zj: r,
+      ey: t,
+      RT: u
+    };
+    h = k[q];
+    for (l = 0; l < h.length; ++l)
+      b.eu[h[l]] = a
+  }
+  return b
+}
+gvjs_.$la = function() {
+  var a = this.V;
+  switch (a.Fa) {
+    case gvjs_d:
+    case gvjs_4u:
+      a.orientation = gvjs_J(this.options, gvjs_9v, "", gvjs_iC);
+      if (!a.orientation)
+        throw Error("Unspecified orientation.");
+      this.je = {};
+      this.Bf = {};
+      this.ke = {};
+      switch (a.orientation) {
+        case gvjs_S:
+          var b = gvjs__I;
+          var c = this.Bf;
+          var d = gvjs_6I;
+          var e = this.ke;
+          break;
+        case gvjs_U:
+          b = gvjs_6I,
+            c = this.ke,
+            d = gvjs__I,
+            e = this.Bf
+      }
+      for (var f = null == this.hU ? [] : gvjs_nj(this.hU), g = 0; g < f.length; ++g) {
+        var h = f[g]
+          , k = new d(a,this.options,["targetAxes." + h, gvjs_Md],h,gvjs_Vd,gvjs_qw);
+        if (k.type != gvjs_Vd)
+          throw Error("Target-axis must be of type value");
+        this.je[h] = k;
+        e[h] = k
+      }
+      d = b;
+      e = this.options;
+      if (this.lb.W(0) == gvjs_l)
+        b: {
+          switch (gvjs_6fa(this)) {
+            case gvjs_at:
+              b = 1 < this.V.$a.length ? gvjs_It : gvjs_Ht;
+              break b;
+            case gvjs_e:
+            case gvjs_Dd:
+            case gvjs_lt:
+            case gvjs_4w:
+            case gvjs_Ft:
+              b = gvjs_Ht;
+              break b
+          }
+          b = null
+        }
+      else
+        b = gvjs_Vd;
+      this.ed = new d(a,e,[gvjs_Pb],0,b,gvjs_Lv);
+      c[0] = this.ed;
+      break;
+    case gvjs_Dd:
+    case gvjs_yt:
+      this.Bf = {
+        0: new gvjs__I(a,this.options,[],0,gvjs_Vd,gvjs_qw)
+      },
+        this.ke = {
+          0: new gvjs_6I(a,this.options,[],0,gvjs_Vd,gvjs_qw)
+        },
+        a.orientation === gvjs_S ? (this.ed = this.Bf[0],
+          this.je = this.ke) : (this.ed = this.ke[0],
+          this.je = this.Bf)
+  }
+}
+;
+function gvjs_6fa(a) {
+  var b = [gvjs_e, gvjs_Dd, gvjs_at, gvjs_4w, gvjs_lt, gvjs_Ft]
+    , c = {};
+  gvjs_u(b, function(d, e) {
+    c[d] = e
+  });
+  a = gvjs_Ee(a.V.C, function(d, e) {
+    return Math.max(d, c[e.type])
+  }, 0);
+  return b[a]
+}
+gvjs_.Kra = function() {
+  var a = this.V;
+  switch (a.Fa) {
+    case gvjs_Dd:
+    case gvjs_yt:
+      if (a.hv == gvjs_l)
+        throw Error("X values column cannot be of type string");
+      var b = a.HL[0];
+      if (b == gvjs_l)
+        throw Error("Data column(s) cannot be of type string");
+      var c = this.Bf[0]
+        , d = this.ke[0];
+      if (c.type != gvjs_Vd)
+        throw Error("The x-axis must be of type value");
+      c.initScale(a.hv);
+      if (d.type != gvjs_Vd)
+        throw Error("The y-axis must be of type value");
+      d.initScale(b);
+      break;
+    case gvjs_d:
+    case gvjs_4u:
+      b = this.ed;
+      a.Fa === gvjs_4u && (c = this.lb.Bd(0, gvjs_8u),
+        gvjs_hq(b.options, 1, {
+          ticks: c
+        }));
+      if (b.type == gvjs_Vd) {
+        if (a.hv == gvjs_l)
+          throw Error("Domain column cannot be of type string, it should be the X values on a continuous domain axis");
+        b.initScale(a.hv)
+      }
+      gvjs_w(this.je, function(e, f) {
+        var g = a.HL[f];
+        if (g == gvjs_l)
+          throw Error("Data column(s) for axis #" + f + " cannot be of type string");
+        e.initScale(g)
+      }, this)
+  }
+  gvjs_w(this.Bf, function(e) {
+    gvjs_yI(e)
+  });
+  gvjs_w(this.ke, function(e) {
+    gvjs_yI(e)
+  })
+}
+;
+function gvjs_7fa(a) {
+  if (null === gvjs_iJ(a))
+    return [];
+  for (var b = (a.V.Mk[0].columns.domain || [])[0], c = [], d = null, e = a.lb, f = 0; f < e.ca(); f++) {
+    var g = e.getValue(f, b)
+      , h = gvjs_jJ(a, f);
+    if (null !== d && null != h) {
+      if (0 > h)
+        throw Error("Invalid gap value (" + h + ") in data row #" + f + ". Gap value must be non-negative.");
+      c.push({
+        Gc: d,
+        xe: g,
+        woa: h
+      })
+    }
+    d = g
+  }
+  return c
+}
+gvjs_.N$ = function() {
+  return this.gs && this.gs.aq == gvjs_g ? null : null != this.ke[0] && null != this.ke[1] ? gvjs_vx : null != this.ke[1] ? gvjs_$c : gvjs_j
+}
+;
+gvjs_.M$ = function() {
+  return this.gs && this.gs.aq == gvjs_g ? gvjs_vx : null
+}
+;
+function gvjs_kJ(a) {
+  var b = a.columns.data;
+  return b ? b[0] : a.columns[gvjs_3v][0]
+}
+function gvjs_8fa(a) {
+  for (var b = a.V, c = a.lb, d = a.ed, e = 0; e < b.$a.length; e++) {
+    for (var f = 0; f < b.C.length; f++) {
+      var g = b.C[f]
+        , h = a.je[g.Qc];
+      g = c.getValue(e, gvjs_kJ(g));
+      g = gvjs_eI(h.ta, g);
+      null != g && gvjs_uI(h, g)
+    }
+    d.type == gvjs_Vd && (f = c.getValue(e, 0),
+      f = gvjs_eI(d.ta, f),
+      gvjs_uI(d, f))
+  }
+}
+function gvjs_9fa(a) {
+  var b = a.V
+    , c = a.lb
+    , d = a.Bf[0];
+  a = a.ke[0];
+  for (var e = 0; e < c.ca(); e++)
+    for (var f = 0; f < b.C.length; f++) {
+      var g = b.C[f]
+        , h = gvjs_kJ(g);
+      g = c.getValue(e, b.Mk[g.We].columns.domain[0]);
+      h = c.getValue(e, h);
+      g = gvjs_eI(d.ta, g);
+      h = gvjs_eI(a.ta, h);
+      null != g && gvjs_uI(d, g);
+      null != h && gvjs_uI(a, h)
+    }
+}
+gvjs_.tN = function() {
+  var a = this, b;
+  return [function() {
+    b = a.ti()
+  }
+    , this.cla.bind(this), function() {
+      (b.vp !== gvjs_f || b.kd || b.Fa === gvjs_4u) && gvjs_w(a.je, function(c) {
+        c.oc(0)
+      })
+    }
+    , function() {
+      if (b.Fa === gvjs_d || b.Fa === gvjs_4u)
+        gvjs_8fa(a),
+        a.ed.type == gvjs_Vd && a.ed.dD(gvjs_7fa(a)),
+          gvjs_wI(a.ed),
+          gvjs_w(a.je, function(e) {
+            e.dD();
+            gvjs_wI(e)
+          }, a);
+      else {
+        var c = a.Bf[0]
+          , d = a.ke[0];
+        b.Fa == gvjs_yt ? gvjs_Nfa(a.gs, c, d) : b.Fa == gvjs_Dd && gvjs_9fa(a);
+        c.dD();
+        gvjs_wI(c);
+        d.dD();
+        gvjs_wI(d)
+      }
+    }
+    , function() {
+      a.Pr = a.Pr || gvjs_K(a.options, "bar.variableWidth");
+      b.Fa === gvjs_4u && (a.Pr = !1)
+    }
+    , function() {
+      b.wh.bars && gvjs_lJ(a, gvjs_lt);
+      b.wh.steppedArea && (a.ed.type == gvjs_Vd && (a.Pr = !0),
+        gvjs_lJ(a, gvjs_4w));
+      b.wh.candlesticks && gvjs_$fa(a);
+      if (b.wh.line) {
+        for (var c = a.V, d = 0; d < c.C.length; d++)
+          gvjs_mJ(a, d);
+        gvjs_nJ(a);
+        gvjs_oJ(a);
+        gvjs_pJ(a)
+      }
+      b.wh.area && gvjs_aga(a);
+      if (b.wh.scatter) {
+        c = a.V;
+        for (d = 0; d < c.C.length; d++)
+          gvjs_qJ(a, d);
+        gvjs_oJ(a);
+        gvjs_pJ(a)
+      }
+      if (b.wh.bubbles) {
+        c = a.gs;
+        d = a.Bf[0];
+        for (var e = a.ke[0], f = a.Dg, g = 0; g < c.Cl.ca(); g++) {
+          a: {
+            var h = c;
+            var k = d
+              , l = e
+              , m = g
+              , n = h.Cl
+              , p = n.getValue(m, h.m1)
+              , q = n.Ha(m, h.m1)
+              , r = n.getValue(m, h.tM)
+              , t = n.getValue(m, h.vM)
+              , u = null;
+            if (null != h.qs && (u = n.getValue(m, h.qs),
+            null == u)) {
+              h = null;
+              break a
+            }
+            var v = null;
+            if (null != h.iu && (v = n.getValue(m, h.iu),
+            null == v)) {
+              h = null;
+              break a
+            }
+            n = h.Zd(q, h.Za).width;
+            if (h.aq == gvjs_g)
+              h.aX = gvjs_8B(h.aX, u);
+            else if (h.aq == gvjs_l) {
+              var w = u
+                , x = h.TB[w];
+              if (!x) {
+                x = gvjs_Qw + w + ".";
+                var y = gvjs_oy(h.m, x + gvjs_1, h.YX[h.$D.length % h.YX.length]);
+                y = gvjs_5F(y);
+                var z = gvjs_K(h.m, x + gvjs_Nx, !0);
+                x = gvjs_J(h.m, x + gvjs_nv, w);
+                x = {
+                  color: y.color,
+                  GF: z,
+                  mD: x
+                };
+                h.TB[w] = x;
+                h.$D.push(w)
+              }
+            }
+            h.t4 = gvjs_8B(h.t4, v);
+            r = k.ta.zc(r);
+            t = l.ta.zc(t);
+            null === r || null === t ? h = null : (gvjs_LI(k, r) && gvjs_LI(l, t) && (k.oc(r),
+              l.oc(t)),
+              k = h.AW(m, q),
+              h = {
+                id: p,
+                text: q,
+                textLength: n,
+                ja: h.Za,
+                wd: k,
+                Kf: {
+                  x: r,
+                  y: t,
+                  color: u,
+                  size: v
+                }
+              })
+          }
+          c.xl.C[0].points.push(h)
+        }
+        if (c.aq == gvjs_g)
+          c.rs = gvjs__H(c.m, c.aX),
+            f.setScale(c.rs);
+        else if (c.aq == gvjs_l)
+          for (d = 0; d < c.$D.length; d++)
+            e = c.$D[d],
+              f = c.TB[e],
+            f.GF && c.xl.Vo.push({
+              index: d,
+              id: e,
+              text: f.mD,
+              brush: new gvjs_3({
+                fill: f.color
+              }),
+              isVisible: !0
+            });
+        c.tL = gvjs_NI(c.m, c.t4);
+        c.Qya && gvjs_u(c.xl.C[0].points, c.fka, c)
+      }
+    }
+    , function() {
+      var c = b.Fa === gvjs_4u
+        , d = b.wh.bars || b.wh.candlesticks
+        , e = null != gvjs_Yx(b.C, function(f) {
+        return null != f.Df
+      });
+      (d && !c && !a.Pr || e) && gvjs_bga(a)
+    }
+    , function() {
+      b.jd = gvjs_Ny(a.Bf, function(c) {
+        return c.wW(this.ne, this.Dg)
+      }, a);
+      b.wc = gvjs_Ny(a.ke, function(c) {
+        return c.wW(this.ne, this.Dg)
+      }, a);
+      gvjs_cga(a)
+    }
+    , this.$ka.bind(this), this.dva.bind(this), function() {
+      gvjs_dga(new gvjs_rJ(a,a.options))
+    }
+    , function() {
+      var c = a.ne.getPosition()
+        , d = a.ne.Za.fontSize
+        , e = null;
+      c != gvjs_j && c != gvjs_ov || null != a.ke[1] || (e = new gvjs_B(b.O.top,b.width - d,b.O.bottom,b.O.right + d));
+      c != gvjs_$c || null != a.ke[0] || (e = new gvjs_B(b.O.top,b.O.left - d,b.O.bottom,d));
+      e && e.right >= e.left && a.ne.qr(e)
+    }
+    , this.Iva.bind(this), function() {
+      a.gs || (gvjs_4fa(a, a.lb),
+        gvjs_3fa(a),
+        gvjs_ega(a))
+    }
+  ]
+}
+;
+gvjs_.cla = function() {
+  var a = this.V
+    , b = this.sc
+    , c = (gvjs_Oy(this.Bf) || gvjs_Oy(this.ke)).title.ja
+    , d = Math.max(a.title.ja.fontSize, c.fontSize)
+    , e = this.ne.Za.fontSize
+    , f = this.ne.getPosition()
+    , g = this.Dg.Za.fontSize
+    , h = this.Dg.getPosition()
+    , k = a.oF == gvjs_Fp ? a.title.text : ""
+    , l = ""
+    , m = "";
+  if (a.DB == gvjs_Fp) {
+    var n = function(w) {
+      var x = gvjs_Ye(w);
+      gvjs_Qe(x);
+      x = gvjs_v(x, function(y) {
+        return w[y].title.text
+      });
+      return gvjs_De(x, function(y) {
+        return "" != y
+      }).join(gvjs_ha)
+    };
+    switch (a.Fa) {
+      case gvjs_Dd:
+      case gvjs_yt:
+        l = n(this.Bf);
+        m = n(this.ke);
+        break;
+      case gvjs_d:
+        l = n({
+          0: this.ed
+        }),
+          m = n(this.je)
+    }
+  }
+  l = l && m ? l + " / " + m : l ? l : m ? m : "";
+  m = Math.max(2, Math.round(d / 1.618));
+  var p = Math.max(2, Math.round(e / 1.618))
+    , q = Math.max(2, Math.round(g / 1.618))
+    , r = a.O.width - 2 * m;
+  g = gvjs_DG(b, k, a.title.ja, r, 1);
+  n = 0 < g.lines.length ? g.lines[0] : "";
+  var t = b(n, a.title.ja).width;
+  r = Math.max(r - t - Math.round(Math.max(2, 1.618 * d)), 0);
+  b = gvjs_DG(b, l, c, r, 1);
+  var u = 0 < b.lines.length ? b.lines[0] : ""
+    , v = [];
+  v.push({
+    key: gvjs_wt,
+    min: 2,
+    extra: [Infinity]
+  });
+  (n || u) && v.push({
+    key: gvjs_fx,
+    min: d + 2,
+    extra: [m - 2]
+  });
+  f == gvjs_Fp && v.push({
+    key: gvjs_rv,
+    min: e + 2,
+    extra: [p - 2]
+  });
+  h == gvjs_Fp && v.push({
+    key: gvjs_1t,
+    min: this.Dg.getHeight() + 2,
+    extra: [q - 2]
+  });
+  f = gvjs_oA(v, Math.floor(a.O.height / 2));
+  d = a.O.top;
+  h = f.title || [];
+  0 < h.length && (d += h[0],
+  n && (a.title.lines.push({
+    text: n,
+    x: a.O.left + m,
+    y: d,
+    length: t
+  }),
+    a.title.tooltip = g.oe ? k : ""),
+  u && (a.cJ = {
+    text: l,
+    ja: c,
+    vl: null,
+    lines: [],
+    ld: gvjs_R,
+    Pc: gvjs_R,
+    tooltip: b.oe ? l : "",
+    anchor: null,
+    angle: 0
+  },
+    a.cJ.lines.push({
+      text: u,
+      x: a.O.right - m,
+      y: d,
+      length: r
+    })));
+  c = f.legend || [];
+  0 < c.length && (d += c[0],
+    this.ne.qr(new gvjs_B(d - e,a.O.right,d,a.O.left)));
+  e = f.colorBar || [];
+  0 < e.length && (d += e[0],
+    a = new gvjs_B(d - this.Dg.getHeight(),a.O.right,d,a.O.left),
+    this.Dg.qr(a))
+}
+;
+function gvjs_lJ(a, b) {
+  var c = a.V;
+  c.kd ? gvjs_fga(a, b) : gvjs_gga(a, b, c.vp)
+}
+function gvjs_bga(a) {
+  var b = a.ed;
+  if (b.ta) {
+    var c = gvjs_De(a.V.$a, function(f, g) {
+      return 0 != gvjs_jJ(this, g)
+    }, a), d = Infinity, e;
+    gvjs_u(c, function(f) {
+      f = b.ta.zc(f.data);
+      if (null != e) {
+        var g = Math.abs(f - e);
+        0 < g && (d = Math.min(d, g))
+      }
+      e = f
+    }, a);
+    isFinite(d) && (a = d / 2,
+      b.oc(b.ta.sn - a),
+      b.oc(b.ta.rn + a))
+  }
+}
+function gvjs_sJ(a, b) {
+  for (var c = a.V, d = [], e = 0; e < c.$a.length; e++) {
+    var f = {
+      positive: 0,
+      negative: 0
+    };
+    d[e] = f;
+    for (var g = 0; g < c.C.length; g++) {
+      var h = c.C[g];
+      if (h.type == b) {
+        var k = a.je[h.Qc];
+        h = a.lb.getValue(e, h.columns.data[0]);
+        null != h && (k = k.ta.zc(h),
+          0 < k ? f.positive += k : f.negative -= k)
+      }
+    }
+  }
+  return d
+}
+function gvjs_tJ(a, b) {
+  for (var c = a.V, d = 0; d < c.C.length; d++) {
+    var e = c.C[d];
+    e.type == b && (a.je[e.Qc].qM = gvjs_Lv)
+  }
+}
+function gvjs_gga(a, b, c) {
+  var d = a.V
+    , e = a.lb
+    , f = a.ed
+    , g = a.V.Fa === gvjs_4u
+    , h = a.Pr
+    , k = c !== gvjs_f
+    , l = k && d.vp !== gvjs_c;
+  c = d.vp === gvjs_ud ? "#.##%" : "0.00#";
+  if (g) {
+    var m = (d.O.height - 1) / gvjs_hga(a, k);
+    a.V.fz = gvjs_uJ(m, gvjs_K(a.options, gvjs_6u))
+  }
+  m = [];
+  l && (m = gvjs_sJ(a, b),
+    gvjs_tJ(a, b));
+  var n = null
+    , p = f.ta ? f.ta.wda : null;
+  h && f.oc(p);
+  for (h = {
+    zm: 0
+  }; h.zm < d.$a.length; h = {
+    kV: h.kV,
+    zm: h.zm
+  },
+         h.zm++) {
+    var q = 0 == gvjs_jJ(a, h.zm)
+      , r = gvjs_Ny(a.je, function() {
+      return {
+        positive: 0,
+        negative: 0
+      }
+    })
+      , t = -1;
+    null != p && (n = p);
+    p = gvjs_vJ(a, h.zm);
+    f.oc(p);
+    h.kV = gvjs_LI(f, p);
+    for (var u = {
+      lB: 0
+    }; u.lB < d.C.length; u = {
+      iV: u.iV,
+      uu: u.uu,
+      Ur: u.Ur,
+      UF: u.UF,
+      DM: u.DM,
+      Vr: u.Vr,
+      Ip: u.Ip,
+      sx: u.sx,
+      lB: u.lB,
+      yM: u.yM
+    },
+           u.lB++)
+      if (u.Ip = d.C[u.lB],
+      u.Ip.type == b)
+        if (t++,
+        k || (r[u.Ip.Qc] = {
+          positive: 0,
+          negative: 0
+        }),
+          u.sx = u.Ip.points,
+          q)
+          u.sx.push(null);
+        else {
+          var v = u.Ip.Qc;
+          u.Vr = a.je[v];
+          u.DM = u.Vr.gw;
+          var w = e.getValue(h.zm, u.Ip.columns.data[0]);
+          w = u.DM ? w : u.Vr.ta.zc(w);
+          u.yM = void 0;
+          l && (gvjs_cI(u.Vr.ta, c),
+            u.yM = gvjs_dI(u.Vr.ta));
+          u.Ur = 0 <= w ? "positive" : "negative";
+          u.uu = r[v];
+          k || (a.Tz = Math.max(a.Tz, t + 1));
+          u.iV = m[h.zm] && m[h.zm][u.Ur] || 1;
+          u.UF = function(A) {
+            return function(B) {
+              return null == B ? null : B / A.iV
+            }
+          }(u);
+          v = function(A, B) {
+            return function(D, C, G) {
+              var J = null;
+              null == D || isNaN(D) || (J = D + (k || g ? A.uu[A.Ur] : 0));
+              l && (J = A.UF(J),
+                G = A.UF(G));
+              A.DM && (J = A.Vr.ta.zc(J),
+                G = A.Vr.ta.zc(G));
+              B.kV && A.Vr.oc(J);
+              var I;
+              null != D && (I = gvjs_wJ(a, A.Ip, B.zm, A.uu[A.Ur], A.UF, !0));
+              C = {
+                Kf: {
+                  Js: B.zm,
+                  cF: C,
+                  from: G,
+                  uk: J,
+                  hy: n,
+                  d: p,
+                  fJ: I
+                }
+              };
+              null == D && (C.$l = !0);
+              A.Ip.type == gvjs_4w && (I = A.sx.length,
+                C.Kf.tea = 0 == I || null == A.sx[I - 1] ? null : A.sx[I - 1].Kf.uk);
+              gvjs_xJ(a, C, A.Ip, A.lB, B.zm);
+              l && C.wd && (C.wd.content = C.wd.content + " (" + A.yM.Ob(J - G) + ")");
+              A.sx.push(C);
+              null == D || isNaN(D) || (A.uu[A.Ur] += D)
+            }
+          }(u, h);
+          var x = k ? 0 : t
+            , y = k || g ? u.uu[u.Ur] : null;
+          if (g && !a.V.fz)
+            for (var z = 0; z < (w || 0); z++)
+              y = k || g ? u.uu[u.Ur] : null,
+                v(1, x, y);
+          else
+            v(w, x, y)
+        }
+  }
+  k || gvjs_w(a.je, function(A) {
+    gvjs_JI(A)
+  })
+}
+function gvjs_fga(a, b) {
+  for (var c = a.V, d = a.lb, e = a.ed, f = gvjs_De(c.C, function(w) {
+    return w.type == b
+  }), g = 0; g < c.$a.length; ++g) {
+    var h = 0 == gvjs_jJ(a, g)
+      , k = gvjs_vJ(a, g);
+    e.oc(k);
+    for (var l = gvjs_LI(e, k), m = [gvjs_3v, gvjs_$t], n = 0; n < f.length; ++n) {
+      var p = f[n];
+      if (h) {
+        p.points.push(null);
+        return
+      }
+      for (var q = a.je[p.Qc], r = q.ta, t = 0; t < m.length; ++t) {
+        var u = m[t]
+          , v = d.getValue(g, p.columns[u][0]);
+        v = r.zc(v);
+        if (null === v) {
+          p.points.push(null);
+          return
+        }
+        l && q.oc(v);
+        a.Tz = Math.max(a.Tz, n + 1);
+        u = {
+          brush: u == gvjs_3v ? p.Ih.background.Qg : null,
+          Kf: {
+            Js: g,
+            cF: n,
+            from: null,
+            uk: v,
+            d: k,
+            bsa: u == gvjs_$t,
+            fJ: gvjs_wJ(a, p, g, 0, null, !0)
+          }
+        };
+        gvjs_xJ(a, u, p, n, g);
+        p.points.push(u)
+      }
+    }
+  }
+  gvjs_w(a.je, function(w) {
+    gvjs_JI(w)
+  })
+}
+function gvjs_$fa(a) {
+  var b = a.V
+    , c = a.lb
+    , d = a.ed
+    , e = gvjs_De(b.C, function(f) {
+    return f.type == gvjs_Ft
+  });
+  gvjs_u(b.$a, function(f, g) {
+    var h = 0 == gvjs_jJ(this, g);
+    gvjs_u(e, function(k, l) {
+      if (h)
+        k.points.push(null);
+      else {
+        var m = k.columns.data
+          , n = this.je[k.Qc];
+        this.Tz = Math.max(this.Tz, l + 1);
+        var p = c.getValue(g, m[0])
+          , q = c.getValue(g, m[1])
+          , r = c.getValue(g, m[2]);
+        m = c.getValue(g, m[3]);
+        p = n.ta.zc(p);
+        q = n.ta.zc(q);
+        r = n.ta.zc(r);
+        m = n.ta.zc(m);
+        if (null === p || null === m || null === q || null === r)
+          k.points.push(null);
+        else {
+          var t = gvjs_vJ(this, g);
+          d.oc(t);
+          var u = r < q;
+          gvjs_LI(d, t) && (n.oc(p),
+            n.oc(m));
+          n = {
+            yG: u ? k.NG.g$ : k.NG.Uea,
+            Oc: gvjs_8z(k.color.color),
+            Kf: {
+              Js: g,
+              cF: l,
+              Qsa: p,
+              lineTo: m,
+              vva: u ? r : q,
+              wva: u ? q : r,
+              Xra: u,
+              d: t
+            }
+          };
+          gvjs_xJ(this, n, k, l, g);
+          k.points.push(n)
+        }
+      }
+    }, this)
+  }, a)
+}
+function gvjs_mJ(a, b) {
+  var c = a.V
+    , d = a.lb
+    , e = a.ed
+    , f = c.C[b];
+  if (f.type == gvjs_e) {
+    c = f.ag ? f.data : c.$a;
+    for (var g = 0; g < c.length; g++) {
+      var h = a.je[f.Qc]
+        , k = f.columns.data[0];
+      k = f.ag ? f.data[g][1] : d.getValue(g, k);
+      k = h.ta.zc(k);
+      var l;
+      if (null != k) {
+        var m = gvjs_vJ(a, g, f);
+        e.oc(m);
+        (l = gvjs_LI(e, m) && !f.ag) && h.oc(k);
+        h = f.ag ? null : gvjs_wJ(a, f, g, 0, null, l)
+      } else
+        l = !1,
+          h = null;
+      h = {
+        Kf: {
+          Js: g,
+          cF: 0,
+          d: m,
+          t: k,
+          fJ: h
+        },
+        shape: f.hE,
+        Lfa: l
+      };
+      null == k && (h.$l = !0);
+      gvjs_xJ(a, h, f, b, g);
+      f.points.push(h)
+    }
+  }
+}
+function gvjs_nJ(a) {
+  for (var b = a.ed, c = a.V.C, d = 0; d < c.length; d++) {
+    var e = c[d];
+    if ((e.type == gvjs_e || e.type == gvjs_at) && 0 != e.lineWidth) {
+      var f = a.je[e.Qc]
+        , g = gvjs_v(e.points, function(l) {
+        return gvjs_XG(l) ? null : new gvjs_z(l.Kf.d,l.Kf.t)
+      })
+        , h = a.V.Zj;
+      e = gvjs_wA(g, gvjs_AI(b), h);
+      a: {
+        switch (b.type) {
+          case gvjs_It:
+            var k = b.nb.max - 1;
+            break a;
+          case gvjs_Ht:
+            k = b.nb.max - .5;
+            break a
+        }
+        k = b.nb.max
+      }
+      g = gvjs_wA(g, k, h);
+      f.oc(e);
+      f.oc(g)
+    }
+  }
+}
+function gvjs_aga(a) {
+  var b = a.V
+    , c = a.lb
+    , d = a.ed
+    , e = b.Zj
+    , f = b.vp !== gvjs_f
+    , g = f && b.vp !== gvjs_c
+    , h = b.vp === gvjs_ud ? "#.##%" : "0.00#"
+    , k = [];
+  g && (k = gvjs_sJ(a, gvjs_at),
+    gvjs_tJ(a, gvjs_at));
+  for (var l = {}, m = 0; m < b.$a.length; l = {
+    jV: l.jV
+  },
+    m++) {
+    var n = gvjs_Ny(a.je, function() {
+      return 0
+    });
+    l.jV = k[m] && k[m].positive + k[m].negative || 1;
+    for (var p = function(I) {
+      return function(M) {
+        return null == M ? null : M / I.jV
+      }
+    }(l), q = null, r = null, t = 0; t < b.C.length; t++) {
+      var u = b.C[t];
+      if (u.type == gvjs_at) {
+        var v = u.Qc
+          , w = a.je[v]
+          , x = null
+          , y = null
+          , z = u.columns.data[0]
+          , A = c.getValue(m, z)
+          , B = gvjs_eI(w.ta, A)
+          , D = null == B || isNaN(B);
+        D && (B = 0);
+        var C = gvjs_vJ(a, m);
+        if (null != C) {
+          A = void 0;
+          g && (gvjs_cI(w.ta, h),
+            A = gvjs_dI(w.ta));
+          var G = void 0
+            , J = void 0;
+          G = void 0;
+          G = 0 < m ? c.getValue(m - 1, z) : null;
+          J = 0 === m || null === G && !isNaN(G);
+          z = m < c.ca() - 1 ? c.getValue(m + 1, z) : null;
+          z = m === c.ca() - 1 || null === z && !isNaN(z);
+          f ? (G = n[v],
+          D || (G += B),
+            x = r,
+            y = q,
+          D || (z || (r = G),
+          J || (q = G))) : (r = q = G = B,
+          e || (z && (r = null),
+          J && (q = null)));
+          d.oc(C);
+          J = gvjs_LI(d, C);
+          G = p(G);
+          q = p(q);
+          r = p(r);
+          J && !D && (z = gvjs_fI(w.ta, G),
+            w.oc(z));
+          z = gvjs_wJ(a, u, m, n[v], p, J);
+          f && !D && (n[v] += B);
+          G = {
+            d: C,
+            t: gvjs_fI(w.ta, G),
+            Js: m,
+            cF: 0,
+            Wla: C,
+            Xla: gvjs_fI(w.ta, q),
+            Ula: C,
+            Vla: gvjs_fI(w.ta, r),
+            Ska: C,
+            Tka: gvjs_fI(w.ta, x),
+            Qka: C,
+            Rka: gvjs_fI(w.ta, y),
+            fJ: z
+          };
+          v = {
+            Kf: G,
+            shape: u.hE,
+            Lfa: J,
+            $l: D
+          };
+          D || (gvjs_xJ(a, v, u, t, m),
+          g && v.wd && (w = p(B),
+            v.wd.content = v.wd.content + " (" + A.Ob(w) + ")"));
+          u.points.push(v)
+        }
+      }
+    }
+  }
+  gvjs_nJ(a);
+  gvjs_oJ(a)
+}
+function gvjs_ega(a) {
+  gvjs_u(a.V.C, function(b, c) {
+    b.ag && (b.type === gvjs_Dd ? gvjs_qJ(this, c) : b.type === gvjs_e && gvjs_mJ(this, c),
+      gvjs_yJ(this, c))
+  }, a)
+}
+function gvjs_qJ(a, b) {
+  var c = a.V
+    , d = a.lb
+    , e = a.Bf[0]
+    , f = a.ke[0]
+    , g = c.C[b]
+    , h = g.We;
+  if (g.type === gvjs_Dd)
+    for (var k = g.ag ? g.data.length : d.ca(), l = 0; l < k; l++) {
+      var m = c.Mk[h].columns.domain[0]
+        , n = gvjs_kJ(g);
+      m = g.ag ? g.data[l][0] : d.getValue(l, m);
+      var p = g.ag ? g.data[l][1] : d.getValue(l, n);
+      n = e.ta.zc(m);
+      m = f.ta.zc(p);
+      null !== n && null !== m ? ((p = gvjs_LI(e, n) && gvjs_LI(f, m)) && !g.ag && (e.oc(n),
+        f.oc(m)),
+        n = {
+          Kf: {
+            x: n,
+            y: m
+          },
+          shape: g.hE,
+          Twa: p
+        },
+        gvjs_xJ(a, n, g, b, l),
+        g.points.push(n)) : g.points.push(null)
+    }
+}
+function gvjs_oJ(a) {
+  function b(q) {
+    var r = null != q.Kf ? q.Kf.Js : null;
+    return {
+      Nx: null != q.Nx ? q.Nx : 1,
+      ty: null != q.ty ? q.ty : 1,
+      scope: null != q.scope ? q.scope : !0,
+      uoa: null != r ? gvjs_jJ(a, r) : null
+    }
+  }
+  function c(q) {
+    return !gvjs_XG(q)
+  }
+  for (var d = null === gvjs_iJ(a), e = 0; e < a.V.C.length; e++) {
+    var f = a.V.C[e]
+      , g = f.$r
+      , h = f.columns.emphasis || []
+      , k = f.columns.scope || [];
+    if (0 != (f.columns.certainty || []).length || 0 != h.length || 0 != k.length || !d) {
+      h = gvjs_Ey(f.points, c);
+      k = b(h || {});
+      for (var l = 0; l < f.points.length; l++) {
+        var m = f.points[l];
+        if (!gvjs_XG(m)) {
+          var n = b(m)
+            , p = f.Oc;
+          n.scope || k.scope || (f.$$ = f.$$ || p.yI(),
+            p = f.$$,
+            m.jt = p,
+          g && (f.Z$ = f.Z$ || g.yI(),
+            m.nQ = f.Z$));
+          if (1 > n.Nx || 1 > k.Nx)
+            p = gvjs_zJ(p, !1),
+              m.jt = p;
+          1 != n.ty && 1 != k.ty && (p = gvjs_iga(p, Math.min(k.ty, n.ty)),
+            m.jt = p);
+          0 != n.uoa || gvjs_XG(h) || (m.jt = null);
+          k = n
+        }
+        h = m
+      }
+    }
+  }
+}
+function gvjs_AJ(a) {
+  var b = {
+    fill: {},
+    stroke: {},
+    shape: {}
+  };
+  null != a && (null != a.visible && (b.visible = a.visible),
+  null != a.size && (b.size = a.size),
+  null != a.color && (b.fill.color = b.stroke.color = a.color),
+  null != a.opacity && (b.fill.opacity = b.stroke.opacity = a.opacity),
+  null != a.fillColor && (b.fill.color = a.fillColor),
+  null != a.fillOpacity && (b.fill.opacity = a.fillOpacity),
+  null == b.fill.color && null == b.fill.opacity && delete b.fill,
+  null != a.strokeColor && (b.stroke.color = a.strokeColor),
+  null != a.strokeOpacity && (b.stroke.opacity = a.strokeOpacity),
+  null != a.strokeWidth && (b.stroke.width = a.strokeWidth),
+  null == b.stroke.color && null == b.stroke.opacity && null == b.stroke.width && delete b.stroke,
+  null != a.shapeType && (b.shape.type = a.shapeType),
+  null != a.shapeSides && (b.shape.sides = a.shapeSides),
+  null != a.shapeRotation && (b.shape.rotation = a.shapeRotation),
+  null != a.shapeDent && (b.shape.dent = a.shapeDent),
+  null != a.shortSize && (b.shortSize = a.shortSize));
+  return b
+}
+function gvjs_BJ(a, b, c) {
+  var d = void 0;
+  b = null != b.columns.style ? b.columns.style[0] : void 0;
+  if (null != b && a.lb.W(b) === gvjs_l && (a = a.lb.getValue(c, b),
+  null != a)) {
+    d = gvjs_kf(a);
+    if (gvjs_0z(d))
+      var e = {
+        fill: {
+          color: d
+        },
+        stroke: {
+          color: d
+        }
+      };
+    else if ("{" === d.charAt(0)) {
+      try {
+        var f = gvjs_Gi(d)
+      } catch (g) {}
+      null != f && (e = f)
+    }
+    null == e && (gvjs_sf(d, "{") ? (e = gvjs_Ny(gvjs_$I(d), gvjs_AJ),
+    gvjs_Ze(e, "") && (Object.assign(e, e[""]),
+      gvjs_Qy(e, "")),
+    gvjs_Ze(e, "*") && (Object.assign(e, e["*"]),
+      gvjs_Qy(e, "*"))) : e = gvjs_AJ(gvjs_Jz(d)));
+    d = e
+  }
+  if (null != d)
+    return new gvjs_Aj([d])
+}
+function gvjs_CJ(a, b, c) {
+  c !== gvjs_0p && (a.Te(gvjs_oy(b, [gvjs_pp, gvjs_np], a.fill)),
+    a.mf(gvjs_ny(b, gvjs_qp, a.fillOpacity)));
+  c !== gvjs_np && (a.rd(gvjs_oy(b, [gvjs_3p, gvjs_0p], a.Uj())),
+    gvjs_ay(a, gvjs_ny(b, gvjs_4p, a.strokeOpacity)),
+    a.hl(gvjs_L(b, gvjs_5p, a.strokeWidth)))
+}
+function gvjs_xJ(a, b, c, d, e) {
+  if (a.wz) {
+    a: {
+      d = a.AW(c, d, e);
+      var f = c.columns.tooltip;
+      if (f && !c.ag) {
+        f = f[0];
+        if (a.lb.W(f) === gvjs_d) {
+          d.T8 = a.lb.getValue(e, f);
+          d.Nh = !0;
+          d.wi = !0;
+          break a
+        }
+        (f = gvjs_gJ(a, f, e)) && f.wi && Object.assign(d, f)
+      }
+      d.Nh = !!d.Nh
+    }
+    b.wd = d
+  }
+  d = gvjs_BJ(a, c, e);
+  a: {
+    f = a.lb;
+    var g = c.columns.certainty || [];
+    if (g.length) {
+      var h = f.getValue(e, g[0]);
+      if (null != h) {
+        f = f.W(g[0]) == gvjs_zb ? h ? 1 : 0 : h;
+        break a
+      }
+    }
+    f = 1
+  }
+  a: {
+    g = a.lb;
+    h = c.columns.emphasis || [];
+    if (h.length) {
+      var k = g.getValue(e, h[0]);
+      if (null != k) {
+        g = g.W(h[0]) == gvjs_zb ? k ? 2 : 1 : k;
+        break a
+      }
+    }
+    g = 1
+  }
+  a: {
+    a = a.lb;
+    h = c.columns.scope || [];
+    if (h.length && (e = a.getValue(e, h[0]),
+    null != e)) {
+      e = !!e;
+      break a
+    }
+    e = !0
+  }
+  a = gvjs_1G(b, c);
+  h = c.Qg;
+  if (null != d) {
+    h = h.clone();
+    b.radius = a = gvjs_Oj(d, "point.size", a);
+    k = d.fa("point.shape");
+    null != k && (b.shape = k);
+    k = d.Dq("point.visible");
+    null != k && (b.visible = k);
+    gvjs_CJ(h, d);
+    switch (c.type) {
+      case gvjs_e:
+      case gvjs_Dd:
+      case gvjs_at:
+        gvjs_CJ(h, d.view(gvjs_Np));
+        null != c.Oc && (b.jt = (b.jt || b.Oc || c.Oc).clone(),
+          gvjs_CJ(b.jt, d.view([gvjs_e, ""]), gvjs_0p));
+        null != c.$r && (b.nQ = (b.nQ || b.Oc || c.$r).clone(),
+          gvjs_CJ(b.nQ, d.view([gvjs_at, ""]), gvjs_np));
+        break;
+      case gvjs_4w:
+        gvjs_CJ(h, d.view(gvjs_at), gvjs_np),
+        null != c.Oc && (b.Oc = (b.Oc || c.Oc).clone(),
+          gvjs_CJ(b.Oc, d.view([gvjs_e, ""]), gvjs_0p));
+      case gvjs_lt:
+        gvjs_CJ(h, d.view(gvjs_wb));
+        break;
+      case gvjs_Ft:
+        b.yG = b.yG.clone(),
+          gvjs_CJ(b.yG, d.view([gvjs_wb, ""])),
+          gvjs_CJ(b.Oc, d.view([gvjs_e, ""]))
+    }
+    b.brush = h
+  }
+  e || (b.scope = e,
+    c.aaa = c.aaa || h.yI(),
+    h = c.aaa,
+    b.brush = h);
+  1 != g && (b.ty = g,
+  c.type == gvjs_e || c.type == gvjs_at || c.type == gvjs_Dd) && (a = Math.round(a * Math.sqrt(g) * 10) / 10,
+    b.radius = a);
+  if (1 > f)
+    switch (b.Nx = f,
+      c.type) {
+      case gvjs_e:
+      case gvjs_at:
+      case gvjs_Dd:
+        b.brush = gvjs_zJ(h, !0);
+        b.radius = Math.max(a - gvjs_fy(b.brush) / 2, 0);
+        break;
+      case gvjs_lt:
+      case gvjs_4w:
+        b.brush = gvjs_zJ(h, !1)
+    }
+}
+function gvjs_gJ(a, b, c) {
+  var d = a.lb;
+  a = a.V.$f && (d.getProperty(c, b, gvjs_av) || d.Bd(b, gvjs_av));
+  b = d.Ha(c, b);
+  return {
+    Nh: !!a,
+    wi: b ? !0 : !1,
+    content: b
+  }
+}
+gvjs_.AW = function(a, b, c) {
+  if (this.V.Fa === gvjs_Dd || a.ag || 0 === a.lineWidth) {
+    var d = this.lb
+      , e = this.V;
+    if (a.ag) {
+      var f = a.data[c][0];
+      var g = a.data[c][1];
+      null != f && (f = gvjs_Hk(f, d.W(a.We)));
+      null != g && (g = gvjs_Hk(g, a.dataType));
+      var h = e.Ig.has(gvjs_Ht) ? g : f + gvjs_ha + g;
+      var k = f
+    } else if (this.V.kd) {
+      var l = this.Bf[0].title.text || "X"
+        , m = this.ke[0].title.text || "Y";
+      f = b % 2 ? b - 1 : b;
+      b = e.C[f];
+      h = e.C[f + 1];
+      f = e.Mk[h.We].columns.domain[0];
+      g = gvjs_kJ(h);
+      f = d.Ha(c, f);
+      g = d.Ha(c, g);
+      h = l + ": " + f + gvjs_ha + m + ": " + g;
+      f = e.Mk[b.We].columns.domain[0];
+      g = gvjs_kJ(b);
+      f = d.Ha(c, f);
+      g = d.Ha(c, g);
+      h += "\n" + l + ": " + f + gvjs_ha + m + ": " + g
+    } else
+      l = gvjs_kJ(a),
+        f = d.Ha(c, e.Mk[a.We].columns.domain[0]),
+        g = d.Ha(c, l),
+        h = e.Ig.has(gvjs_Ht) ? g : f + gvjs_ha + g;
+    a = {
+      wi: !1,
+      content: h,
+      En: a.title,
+      Mx: k
+    }
+  } else
+    a = gvjs_jga(this, a, c);
+  return a
+}
+;
+function gvjs_jga(a, b, c) {
+  var d = a.lb
+    , e = a.V.$a[c];
+  e = b.ag ? b.data[c][0].toString() : e.$w[b.We];
+  if (b.type == gvjs_Ft)
+    a = b.columns.data,
+      a = d.Ha(c, a[0]) + gvjs_ar + d.Ha(c, a[3]) + gvjs_ha + d.Ha(c, a[1]) + gvjs_ar + d.Ha(c, a[2]);
+  else if (a.V.kd) {
+    var f = b.columns[gvjs_3v]
+      , g = b.columns.data
+      , h = a.lb.getValue(c, f[0]);
+    a = a.lb.getValue(c, g[0]);
+    f = d.Ha(c, f[0]);
+    g = d.Ha(c, g[0]);
+    if (null === h && gvjs_jf(f) && null === a && gvjs_jf(g))
+      return {
+        wi: !1,
+        content: null
+      };
+    a = g + "\n" + f
+  } else {
+    g = b.columns.data;
+    h = b.ag ? b.data[c][1] : a.lb.getValue(c, g[0]);
+    a = b.ag ? b.data[c][1].toString() : a.lb.Ha(c, g[0]);
+    if (null === h && gvjs_jf(a))
+      return {
+        wi: !1,
+        content: null
+      };
+    h = b.columns.interval || [];
+    h.length && (h = gvjs_v(h, function(k) {
+      return d.Ha(c, k)
+    }),
+      a += " [" + h.join(gvjs_ha) + "]")
+  }
+  return {
+    wi: !1,
+    content: a,
+    Mx: e,
+    En: b.title,
+    Nh: !1
+  }
+}
+function gvjs_pJ(a) {
+  function b(x, y, z) {
+    k.oc(z.d);
+    y.Lfa && a.je[x.Qc].oc(z.t)
+  }
+  function c(x) {
+    return {
+      d: x.x,
+      t: x.y
+    }
+  }
+  function d(x) {
+    return new gvjs_ok(x.d,x.t)
+  }
+  function e(x, y, z) {
+    y.Twa && (a.Bf[0].oc(z.x),
+      a.ke[0].oc(z.y))
+  }
+  function f(x) {
+    return {
+      x: x.x,
+      y: x.y
+    }
+  }
+  function g(x) {
+    return new gvjs_ok(x.x,x.y)
+  }
+  var h = a.V
+    , k = a.ed;
+  switch (h.Fa) {
+    case gvjs_Dd:
+      var l = g;
+      var m = f;
+      var n = e;
+      break;
+    case gvjs_d:
+      l = d,
+        m = c,
+        n = b
+  }
+  for (var p = 0; p < h.C.length; p++) {
+    var q = h.C[p];
+    if (q.type == gvjs_Dd || q.type == gvjs_e)
+      if (gvjs_He([gvjs_d, "phase", gvjs_Zt], q.ey)) {
+        var r = q.type == gvjs_Dd && q.ey == gvjs_Zt
+          , t = q.ey == gvjs_d;
+        q.N_ = !0;
+        q.Zra = r;
+        r = gvjs_jA(gvjs_v(q.points, function(x) {
+          return gvjs_XG(x) ? null : l(x.Kf)
+        }), q.RT, t, r, h.Zj);
+        for (t = 0; t < q.points.length; ++t) {
+          var u = q.points[t];
+          if (r[t]) {
+            var v = m(r[t][0])
+              , w = m(r[t][1]);
+            u.nda = v;
+            u.oda = w;
+            n(q, u, v);
+            n(q, u, w)
+          }
+        }
+      } else
+        q.N_ = !1
+  }
+}
+gvjs_.$ka = function() {
+  if (this.V.Ig.has(gvjs_Ht)) {
+    var a = this.V.$a
+      , b = gvjs_v(a, function(n, p) {
+      return gvjs_DJ(this, p)
+    }, this)
+      , c = this.ed;
+    a = gvjs_Ky(a.length);
+    gvjs_Se(a, function(n, p) {
+      return gvjs_Re(b[n], b[p])
+    });
+    var d = c.Pf
+      , e = c.ef;
+    if (d > e) {
+      var f = d;
+      d = e;
+      e = f
+    }
+    for (f = 0; f < a.length; f++) {
+      var g = gvjs_DJ(this, a[f]);
+      if (null != g) {
+        if (gvjs_KI(c, g))
+          return;
+        if (!(isNaN(g) || g * c.direction < c.Pf * c.direction)) {
+          var h = f;
+          break
+        }
+      }
+    }
+    if (void 0 !== h) {
+      f = d;
+      d = null;
+      for (var k = h; k < a.length; k++) {
+        null != d && k < d && (k = d,
+          d = null);
+        var l = a[k];
+        h = f;
+        if (k == a.length - 1) {
+          gvjs_EJ(this, l, h, e);
+          break
+        }
+        var m = gvjs_DJ(this, a[k + 1]);
+        if (null == m) {
+          for (f = k + 2; f < a.length; f++)
+            if (m = gvjs_DJ(this, a[f]),
+            null != m) {
+              d = f;
+              break
+            }
+          if (null == m) {
+            gvjs_EJ(this, l, h, e);
+            break
+          }
+        }
+        if (gvjs_KI(c, m)) {
+          gvjs_EJ(this, l, h, e);
+          break
+        }
+        f = gvjs_bz(g, m);
+        gvjs_EJ(this, l, h, f);
+        g = m
+      }
+    }
+  }
+}
+;
+function gvjs_DJ(a, b) {
+  var c = a.V.$a;
+  a = a.ed;
+  return a.type == gvjs_Vd ? null == c[b].data ? null : a.vN(c[b].data) : a.Jc(b)
+}
+function gvjs_EJ(a, b, c, d) {
+  function e() {
+    var m = c;
+    c = d;
+    d = m
+  }
+  var f = a.V.O.top
+    , g = a.V.O.bottom
+    , h = a.V.O.left
+    , k = a.V.O.right
+    , l = a.ed.direction;
+  b = a.V.$a[b];
+  a.V.orientation == gvjs_S ? 1 == l ? (d < c && e(),
+    b.dT = new gvjs_B(f,d,g,c)) : (d > c && e(),
+    b.dT = new gvjs_B(f,c,g,d)) : 1 == l ? (d < c && e(),
+    b.dT = new gvjs_B(c,k,d,h)) : (d > c && e(),
+    b.dT = new gvjs_B(d,k,c,h))
+}
+gvjs_.Iva = function() {
+  gvjs_kga(this);
+  gvjs_lga(this)
+}
+;
+function gvjs_kga(a) {
+  var b = a.V;
+  gvjs_w(b.wc, function(c, d) {
+    gvjs_FJ(this, this.ke[d], b.wc[d], this.usa)
+  }, a);
+  gvjs_w(b.jd, function(c, d) {
+    gvjs_FJ(this, this.Bf[d], b.jd[d], this.fsa)
+  }, a)
+}
+function gvjs_lga(a) {
+  var b = a.V;
+  gvjs_w(b.wc, function(c, d) {
+    gvjs_FJ(a, a.ke[d], c, function() {
+      return !0
+    })
+  });
+  gvjs_w(b.jd, function(c, d) {
+    gvjs_FJ(a, a.Bf[d], c, function(e, f) {
+      return gvjs_mga(a, f)
+    })
+  })
+}
+function gvjs_FJ(a, b, c, d) {
+  c.text && (c.text = gvjs_De(c.text, d.bind(a, b)))
+}
+gvjs_.fsa = function(a, b) {
+  var c = this.V;
+  b = b.Da;
+  return b.angle ? !0 : (b = gvjs_RF(b)) ? a.uj != gvjs_Fp || (new gvjs_B(c.O.top,c.O.right,c.O.bottom,c.O.left)).contains(b) ? !0 : !1 : !0
+}
+;
+function gvjs_mga(a, b) {
+  var c = a.V
+    , d = b.Da;
+  if (d.angle)
+    return !0;
+  b = gvjs_RF(d);
+  if (!b)
+    return !0;
+  d = Math.ceil(d.ja.fontSize / 8);
+  var e = new gvjs_B(b.top,b.right + d,b.bottom,b.left - d), f;
+  for (f in c.wc) {
+    var g = Number(f);
+    if (a.ke[g].uj == gvjs_Fp && !(1 > (c.wc[g].text ? c.wc[g].text.length : 0))) {
+      var h = gvjs_RF(c.wc[g].text[0].Da)
+        , k = gvjs_RF(gvjs_Ae(c.wc[g].text).Da);
+      if (h || k) {
+        if (h && gvjs_lz(e, h) || k && gvjs_lz(e, k))
+          return !1;
+        h ? k ? (g = Math.min(h.left, k.left),
+          h = Math.max(h.right, k.right)) : (g = h.left,
+          h = h.right) : (g = k.left,
+          h = k.right);
+        if (Math.abs(b.left - g) < d || Math.abs(b.right - h) < d)
+          return !1
+      }
+    }
+  }
+  return !0
+}
+gvjs_.usa = function(a, b) {
+  var c = this.V
+    , d = new gvjs_B(c.O.top,c.O.right,c.O.bottom,c.O.left)
+    , e = b.Da;
+  b = e.ja.fontSize / 8;
+  e = gvjs_RF(e);
+  if (!e)
+    return !0;
+  if (a.uj == gvjs_Fp && !d.contains(e))
+    return !1;
+  a = new gvjs_B(e.top,e.right + b,e.bottom,e.left - b);
+  return (d = gvjs_RF(c.title)) && gvjs_lz(a, d) || (c = c.cJ ? gvjs_RF(c.cJ) : null) && gvjs_lz(a, c) ? !1 : (c = this.ne.getArea()) && gvjs_lz(a, c) ? !1 : !0
+}
+;
+function gvjs_yJ(a, b) {
+  b = a.V.C[b];
+  var c = gvjs_nga(a, b);
+  b.points && gvjs_u(b.points, function(d) {
+    null == d || d.$l || (d.ia = c(d.Kf),
+    null != d.nda && (d.wt = c(d.nda)),
+    null != d.oda && (d.fr = c(d.oda)))
+  });
+  b.Df && (0 < b.Df.lines.length || 0 < b.Df.areas.length) && gvjs_oga(b)
+}
+gvjs_.dva = function() {
+  gvjs_u(this.V.C, function(a, b) {
+    gvjs_yJ(this, b)
+  }, this)
+}
+;
+function gvjs_oga(a) {
+  function b(q) {
+    var r = e[q];
+    delete e[q];
+    if (r && 1 < r.line.length) {
+      r.bottom && r.bottom.reverse();
+      if (f[q].ey != gvjs_f) {
+        var t = f[q].ey == gvjs_d;
+        q = f[q].RT;
+        r.kX = gvjs_jA(r.line, q, t, !1, !1);
+        r.bottom && (r.Pka = gvjs_jA(r.bottom, q, t, !1, !1))
+      }
+      a.Df.paths.push(r)
+    }
+  }
+  function c(q, r) {
+    if (!e[q]) {
+      var t = f[q].brush.clone()
+        , u = f[q].style
+        , v = {};
+      v.ss = q;
+      v.line = [];
+      u == gvjs_at ? (t.hl(0),
+        v.bottom = []) : t.mf(0);
+      v.brush = t;
+      e[q] = v
+    }
+    e[q].line.push(new gvjs_ok(r.left,r.top));
+    e[q].bottom && e[q].bottom.push(new gvjs_ok(r.left + r.width,r.top + r.height))
+  }
+  function d(q) {
+    q = f[q].style;
+    return q == gvjs_at || q == gvjs_e
+  }
+  var e = {}
+    , f = a.Df.eu;
+  a.Df.paths = [];
+  for (var g = 0; g < a.points.length; g++) {
+    var h = {}
+      , k = a.points[g];
+    if (k && k.ia && k.ia.mt) {
+      k = k.ia.mt;
+      for (var l = 0; l < k.length; ++l) {
+        var m = k[l].ss;
+        d(m) && (h[m] = !0,
+          c(m, k[l].rect))
+      }
+    }
+    for (var n in e)
+      k = Number(n),
+      h[k] || f[k].Zj || b(k)
+  }
+  for (var p in e)
+    b(Number(p))
+}
+function gvjs_nga(a, b) {
+  switch (b.type) {
+    case gvjs_Dd:
+      return a.awa.bind(a, b);
+    case gvjs_At:
+      return a.Yva.bind(a, b);
+    case gvjs_e:
+      return a.$va.bind(a, b);
+    case gvjs_lt:
+      return a.Xva.bind(a, b);
+    case gvjs_4w:
+      return a.bwa.bind(a, b);
+    case gvjs_Ft:
+      return a.Zva.bind(a, b);
+    case gvjs_at:
+      return a.Wva.bind(a, b)
+  }
+  return null
+}
+gvjs_.awa = function(a, b) {
+  a = this.Bf[0].Jc(b.x);
+  b = this.ke[0].Jc(b.y);
+  return {
+    x: a,
+    y: b
+  }
+}
+;
+gvjs_.Yva = function(a, b) {
+  var c = this.gs
+    , d = this.ke[0];
+  a = this.Bf[0].Jc(b.x);
+  d = d.Jc(b.y);
+  var e = gvjs_PI(c, b);
+  e = new gvjs_3({
+    fill: e,
+    fillOpacity: c.lK,
+    stroke: c.$T
+  });
+  b = gvjs_MI(c.tL, b.size);
+  return {
+    x: a,
+    y: d,
+    brush: e,
+    radius: b,
+    eT: b
+  }
+}
+;
+gvjs_.$va = function(a, b) {
+  var c = gvjs_GJ(this, a.Qc, b.d, b.t);
+  c.mt = gvjs_HJ(this, a, b);
+  return c
+}
+;
+gvjs_.Xva = function(a, b) {
+  var c = gvjs_IJ(this, a, b, b.from, b.uk);
+  return c ? {
+    top: c.top,
+    left: c.left,
+    width: Math.max(.5, c.width),
+    height: Math.max(.5, c.height),
+    mt: gvjs_HJ(this, a, b)
+  } : null
+}
+;
+gvjs_.Zva = function(a, b) {
+  var c = gvjs_IJ(this, a, b, b.vva, b.wva)
+    , d = gvjs_IJ(this, a, b, b.Qsa, b.lineTo);
+  if (!c || !d)
+    return null;
+  var e = gvjs_JJ(this, d.left, d.top)
+    , f = gvjs_JJ(this, c.width, c.height)
+    , g = gvjs_JJ(this, d.width, d.height);
+  g.domain = 2;
+  e.domain += (f.domain - (f.domain % 2 ? 3 : 2)) / 2;
+  e = gvjs_KJ(this, e.domain, e.target);
+  g = gvjs_KJ(this, g.domain, g.target);
+  d.width = g.x;
+  d.height = g.y;
+  d.left = e.x;
+  d.top = e.y;
+  a = b.Xra ? a.NG.g$ : a.NG.Uea;
+  gvjs_ey(a) && (a = a.strokeWidth / 2,
+    c.height -= 2 * a,
+    c.width -= 2 * a,
+    c.left += a,
+    c.top += a);
+  c.height = Math.max(c.height, 2);
+  c.width = Math.max(c.width, 1);
+  return {
+    rect: c,
+    line: d
+  }
+}
+;
+gvjs_.bwa = function(a, b) {
+  var c = this.je[a.Qc];
+  null == b.from && (b.from = c.ta.zc(c.baseline.za),
+  null == b.from && (b.from = 0));
+  var d = this.ed
+    , e = b.Js;
+  if (this.Pr || d.ta) {
+    if (null == b.hy)
+      return null;
+    e = Math.floor(d.Jc(b.hy));
+    var f = Math.floor(d.Jc(b.d));
+    d.oc(b.hy)
+  } else {
+    var g = d.ticks[e].Na;
+    f = d.ww;
+    e = Math.floor(g - d.direction * f / 2);
+    f = Math.floor(g + d.direction * f / 2)
+  }
+  d.oc(b.d);
+  d = c.Jc(b.from);
+  var h = c.Jc(b.uk);
+  d = gvjs_KJ(this, e, d);
+  g = gvjs_KJ(this, e, h);
+  f = gvjs_KJ(this, f, h);
+  h = [];
+  gvjs_K(this.options, "connectSteps", !0) && null != b.tea && (c = c.Jc(b.tea),
+    c = gvjs_KJ(this, e, c),
+    h.push(c));
+  h.push(g);
+  h.push(f);
+  return {
+    bar: gvjs_5I(d.x, d.y, f.x, f.y),
+    outline: h,
+    mt: gvjs_HJ(this, a, b)
+  }
+}
+;
+function gvjs_IJ(a, b, c, d, e) {
+  var f = a.ed
+    , g = a.je[b.Qc];
+  b = a.LH;
+  var h = g.ta.zc(g.baseline.za);
+  null == d && (d = h || 0);
+  null == e && (e = h || 0);
+  h = e;
+  h = Math.min(g.Jc(d), g.Jc(h));
+  d = Math.max(g.Jc(d), g.Jc(e));
+  g = a.V.Fa === gvjs_4u ? gvjs_uJ(g.ww, gvjs_K(a.options, gvjs_6u)) ? 0 : 1 : Math.min(1, .2 * (d - h));
+  0 === g || Math.floor(h + g) < Math.floor(d) && Math.floor(h + g) > Math.floor(h) ? (h = Math.floor(h + g),
+    d = Math.floor(d)) : h += g;
+  g = gvjs_L(a.options, "diff.newData.widthFactor", .3);
+  g = c.bsa ? g : 1;
+  if (a.Pr) {
+    if (null == c.hy)
+      return null;
+    g = Math.floor(f.Jc(c.hy));
+    b = Math.floor(f.Jc(c.d));
+    f.oc(c.hy)
+  } else
+    c = gvjs_LJ(a, c),
+      e = g * b.P4 / 2,
+      g = b.j3(c - e),
+      b = b.j3(c + e);
+  f.oc(f.uN(g));
+  f.oc(f.uN(b));
+  f = gvjs_KJ(a, g, h);
+  a = gvjs_KJ(a, b, d);
+  return gvjs_5I(f.x, f.y, a.x, a.y)
+}
+gvjs_.Wva = function(a, b) {
+  function c(l) {
+    return null != l ? l : e
+  }
+  var d = this.je[a.Qc];
+  d = d.ta.zc(d.baseline.za);
+  var e = null != d ? d : 0;
+  d = gvjs_GJ(this, a.Qc, b.d, b.t);
+  var f = gvjs_GJ(this, a.Qc, b.Qka, c(b.Rka))
+    , g = gvjs_GJ(this, a.Qc, b.Ska, c(b.Tka))
+    , h = gvjs_GJ(this, a.Qc, b.Ula, c(b.Vla))
+    , k = gvjs_GJ(this, a.Qc, b.Wla, c(b.Xla));
+  a = gvjs_HJ(this, a, b);
+  return {
+    x: d.x,
+    y: d.y,
+    kW: f.x,
+    lW: f.y,
+    mW: g.x,
+    nW: g.y,
+    UN: h.x,
+    VN: h.y,
+    WN: k.x,
+    XN: k.y,
+    mt: a
+  }
+}
+;
+function gvjs_HJ(a, b, c) {
+  if (!c.fJ)
+    return [];
+  var d = a.ed;
+  b = a.je[b.Qc];
+  var e = a.LH;
+  if (c.cF >= e.Zta || d.type != gvjs_Vd && c.Js >= d.ticks.length)
+    return [];
+  var f = gvjs_LJ(a, c)
+    , g = e.j3;
+  a.Pr ? (d = d.Jc(c.d) - d.Jc(c.hy),
+    f -= d / 2) : d = e.P4 + e.pga;
+  e = [];
+  for (var h = 0, k; k = c.fJ[h]; h++) {
+    var l = b.Jc(k.rra)
+      , m = b.Jc(k.Wsa)
+      , n = d * k.xxa / 2
+      , p = g(f - n);
+    n = g(f + n);
+    p = gvjs_KJ(a, p, Math.min(m, l));
+    l = gvjs_KJ(a, n, Math.max(m, l));
+    e.push({
+      rect: gvjs_5I(p.x, p.y, l.x, l.y),
+      ss: k.ss,
+      brush: k.brush
+    })
+  }
+  return e
+}
+function gvjs_LJ(a, b) {
+  var c = a.ed
+    , d = a.LH;
+  c = c.type == gvjs_Vd ? c.Jc(b.d) : c.ticks && c.ticks[b.Js] && c.ticks[b.Js].Na;
+  if (a.Pr)
+    return c;
+  a = d.P4;
+  return c - d.ena + (a + d.pga) * b.cF + a / 2
+}
+function gvjs_JJ(a, b, c) {
+  switch (a.V.orientation) {
+    case gvjs_S:
+      return {
+        domain: b,
+        target: c
+      };
+    case gvjs_U:
+      return {
+        domain: c,
+        target: b
+      }
+  }
+  throw Error(gvjs_is);
+}
+function gvjs_KJ(a, b, c) {
+  switch (a.V.orientation) {
+    case gvjs_S:
+      return {
+        x: b,
+        y: c
+      };
+    case gvjs_U:
+      return {
+        x: c,
+        y: b
+      }
+  }
+  throw Error(gvjs_is);
+}
+function gvjs_GJ(a, b, c, d) {
+  b = a.je[b];
+  c = a.ed.Jc(c);
+  d = b.Jc(d);
+  return gvjs_KJ(a, c, d)
+}
+function gvjs_zJ(a, b) {
+  a = a.clone();
+  gvjs_gy(a) && a.fill != gvjs_ea ? (gvjs_by(a, new gvjs_$x(gvjs_rw,a.fill)),
+  !gvjs_ey(a) && b && (a.rd(a.fill),
+    a.hl(1))) : gvjs_ey(a) && (a.Mi = gvjs_9t);
+  return a
+}
+function gvjs_iga(a, b) {
+  a = a.clone();
+  a.hl(a.strokeWidth * b);
+  return a
+}
+function gvjs_jJ(a, b) {
+  var c = gvjs_iJ(a);
+  return null !== c ? a.lb.getValue(b, c) : null
+}
+function gvjs_iJ(a) {
+  if (null === a.ed || a.ed.type != gvjs_Vd)
+    return null;
+  a = a.V.Mk[0].columns.gap || [];
+  return 0 == a.length ? null : a[0]
+}
+function gvjs_wJ(a, b, c, d, e, f) {
+  function g(u, v, w, x, y) {
+    var z = h.eu[u]
+      , A = p.getValue(c, u);
+    A = m ? A : n(A);
+    v = p.getValue(c, v);
+    v = m ? v : n(v);
+    null != A && null != v && (A += d,
+      v += d,
+    e && (A = e(A),
+      v = e(v)),
+    m && (A = n(A),
+      v = n(v)),
+    f && (l.oc(A),
+      l.oc(v)),
+      z = z.brush,
+    null != k && (z = z.clone(),
+      gvjs_CJ(z, k.view([x, ""])),
+      y = y || gvjs_Xw,
+      w = gvjs_L(k, [x + "." + y, y], w)),
+      q.push({
+        Wsa: A,
+        rra: v,
+        xxa: w,
+        ss: u,
+        brush: z
+      }))
+  }
+  var h = b.Df;
+  if (!h)
+    return null;
+  var k = gvjs_BJ(a, b, c)
+    , l = a.je[b.Qc]
+    , m = l.gw
+    , n = l.ta.zc.bind(l.ta)
+    , p = a.lb
+    , q = [];
+  for (a = 0; a < h.IA.length; a += 2)
+    g(h.IA[a], h.IA[a + 1], 0, "interval stick");
+  a = 0;
+  for (b = h.qN.length - 1; a <= b; a++,
+    b--) {
+    var r = h.qN[a];
+    g(r, h.qN[b], h.eu[r].Vka, "interval box")
+  }
+  for (a = 0; a < h.points.length; a++)
+    b = h.points[a],
+      g(b, b, 0, "interval point");
+  for (a = 0; a < h.Mb.length; a++) {
+    b = h.Mb[a];
+    r = h.eu[b];
+    var t = !(0 == a || a == h.Mb.length - 1);
+    g(b, b, t ? r.Qwa : r.Ika, "interval bar", t ? "shortSize" : void 0)
+  }
+  a = 0;
+  for (b = h.areas.length - 1; a <= b; a++,
+    b--)
+    g(h.areas[a], h.areas[b], 0, "interval area");
+  for (a = 0; a < h.lines.length; a++)
+    b = h.lines[a],
+      g(b, b, 0, "interval line");
+  return q.length ? q : null
+}
+function gvjs_cga(a) {
+  function b() {
+    m = h / f;
+    7 > m && (m = Math.floor(m));
+    m = Math.max(1, m);
+    n = a.options.Mg("bar.gap", m);
+    p = gvjs_Fj(a.options, gvjs_Rj, 0, gvjs_kt, gvjs_So, m);
+    null == n && (n = Math.max(1 < f ? 1 : 0, m - p));
+    p = m - n
+  }
+  var c = a.V.Fa === gvjs_4u
+    , d = a.ed
+    , e = gvjs_pga(a)
+    , f = a.Tz
+    , g = a.options.Mg("bar.group.gap", e)
+    , h = a.options.Mg(["bar.group.width", gvjs_jt], e);
+  1 == f && (null == g && (g = a.options.Mg("bar.gap", e)),
+  null == h && (h = a.options.Mg([gvjs_kt], e)));
+  null == g && c && (g = 1);
+  if (null == h) {
+    var k = a.options.Aa("bar.gap") || 1
+      , l = a.options.Aa(gvjs_kt);
+    null != l ? h = f * (l + k) - k : c || (h = gvjs_Rj(100 / 1.618 + "%", e))
+  }
+  null == g && (g = Math.max(0, e - h));
+  h = Math.max(f, e - g);
+  g = e - h;
+  var m, n = null;
+  b();
+  n > g && (g = n,
+    h = e - g);
+  g -= n;
+  h += n;
+  b();
+  var p = gvjs_qA(10, p);
+  n = gvjs_qA(10, n);
+  h = gvjs_qA(10, h);
+  g = gvjs_qA(10, g);
+  d = d.direction;
+  e = g + n;
+  a.LH = {
+    Zta: f,
+    ena: gvjs_qA(10, c ? (-1 === d ? h + g : 0) + -(g + n) / 2 : (h - n) / 2),
+    GCa: g,
+    HCa: h,
+    P4: p,
+    pga: n,
+    j3: 7 > p && 0 == p % 2 || 7 > e && 0 == e % 2 ? function(q) {
+        return Math.floor(q) + .5
+      }
+      : function(q) {
+        return Math.floor(q + .5)
+      }
+  }
+}
+function gvjs_pga(a) {
+  var b = a.ed
+    , c = a.V.$a;
+  c = gvjs_De(c, function(h, k) {
+    return 0 != gvjs_jJ(a, k)
+  });
+  if (0 == c.length)
+    return 0;
+  var d = a.jN;
+  if (!d || 0 === d.size)
+    return 0;
+  if (b.type == gvjs_Vd) {
+    d = b.vG;
+    for (var e = null, f = 0; f < c.length; f++) {
+      var g = gvjs_vJ(a, f);
+      g = null == g ? null : b.Jc(g);
+      null != g && null != e && (e = Math.abs(g - e),
+      0 < e && (d = Math.min(d, e)));
+      e = g
+    }
+    return d
+  }
+  return Math.abs(b.vN(1) - b.vN(0))
+}
+function gvjs_vJ(a, b, c) {
+  var d = a.lb;
+  a = a.ed;
+  a.type == gvjs_Vd && (b = c && c.ag ? c.data[b][0] : d.getValue(b, 0),
+    b = a.ta.zc(b));
+  return b
+}
+function gvjs_rJ(a, b) {
+  this.Ti = a;
+  this.m = b
+}
+function gvjs_dga(a) {
+  var b = a.Ti.ti()
+    , c = a.m
+    , d = a.Ti.ed
+    , e = b.orientation || gvjs_S;
+  if (d) {
+    var f = d.direction
+      , g = -1;
+    e === gvjs_U && (f = 1,
+      g = d.direction);
+    var h = a.Ti.LH
+      , k = h && h.GEa;
+    h = {
+      bb: b.Hj,
+      fontSize: b.Dl,
+      Lb: b.oz
+    };
+    var l = gvjs_ry(c, [gvjs_2s, gvjs_9s], h)
+      , m = gvjs_qy(c, ["annotations.domain.boxStyle", gvjs__s])
+      , n = gvjs_oy(c, ["annotations.domain.stem.color", gvjs_0s, gvjs_4s, gvjs_6s], "")
+      , p = gvjs_L(c, ["annotations.domain.stem.length", "annotations.domain.stemLength", gvjs_5s, gvjs_7s], 5)
+      , q = 90;
+    e === gvjs_U && (q = 0);
+    gvjs_L(c, ["annotations.domain.stem.angle", "annotations.stem.angle"], q);
+    var r = gvjs_J(c, [gvjs_1s, gvjs_8s], gvjs_Np, gvjs_pC);
+    "letter" === r && (r = gvjs_Np);
+    gvjs_u(b.$a, function(B, D) {
+      var C = []
+        , G = [];
+      gvjs_u(b.Mk, function(H) {
+        H = this.VO(D, H.columns, r);
+        gvjs_Me(C, H.point);
+        gvjs_Me(G, H.line)
+      }, this);
+      if (C.length || G.length) {
+        var J = gvjs_vJ(this.Ti, D);
+        J = d.Jc(J);
+        var I = null
+          , M = null;
+        e === gvjs_U ? (I = b.O.left,
+          M = J) : (I = J,
+          M = b.O.top + b.O.height);
+        C.length && (B.Bc = gvjs_MJ(this, I, M, null, gvjs_f, "", e, f, g, C, l, m, p, n));
+        G.length && (b.orientation === gvjs_U ? I = null : M = null,
+          B.Bc = gvjs_NJ(this, I, M, e, G, l, n))
+      }
+    }, a);
+    var t = gvjs_Xe(gvjs_hC)
+      , u = gvjs_K(c, ["annotations.datum.highContrast", gvjs_3s], !0)
+      , v = gvjs_K(c, ["annotations.datum.alwaysOutside", "annotations.alwaysOutside"], !1)
+      , w = gvjs_ry(c, ["annotations.datum.textStyle", gvjs_9s], h, t)
+      , x = gvjs_qy(c, ["annotations.datum.boxStyle", gvjs__s])
+      , y = gvjs_oy(c, ["annotations.datum.stem.color", "annotations.datum.stemColor", gvjs_4s, gvjs_6s], "", t)
+      , z = gvjs_L(c, ["annotations.datum.stem.length", "annotations.datum.stemLength", gvjs_5s, gvjs_7s], 12)
+      , A = gvjs_J(c, ["annotations.datum.style", gvjs_8s], gvjs_Np, gvjs_pC);
+    "letter" === A && (A = gvjs_Np);
+    gvjs_u(b.C, function(B, D) {
+      if (B.type == gvjs_at || B.type == gvjs_lt || B.type == gvjs_e || B.type == gvjs_Dd || B.type == gvjs_4w) {
+        var C = gvjs_Qw + D + ".annotations.";
+        D = gvjs_K(c, C + gvjs_2u, u);
+        var G = gvjs_K(c, C + "alwaysOutside", v)
+          , J = gvjs_ry(c, C + gvjs_bx, w, t);
+        J.color = gvjs_$G(J.color, B.color);
+        var I = gvjs_qy(c, [C + "boxStyle"], x)
+          , M = gvjs_oy(c, [C + "stemColor", C + "stem.color"], y, t)
+          , H = gvjs_L(c, [C + "stemLength", C + "stem.length"], z);
+        gvjs_L(c, [C + "stem.angle"], z);
+        M = gvjs_$G(M, B.color);
+        gvjs_J(c, C + gvjs_Jd, A, gvjs_pC);
+        C = a.Ti.je[B.Qc];
+        for (var Q = 0; Q < B.points.length; ++Q)
+          if (null != B.points[Q] && null != B.points[Q].ia) {
+            var R = B.points[Q]
+              , T = a.VO(Q, B.columns, A)
+              , O = R.ia
+              , K = gvjs_gy(B.Qg) ? B.Qg.fill : D ? gvjs_Br : gvjs_kr;
+            R = R.brush && gvjs_gy(R.brush) ? R.brush.fill : K;
+            if (R !== K && D) {
+              K = gvjs_x(J);
+              var E = [.1, .2, .3]
+                , F = gvjs_vj(R)
+                , L = gvjs_vj(b.xG.fill)
+                , N = gvjs_v(E, gvjs_re(gvjs_1z, F));
+              E = gvjs_v(E, gvjs_re(gvjs_2z, F));
+              F = gvjs_Ke([F], N, E);
+              L = gvjs_uj(gvjs_4z(L, F));
+              K.color = L
+            } else
+              K = J;
+            N = F = L = null;
+            E = d;
+            var P = C;
+            e === gvjs_U && (E = C,
+              P = d);
+            if (null != O.x)
+              L = O.x,
+                F = O.y;
+            else if (null != O.bar || null != O.left)
+              N = O.bar,
+              null == N && (N = new gvjs_5(O.left,O.top,O.width,O.height)),
+                L = N.left,
+                F = N.top,
+                k ? (1 == E.direction && (L = N.left + N.width),
+                1 == P.direction && (F = N.top + N.height)) : e === gvjs_U ? (F = N.top + N.height / 2,
+                1 == E.direction && (L = N.left + N.width)) : (L = N.left + N.width / 2,
+                1 == P.direction && (F = N.top + N.height));
+            T.point.length && (B.points[Q].Bc = gvjs_MJ(a, L, F, N, B.type, R, e, E.direction, P.direction, T.point, K, I, H, M, D, G));
+            T.line.length && (B.points[Q].Bc = gvjs_NJ(a, L, F, e, T.line, J, M))
+          }
+      }
+    })
+  }
+}
+gvjs_rJ.prototype.VO = function(a, b, c) {
+  var d = this.Ti.lb
+    , e = b.annotation
+    , f = {
+    line: [],
+    point: []
+  };
+  if (null == e)
+    return f;
+  b = b.annotationText || [];
+  for (var g = 0; g < e.length; ++g) {
+    var h = e[g]
+      , k = h + 1;
+    0 <= gvjs_Be(b, k) && d.Ha(a, k) || (k = null);
+    null != d.getValue(a, h) && (k = {
+      text: d.Ha(a, h),
+      pF: k,
+      rowIndex: a
+    },
+      gvjs_J(this.m, "annotation." + h + ".style", c, gvjs_pC) == gvjs_e ? f.line.push(k) : f.point.push(k))
+  }
+  return f
+}
+;
+function gvjs_MJ(a, b, c, d, e, f, g, h, k, l, m, n, p, q, r, t) {
+  var u = a.Ti.ti()
+    , v = l.length
+    , w = [[64, 64, 64], [128, 128, 128], [255, 255, 255]];
+  r = null == r ? !0 : r;
+  var x = e === gvjs_lt || e === gvjs_4w;
+  x && d && (g === gvjs_U ? c = Math.floor(d.top + d.height / 2) : b = Math.floor(d.left + d.width / 2));
+  if (g === gvjs_S && 1 === k || g === gvjs_U && 1 === h)
+    p *= -1;
+  var y = g === gvjs_S ? 1 === k ? gvjs_vt : gvjs_vx : 1 === h ? gvjs_j : gvjs_$c
+    , z = b
+    , A = c - p;
+  g === gvjs_U && (z = b - p,
+    A = c);
+  e = -p;
+  var B = !1
+    , D = p + m.fontSize * v;
+  c - D < u.O.top && c + D < u.O.bottom && (A = c + D,
+    e = p);
+  p = [];
+  for (u = 0; u < v; u++) {
+    D = l[u];
+    var C = (0,
+      a.Ti.sc)(D.text, m)
+      , G = {}
+      , J = new gvjs_HG(null == z ? void 0 : z,null == A ? void 0 : A)
+      , I = null;
+    G.ja = new gvjs_ly(m);
+    if (!x)
+      G.ld = gvjs_0,
+        G.Pc = gvjs_R;
+    else if (d && !t && 1 === v) {
+      I = gvjs_vj(f);
+      I = gvjs_uj(gvjs_4z(I, w));
+      var M = gvjs_Ji(m, gvjs_Ki);
+      r && (M.Lb = gvjs_f,
+        M.color = I);
+      a: {
+        var H = D.text;
+        I = new gvjs_5(d.left,d.top + 0,d.width,d.height);
+        var Q = a.Ti.sc
+          , R = a.Ti.wz
+          , T = Q(H, M)
+          , O = I.Tb();
+        var K = T.width <= O.width && T.height <= O.height;
+        O = {};
+        var E = [];
+        O.text = H;
+        O.ja = M;
+        if (y === gvjs_vx) {
+          var F = Math.floor(I.getCenter().x)
+            , L = I.top + 2;
+          O.ld = gvjs_0;
+          O.Pc = gvjs_2
+        } else if (y === gvjs_j)
+          F = I.left + I.width - 4,
+            L = Math.floor(I.getCenter().y),
+            O.ld = gvjs_R,
+            O.Pc = gvjs_0;
+        else if (y === gvjs_vt)
+          F = Math.floor(I.getCenter().x),
+            L = I.top + I.height - 2,
+            O.ld = gvjs_0,
+            O.Pc = gvjs_R;
+        else if (y === gvjs_$c)
+          F = I.left + 4,
+            L = Math.floor(I.getCenter().y),
+            O.ld = gvjs_2,
+            O.Pc = gvjs_0;
+        else
+          throw Error("Invalid text block position.");
+        if (!K || T.width > I.width - 4)
+          if (T.height < I.height) {
+            if (M = gvjs_DG(Q, H, M, I.width - 4, I.height / (T.height + 2)),
+              E = M.lines,
+              M.oe) {
+              var N = H;
+              O.hx = !0
+            }
+          } else if (I.height > M.fontSize / 3)
+            N = H,
+              E = [gvjs_Kr],
+              L = Math.floor(I.getCenter().y),
+              O.Pc = gvjs_0,
+              O.hx = !0;
+          else {
+            I = null;
+            break a
+          }
+        O.lines = [];
+        if (E.length)
+          for (H = M = 0,
+                 Q = E.length; H < Q; H++)
+            O.lines.push(new gvjs_cJ({
+              x: 0,
+              y: M,
+              length: I.width,
+              text: E[H]
+            })),
+              M += T.height;
+        else
+          O.lines.push(new gvjs_cJ({
+            x: 0,
+            y: 0,
+            length: T.width,
+            text: H
+          }));
+        O.angle = 0;
+        O.anchor = new gvjs_HG(F,L);
+        R && N && (O.wd = {
+          Nh: !1,
+          wi: !1,
+          content: N
+        });
+        I = new gvjs_dJ(O)
+      }
+    }
+    if (I && !I.hx && 1 === v)
+      p.push(I),
+        B = !0;
+    else {
+      switch (g) {
+        case gvjs_S:
+          G.ld = gvjs_0;
+          G.Pc = -1 === k ? gvjs_R : gvjs_2;
+          break;
+        case gvjs_U:
+          G.ld = 1 === h ? gvjs_2 : gvjs_R,
+            G.Pc = gvjs_0
+      }
+      G.text = D.text;
+      G.ja = m;
+      G.vl = n;
+      G.anchor = J;
+      G.hx = !1;
+      G.lines = [{
+        x: 0,
+        y: 0,
+        length: C.width,
+        text: D.text
+      }];
+      G.angle = 0;
+      C = D.pF;
+      a.Ti.wz && null != C && (G.wd = gvjs_gJ(a.Ti, C, D.rowIndex));
+      p.push(new gvjs_dJ(G));
+      A += k * m.fontSize * G.lines.length
+    }
+  }
+  a = gvjs_U;
+  g === gvjs_U && (a = gvjs_S);
+  return {
+    kga: {
+      x: b,
+      y: c,
+      length: B ? 0 : e,
+      orientation: a,
+      color: q
+    },
+    labels: p,
+    Rp: null
+  }
+}
+function gvjs_NJ(a, b, c, d, e, f, g) {
+  for (var h = a.Ti.ti(), k = f.fontSize, l = [], m = a.Ti.sc, n = 0; n < e.length; n++) {
+    var p = gvjs_DG(m, e[n].text, f, h.O.height - k);
+    l.push(p)
+  }
+  m = gvjs_U;
+  n = 270;
+  var q = c
+    , r = h.O.top;
+  p = h.O.bottom;
+  d === gvjs_U && (m = gvjs_S,
+    n = 0,
+    q = b,
+    r = h.O.left,
+    p = h.O.right);
+  if (null != b && null != c) {
+    for (var t = h = 0; t < l.length; t++)
+      h = Math.max(h, l[t].Oq);
+    h += k;
+    k = Math.max(Math.round(q - h / 2), r);
+    p = Math.min(k + h, p);
+    k = p - h
+  } else
+    k = r;
+  r = Math.round((k + p) / 2);
+  h = b;
+  q = k;
+  d === gvjs_U && (h = k,
+    q = c);
+  d === gvjs_U ? (b = r,
+    c += 2) : (b += 2,
+    c = r);
+  r = [];
+  for (t = 0; t < e.length; t++) {
+    var u = e[t]
+      , v = l[t];
+    v = {
+      text: u,
+      ja: f,
+      lines: [{
+        x: b,
+        y: c,
+        length: v.Oq,
+        text: v.lines[0] || ""
+      }],
+      ld: gvjs_0,
+      Pc: gvjs_2,
+      anchor: null,
+      angle: n
+    };
+    var w = u.pF;
+    a.Ti.wz && null != w && (v.wd = gvjs_gJ(a.Ti, w, u.rowIndex));
+    r.push(v);
+    d === gvjs_U ? c += f.fontSize : b += f.fontSize
+  }
+  return {
+    kga: {
+      x: h,
+      y: q,
+      length: p - k,
+      orientation: m,
+      color: g
+    },
+    labels: r,
+    Rp: null
+  }
+}
+;function gvjs_OJ(a) {
+  gvjs_F.call(this);
+  this.Vk = a;
+  this.h1 = [];
+  this.xQ = !1;
+  this.Kh = {
+    De: null,
+    wL: 0,
+    xp: 0,
+    rH: 0,
+    sH: 0
+  }
+}
+gvjs_o(gvjs_OJ, gvjs_F);
+gvjs_OJ.prototype.Cf = function(a, b, c) {
+  this.h1[c] = !0;
+  0 === c && (this.Kh.De = b,
+    this.Kh.wL = a.x,
+    this.Kh.xp = a.y,
+    this.Kh.rH = a.x,
+    this.Kh.sH = a.y)
+}
+;
+gvjs_OJ.prototype.dispatchEvent = function(a, b) {
+  this.Vk.dispatchEvent({
+    type: a,
+    data: b
+  })
+}
+;
+gvjs_OJ.prototype.M = function() {
+  this.Vk = null;
+  gvjs_F.prototype.M.call(this)
+}
+;
+function gvjs_PJ(a, b, c, d) {
+  gvjs_F.call(this);
+  this.Vk = a;
+  this.renderer = b;
+  this.zw = c;
+  this.Xg = d;
+  this.hz = null;
+  this.fP = new gvjs_OJ(a);
+  gvjs_6x(this, this.fP);
+  this.TS = null
+}
+gvjs_t(gvjs_PJ, gvjs_F);
+gvjs_ = gvjs_PJ.prototype;
+gvjs_.M = function() {
+  this.Vk = null;
+  gvjs_E(this.TS);
+  gvjs_PJ.G.M.call(this)
+}
+;
+function gvjs_QJ(a) {
+  var b = a.renderer.kw;
+  gvjs_RJ(a, gvjs_s(function(c, d) {
+    this.renderer.ic(b, c, d)
+  }, a));
+  gvjs_E(a.TS);
+  a.TS = new gvjs_TE(a.renderer.getContainer());
+  gvjs_G(a.TS, gvjs_Wv, gvjs_s(a.Tqa, a))
+}
+function gvjs_SJ(a) {
+  var b = a.zw.getContainer();
+  gvjs_RJ(a, gvjs_s(function(c, d) {
+    this.zw.ic(b, c, d)
+  }, a))
+}
+function gvjs_TJ(a) {
+  var b = gvjs_Ph();
+  gvjs_qga(a, gvjs_s(function(c, d) {
+    this.zw.ic(b, c, d)
+  }, a))
+}
+function gvjs_qga(a, b) {
+  b(gvjs_jd, gvjs_s(a.Dqa, a));
+  b(gvjs_md, gvjs_s(a.Eqa, a))
+}
+function gvjs_RJ(a, b) {
+  b(gvjs_ld, gvjs_s(a.waa, a));
+  b(gvjs_kd, gvjs_s(a.Bqa, a));
+  b(gvjs_jd, gvjs_s(a.waa, a));
+  b(gvjs_md, gvjs_s(a.Aqa, a));
+  b(gvjs_gd, gvjs_s(a.vqa, a));
+  b(gvjs_Wt, gvjs_s(a.Ipa, a));
+  b(gvjs_3t, gvjs_s(a.Rqa, a));
+  b(gvjs_du, gvjs_s(a.Qpa, a))
+}
+gvjs_.Dqa = function(a) {
+  var b = gvjs_zz(this.renderer.getContainer());
+  a = gvjs_zz(a);
+  a.x -= b.x;
+  a.y -= b.y;
+  b = this.fP;
+  b.h1[0] && (b.Kh.rH = a.x,
+    b.Kh.sH = a.y,
+  b.xQ || b.dispatchEvent(gvjs_Ot, {
+    De: b.Kh.De,
+    xb: {
+      x: b.Kh.wL,
+      y: b.Kh.xp
+    }
+  }),
+    b.xQ = !0,
+    b.dispatchEvent("chartDrag", {
+      De: b.Kh.De,
+      xb: {
+        x: b.Kh.rH,
+        y: b.Kh.sH
+      }
+    }))
+}
+;
+gvjs_.Eqa = function(a) {
+  var b = gvjs_zz(this.renderer.getContainer())
+    , c = gvjs_zz(a);
+  c.x -= b.x;
+  c.y -= b.y;
+  b = this.fP;
+  a = a.button;
+  b.h1[a] = !1;
+  0 === a && b.xQ && (b.xQ = !1,
+    b.Kh.rH = c.x,
+    b.Kh.sH = c.y,
+    b.dispatchEvent("chartDragEnd", {
+      De: b.Kh.De,
+      xb: {
+        x: b.Kh.rH,
+        y: b.Kh.sH
+      }
+    }))
+}
+;
+gvjs_.waa = function(a) {
+  var b = gvjs_qB(a);
+  try {
+    gvjs_qB(a)
+  } catch (d) {
+    return
+  }
+  if (b) {
+    var c = this.Gs(a);
+    a.type == gvjs_jd && this.dispatchEvent(gvjs_Qt, {
+      xb: b,
+      De: c
+    });
+    c != this.hz && (null != this.hz && gvjs_UJ(this, this.hz),
+      this.dispatchEvent("chartHoverIn", {
+        xb: b
+      }),
+      gvjs_VJ(this, "HoverIn", c),
+      this.hz = c)
+  }
+}
+;
+gvjs_.Bqa = function(a) {
+  a = this.Gs(a);
+  a == this.hz && (gvjs_UJ(this, a),
+    this.hz = null)
+}
+;
+function gvjs_UJ(a, b) {
+  a.dispatchEvent("chartHoverOut", null);
+  gvjs_VJ(a, "HoverOut", b)
+}
+gvjs_.Aqa = function(a) {
+  var b = gvjs_qB(a);
+  b && (a = this.Gs(a),
+    this.dispatchEvent("chartMouseUp", {
+      xb: b,
+      De: a
+    }),
+    gvjs_VJ(this, "MouseUp", a))
+}
+;
+gvjs_.vqa = function(a) {
+  var b = gvjs_qB(a)
+    , c = this.Gs(a);
+  this.dispatchEvent(gvjs_Pt, {
+    xb: b,
+    De: c,
+    preventDefault: gvjs_s(a.preventDefault, a)
+  });
+  gvjs_VJ(this, "MouseDown", c);
+  this.fP.Cf(b, c, a.button)
+}
+;
+gvjs_.Ipa = function(a) {
+  var b = gvjs_qB(a);
+  a = this.Gs(a);
+  this.dispatchEvent("chartClick", {
+    xb: b,
+    De: a
+  });
+  gvjs_VJ(this, "Click", a)
+}
+;
+gvjs_.Rqa = function(a) {
+  var b = gvjs_qB(a)
+    , c = this.Gs(a);
+  this.dispatchEvent(gvjs_Rt, {
+    xb: b,
+    De: c
+  });
+  gvjs_VJ(this, "RightClick", c);
+  gvjs_Lz(a)
+}
+;
+gvjs_.Qpa = function(a) {
+  var b = gvjs_qB(a);
+  a = this.Gs(a);
+  this.dispatchEvent("chartDblClick", {
+    xb: b,
+    De: a
+  });
+  gvjs_VJ(this, "DblClick", a)
+}
+;
+gvjs_.Tqa = function(a) {
+  var b = gvjs_qB(a)
+    , c = this.Gs(a);
+  this.dispatchEvent("chartScroll", {
+    xb: b,
+    De: c,
+    wheelDelta: a.detail,
+    preventDefault: gvjs_s(a.preventDefault, a)
+  });
+  gvjs_VJ(this, "Scroll", c)
+}
+;
+function gvjs_VJ(a, b, c) {
+  var d = c.split("#");
+  switch (d[0]) {
+    case gvjs_Pd:
+      var e = c = null
+        , f = null;
+      a.Xg == gvjs_fw ? c = gvjs_gA(d[1]) : 4 == d.length ? (c = gvjs_gA(d[1]),
+        e = gvjs_gA(d[2]),
+        f = gvjs_gA(d[3])) : 3 == d.length ? (c = gvjs_gA(d[1]),
+        e = gvjs_gA(d[2])) : e = gvjs_gA(d[1]);
+      d = {
+        Vb: c,
+        Kk: e,
+        lG: f
+      };
+      a.dispatchEvent(gvjs_Pd + b, d);
+      break;
+    case gvjs_Ss:
+      d = {
+        wy: d[1]
+      };
+      a.dispatchEvent("actionsMenuEntry" + b, d);
+      break;
+    case gvjs_zv:
+      d = gvjs_gA(d[1]);
+      if (0 > d)
+        break;
+      d = {
+        TQ: d
+      };
+      a.dispatchEvent("legendEntry" + b, d);
+      break;
+    case gvjs_Av:
+      d = {
+        hwa: gvjs_gA(d[1]),
+        Xi: gvjs_gA(d[2]),
+        xF: gvjs_gA(d[3])
+      };
+      a.dispatchEvent("legendScrollButton" + b, d);
+      break;
+    case gvjs_uw:
+      d = gvjs_gA(d[1]);
+      d = {
+        TQ: d
+      };
+      a.dispatchEvent("removeSerieButton" + b, d);
+      break;
+    default:
+      a.v9(b, c)
+  }
+}
+gvjs_.dispatchEvent = function(a, b) {
+  this.Vk && this.Vk.dispatchEvent({
+    type: a,
+    data: b
+  })
+}
+;
+function gvjs_WJ(a, b, c, d) {
+  gvjs_PJ.call(this, a, b, c, d.Fa);
+  this.ha = d;
+  this.o2 = gvjs_XJ(this)
+}
+gvjs_t(gvjs_WJ, gvjs_PJ);
+gvjs_WJ.prototype.I5 = function(a) {
+  this.ha = a;
+  this.o2 = gvjs_XJ(this)
+}
+;
+function gvjs_XJ(a) {
+  var b = a.ha;
+  if (b.Fa != gvjs_d && b.Fa != gvjs_Dd)
+    return {};
+  a = {};
+  b = b.C;
+  for (var c = 0; c < b.length; c++) {
+    var d = b[c];
+    if (gvjs_YG(d))
+      for (var e = d.points, f = 0; f < e.length; f++) {
+        var g = e[f];
+        if (g && g.ia && !g.$l) {
+          var h = gvjs_4E([gvjs_Np, c, f]);
+          a[h] = {
+            center: g.ia,
+            radius: g.ia && null != g.ia.eT ? g.ia.eT : null != g.eT ? g.eT : d.jea,
+            Vb: c,
+            Kk: f
+          }
+        }
+      }
+  }
+  return a
+}
+gvjs_WJ.prototype.Gs = function(a) {
+  var b = this.renderer.xv(a.target)
+    , c = gvjs_qB(a);
+  if (!c)
+    return gvjs_Bb;
+  if ((new gvjs_5(this.ha.O.left + 1,this.ha.O.top + 1,this.ha.O.width - 2,this.ha.O.height - 2)).contains(c)) {
+    var d = this.ha.Ig
+      , e = null;
+    if (d.has(gvjs_gp)) {
+      e = c.x;
+      var f = c.y, g = null, h = Infinity, k;
+      for (k in this.o2) {
+        var l = this.o2[k]
+          , m = l.center.x
+          , n = l.center.y
+          , p = l.radius;
+        m - e <= p && m - e >= -p && n - f <= p && n - f >= -p && (m = (m - e) * (m - e) + (n - f) * (n - f),
+        m <= p * p && m <= h && (g = gvjs_4E([gvjs_ow, l.Vb, l.Kk]),
+          h = m))
+      }
+      e = g
+    }
+    if (null == e && d.has(gvjs_Ht))
+      b: {
+        d = this.ha.$a;
+        for (k = 0; k < d.length; k++)
+          if ((e = d[k].dT) && e.contains(c)) {
+            e = gvjs_4E([gvjs_Jt, k]);
+            break b
+          }
+        e = null
+      }
+    c = e
+  } else
+    c = null;
+  if (a.type == gvjs_kd) {
+    a = this.hz;
+    if (null == a)
+      return b;
+    c = c == a ? null : a
+  }
+  null != c && (gvjs_YJ(this, b) ? (a = gvjs_Be(gvjs_5E, b.split("#")[0]),
+    d = gvjs_Be(gvjs_5E, c.split("#")[0]),
+    b = a > d ? b : c) : b = c);
+  return gvjs_YJ(this, b) ? b : gvjs_Bb
+}
+;
+function gvjs_YJ(a, b) {
+  a = a.ha.Ig;
+  return a.has(gvjs_Ht) && !a.has(gvjs_gp) ? (b = b.split("#")[0],
+  b != gvjs_wb && b != gvjs_yt && b != gvjs_Ct && b != gvjs_Np && b != gvjs_ow && b != gvjs_5w) : !0
+}
+gvjs_WJ.prototype.v9 = function(a, b) {
+  b = b.split("#");
+  switch (b[0]) {
+    case gvjs_wb:
+    case gvjs_yt:
+    case gvjs_Ct:
+    case gvjs_Np:
+    case gvjs_ow:
+    case gvjs_5w:
+      var c = gvjs_gA(b[1]);
+      b = {
+        Vb: c,
+        Kk: gvjs_gA(b[2])
+      };
+      this.dispatchEvent(gvjs_gp + a, b);
+      break;
+    case gvjs_Jt:
+      b = gvjs_gA(b[1]);
+      b = {
+        Vb: null,
+        Kk: b
+      };
+      this.dispatchEvent(gvjs_Ht + a, b);
+      break;
+    case gvjs_$s:
+      c = gvjs_gA(gvjs_Ae(b));
+      this.dispatchEvent(gvjs_Zs + a, 3 == b.length ? {
+        Vb: null,
+        Kk: gvjs_gA(b[1]),
+        lG: c
+      } : {
+        Vb: gvjs_gA(b[1]),
+        Kk: gvjs_gA(b[2]),
+        lG: c
+      });
+      break;
+    case gvjs_e:
+    case gvjs_at:
+      c = gvjs_gA(b[1]),
+        b = {
+          Vb: c,
+          Kk: null
+        },
+        this.dispatchEvent("serie" + a, b)
+  }
+}
+;
+function gvjs_ZJ(a) {
+  this.Ea = a
+}
+gvjs_o(gvjs_ZJ, gvjs_qG);
+gvjs_ZJ.prototype.getKey = function(a) {
+  return this.Ea.dZ(a)
+}
+;
+gvjs_ZJ.prototype.getTitle = function(a) {
+  return this.Ea.iP(a)
+}
+;
+gvjs_ZJ.prototype.getContent = function(a, b, c) {
+  var d = gvjs_8F(this.Ea, c);
+  return gvjs__J(a, d, b.content || "", !0, a.bxa, this.Ea.C[c.Hb])
+}
+;
+function gvjs_0J(a) {
+  this.Ea = a
+}
+gvjs_o(gvjs_0J, gvjs_qG);
+gvjs_0J.prototype.getKey = function(a) {
+  return a.Hb
+}
+;
+gvjs_0J.prototype.getTitle = function(a) {
+  return gvjs_8F(this.Ea, a)
+}
+;
+gvjs_0J.prototype.getContent = function(a, b, c) {
+  c = this.Ea.iP(c) || "";
+  return [c ? gvjs_hG(b.content || "", a.FG, c, a.Za) : null]
+}
+;
+function gvjs_1J(a, b, c, d) {
+  gvjs_pG.call(this, a, b, c, d)
+}
+gvjs_o(gvjs_1J, gvjs_pG);
+gvjs_1J.prototype.N8 = function(a, b, c) {
+  var d = a.Ea
+    , e = d.C[b];
+  c = d.xI(b, c);
+  var f = !1
+    , g = null
+    , h = null
+    , k = null != d.kd && d.kd;
+  if (d.kd)
+    if (f = !0,
+      h = [this.r9, this.s9],
+      d = e.type,
+    d === gvjs_lt)
+      g = [{
+        color: e.Qg.fill,
+        alpha: e.Qg.fillOpacity
+      }, {
+        color: e.Ih.background.Qg.fill,
+        alpha: e.Ih.background.Qg.fillOpacity
+      }];
+    else if (d === gvjs_Dd)
+      d = b % 2 ? b - 1 : b,
+        b = a.Ea.C[d],
+        d = a.Ea.C[d + 1],
+        g = [{
+          color: d.Qg.fill,
+          alpha: d.Qg.fillOpacity
+        }, {
+          color: b.Qg.fill,
+          alpha: b.Qg.fillOpacity
+        }];
+    else
+      throw Error("Diff chart not supported for the chosen chart type.");
+  b = {
+    entries: []
+  };
+  if (c.lines)
+    for (c.title && gvjs_2J(this, b, c.title),
+           e = 0; e < c.lines.length; e++)
+      f = c.lines[e],
+        f = (h = f.title) ? gvjs_hG(f.value, this.FG, h, this.Za) : null,
+      null != f && b.entries.push(f);
+  else
+    c.Mx && !c.wi ? (gvjs_2J(this, b, c.Mx),
+      gvjs_3J(this, b, c.En, c.content, !0, this.fu, e, f, g, h, k)) : c.En && !c.wi ? gvjs_3J(this, b, c.En, c.content, !0, this.fu, e, !0, g, h, k) : null != c.content && gvjs_3J(this, b, null, c.content, !1, this.fu, e);
+  this.ov(b, a.yk);
+  return b
+}
+;
+function gvjs_4J(a, b, c, d) {
+  var e = b.Ea
+    , f = new gvjs_ZJ(e)
+    , g = new gvjs_0J(e)
+    , h = null;
+  d == gvjs_Ht ? h = f : d == gvjs_Mw && (h = g);
+  if (h)
+    var k = h.aggregate(c);
+  else {
+    d = f.aggregate(c);
+    var l = g.aggregate(c);
+    h = g;
+    k = l;
+    1 == d.order.length && 1 < l.order.length && (h = f,
+      k = d)
+  }
+  var m = {
+    entries: []
+  };
+  gvjs_u(k.order, function(n) {
+    gvjs_2J(this, m, (k.$w[n] || "").toString());
+    gvjs_u(k.index[n], function(p) {
+      var q = e.xI(p.Hb, p.Eb);
+      q.wi ? gvjs_3J(this, m, null, q.content, !1, this.fu, e.C[p.Hb]) : m.entries.push.apply(m.entries, h.getContent(this, q, p))
+    }, this)
+  }, a);
+  a.ov(m, b.yk, 0 < c.length);
+  return m
+}
+gvjs_1J.prototype.O8 = function(a, b) {
+  var c = a.Ea
+    , d = c.C[b]
+    , e = d.wd
+    , f = null
+    , g = null
+    , h = null != c.kd && c.kd;
+  c.kd && (f = c.C.length,
+    f = (b + f / c.pie.Gd.length) % f,
+    g = c.C[f],
+    c = {
+      color: d.brush.fill,
+      alpha: d.brush.fillOpacity
+    },
+    g = {
+      color: g.brush.fill,
+      alpha: g.brush.fillOpacity
+    },
+    f = b > f ? [c, g] : [g, c],
+    g = [this.r9, this.s9]);
+  b = {
+    entries: []
+  };
+  e.En ? gvjs_3J(this, b, e.En, e.content, !0, this.fu, d, !0, f, g, h) : gvjs_3J(this, b, null, e.content, !1, this.fu, d);
+  this.ov(b, a.yk);
+  return b
+}
+;
+function gvjs_rga(a, b, c) {
+  var d = b.Ea
+    , e = {
+    entries: []
+  };
+  gvjs_u(c, function(f) {
+    f = d.C[f];
+    var g = f.wd;
+    g.En ? gvjs_3J(a, e, g.En, g.content, !0, a.fu, f, !0) : gvjs_3J(a, e, null, g.content, !1, a.fu, f)
+  });
+  a.ov(e, b.yk);
+  return e
+}
+gvjs_1J.prototype.L8 = function(a, b) {
+  var c = a.Ea
+    , d = c.$a[b].wd
+    , e = !1
+    , f = {
+    entries: []
+  };
+  if (d && d.content)
+    gvjs_3J(this, f, null, d.content, !1, !1);
+  else {
+    var g = 0
+      , h = 1
+      , k = c.C.length;
+    gvjs_2G(c) && (g = c.C.length - 1,
+      k = h = -1);
+    for (var l = null; g != k; g += h) {
+      var m = c.C[g];
+      if (m.NT) {
+        d = gvjs_7F(c, g, b);
+        if (l != m.We) {
+          l = m.We;
+          var n = c.$a[b].$w[l];
+          gvjs_jf(gvjs_gg(n)) || gvjs_2J(this, f, n)
+        }
+        m.points[d] && m.points[d].wd && m.points[d].wd.content && (d = m.points[d].wd,
+          gvjs_3J(this, f, d.En, d.content, !0, this.fu, m, void 0, void 0, void 0, void 0, d.wi && d.Nh),
+          e = !0)
+      }
+    }
+  }
+  null != a.yk && 0 < a.yk.length && (e = !0);
+  this.ov(f, a.yk);
+  return e || this.cxa ? f : null
+}
+;
+function gvjs_2J(a, b, c) {
+  a = gvjs_hG(c, a.FG);
+  b.entries.push(a)
+}
+function gvjs__J(a, b, c, d, e, f, g, h, k, l, m) {
+  d = d ? a.FG : a.Za;
+  c = c.split("\n");
+  g = (null != g ? g : !1) || null != h;
+  var n = e ? f.color.color : null;
+  n = g && null != b ? gvjs_hG(b, a.Za, null, null, n, f && f.dH) : gvjs_hG(c[0], d, b, a.Za, n, f && f.dH, null, m);
+  a = [n];
+  for (g = g ? 0 : 1; g < c.length; g++)
+    n = null != h ? h[g].color : e ? gvjs_f : null,
+      b = null != h ? h[g].alpha : null,
+      k = null != k ? k[g] : null,
+      n = gvjs_hG(c[g], d, null, null, n, b, k, m),
+      n.gG = l,
+      a.push(n);
+  return a
+}
+function gvjs_3J(a, b, c, d, e, f, g, h, k, l, m, n) {
+  b.entries.push.apply(b.entries, gvjs__J(a, c, d, e, f, g, h, k, l, m, n))
+}
+gvjs_1J.prototype.ov = function(a, b, c) {
+  b && 0 !== b.length && ((void 0 == c || c) && a.entries.push(gvjs_jG()),
+    gvjs_Me(a.entries, b))
+}
+;
+function gvjs_5J(a, b, c) {
+  gvjs_pG.call(this, a, b, c, void 0);
+  this.nha = this.FG;
+  this.pU = gvjs_x(this.Za);
+  this.pU.color = gvjs_pr;
+  this.pU.fontSize -= 2
+}
+gvjs_o(gvjs_5J, gvjs_1J);
+gvjs_5J.prototype.N8 = function(a, b, c) {
+  b = a.Ea.C[b];
+  a = b.points[c].wd;
+  c = [];
+  b.GF || (b = gvjs_hG(b.title || "", this.nha),
+    c.push(b));
+  b = gvjs_hG(a.content, this.nha);
+  c.push(b);
+  a = gvjs_hG(a.Mx, this.pU);
+  c.push(a);
+  return {
+    entries: c
+  }
+}
+;
+gvjs_5J.prototype.O8 = function() {
+  return {
+    entries: []
+  }
+}
+;
+gvjs_5J.prototype.L8 = function() {
+  return {
+    entries: []
+  }
+}
+;
+function gvjs_sga(a, b, c) {
+  this.es = b;
+  this.af = new gvjs_B(0,c.width,c.height,0);
+  gvjs_K(a, ["tooltip.ignoreBounds.left", gvjs_mx], !1) ? this.af.left = -Infinity : this.af.left -= gvjs_L(a, ["tooltip.bounds.left", gvjs_lx], 0);
+  gvjs_K(a, ["tooltip.ignoreBounds.top", gvjs_mx], !1) ? this.af.top = -Infinity : this.af.top -= gvjs_L(a, ["tooltip.bounds.top", gvjs_lx], 0);
+  gvjs_K(a, ["tooltip.ignoreBounds.right", gvjs_mx], !1) ? this.af.right = Infinity : this.af.right += gvjs_L(a, ["tooltip.bounds.right", gvjs_lx], 0);
+  gvjs_K(a, ["tooltip.ignoreBounds.bottom", gvjs_mx], !1) ? this.af.bottom = Infinity : this.af.bottom += gvjs_L(a, ["tooltip.bounds.bottom", gvjs_lx], 0);
+  this.gy = null;
+  c = a.Aa("tooltip.pivot.x");
+  var d = a.Aa("tooltip.pivot.y");
+  null != c && typeof c === gvjs_g && isFinite(c) && null != d && typeof d === gvjs_g && isFinite(d) && (this.gy = new gvjs_z(c,d));
+  b = null != b.le && 0 < b.le.getEntries().length ? gvjs_ut : gvjs_xu;
+  this.u5 = gvjs_J(a, gvjs_qx, b, gvjs_mC)
+}
+function gvjs_6J(a) {
+  if (a.Fa == gvjs_fw) {
+    var b = a.pie.center;
+    return new gvjs_z(b.x,b.y)
+  }
+  b = gvjs_Oy(a.jd);
+  a = gvjs_Oy(a.wc);
+  return new gvjs_z(null != b.baseline ? b.baseline.Na : Math.min(b.Pf, b.ef),null != a.baseline ? a.baseline.Na : Math.max(a.Pf, a.ef))
+}
+function gvjs_tga(a, b) {
+  a.af = b
+}
+function gvjs_7J(a, b, c) {
+  var d = b.ia;
+  a = gvjs_6J(a);
+  b = 1 + Math.ceil(gvjs_1G(b, c) / Math.sqrt(2));
+  return new gvjs_z(d.x + (d.x >= a.x ? b : -b),d.y + (d.y <= a.y ? -b : b))
+}
+function gvjs_8J(a, b) {
+  var c = gvjs_eA(a.pie.center, gvjs_3I(((b.rt ? 45 : (b.de + b.vd) / 2) / 180 - .5) * Math.PI, a.pie.radiusX, a.pie.radiusY));
+  b = new gvjs_z(c.x + b.offset.x,c.y + b.offset.y);
+  b.x = gvjs_0g(b.x, 0, a.width);
+  b.y = gvjs_0g(b.y, 0, a.height);
+  return b
+}
+function gvjs_9J(a) {
+  var b = a.anchor ? a.anchor : new gvjs_z(0,0)
+    , c = a.lines[0]
+    , d = a.ja.fontSize;
+  return 270 == a.angle ? new gvjs_z(b.x + c.x + d,b.y + c.y - c.length / 2) : new gvjs_z(b.x + c.x + c.length / 2,b.y + c.y - d)
+}
+function gvjs_$J(a, b, c) {
+  var d = a.C[b]
+    , e = d.type;
+  c = gvjs_7F(a, b, c);
+  b = d.points[c];
+  if (!b)
+    return new gvjs_z(0,0);
+  switch (a.Fa) {
+    case gvjs_d:
+    case gvjs_4u:
+      switch (e) {
+        case gvjs_lt:
+        case gvjs_4w:
+          return d = b.ia.bar || b.ia,
+            e = gvjs_6J(a),
+            d = new gvjs_z(d.left + (d.left < e.x ? 0 : d.width),d.top + (d.top < e.y ? 0 : d.height)),
+            gvjs_aK(a, d),
+            d;
+        case gvjs_e:
+        case gvjs_at:
+        case gvjs_Dd:
+          return gvjs_7J(a, b, d);
+        case gvjs_Ft:
+          return d = b.ia.rect,
+            e = gvjs_6J(a),
+            d = new gvjs_z(d.left + d.width > e.x ? d.left + d.width : d.left,d.top < e.y ? d.top : d.top + d.height),
+            gvjs_aK(a, d),
+            d
+      }
+    case gvjs_Dd:
+      return gvjs_7J(a, b, d);
+    case gvjs_yt:
+      e = b.ia;
+      d = gvjs_7J(a, b, d);
+      if (d.x < a.O.left || d.x > a.O.right)
+        d.x += 2 * (e.x - d.x);
+      if (d.y < a.O.top || d.y > a.O.bottom)
+        d.y += 2 * (e.y - d.y);
+      return d
+  }
+  return new gvjs_z(0,0)
+}
+function gvjs_aK(a, b) {
+  a = a.O;
+  b.x = gvjs_0g(b.x, a.left, a.right);
+  b.y = gvjs_0g(b.y, a.top, a.bottom)
+}
+function gvjs_bK(a, b, c, d) {
+  var e = null
+    , f = null
+    , g = gvjs_Oy(b.jd)
+    , h = gvjs_Oy(b.wc)
+    , k = g.ro
+    , l = h.ro
+    , m = d;
+  b.orientation && b.orientation !== gvjs_S ? (l = -l,
+  h.type === gvjs_Vd && (m = b.$a[d].data),
+    f = h.position.hf(m)) : (g.type === gvjs_Vd && (m = b.$a[d].data),
+    e = g.position.hf(m));
+  a = a.es.Za.fontSize;
+  c.x = null === e ? c.x : e;
+  c.y = null === f ? c.y : f;
+  e = c.x - k * a;
+  f = c.y + l * a;
+  return new gvjs_z(e,f)
+}
+function gvjs_cK(a, b) {
+  a = gvjs_eA(a.pie.center, gvjs_3I(((b.rt ? 45 : (b.de + b.vd) / 2) / 180 - .5) * Math.PI, a.pie.radiusX - .1, a.pie.radiusY - .1));
+  return new gvjs_z(a.x + b.offset.x,a.y + b.offset.y)
+}
+function gvjs_dK(a) {
+  var b = a.anchor ? a.anchor : new gvjs_z(0,0)
+    , c = a.lines[0]
+    , d = a.ja.fontSize;
+  return 270 == a.angle ? new gvjs_z(b.x + c.x + d / 2,b.y + c.y) : new gvjs_z(b.x + c.x,b.y + c.y - d / 2)
+}
+function gvjs_eK(a, b, c) {
+  c = gvjs_7F(a, b, c);
+  var d = a.C[b];
+  b = d.type;
+  c = d.points[c].ia;
+  if (b == gvjs_lt || b == gvjs_4w || b == gvjs_Ft) {
+    var e = c.bar || c.rect || c;
+    c = e.left;
+    b = e.width;
+    d = e.top;
+    e = e.height;
+    var f = d + e
+      , g = gvjs_6J(a);
+    a = a.orientation == gvjs_S ? f > g.y ? new gvjs_z(c + b / 2,f - .1) : new gvjs_z(c + b / 2,d + .1) : c < g.x ? new gvjs_z(c + .1,d + e / 2) : new gvjs_z(c + b - .1,d + e / 2)
+  } else
+    a = new gvjs_z(c.x,c.y);
+  return a
+}
+function gvjs_fK(a, b, c, d, e, f) {
+  if (null !== c && null !== d && null !== e) {
+    var g = b.Ea
+      , h = g.C[c].points[d].Bc.labels[e]
+      , k = h.wd;
+    k ? (f = gvjs_9J(h),
+      h = gvjs_dK(h),
+      k.Nh && k.wi ? (b = gvjs_OA(k.content || ""),
+        a = gvjs_gK(a, b, f, h)) : (k = a.es,
+        d = {
+          entries: [gvjs_hG(b.Ea.C[c].points[d].Bc.labels[e].wd.content, k.Za)]
+        },
+        k.ov(d, b.yk),
+        a = gvjs_kG(d, g.sc, !1, f, a.af, h, void 0, g.$f, g.bw, g.ax))) : a = null
+  } else if (null !== c && null !== d)
+    if (g = b.Ea,
+      g.C[c].NT)
+      if (e = gvjs_$J(g, c, d),
+        f = a.gy ? gvjs_ez(e, a.gy) : gvjs_eK(g, c, d),
+        h = g.C[c].points[d].wd)
+        if (typeof h.T8 === gvjs_d) {
+          b = h.T8(g, c, d);
+          d = null;
+          b instanceof gvjs_Zf ? d = b : typeof b === gvjs_l && (d = (new gvjs_wm).cd().sanitize(b));
+          if (!d)
+            throw Error("Custom calc function for tooltip content should produce string literal or safe HTML.");
+          a = gvjs_gK(a, d, e, f)
+        } else
+          h.Nh && h.wi ? (b = gvjs_OA(h.content || ""),
+            a = gvjs_gK(a, b, e, f)) : (b = a.es.N8(b, c, d),
+            a = gvjs_kG(b, g.sc, !0, e, a.af, f, void 0, g.$f, g.bw, g.ax));
+      else
+        a = null;
+    else
+      a = null;
+  else
+    null !== c && null === d ? (e = b.Ea,
+      f = e.C[c],
+      null == f.offset ? a = null : (d = gvjs_8J(e, f),
+        f = gvjs_cK(e, f),
+        g = e.C[c].wd,
+        g.Nh && g.wi ? (b = gvjs_OA(g.content || ""),
+          a = gvjs_gK(a, b, d, f)) : (b = a.es.O8(b, c),
+          a = gvjs_kG(b, e.sc, !0, d, a.af, f, void 0, e.$f, e.bw, e.ax)))) : null === c && null !== d && null !== e ? (f = b.Ea,
+      g = f.$a[d].Bc.labels[e],
+      (h = g.wd) ? (c = gvjs_9J(g),
+        g = gvjs_dK(g),
+        h.Nh && h.wi ? (b = gvjs_OA(h.content || ""),
+          a = gvjs_gK(a, b, c, g)) : (h = a.es,
+          d = b.Ea.$a[d],
+          d = {
+            entries: [gvjs_hG((d.Bc && d.Bc.labels[e]).wd.content, h.Za)]
+          },
+        0 < b.yk.length && h.ov(d, b.yk),
+          a = gvjs_kG(d, f.sc, !1, c, a.af, g, void 0, f.$f, f.bw, f.ax))) : a = null) : null === c && null !== d ? (c = b.Ea,
+      e = f.clone(),
+      f = gvjs_bK(a, c, e, d),
+      e = a.gy ? gvjs_ez(f, a.gy) : e,
+      (g = c.$a[d].wd) && g.Nh && g.wi ? (b = gvjs_OA(g.content),
+        a = gvjs_gK(a, b, f, e)) : (b = a.es.L8(b, d),
+        a = null === b ? null : gvjs_kG(b, c.sc, !1, f, a.af, e, void 0, c.$f, c.bw, c.ax))) : a = null;
+  return a
+}
+function gvjs_uga(a, b, c, d, e) {
+  var f = b.Ea;
+  d = d.clone();
+  var g = gvjs_bK(a, f, d, c[c.length - 1]);
+  d = a.gy ? gvjs_ez(g, a.gy) : d;
+  var h = [];
+  gvjs_u(c, function(k) {
+    gvjs_u(f.C, function(l, m) {
+      h.push({
+        Hb: m,
+        Eb: k
+      })
+    })
+  });
+  b = gvjs_4J(a.es, b, h, e);
+  return null === b ? null : gvjs_kG(b, f.sc, !1, g, a.af, d, void 0, f.$f, f.bw, f.ax)
+}
+function gvjs_gK(a, b, c, d) {
+  return {
+    html: gvjs_5f(gvjs_Ob, {
+      "class": gvjs_Nu
+    }, b),
+    hO: !0,
+    pivot: d,
+    anchor: c,
+    HG: a.af,
+    spacing: 20,
+    margin: 5
+  }
+}
+;function gvjs_hK(a, b, c, d, e, f) {
+  this.le = f;
+  d == gvjs_lu || this.le ? null != this.le && this.le.updateOptions(a, c) : this.le = new gvjs_nG(a,c);
+  c = d == gvjs_lu ? new gvjs_5J(a,c,e) : new gvjs_1J(a,c,e,this.le);
+  this.Cp = new gvjs_sga(a,c,b)
+}
+function gvjs_iK(a, b, c) {
+  var d = {};
+  if (null != c.legend.Xi) {
+    d.legend = d.legend || {};
+    var e = b.legend
+      , f = c.legend.Xi;
+    d.legend.ev = e.Pe[f];
+    var g = f + 1 + "/" + e.Pe.length
+      , h = e.$K.w2
+      , k = 0 < f;
+    e = e.$K.s1;
+    f = f < b.legend.Pe.length - 1;
+    d.legend.$K = {
+      w2: {
+        brush: k ? h.Rb.active : h.Rb.mQ,
+        active: k
+      },
+      s1: {
+        brush: f ? e.Rb.active : e.Rb.mQ,
+        active: f
+      },
+      a2: {
+        text: g,
+        lines: {
+          0: {
+            text: g
+          }
+        }
+      }
+    }
+  }
+  a.Us(b, c, d);
+  return d
+}
+gvjs_hK.prototype.xh = function(a) {
+  this.le && gvjs_oG(this.le, a)
+}
+;
+gvjs_hK.prototype.ng = function(a) {
+  if (this.le)
+    return this.le.ng(a)
+}
+;
+gvjs_hK.prototype.th = function(a) {
+  this.le && this.le.removeEntry(a)
+}
+;
+function gvjs_jK(a, b, c, d, e, f, g) {
+  gvjs_hK.call(this, a, b, c, d, e, g);
+  this.dO = a.cb("crosshair.trigger", gvjs_$da);
+  this.jma = gvjs_J(a, ["crosshair.selected.orientation", gvjs_6t], gvjs_ut, gvjs_nC);
+  this.gma = gvjs_J(a, ["crosshair.focused.orientation", gvjs_6t], gvjs_ut, gvjs_nC);
+  this.hma = a.mz(["crosshair.selected.color", gvjs_4t]);
+  this.ema = a.mz(["crosshair.focused.color", gvjs_4t]);
+  this.ima = gvjs_ny(a, ["crosshair.selected.opacity", gvjs_5t], 1);
+  this.fma = gvjs_ny(a, ["crosshair.focused.opacity", gvjs_5t], 1);
+  this.KV = gvjs_J(a, "aggregationTarget", gvjs_f, gvjs_cea);
+  this.jQ = !0
+}
+gvjs_o(gvjs_jK, gvjs_hK);
+gvjs_jK.prototype.Us = function(a, b, c) {
+  this.jQ = !0;
+  switch (a.qz) {
+    case gvjs_eu:
+      this.QX(a, b, c);
+      break;
+    case gvjs_lu:
+      gvjs_vga(this, a, b, c)
+  }
+}
+;
+gvjs_jK.prototype.xY = function(a, b) {
+  return a.equals(b, this.jQ)
+}
+;
+function gvjs_wga(a) {
+  return gvjs_Fe(a.C, function(b) {
+    return b.Yg
+  })
+}
+function gvjs_kK(a, b, c) {
+  a.C = a.C || {};
+  a = a.C;
+  a[b] = a[b] || {};
+  b = a[b];
+  b.points = b.points || {};
+  b = b.points;
+  b[c] = b[c] || {};
+  return b[c]
+}
+function gvjs_lK(a, b, c) {
+  if (null != b)
+    return a = gvjs_kK(a, b, c),
+      a.Bc = a.Bc || {},
+      a.Bc;
+  a = gvjs_mK(a, c);
+  a.Bc = a.Bc || {};
+  return a.Bc
+}
+function gvjs_nK(a, b) {
+  a.C = a.C || {};
+  a = a.C;
+  a[b] = a[b] || {};
+  return a[b]
+}
+function gvjs_mK(a, b) {
+  a.$a = a.$a || {};
+  a = a.$a;
+  a[b] = a[b] || {};
+  return a[b]
+}
+function gvjs_oK(a, b) {
+  a.legend = a.legend || {};
+  a = a.legend;
+  a.ev = a.ev || {};
+  a = a.ev;
+  a[b] = a[b] || {};
+  return a[b]
+}
+gvjs_jK.prototype.QX = function(a, b, c) {
+  var d = {
+    Ea: a,
+    yk: this.le.getEntries(),
+    Yv: c,
+    zk: b.gi
+  }
+    , e = b.gi.focused.wy;
+  null != e && (b.gi.focused.action = this.le.ng(e).action);
+  e = this.Cp.u5;
+  var f = e == gvjs_Jw || e == gvjs_ut;
+  e = e == gvjs_xu || e == gvjs_ut;
+  for (var g = this.KV != gvjs_f, h = this.le && 0 < d.yk.length, k = gvjs_co(b.selected), l = 1 < k.length && (g || h), m = 0; m < k.length; ++m) {
+    var n = k[m]
+      , p = n.column
+      , q = a.Jk[p]
+      , r = q.Vb;
+    if (n = a.lP({
+      column: p,
+      row: n.row
+    }))
+      switch (q.role) {
+        case gvjs_$t:
+          gvjs_pK(this, a, n.Hb, n.Eb, c);
+          f && !l && gvjs_qK(this, d, n.Hb, n.Eb);
+          break;
+        case gvjs_Zs:
+          if (null != r ? a.C[r].Yg : a.Yg)
+            q = q.wE,
+            null != q && (gvjs_xga(n.Hb, n.Eb, q, c),
+            f && gvjs_rK(this, d, n.Hb, n.Eb, q))
+      }
+  }
+  f && l && !a.fz && (k = gvjs_De(gvjs_v(k, function(t) {
+    return a.lP({
+      column: t.column,
+      row: t.row
+    })
+  }), function(t) {
+    return null != t
+  }),
+  0 < k.length && gvjs_yga(this, d, g ? k : [], k[k.length - 1]));
+  m = gvjs_ao(b.selected, gvjs_Fb);
+  for (k = 0; k < m.length; ++k)
+    l = a.Jk[m[k]],
+    null != l && (l = l.Vb,
+    null != l && gvjs_sK(this, a, l, c));
+  m = a.Fa === gvjs_yt;
+  q = gvjs_bo(b.selected);
+  g = 1 < q.length && (g || h);
+  for (k = 0; k < q.length; ++k)
+    h = a.Ds[q[k]],
+      m ? (l = 0,
+        gvjs_pK(this, a, l, h, c),
+      f && !g && gvjs_qK(this, d, l, h)) : (gvjs_zga(this, a, h, c),
+      f && !g && gvjs_tK(this, d, b.cursor.p2, h));
+  g && (m ? gvjs_qK(this, d, 0, a.Ds[q[q.length - 1]]) : f && (f = gvjs_v(q, function(t) {
+    return a.Ds[t]
+  }),
+  0 < f.length && gvjs_Aga(this, d, b.cursor.p2, f)));
+  f = b.focused.Hb;
+  g = b.focused.datum;
+  null != g ? a.C[f].Yg && (gvjs_uK(this, a, f, g, c),
+  e && gvjs_qK(this, d, f, g),
+    gvjs_Bga(a, f, g, c)) : null != f && a.C[f].Yg && gvjs_vK(this, a, f, c);
+  f = b.legend.focused.Xc;
+  null != f && a.C[f].Yg && gvjs_vK(this, a, f, c);
+  f = b.focused.Eb;
+  null != f && a.$a[f] && (gvjs_Cga(this, a, f, c),
+  e && gvjs_wga(d.Ea) && (gvjs_tK(this, d, b.cursor.position, f),
+    this.jQ = !1));
+  if (f = b.annotations.dI)
+    f = gvjs_lK(c, f.Vb, f.oO),
+      f.Rp = f.Rp || {},
+      f.Rp.Eba = !0;
+  (f = b.annotations.focused) && e && (g = a.Jk[f.column],
+    e = g.Vb,
+    f = a.Ds[f.row],
+    g = g.wE,
+  (null != e ? a.C[e].Yg : a.Yg) && gvjs_rK(this, d, e, f, g));
+  if (b = b.Ii)
+    c.Ii = b
+}
+;
+function gvjs_uK(a, b, c, d, e) {
+  var f = b.C[c]
+    , g = f.points[d];
+  if (!gvjs_XG(g) && g.ia && (!gvjs_YG(f) || 0 != f.lineWidth || gvjs_ZG(g, f))) {
+    var h = f.type == gvjs_lt ? gvjs_Dga : gvjs_Ega;
+    e = gvjs_kK(e, c, d);
+    e.Ko = {};
+    c = e.Ko;
+    c.levels = [];
+    for (d = 0; d < h.length; d++) {
+      var k = new gvjs_3({
+        fill: gvjs_f,
+        stroke: gvjs_rt,
+        strokeOpacity: h[d],
+        strokeWidth: 1
+      });
+      c.levels.push({
+        brush: k
+      })
+    }
+    switch (f.type) {
+      case gvjs_lt:
+      case gvjs_4w:
+      case gvjs_Ft:
+        a = g.ia.bar || g.ia.rect || g.ia;
+        b = new gvjs_5(a.left,a.top,a.width,a.height);
+        for (d = 0; d < h.length; d++)
+          a = c.levels[d].brush.strokeWidth,
+            c.levels[d].rect = new gvjs_5(b.left - a / 2,b.top - a / 2,b.width + a,b.height + a),
+            b.left -= a,
+            b.top -= a,
+            b.width += 2 * a,
+            b.height += 2 * a;
+        break;
+      case gvjs_e:
+      case gvjs_at:
+      case gvjs_Dd:
+      case gvjs_At:
+        e.visible = !0;
+        c.x = g.ia.x;
+        c.y = g.ia.y;
+        if (a.dO === gvjs_ut || a.dO === gvjs_xu)
+          d = gvjs_WG(g, f),
+            d = gvjs_9z(a.ema || d.fill, 1, !1, a.fma),
+            gvjs_wK(b, g, e, d, a.gma);
+        e.nj ? (a = e.nj,
+          b = a.radius + a.brush.strokeWidth / 2) : b = gvjs_1G(g, f);
+        for (d = 0; d < h.length; d++)
+          a = c.levels[d].brush.strokeWidth,
+            c.levels[d].radius = b + a / 2,
+            b += a
+    }
+  }
+}
+function gvjs_vK(a, b, c, d) {
+  var e = b.C[c];
+  if (gvjs_YG(e) && 0 < e.lineWidth) {
+    var f = gvjs_nK(d, c);
+    f.Ko = {};
+    f = f.Ko;
+    f.levels = [];
+    var g = e.type == gvjs_at ? b.vp !== gvjs_f ? gvjs_4G(e) : gvjs_3G(e, !1) : gvjs_3G(e, b.Zj);
+    g = gvjs_7B(g);
+    for (var h = e.Oc.strokeWidth / 2, k = 0; k < gvjs_xK.length; k++) {
+      var l = new gvjs_3({
+        fill: gvjs_f,
+        stroke: gvjs_rt,
+        strokeOpacity: gvjs_xK[k],
+        strokeWidth: 1
+      })
+        , m = gvjs_cC(g, h + l.strokeWidth / 2);
+      f.levels.push({
+        brush: l,
+        path: m
+      });
+      h += l.strokeWidth
+    }
+  }
+  f = (f = (f = d.C) && f[c]) && f.points;
+  for (g = 0; g < e.points.length; ++g)
+    h = e.points[g],
+    gvjs_XG(h) || (gvjs_ZG(h, e) || f && f[g] && f[g].visible) && gvjs_uK(a, b, c, g, d);
+  b.kd && e.type === gvjs_Dd && !a.fL(e.columns) && gvjs_vK(a, b, c - 1, d)
+}
+gvjs_jK.prototype.fL = function(a) {
+  a = a[gvjs_3v];
+  return null != a && 0 < a.length
+}
+;
+function gvjs_Cga(a, b, c, d) {
+  for (var e = b.C, f = 0; f < e.length; ++f) {
+    var g = gvjs_7F(b, f, c);
+    b.C[f].Yg && null != g && gvjs_uK(a, b, f, g, d)
+  }
+}
+function gvjs_pK(a, b, c, d, e) {
+  var f = b.C[c]
+    , g = f.points[d];
+  if (!gvjs_XG(g) && g.ia && (!gvjs_YG(f) || 0 != f.lineWidth || gvjs_ZG(g, f))) {
+    var h = gvjs_WG(g, f);
+    c = gvjs_kK(e, c, d);
+    c.nj = {};
+    d = c.nj;
+    var k = b.SM;
+    e = 1;
+    null == k && (k = gvjs_Ox,
+      e = 0);
+    switch (f.type) {
+      case gvjs_lt:
+      case gvjs_4w:
+      case gvjs_Ft:
+        e = 1;
+        d.brush = new gvjs_3(gvjs_iy);
+        d.brush.rd(k);
+        f.type == gvjs_Ft && (a = gvjs_vj(gvjs_qj(h.fill).hex),
+          b = gvjs_vj(gvjs_qj(k).hex),
+          f = gvjs_vj(gvjs_qj(g.yG.fill).hex),
+          d.brush.rd(gvjs_uj(gvjs_4z(f, [a, b]))));
+        gvjs_ay(d.brush, e);
+        d.brush.hl(1);
+        g = g.ia.bar || g.ia.rect || g.ia;
+        h = h.strokeWidth;
+        a = d.brush.strokeWidth;
+        d.rect = new gvjs_5(g.left + h / 2 + 1.5 + a / 2,g.top + h / 2 + 1.5 + a / 2,g.width - (h + 3 + a),g.height - (h + 3 + a));
+        (0 >= d.rect.width || 0 >= d.rect.height) && delete c.nj;
+        break;
+      case gvjs_e:
+      case gvjs_at:
+      case gvjs_Dd:
+      case gvjs_At:
+        c.visible = !0;
+        d.x = g.ia.x;
+        d.y = g.ia.y;
+        if (a.dO === gvjs_ut || a.dO === gvjs_Jw) {
+          var l = gvjs_9z(a.hma || h.fill, 1, !1, a.ima);
+          gvjs_wK(b, g, c, l, a.jma)
+        }
+        d.brush = new gvjs_3({
+          fill: k,
+          fillOpacity: e,
+          stroke: h.fill,
+          strokeWidth: 1
+        });
+        d.radius = gvjs_1G(g, f) + 1.5 + d.brush.strokeWidth / 2
+    }
+  }
+}
+function gvjs_wK(a, b, c, d, e) {
+  c = c.P8 || (c.P8 = {});
+  c.x = b.ia.x;
+  c.y = b.ia.y;
+  c.brush = d;
+  b = new gvjs_z(a.O.left,c.y);
+  d = new gvjs_z(a.O.right,c.y);
+  var f = new gvjs_z(c.x,a.O.top);
+  a = new gvjs_z(c.x,a.O.bottom);
+  c.path = c.path || new gvjs_SA;
+  if (e === gvjs_ut || e === gvjs_U)
+    for (f = gvjs_UA([f, a]),
+           a = 0; a < f.vc.length - 1; a++)
+      c.path.Cj(f.vc[a]);
+  if (e === gvjs_ut || e === gvjs_S)
+    for (e = gvjs_UA([b, d]),
+           a = 0; a < e.vc.length - 1; a++)
+      c.path.Cj(e.vc[a]);
+  c.path.close()
+}
+function gvjs_sK(a, b, c, d) {
+  var e = b.C[c];
+  if ((e.type == gvjs_e || e.type == gvjs_at || e.type == gvjs_Dd) && 0 < e.lineWidth) {
+    var f = gvjs_nK(d, c);
+    f.nj = {};
+    f = f.nj;
+    var g = e.type == gvjs_at ? b.vp !== gvjs_f ? gvjs_4G(e) : gvjs_3G(e, !1) : gvjs_3G(e, b.Zj);
+    g = gvjs_7B(g);
+    f.brush = new gvjs_3({
+      stroke: e.Oc.Uj(),
+      strokeWidth: Math.min(1, e.Oc.strokeWidth / 2)
+    });
+    f.path = gvjs_cC(g, -(e.Oc.strokeWidth / 2 + 2 + f.brush.strokeWidth / 2))
+  }
+  for (f = 0; f < e.points.length; ++f)
+    g = e.points[f],
+    gvjs_XG(g) || (gvjs_ZG(g, e) || gvjs__G(e, f) && !b.Zj) && gvjs_pK(a, b, c, f, d);
+  b.kd && e.type === gvjs_Dd && !a.fL(e.columns) && gvjs_sK(a, b, c - 1, d)
+}
+function gvjs_zga(a, b, c, d) {
+  for (var e = b.C, f = 0; f < e.length; ++f) {
+    var g = gvjs_7F(b, f, c);
+    null != g && gvjs_pK(a, b, f, g, d)
+  }
+}
+function gvjs_yK(a, b, c, d) {
+  c = gvjs_kK(b.Yv, c.Hb, c.Eb);
+  var e = null != b.zk;
+  c.tooltip = d;
+  e && a.le.Us(d, b.zk, c.tooltip)
+}
+function gvjs_qK(a, b, c, d) {
+  var e = gvjs_fK(a.Cp, b, c, d, null);
+  null != e && gvjs_yK(a, b, {
+    Hb: c,
+    Eb: d
+  }, e)
+}
+function gvjs_yga(a, b, c, d) {
+  var e = a.Cp;
+  var f = a.KV
+    , g = b.Ea
+    , h = gvjs_$J(g, d.Hb, d.Eb)
+    , k = gvjs_eK(g, d.Hb, d.Eb);
+  c = gvjs_4J(e.es, b, c, f);
+  e = gvjs_kG(c, g.sc, !0, h, e.af, k, void 0, g.$f, g.bw, g.ax);
+  gvjs_yK(a, b, d, e)
+}
+function gvjs_Aga(a, b, c, d) {
+  if (c) {
+    c = gvjs_uga(a.Cp, b, d, c, a.KV);
+    d = gvjs_mK(b.Yv, d[d.length - 1]);
+    var e = null != b.zk;
+    d.tooltip = c;
+    e && a.le.Us(c, b.zk, d.tooltip)
+  }
+}
+function gvjs_tK(a, b, c, d) {
+  if (c) {
+    var e = gvjs_mK(b.Yv, d)
+      , f = null != b.zk;
+    c = gvjs_fK(a.Cp, b, null, d, null, c);
+    null !== c && (e.tooltip = c,
+    f && a.le.Us(c, b.zk, e.tooltip))
+  }
+}
+function gvjs_rK(a, b, c, d, e) {
+  if (null != c && null != e) {
+    var f = gvjs_lK(b.Yv, c, d);
+    f.labels = f.labels || {};
+    f = f.labels;
+    f[e] = f[e] || {};
+    f = f[e];
+    var g = null != b.zk;
+    c = gvjs_fK(a.Cp, b, c, d, e);
+    f.xa = c;
+    g && c && a.le.Us(c, b.zk, f.xa)
+  }
+}
+function gvjs_Bga(a, b, c, d) {
+  if (a.Vi) {
+    var e = a.Vi;
+    a = gvjs_0H(e.scale, e.SH, [{
+      value: a.C[b].points[c].Kf.color
+    }], a.sc);
+    d.Vi = {
+      definition: a
+    }
+  }
+}
+function gvjs_xga(a, b, c, d) {
+  a = gvjs_lK(d, a, b);
+  a.labels = a.labels || {};
+  a = a.labels;
+  a[c] = a[c] || {};
+  c = a[c];
+  c.ja = c.ja || {};
+  c.ja.bold = !0
+}
+function gvjs_vga(a, b, c, d) {
+  var e = {
+    Ea: b,
+    yk: [],
+    Yv: d,
+    zk: null
+  }
+    , f = c.focused.Hb
+    , g = c.focused.datum;
+  b.legend && gvjs_tga(a.Cp, new gvjs_B(0,b.legend.area.left,b.height,0));
+  var h = a.Cp.u5;
+  if (null != f && null == g) {
+    var k = c.cursor.position.x
+      , l = b.C[f].points;
+    g = gvjs_De(l, function(p) {
+      return null != p
+    });
+    for (var m = 0; m < g.length && g[m].ia.x < k; )
+      m++;
+    0 == m ? g = 0 : m == g.length ? g = g.length - 1 : (k = k < gvjs_bz(g[m - 1].ia.x, g[m].ia.x) ? m - 1 : m,
+      g = gvjs_Be(l, g[k]));
+    a.jQ = !1
+  }
+  l = null;
+  if (null != g)
+    for (l = gvjs_kK(d, f, g),
+           l.visible = !0,
+         h == gvjs_xu && gvjs_qK(a, e, f, g),
+         b.legend && (l = gvjs_oK(d, f),
+           l.Rg = {
+             isVisible: b.Ofa
+           }),
+           l = 0; l < b.C.length; l++)
+      l != f && (b.legend && (g = gvjs_oK(d, l),
+        g.Da = {
+          ja: {
+            color: gvjs_ur
+          }
+        }),
+        g = gvjs_nK(d, l),
+        k = b.C[l],
+        g.Oc = k.Oc.clone(),
+        gvjs_ay(g.Oc, .3));
+  if (f = c.annotations.dI)
+    f = gvjs_lK(d, f.Vb, f.oO),
+      f.Rp = f.Rp || {},
+      f.Rp.Eba = !0;
+  if (g = c.annotations.focused)
+    l = b.Jk[g.column],
+      f = l.Vb,
+      g = b.Ds[g.row],
+      l = l.wE,
+    (null != f ? b.C[f].Yg : b.Yg) && gvjs_rK(a, e, f, g, l);
+  if (b.legend && b.legend.position == gvjs_ov && null != c.legend.focused.Xc) {
+    c = c.legend.focused.Xc;
+    l = gvjs_oK(d, c);
+    l.Rg = {
+      isVisible: b.Ofa
+    };
+    f = b.C[c].points;
+    for (l = f.length - 1; 0 <= l; l--)
+      if (g = f[l],
+      !gvjs_XG(g) && g.ia && (new gvjs_B(b.O.top,b.O.right,b.O.bottom,b.O.left)).contains(new gvjs_z(g.ia.x,g.ia.y))) {
+        var n = l;
+        break
+      }
+    null != n && (l = gvjs_kK(d, c, n),
+      l.visible = !0,
+    h == gvjs_xu && gvjs_qK(a, e, c, n));
+    for (l = 0; l < b.C.length; l++)
+      l != c && (g = gvjs_oK(d, l),
+        g.Da = {
+          ja: {
+            color: gvjs_ur
+          }
+        },
+        g = gvjs_nK(d, l),
+        k = b.C[l],
+        g.Oc = k.Oc.clone(),
+        gvjs_ay(g.Oc, .3))
+  }
+}
+var gvjs_Ega = [.25, .1, .05]
+  , gvjs_xK = [.3, .1, .05]
+  , gvjs_Dga = [.3, .15, .05];
+function gvjs_zK(a, b) {
+  this.ks = a;
+  this.Qx = b;
+  this.$j = gvjs_x(a);
+  var c = a.width != b.width || a.height != b.height;
+  !c && a.O && b.O && (c = a.O.width != b.O.width || a.O.height != b.O.height || a.O.left != b.O.left || a.O.top != b.O.top);
+  this.$j.title && c && (this.$j.title.ja.opacity = 0);
+  this.$j.jd && (this.$j.jd = gvjs_Ny(this.$j.jd, gvjs_x),
+    this.hpa = gvjs_Ny(a.jd, function(d, e) {
+      return gvjs_AK(a.jd[e], b.jd[e], this.$j.jd[e], !0, !1, c)
+    }, this));
+  this.$j.wc && (this.$j.wc = gvjs_Ny(this.$j.wc, gvjs_x),
+    this.Uya = gvjs_Ny(a.wc, function(d, e) {
+      return gvjs_AK(a.wc[e], b.wc[e], this.$j.wc[e], !1, !0, c)
+    }, this));
+  this.Gn = this.qj = null;
+  gvjs_Fga(this);
+  this.hca = this.gca = null;
+  gvjs_Gga(this)
+}
+function gvjs_AK(a, b, c, d, e, f) {
+  if (!a || !b)
+    return null;
+  var g = gvjs_x(a)
+    , h = gvjs_x(a);
+  h.zp = b.zp;
+  h.Pf = b.Pf;
+  h.ef = b.ef;
+  c.title && f && (c.title.ja.opacity = 0);
+  if (a.type == gvjs_Vd && b.type == gvjs_Vd && a.dataType === b.dataType) {
+    a.baseline && b.baseline && (h.baseline = b.baseline,
+      c.baseline = gvjs_x(c.baseline));
+    h.number = gvjs_x(h.number);
+    h.position = gvjs_x(h.position);
+    c.number = gvjs_x(c.number);
+    c.position = gvjs_x(c.position);
+    h.position.hf = b.position.hf;
+    if (a.Ja && b.Ja) {
+      h.Ja = gvjs_Le(h.Ja);
+      c.Ja = gvjs_Le(c.Ja);
+      var k = h.Ja
+        , l = c.Ja;
+      for (f = 0; f < k.length; f++) {
+        k[f] = gvjs_x(k[f]);
+        l[f] = gvjs_x(l[f]);
+        var m = k[f]
+          , n = a.number.hf(m.za);
+        n = b.number.ol(n);
+        m.Na = b.position.hf(n)
+      }
+    }
+    if (a.text && b.text)
+      for (h.text = gvjs_Le(h.text),
+             c.text = gvjs_Le(c.text),
+             k = h.text,
+             c = c.text,
+             gvjs_BK(k),
+             gvjs_BK(c),
+             f = 0; f < k.length; f++)
+        gvjs_Hga(a, b, a.text[f], b.text[f], k[f], d, e)
+  } else if (a.text && b.text) {
+    var p = gvjs_sA(a.text, b.text, function(q, r) {
+      return q.za == r.za
+    });
+    g.text = gvjs_De(a.text, function(q, r) {
+      return null != p.vca[r]
+    });
+    h.text = gvjs_De(b.text, function(q, r) {
+      return null != p.wca[r]
+    });
+    c.text = gvjs_Le(g.text);
+    gvjs_BK(g.text);
+    gvjs_BK(h.text);
+    gvjs_BK(c.text)
+  }
+  return [g, h]
+}
+function gvjs_Hga(a, b, c, d, e, f, g) {
+  var h = e.Da
+    , k = a.number.hf(e.za);
+  k = b.number.ol(k);
+  a = a.position.hf(e.za);
+  b = b.position.hf(k);
+  f && (f = c.Da.anchor.x - a,
+    h.anchor.x = b + f,
+  d && (h.anchor.y = d.Da.anchor.y));
+  g && (f = c.Da.anchor.y - a,
+    h.anchor.y = b + f,
+  d && (h.anchor.x = d.Da.anchor.x))
+}
+function gvjs_BK(a) {
+  gvjs_u(a, function(b, c) {
+    a[c] = gvjs_x(a[c]);
+    b = a[c];
+    b.Da = gvjs_x(b.Da);
+    b = b.Da;
+    b.anchor && (c = b.anchor,
+      b.anchor = new gvjs_HG(c.x,c.y))
+  })
+}
+function gvjs_Fga(a) {
+  var b = a.ks
+    , c = a.Qx;
+  if (b.C && c.C) {
+    var d = gvjs_sA(b.C, c.C, function(e, f) {
+      return e.id == f.id
+    });
+    a.qj = gvjs_De(b.C, function(e, f) {
+      return null != d.vca[f]
+    });
+    a.Gn = gvjs_De(c.C, function(e, f) {
+      return null != d.wca[f]
+    });
+    b.Fa == gvjs_d || b.Fa == gvjs_Dd ? (b = null == b.orientation || b.orientation == gvjs_S ? b.jd[0] : b.wc[0],
+      c = null == c.orientation || c.orientation == gvjs_S ? c.jd[0] : c.wc[0],
+      b.type == gvjs_Vd && c.type == gvjs_Vd && b.dataType === c.dataType ? gvjs_Iga(a, b.number.hf, b.number.ol) : gvjs_Jga(a)) : b.Fa == gvjs_yt && gvjs_Kga(a)
+  }
+}
+function gvjs_Jga(a) {
+  var b = a.ks.$a
+    , c = a.Qx.$a;
+  if (b && c) {
+    var d = {}
+      , e = {}
+      , f = {}
+      , g = {};
+    gvjs_u(b, function(p, q) {
+      null != p.data && (f[p.data] = q)
+    });
+    gvjs_u(c, function(p, q) {
+      null != p.data && (g[p.data] = q)
+    });
+    gvjs_u(b, function(p, q) {
+      null != p.data && (d[q] = g[p.data])
+    });
+    gvjs_u(c, function(p, q) {
+      null != p.data && (p = f[p.data],
+      d[p] !== q && (p = null),
+        e[q] = p)
+    });
+    gvjs_u(b, function(p, q) {
+      null != p.data && e[g[p.data]] !== q && (d[q] = null)
+    });
+    for (var h = 0, k = 0, l = [], m = []; h < b.length || k < c.length; )
+      h < b.length && null == d[h] ? (m.push({
+        Ix: {
+          idx: h,
+          zy: !0
+        },
+        Jx: {
+          idx: k,
+          zy: !1
+        }
+      }),
+        l.push({
+          data: b[h].data
+        }),
+        h++) : (k < c.length && null == e[k] ? (m.push({
+        Ix: {
+          idx: h,
+          zy: !1
+        },
+        Jx: {
+          idx: k,
+          zy: !0
+        }
+      }),
+        l.push({
+          data: c[k].data
+        })) : (m.push({
+        Ix: {
+          idx: h,
+          zy: !0
+        },
+        Jx: {
+          idx: k,
+          zy: !0
+        }
+      }),
+        l.push({
+          data: b[h].data
+        }),
+        h++),
+        k++);
+    a.$j.$a = l;
+    var n = function(p, q) {
+      return 0 == q ? p[0] : q >= p.length ? gvjs_Ae(p) : gvjs_CK(p[q - 1], p[q], .5)
+    };
+    a.ks.kd ? gvjs_DK(a, m, function(p, q, r, t) {
+      return q.zy ? p[q.idx * r + t] : n(p, q.idx * r + t)
+    }) : gvjs_EK(a, m, function(p, q) {
+      return q.zy ? p[q.idx] : n(p, q.idx)
+    })
+  }
+}
+function gvjs_Iga(a, b, c) {
+  var d = a.ks.$a
+    , e = a.Qx.$a;
+  if (d && e)
+    if (0 == d.length || 0 == e.length)
+      a.$j.$a = [],
+        gvjs_EK(a, [], function() {
+          return null
+        });
+    else {
+      var f = function(l) {
+        return b(l.data)
+      }
+        , g = []
+        , h = [];
+      if (d.length === e.length)
+        for (var k = 0; k < d.length; k++)
+          h.push({
+            Ix: k,
+            Jx: k
+          }),
+            g.push({
+              data: c(gvjs_bz(f(d[k]), f(e[k])))
+            });
+      else
+        k = gvjs_Kda(d, e, f),
+          gvjs_u(k, function(l) {
+            var m = l.yB;
+            l = l.zB;
+            var n;
+            null != d[m] && null != e[l] && (n = c(gvjs_bz(f(d[m]), f(e[l]))));
+            null != n && (h.push({
+              Ix: m,
+              Jx: l
+            }),
+              g.push({
+                data: n
+              }))
+          });
+      a.$j.$a = g;
+      a.ks.kd ? gvjs_DK(a, h, function(l, m, n, p) {
+        return l[m * n + p]
+      }) : gvjs_EK(a, h, function(l, m) {
+        return l[m]
+      })
+    }
+}
+function gvjs_Kga(a) {
+  function b(l) {
+    l = gvjs_x(l);
+    l.ia = gvjs_x(l.ia);
+    l.ia.brush = l.ia.brush.clone();
+    l.ia.brush.mf(0);
+    gvjs_ay(l.ia.brush, 0);
+    l.ja = gvjs_x(l.ja);
+    l.ja.opacity = 0;
+    return l
+  }
+  var c = a.qj[0].points
+    , d = a.Gn[0].points
+    , e = []
+    , f = []
+    , g = []
+    , h = {};
+  gvjs_u(d, function(l, m) {
+    null != l && (void 0 === h[l.id] && (h[l.id] = []),
+      h[l.id].push(m))
+  });
+  gvjs_w(c, function(l, m) {
+    if (null != l) {
+      var n = l.id && h[l.id];
+      n = n && n.shift();
+      void 0 !== n ? g.push({
+        Ix: m,
+        Jx: n
+      }) : e.push(l)
+    }
+  });
+  gvjs_w(h, function(l) {
+    gvjs_u(l, function(m) {
+      f.push(d[m])
+    })
+  });
+  gvjs_EK(a, g, function(l, m) {
+    return l[m]
+  });
+  c = gvjs_v(e, b);
+  var k = gvjs_v(f, b);
+  a.qj[0].nC = gvjs_Ke(e, k);
+  a.Gn[0].nC = gvjs_Ke(c, f)
+}
+function gvjs_EK(a, b, c) {
+  for (var d = 0; d < a.qj.length; d++) {
+    var e = a.qj[d].points
+      , f = a.Gn[d].points
+      , g = []
+      , h = [];
+    if (a.qj[d].ag)
+      g = gvjs_Le(a.qj[d].points),
+        h = gvjs_Le(a.Gn[d].points);
+    else
+      for (var k = 0; k < b.length; k++) {
+        var l = b[k]
+          , m = c(e, l.Ix);
+        l = c(f, l.Jx);
+        m && l && (g.push(m),
+          h.push(l))
+      }
+    a.qj[d] = gvjs_FK(a.qj[d], g);
+    a.Gn[d] = gvjs_FK(a.Gn[d], h)
+  }
+}
+function gvjs_DK(a, b, c) {
+  for (var d = 0; d < a.qj.length; d++) {
+    var e = a.qj[d].points
+      , f = a.Gn[d].points
+      , g = []
+      , h = [];
+    if (0 < b.length)
+      for (var k = Math.ceil(e.length / b.length), l = Math.ceil(f.length / b.length), m = 0; m < b.length; m++) {
+        for (var n = b[m], p = 0; p < k; p++) {
+          var q = c(e, n.Ix, k, p);
+          q && g.push(q)
+        }
+        for (p = 0; p < l; p++)
+          (q = c(f, n.Jx, l, p)) && h.push(q)
+      }
+    a.qj[d] = gvjs_FK(a.qj[d], g);
+    a.Gn[d] = gvjs_FK(a.Gn[d], h)
+  }
+}
+function gvjs_FK(a, b) {
+  a = gvjs_x(a);
+  a.points = b;
+  return a
+}
+function gvjs_Gga(a) {
+  var b = a.ks
+    , c = a.Qx;
+  b.legend && b.legend.Pe && c.legend && c.legend.Pe && (a.$j.legend = null)
+}
+function gvjs_GK(a, b, c) {
+  if (a === b)
+    return a;
+  if (a && a.constructor == gvjs_3 && b && b.constructor == gvjs_3)
+    return new gvjs_3({
+      fill: gvjs_7z(a.fill, b.fill, 1 - c),
+      fillOpacity: gvjs_GK(a.fillOpacity, b.fillOpacity, c),
+      stroke: gvjs_7z(a.Uj(), b.Uj(), 1 - c),
+      strokeWidth: gvjs_GK(a.strokeWidth, b.strokeWidth, c),
+      strokeOpacity: gvjs_GK(a.strokeOpacity, b.strokeOpacity, c),
+      Mi: a.Mi,
+      gradient: a.gradient,
+      pattern: a.pattern
+    });
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a)
+      if (b) {
+        for (var d = [], e = Math.min(a.length, b.length), f = 0; f < e; f++)
+          d.push(gvjs_GK(a[f], b[f], c));
+        c = d
+      } else
+        c = a;
+    else
+      c = b;
+    return c
+  }
+  return gvjs_r(a) || gvjs_r(b) ? gvjs_HK(a, b, c) : typeof a === gvjs_l || typeof b === gvjs_l ? a : typeof a === gvjs_g && typeof b === gvjs_g ? (a = isNaN(a) ? 0 : a,
+    b = isNaN(b) ? 0 : b,
+    isFinite(a) && isFinite(b) ? a * (1 - c) + b * c : Infinity) : null
+}
+function gvjs_HK(a, b, c) {
+  if (!a)
+    return b;
+  if (!b)
+    return a;
+  var d = {};
+  gvjs_w(a, function(e, f) {
+    void 0 !== b[f] && (d[f] = gvjs_GK(a[f], b[f], c))
+  });
+  return d
+}
+function gvjs_IK(a, b, c, d, e) {
+  b = !e || (c ? b >= c.top && b <= c.bottom : !1);
+  return (!d || (c ? a >= c.left && a <= c.right : !1)) && b
+}
+function gvjs_JK(a, b, c, d, e) {
+  a.position && a.position.hf && b.position && b.position.hf && (c.position.hf = function(f) {
+      var g = a.position.hf(f);
+      f = b.position.hf(f);
+      return gvjs_GK(g, f, e)
+    }
+  );
+  a.title && b.title && gvjs_u(c.title.lines, function(f, g) {
+    f.x = gvjs_GK(a.title.lines[g].x, b.title.lines[g].x, e);
+    f.y = gvjs_GK(a.title.lines[g].y, b.title.lines[g].y, e)
+  });
+  a.baseline && b.baseline && (c.baseline.Na = gvjs_GK(a.baseline.Na, b.baseline.Na, e));
+  a.Ja && b.Ja && gvjs_u(c.Ja, function(f, g) {
+    f.Na = gvjs_GK(a.Ja[g].Na, b.Ja[g].Na, e);
+    f.isVisible = d(f.Na, f.Na)
+  });
+  a.zp && b.zp && (c.zp = gvjs_HK(a.zp, b.zp, e));
+  null != a.Pf && null != b.Pf && (c.Pf = gvjs_GK(a.Pf, b.Pf, e));
+  null != a.ef && null != b.ef && (c.ef = gvjs_GK(a.ef, b.ef, e));
+  a.text && b.text && gvjs_u(c.text, function(f, g) {
+    if (f) {
+      var h = a.text[g].Da;
+      g = b.text[g].Da;
+      var k = f.Da;
+      k && k.anchor && (k.anchor.x = gvjs_GK(h.anchor.x, g.anchor.x, e),
+        k.anchor.y = gvjs_GK(h.anchor.y, g.anchor.y, e));
+      f.Da && (h = 0 < f.Da.lines.length,
+        f.isVisible = d((h ? f.Da.lines[0].x : 0) + f.Da.anchor.x, (h ? f.Da.lines[0].y : 0) + f.Da.anchor.y))
+    }
+  })
+}
+function gvjs_CK(a, b, c) {
+  if (!a || !b)
+    return null;
+  var d = gvjs_x(a);
+  if (a.$l || b.$l)
+    d.$l = !0;
+  if (void 0 !== a.ia || void 0 !== b.ia)
+    d.ia = gvjs_GK(a.ia || {}, b.ia || {}, c),
+      d.Kf = gvjs_GK(a.Kf || {}, b.Kf || {}, c);
+  void 0 !== a.wt && void 0 !== b.wt && (d.wt = gvjs_GK(a.wt, b.wt, c));
+  void 0 !== a.fr && void 0 !== b.fr && (d.fr = gvjs_GK(a.fr, b.fr, c));
+  void 0 !== a.ja && void 0 !== b.ja && a.ja !== b.ja && (d.ja = gvjs_x(a.ja),
+    d.ja.color = gvjs_7z(a.ja.color, b.ja.color, 1 - c),
+    d.ja.opacity = gvjs_GK(void 0 !== a.ja.opacity ? a.ja.opacity : 1, void 0 !== b.ja.opacity ? b.ja.opacity : 1, c));
+  null != a.Bc && null != b.Bc && a.Bc.labels[0].text === b.Bc.labels[0].text ? d.Bc = gvjs_GK(a.Bc, b.Bc, c) : delete d.Bc;
+  return d
+}
+gvjs_zK.prototype.interpolate = function(a) {
+  var b = this.$j;
+  if (b.jd) {
+    var c = function(r, t) {
+      return gvjs_IK(r, t, b.O, !0, !1)
+    };
+    gvjs_w(b.jd, function(r, t) {
+      (t = this.hpa[t]) && gvjs_JK(t[0], t[1], r, c, a)
+    }, this)
+  }
+  if (b.wc) {
+    var d = function(r, t) {
+      return gvjs_IK(r, t, b.O, !1, !0)
+    };
+    gvjs_w(b.wc, function(r, t) {
+      (t = this.Uya[t]) && gvjs_JK(t[0], t[1], r, d, a)
+    }, this)
+  }
+  if (this.qj && this.Gn) {
+    b.C = [];
+    for (var e = 0; e < this.qj.length; ++e) {
+      var f = this.qj[e]
+        , g = this.Gn[e]
+        , h = gvjs_x(g);
+      if (f && g && f.type == g.type) {
+        if (f.points && g.points) {
+          h.points = [];
+          for (var k = 0; k < f.points.length; k++)
+            h.points[k] = gvjs_CK(f.points[k], g.points[k], a);
+          if (f.nC && g.nC)
+            for (k = 0; k < f.nC.length; k++)
+              h.points.push(gvjs_CK(f.nC[k], g.nC[k], a))
+        }
+        f.Df && f.Df.paths && g.Df && g.Df.paths && (h.Df = gvjs_x(h.Df),
+          h.Df.paths = gvjs_GK(f.Df.paths, g.Df.paths, a))
+      }
+      b.C[e] = h
+    }
+  }
+  b.height && (b.height = gvjs_GK(this.ks.height, this.Qx.height, a));
+  b.width && (b.width = gvjs_GK(this.ks.width, this.Qx.width, a));
+  b.O && (b.O = gvjs_GK(this.ks.O, this.Qx.O, a));
+  if (this.gca && this.hca && b.legend && b.legend.ev)
+    for (e = 0; e < b.legend.ev.length; e++) {
+      f = b.legend.ev[e];
+      g = this.gca[e];
+      h = this.hca[e];
+      if (f.Da && f.Da.lines && g.Da && g.Da.lines && 0 != g.Da.lines.length && h.Da && h.Da.lines) {
+        var l = f.Da.lines
+          , m = g.Da.lines
+          , n = h.Da.lines
+          , p = m.length;
+        for (k = 0; k < l.length; k++) {
+          var q = k < p ? m[k] : m[p - 1];
+          l[k].x = gvjs_GK(q.x, n[k].x, a);
+          l[k].y = gvjs_GK(q.y, n[k].y, a)
+        }
+      }
+      f.square && f.square.coordinates && g.square && g.square.coordinates && h.square && h.square.coordinates && (k = gvjs_GK(g.square.coordinates, h.square.coordinates, a),
+        f.square.coordinates = new gvjs_5(k.left,k.top,k.width,k.height));
+      f.Rg && f.Rg.coordinates && g.Rg && g.Rg.coordinates && h.Rg && h.Rg.coordinates && (f.Rg.coordinates = gvjs_GK(g.Rg.coordinates, h.Rg.coordinates, a))
+    }
+  return b
+}
+;
+function gvjs_KK(a) {
+  gvjs_F.call(this);
+  this.KG = a;
+  this.fq = Infinity;
+  this.zJ = 0;
+  a = new gvjs_IA(15);
+  gvjs_6x(this, a);
+  gvjs_G(a, gvjs_dx, gvjs_s(this.Y4, this));
+  this.Hc = a
+}
+gvjs_o(gvjs_KK, gvjs_F);
+function gvjs_LK(a, b) {
+  var c = a.fq;
+  a.fq = Math.min(a.fq, b);
+  isFinite(a.fq) ? isFinite(c) || a.Hc.start() : a.Hc.stop()
+}
+gvjs_KK.prototype.Y4 = function() {
+  var a = Date.now();
+  this.fq -= a - this.zJ;
+  this.zJ = a;
+  0 >= this.fq && (this.KG(),
+    this.fq = Infinity,
+    this.Hc.stop())
+}
+;
+function gvjs_MK(a, b, c, d, e, f) {
+  gvjs_F.call(this);
+  this.ha = a;
+  this.Ra = b;
+  this.Vk = c;
+  this.zd = d;
+  this.zb = new gvjs_KK(e);
+  gvjs_6x(this, this.zb);
+  this.zo = f;
+  this.zo.zb = this.zb;
+  this.S2()
+}
+gvjs_o(gvjs_MK, gvjs_F);
+gvjs_ = gvjs_MK.prototype;
+gvjs_.M = function() {
+  gvjs_li(this.Vk);
+  gvjs_F.prototype.M.call(this)
+}
+;
+gvjs_.xpa = function(a) {
+  this.Ra.cursor.position = a.data.xb;
+  gvjs_LK(this.zb, 5)
+}
+;
+gvjs_.ypa = function() {}
+;
+gvjs_.Apa = function(a) {
+  this.Ra.cursor.position = a.data.xb;
+  this.zd.dispatchEvent(gvjs_5v, {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  })
+}
+;
+gvjs_.Bpa = function(a) {
+  this.zd.dispatchEvent("onmouseup", {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  })
+}
+;
+gvjs_.zpa = function(a) {
+  var b = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  };
+  this.zd.dispatchEvent(gvjs_4v, b);
+  this.zo.xn(gvjs_4v, b, a.data.preventDefault)
+}
+;
+gvjs_.spa = function(a) {
+  this.zd.dispatchEvent(gvjs_Wt, {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  })
+}
+;
+gvjs_.Fpa = function(a) {
+  var b = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  };
+  this.zd.dispatchEvent(gvjs_Aw, b);
+  this.zo.xn(gvjs_Aw, b, a.data.preventDefault)
+}
+;
+gvjs_.tpa = function(a) {
+  this.zd.dispatchEvent(gvjs_du, {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  })
+}
+;
+gvjs_.Gpa = function(a) {
+  var b = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y,
+    wheelDelta: a.data.wheelDelta
+  };
+  this.zd.dispatchEvent(gvjs_Gw, b);
+  this.zo.xn(gvjs_Gw, b, a.data.preventDefault)
+}
+;
+gvjs_.vpa = function(a) {
+  a = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  };
+  this.zd.dispatchEvent(gvjs_pu, a);
+  this.zo.xn(gvjs_pu, a)
+}
+;
+gvjs_.wpa = function(a) {
+  a = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  };
+  this.zd.dispatchEvent(gvjs_nu, a);
+  this.zo.xn(gvjs_nu, a)
+}
+;
+gvjs_.upa = function(a) {
+  a = {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y
+  };
+  this.zd.dispatchEvent(gvjs_ou, a);
+  this.zo.xn(gvjs_ou, a)
+}
+;
+gvjs_.Dpa = function(a) {
+  this.zo.xn("pinchstart", {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y,
+    gesture: a.data.F$
+  }, a.data.preventDefault)
+}
+;
+gvjs_.Epa = function(a) {
+  this.zo.xn("pinch", {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y,
+    gesture: a.data.F$
+  }, a.data.preventDefault)
+}
+;
+gvjs_.Cpa = function(a) {
+  this.zo.xn("pinchend", {
+    targetID: a.data.De,
+    x: a.data.xb.x,
+    y: a.data.xb.y,
+    gesture: a.data.F$
+  }, a.data.preventDefault)
+}
+;
+gvjs_.jaa = function(a) {
+  this.Ra.focused.Eb = a.data.Kk;
+  gvjs_LK(this.zb, 50)
+}
+;
+gvjs_.kaa = function() {
+  this.Ra.cursor.position = null;
+  this.Ra.focused.Eb = null;
+  gvjs_LK(this.zb, 50)
+}
+;
+gvjs_.iaa = function(a) {
+  var b = this
+    , c = this.ha;
+  this.Ra.cursor.p2 = this.Ra.cursor.position.clone();
+  a = a.data.Kk;
+  if (gvjs_Fe(c.C, function(g) {
+    return g.Yg
+  })) {
+    var d = c.$a[a].Cs;
+    a = c.FE == gvjs_Ww;
+    if (!a && c.Ig.has(gvjs_gp)) {
+      var e = new Set
+        , f = new Set;
+      gvjs_u(this.ha.C, function(g) {
+        var h = g.points[d];
+        null == h || h.$l || (g = g.Cs,
+          gvjs_fo(this.Ra.selected, d, g) ? e.add(g) : f.add(g))
+      }, this);
+      c = f.size;
+      0 < e.size && 0 === c ? e.forEach(function(g) {
+        b.Ra.selected.MK(d, g)
+      }) : 0 < c && f.forEach(function(g) {
+        gvjs_go(b.Ra.selected, d, g)
+      })
+    } else
+      gvjs_ty(this.Ra.selected, d, a);
+    gvjs_LK(this.zb, 0)
+  }
+}
+;
+gvjs_.saa = function(a) {
+  this.ha.Fa != gvjs_yt && (this.Ra.legend.focused.Xc = a.data.TQ,
+    gvjs_LK(this.zb, 50))
+}
+;
+gvjs_.taa = function() {
+  this.ha.Fa != gvjs_yt && (this.Ra.legend.focused.Xc = null,
+    gvjs_LK(this.zb, 250))
+}
+;
+gvjs_.nqa = function(a) {
+  this.ha.Fa != gvjs_yt && (gvjs_NK(this, a.data.TQ),
+    gvjs_LK(this.zb, 0))
+}
+;
+gvjs_.oqa = function(a) {
+  null == this.Ra.legend.Xi && (this.Ra.legend.Xi = a.data.Xi || 0,
+    this.Ra.legend.xF = a.data.xF || 0);
+  this.Ra.legend.Xi += a.data.hwa;
+  gvjs_LK(this.zb, 0)
+}
+;
+gvjs_.Baa = function(a) {
+  if (this.ha.Fa != gvjs_yt) {
+    var b = this.ha.qz;
+    if (this.ha.Ig.has(gvjs_Mw) || b == gvjs_lu)
+      this.Ra.focused.Hb = a.data.Vb,
+        gvjs_LK(this.zb, 50)
+  }
+}
+;
+gvjs_.Caa = function() {
+  if (this.ha.Fa != gvjs_yt) {
+    var a = this.ha.qz;
+    if (this.ha.Ig.has(gvjs_Mw) || a == gvjs_lu)
+      this.Ra.focused.Hb = null,
+        gvjs_LK(this.zb, 250)
+  }
+}
+;
+gvjs_.Aaa = function(a) {
+  this.ha.Fa != gvjs_yt && this.ha.Ig.has(gvjs_Mw) && (gvjs_NK(this, a.data.Vb),
+    gvjs_LK(this.zb, 0))
+}
+;
+gvjs_.Nqa = function(a) {
+  this.saa(a)
+}
+;
+gvjs_.Oqa = function(a) {
+  this.taa(a)
+}
+;
+gvjs_.Mqa = function(a) {
+  this.zd.dispatchEvent("removeserie", {
+    index: a.data.TQ
+  })
+}
+;
+gvjs_.Opa = function(a) {
+  var b = this.ha.Ig;
+  if (b.has(gvjs_gp))
+    this.Ra.focused.Hb = a.data.Vb,
+      this.Ra.focused.datum = a.data.Kk;
+  else {
+    if (b.has(gvjs_Mw)) {
+      this.Baa(a);
+      return
+    }
+    if (b.has(gvjs_Ht)) {
+      this.jaa(a);
+      return
+    }
+  }
+  gvjs_LK(this.zb, 50)
+}
+;
+gvjs_.Ppa = function(a) {
+  var b = this.ha.Ig;
+  if (b.has(gvjs_gp))
+    this.Ra.focused.Hb = null,
+      this.Ra.focused.datum = null;
+  else {
+    if (b.has(gvjs_Mw)) {
+      this.Caa(a);
+      return
+    }
+    if (b.has(gvjs_Ht)) {
+      this.kaa(a);
+      return
+    }
+  }
+  gvjs_LK(this.zb, 250)
+}
+;
+gvjs_.Npa = function(a) {
+  var b = this.ha;
+  if (b.Ig.has(gvjs_gp)) {
+    var c = b.FE == gvjs_Ww;
+    a = {
+      Eb: a.data.Kk,
+      Hb: a.data.Vb
+    };
+    var d = b.C[a.Hb];
+    d.Yg && (b.Fa == gvjs_yt ? gvjs_ty(this.Ra.selected, a.Eb, c) : d.ag || (b = b.eZ(a),
+      a = this.ha.Ig,
+      a.has(gvjs_gp) ? gvjs_vy(this.Ra.selected, b.row, b.column, c) : a.has(gvjs_Mw) && gvjs_uy(this.Ra.selected, b.column, c)));
+    gvjs_LK(this.zb, 0)
+  } else
+    b.Ig.has(gvjs_Mw) ? this.Aaa(a) : b.Ig.has(gvjs_Ht) && this.iaa(a)
+}
+;
+gvjs_.opa = function(a) {
+  var b = a.data.lG;
+  -1 != b && (this.Ra.annotations.focused = {
+    row: a.data.Kk,
+    column: gvjs_OK(this, a.data.Vb, b)
+  },
+    this.Ra.focused.Hb = null,
+    this.Ra.focused.datum = null,
+    gvjs_LK(this.zb, 50))
+}
+;
+gvjs_.ppa = function(a) {
+  -1 != a.data.lG && (this.Ra.annotations.focused = null,
+    gvjs_LK(this.zb, 250))
+}
+;
+gvjs_.npa = function(a) {
+  var b = this.ha
+    , c = b.FE == gvjs_Ww
+    , d = a.data.Kk
+    , e = a.data.Vb;
+  a = a.data.lG;
+  if (null == e || b.C[e].Yg)
+    -1 == a ? this.Ra.annotations.dI = {
+      Vb: e,
+      oO: d
+    } : gvjs_vy(this.Ra.selected, d, gvjs_OK(this, e, a), c);
+  gvjs_LK(this.zb, 0)
+}
+;
+gvjs_.bra = function() {}
+;
+gvjs_.cra = function() {}
+;
+gvjs_.kpa = function(a) {
+  this.Ra.gi.focused.wy = a.data.wy;
+  gvjs_LK(this.zb, 50)
+}
+;
+gvjs_.lpa = function() {
+  this.Ra.gi.focused.wy = null;
+  gvjs_LK(this.zb, 250)
+}
+;
+gvjs_.jpa = function() {
+  var a = this.Ra.gi.focused.action;
+  a && a();
+  gvjs_LK(this.zb, 250)
+}
+;
+gvjs_.Bq = function() {
+  this.zo.xn(gvjs_i)
+}
+;
+function gvjs_OK(a, b, c) {
+  a = a.ha;
+  var d = null;
+  if (null != b)
+    d = a.C[b].columns.annotation;
+  else
+    for (b = 0; b < a.Mk.length; ++b)
+      d = a.Mk[b].columns.annotation;
+  return d[c]
+}
+gvjs_.S2 = function() {
+  var a = gvjs_s(function(b, c) {
+    gvjs_G(this.Vk, b, gvjs_s(c, this))
+  }, this);
+  a("chartHoverIn", this.xpa);
+  a("chartHoverOut", this.ypa);
+  a(gvjs_Qt, this.Apa);
+  a("chartMouseUp", this.Bpa);
+  a(gvjs_Pt, this.zpa);
+  a("chartClick", this.spa);
+  a(gvjs_Rt, this.Fpa);
+  a("chartDblClick", this.tpa);
+  a("chartScroll", this.Gpa);
+  a(gvjs_Ot, this.vpa);
+  a("chartDrag", this.wpa);
+  a("chartDragEnd", this.upa);
+  a("chartPinchStart", this.Dpa);
+  a("chartPinch", this.Epa);
+  a("chartPinchEnd", this.Cpa);
+  a("categoryHoverIn", this.jaa);
+  a("categoryHoverOut", this.kaa);
+  a("categoryClick", this.iaa);
+  a("legendEntryHoverIn", this.saa);
+  a("legendEntryHoverOut", this.taa);
+  a("legendEntryClick", this.nqa);
+  a("legendScrollButtonClick", this.oqa);
+  a("serieHoverIn", this.Baa);
+  a("serieHoverOut", this.Caa);
+  a("serieClick", this.Aaa);
+  a("removeSerieButtonHoverIn", this.Nqa);
+  a("removeSerieButtonHoverOut", this.Oqa);
+  a("removeSerieButtonClick", this.Mqa);
+  a("datumHoverIn", this.Opa);
+  a("datumHoverOut", this.Ppa);
+  a("datumClick", this.Npa);
+  a("annotationHoverIn", this.opa);
+  a("annotationHoverOut", this.ppa);
+  a("annotationClick", this.npa);
+  a("tooltipHoverIn", this.bra);
+  a("tooltipHoverOut", this.cra);
+  a("actionsMenuEntryHoverIn", this.kpa);
+  a("actionsMenuEntryHoverOut", this.lpa);
+  a("actionsMenuEntryClick", this.jpa)
+}
+;
+function gvjs_NK(a, b) {
+  var c = a.ha;
+  if (c.C[b].Yg) {
+    var d = c.FE == gvjs_Ww
+      , e = c.Ig
+      , f = c.C[b].Cs;
+    if (c.Fa == gvjs_fw)
+      gvjs_ty(a.Ra.selected, f, d);
+    else if (!d && e.has(gvjs_gp)) {
+      var g = new Set
+        , h = new Set;
+      gvjs_u(a.ha.C[b].points, function(k, l) {
+        null == k || k.$l || (gvjs_fo(this.Ra.selected, l, f) ? g.add(l) : h.add(l))
+      }, a);
+      b = h.size;
+      0 < g.size && 0 === b ? g.forEach(function(k) {
+        a.Ra.selected.MK(k, f)
+      }) : 0 < b && h.forEach(function(k) {
+        gvjs_go(a.Ra.selected, k, f)
+      })
+    } else
+      gvjs_uy(a.Ra.selected, f, d)
+  }
+}
+;function gvjs_PK() {}
+gvjs_o(gvjs_PK, gvjs_6F);
+gvjs_ = gvjs_PK.prototype;
+gvjs_.iP = function(a) {
+  var b = a.Hb
+    , c = a.Eb;
+  return this.fz ? gvjs_6F.prototype.iP.call(this, a) : this.C[b].properties.histogramBucketItems[c].label.Mx
+}
+;
+gvjs_.dZ = function(a) {
+  return this.fz ? gvjs_6F.prototype.dZ.call(this, a) : this.C[a.Hb].properties.histogramBucketItems[a.Eb].row
+}
+;
+gvjs_.eZ = function(a) {
+  if (this.fz)
+    return gvjs_6F.prototype.eZ.call(this, a);
+  a = this.C[a.Hb].properties.histogramBucketItems[a.Eb];
+  return {
+    row: a.row,
+    column: a.column
+  }
+}
+;
+gvjs_.lP = function(a) {
+  var b = this.Jk[a.column].Vb;
+  return null == b ? null : this.fz ? gvjs_6F.prototype.lP.call(this, a) : {
+    Hb: b,
+    Eb: this.C[b].properties.histogramElementIndexes[a.row]
+  }
+}
+;
+gvjs_.xI = function(a, b) {
+  a = this.C[a];
+  var c = a.points[b];
+  return this.fz ? {
+    lines: [{
+      title: "Items",
+      value: gvjs_qA(15, (this.orientation === gvjs_S ? this.wc[a.Qc] : this.jd[a.Qc]).number.ol(c.Kf.uk - c.Kf.from))
+    }]
+  } : a.properties.histogramBucketItems[b].label
+}
+;
+function gvjs_QK(a, b, c, d, e) {
+  gvjs_eJ.call(this, a, b, c, d, e)
+}
+gvjs_o(gvjs_QK, gvjs_eJ);
+gvjs_QK.prototype.nz = function() {
+  return gvjs_eJ.prototype.nz.call(this)
+}
+;
+gvjs_QK.prototype.B8 = function() {
+  return new gvjs_PK
+}
+;
+gvjs_QK.prototype.M8 = function() {
+  var a = this.Ta
+    , b = a.W(0) === gvjs_l ? 1 : 0
+    , c = a.$();
+  this.cQ = new gvjs_M;
+  for (this.cQ.xd(gvjs_g, gvjs_8c); b < c; b++) {
+    var d = a.Ga(b) + " (count)";
+    this.cQ.xd(gvjs_g, d)
+  }
+  this.lb = this.cQ
+}
+;
+gvjs_QK.prototype.mea = function() {
+  var a = this.Ta
+    , b = a.W(0) === gvjs_l
+    , c = b ? 1 : 0
+    , d = a.ca()
+    , e = a.$();
+  this.toNumber = [];
+  for (var f = c; f < e; f++)
+    this.toNumber[f] = gvjs_7H(a.W(f)).toNumber;
+  a = gvjs_Lga(this);
+  var g = gvjs_Le(a)
+    , h = gvjs_v(a, function(u) {
+    return gvjs_r(u) ? u.v : u
+  })
+    , k = h.length
+    , l = (h[1] - h[0]).toPrecision(15) - 0
+    , m = h[0].toPrecision(15) - 0
+    , n = h[k - 1].toPrecision(15) - 0;
+  a = [];
+  for (f = c; f < e; f++) {
+    a[f - c] = [];
+    for (var p = 0; p < k; p++)
+      a[f - c].push([])
+  }
+  f = this.cQ;
+  f.rA(0, gvjs_8u, g);
+  for (g = 0; g < k; g++) {
+    p = [h[g]];
+    for (var q = c; q < e; q++)
+      p.push(0);
+    f.Kp(p)
+  }
+  for (h = 0; h < d; h++)
+    for (g = b ? this.Ta.getValue(h, 0) : "",
+           p = c; p < e; p++)
+      if (q = this.Ta.getValue(h, p),
+        q = null != q ? this.toNumber[p](q) : null,
+      (typeof q !== gvjs_g || isFinite(q)) && (null != q || this.V.Zj)) {
+        q = q || 0;
+        q = 0 == l || q < m ? 0 : q >= n ? k - 1 : Math.floor((q - m) / l);
+        var r = p + 1 - c;
+        f.Wa(q, r, (f.getValue(q, r) || 0) + 1);
+        r = this.Ta.Ga(p) || "Value";
+        r = {
+          row: h,
+          column: p,
+          label: {
+            title: g,
+            Mx: g,
+            En: r,
+            content: this.Ta.Ha(h, p),
+            lines: [{
+              title: r,
+              value: this.Ta.Ha(h, p) || 0
+            }]
+          }
+        };
+        a[p - c][q].push(r)
+      }
+  var t = [];
+  for (b = c; b < e; b++)
+    t[b] = [];
+  b = gvjs_K(this.options, "histogram.sortBucketItems");
+  for (d = c; d < e; d++)
+    k = gvjs_Ly(a[d - c]),
+    b && k.sort(function(u, v) {
+      u = u.label.lines[0].value;
+      v = v.label.lines[0].value;
+      return u < v ? -1 : u > v ? 1 : 0
+    }),
+      f.rA(d - c, "histogramBucketItems", k),
+      gvjs_u(k, function(u, v) {
+        t[u.column][u.row] = v
+      });
+  for (a = c; a < e; a++)
+    f.rA(a - c, "histogramElementIndexes", t[a])
+}
+;
+function gvjs_Lga(a) {
+  var b = a.Ta
+    , c = b.ca()
+    , d = b.$()
+    , e = b.W(0) === gvjs_l ? 1 : 0
+    , f = a.options.$I("histogram.buckets");
+  if (f)
+    return f;
+  f = [];
+  for (var g = 0; g < c; g++)
+    for (var h = e; h < d; h++) {
+      var k = b.getValue(g, h);
+      k = null != k ? a.toNumber[h](k) : null;
+      typeof k === gvjs_g && !isFinite(k) || null == k && !a.V.Zj || (k = k || 0,
+        f.push(k))
+    }
+  f = f.sort(function(m, n) {
+    return m - n
+  });
+  d = gvjs_L(a.options, gvjs_7u, 0);
+  b = f[Math.max(0, Math.ceil(d / 100 * f.length) - 1)];
+  f = f[Math.min(f.length - 1, Math.ceil((100 - d) / 100 * f.length) - 1)];
+  d = a.options.Aa("histogram.minValue");
+  e = a.options.Aa("histogram.maxValue");
+  null != d && (b = Math.min(d, b));
+  null != e && (f = Math.max(e, f));
+  d = a.V.O.left;
+  e = d + a.V.O.width;
+  g = gvjs_L(a.options, "histogram.minSpacing", 1);
+  k = gvjs_L(a.options, "histogram.minNumBuckets", 2);
+  h = gvjs_L(a.options, "histogram.maxNumBuckets", (e - d) / g);
+  var l = a.options.cb("histogram.numBucketsRule", gvjs_Mga);
+  c = (0,
+    gvjs_Nga[l])(c);
+  c = Math.max(k, Math.min(h, c));
+  c == k && (c = Math.min(2 * c, (k + h) / 2));
+  k = Math.max(g, (e - d) / (2 + c));
+  l = (f - b) / c;
+  a = a.options.Aa(gvjs_5u);
+  null != a && (0 >= a ? a = null : l = a,
+    c = Math.min(h, (f - b) / l),
+    k = Math.max(g, (e - d) / (2 * c)));
+  b -= Math.min(l, Math.abs(b));
+  f += Math.min(l, Math.abs(f));
+  a = gvjs_$ea(b, f, d, e, new gvjs_Aj([{
+    gridlines: {
+      minSpacing: k
+    }
+  }]));
+  return f = gvjs_v(a, function(m) {
+    return m.getValue()
+  })
+}
+function gvjs_uJ(a, b) {
+  return 4 > a || b
+}
+function gvjs_hga(a, b) {
+  var c = a.lb
+    , d = a.V;
+  a = [];
+  for (var e = 0; e < d.$a.length; e++) {
+    a[e] = [];
+    for (var f = 0; f < d.C.length; f++) {
+      var g = d.C[f];
+      if (g.type == gvjs_lt) {
+        var h = b ? 0 : f;
+        a[e][h] = (a[e][h] || 0) + c.getValue(e, g.columns.data[0])
+      }
+    }
+  }
+  for (c = b = 0; c < a.length; c++)
+    for (d = 0; d < a[c].length; d++)
+      b = Math.max(a[c][d], b);
+  return b
+}
+var gvjs_Mga = {
+  SQRT: "sqrt",
+  CBa: "sturges",
+  jBa: "rice"
+}
+  , gvjs_Nga = {
+  sqrt: function(a) {
+    return Math.sqrt(a)
+  },
+  rice: function(a) {
+    return 2 * Math.cbrt(a)
+  },
+  sturges: function(a) {
+    return 1 + Math.log2(a)
+  }
+};
+function gvjs_RK(a, b, c, d, e) {
+  var f = a.right - a.left
+    , g = gvjs_x(d)
+    , h = gvjs_x(d);
+  h.color = "9e9e9e";
+  d = d.fontSize / 3.236;
+  var k = g.fontSize + d
+    , l = h.fontSize + d
+    , m = gvjs_Oga(a, f, b, g, h, d, e)
+    , n = [];
+  if (2 == c) {
+    c = a.right;
+    a = a.left;
+    var p = gvjs_R
+  } else
+    c = a.left,
+      a = a.right,
+      p = gvjs_2;
+  for (var q = 0; q < e.length; ++q) {
+    var r = e[q]
+      , t = m[q];
+    if (null != t) {
+      var u = gvjs_DG(b, r.pB, g, f, t.dG)
+        , v = gvjs_DG(b, r.EB, h, f, t.DG)
+        , w = gvjs_2I(new gvjs_ok(c,t.y));
+      n.push({
+        gga: 2,
+        wp: gvjs_2I(r.Rda(gvjs_0g(t.y, r.aS.start, r.aS.end))),
+        K8: a,
+        YH: w,
+        Bxa: new gvjs_3({
+          fill: "636363",
+          fillOpacity: .7
+        }),
+        Oc: new gvjs_3({
+          stroke: "636363",
+          strokeWidth: 1,
+          strokeOpacity: .7
+        }),
+        HEa: d,
+        pB: {
+          text: r.pB,
+          ja: g,
+          anchor: new gvjs_HG(w.x,w.y),
+          lines: gvjs_v(u.lines, function(x, y) {
+            return {
+              x: 0,
+              y: (y - u.lines.length) * k,
+              length: u.Oq,
+              text: x
+            }
+          }),
+          ld: p,
+          Pc: gvjs_2,
+          tooltip: u.oe ? r.pB : "",
+          angle: 0
+        },
+        aCa: g,
+        EB: {
+          text: r.EB,
+          ja: h,
+          anchor: new gvjs_HG(w.x,w.y),
+          lines: gvjs_v(v.lines, function(x, y) {
+            return {
+              x: 0,
+              y: (y + 1) * l,
+              length: v.Oq,
+              text: x
+            }
+          }),
+          ld: p,
+          Pc: gvjs_R,
+          tooltip: v.oe ? r.EB : "",
+          angle: 0
+        },
+        pCa: h,
+        W6: p,
+        index: r.index
+      })
+    }
+  }
+  return n
+}
+function gvjs_Oga(a, b, c, d, e, f, g) {
+  var h = d.fontSize + f
+    , k = e.fontSize + f
+    , l = gvjs_v(g, function(r, t) {
+    var u = gvjs_DG(c, r.pB, d, b, Infinity)
+      , v = gvjs_DG(c, r.EB, e, b, Infinity);
+    return {
+      $H: t,
+      u2: r.oea,
+      Cx: r.oea,
+      dG: u.lines.length,
+      DG: v.lines.length,
+      PM: f,
+      mN: f
+    }
+  });
+  gvjs_Qe(l, function(r, t) {
+    return r.Cx - t.Cx
+  });
+  l = gvjs_Le(l);
+  gvjs_Qe(l, function(r, t) {
+    return g[r.$H].kba - g[t.$H].kba
+  });
+  var m = [];
+  0 < l.length && m.push(l.pop());
+  for (var n = null, p = 0, q; q = gvjs_SK(a, h, k, g, m, !1),
+    !(0 === l.length || q.aM && 15 < p); )
+    q.aM ? (p++,
+    n && gvjs_Ie(m, n)) : p = 0,
+      n = l.pop(),
+      m.push(n),
+      gvjs_Qe(m, function(r, t) {
+        return r.Cx - t.Cx
+      });
+  q.aM && n && (gvjs_Ie(m, n),
+    q = gvjs_SK(a, h, k, g, m, !1));
+  a = gvjs_SK(a, h, k, g, m, !0);
+  a.aM || (q = a);
+  return q.layout
+}
+function gvjs_SK(a, b, c, d, e, f) {
+  0 < e.length && (e[0].PM = 0,
+    gvjs_Ae(e).mN = 0);
+  for (var g = 0; g < e.length; g++) {
+    var h = e[g]
+      , k = e[g - 1]
+      , l = e[g + 1];
+    h.e7 = new gvjs_O(Math.min(h.u2, k ? d[k.$H].aS.start + 5 : a.top),Math.max(h.u2, l ? d[l.$H].aS.end - 5 : a.bottom))
+  }
+  a = gvjs_Pga(a, b, c, e, f);
+  d = !1;
+  f = {};
+  for (g = 0; g < e.length; g++) {
+    h = e[g];
+    k = a[g];
+    l = (k.anchor - k.top - h.PM) / b;
+    var m = (k.bottom - k.anchor - h.mN) / c;
+    l = Math.floor(l + .1);
+    m = Math.floor(m + .1);
+    var n = l < h.dG || m < h.DG;
+    d = d || n;
+    f[h.$H] = {
+      y: k.anchor,
+      dG: l,
+      DG: m,
+      aM: n
+    }
+  }
+  return {
+    layout: f,
+    aM: d
+  }
+}
+function gvjs_Pga(a, b, c, d, e) {
+  var f = gvjs_v(d, function(k) {
+    return {
+      anchor: k.Cx,
+      top: k.Cx - (k.dG * b + k.PM),
+      bottom: k.Cx + (k.DG * c + k.mN)
+    }
+  })
+    , g = [];
+  g.push(function(k, l) {
+    var m = k[l].top;
+    if (0 == l)
+      return {
+        top: Math.max(a.top - m, 0)
+      };
+    l = gvjs_jg(l) - 1;
+    return {
+      top: Math.max(k[l].bottom - m, 0) / 2
+    }
+  });
+  g.push(function(k, l) {
+    var m = k[l].bottom;
+    if (l == d.length - 1)
+      return {
+        bottom: Math.min(a.bottom - m, 0)
+      };
+    l = gvjs_jg(l) + 1;
+    return {
+      bottom: Math.min(k[l].top - m, 0) / 2
+    }
+  });
+  g.push(function(k, l, m) {
+    k = k[l].anchor - k[l].top;
+    var n = Math;
+    l = d[l];
+    m = (Math.max(-k, 0) + n.max.call(n, l.dG * b + l.PM - Math.max(k, 0), 0) * (e ? 1 : m)) / 2;
+    return {
+      anchor: m,
+      top: -m
+    }
+  });
+  g.push(function(k, l, m) {
+    k = k[l].bottom - k[l].anchor;
+    var n = Math;
+    l = d[l];
+    m = (Math.max(-k, 0) + n.max.call(n, l.DG * c + l.mN - Math.max(k, 0), 0) * (e ? 1 : m)) / 2;
+    return {
+      anchor: -m,
+      bottom: m
+    }
+  });
+  g.push(function(k, l) {
+    k = k[l].anchor;
+    l = d[l];
+    return {
+      anchor: gvjs_0g(k, l.e7.start, l.e7.end) - k
+    }
+  });
+  e && g.push(function(k, l, m) {
+    return {
+      anchor: (d[l].u2 - k[l].anchor) * m
+    }
+  });
+  var h = gvjs_Lda(f, g, function(k, l) {
+    return {
+      anchor: k.anchor + (l.anchor || 0),
+      top: k.top + (l.top || 0),
+      bottom: k.bottom + (l.bottom || 0)
+    }
+  }, function(k, l) {
+    return Math.max(Math.abs(k.anchor - l.anchor), Math.abs(k.top - l.top), Math.abs(k.bottom - l.bottom))
+  });
+  return gvjs_v(d, function(k, l) {
+    k = h[String(l)];
+    return {
+      anchor: k.anchor,
+      top: k.top,
+      bottom: k.bottom
+    }
+  })
+}
+function gvjs_Qga(a, b) {
+  a = gvjs_Xx(a, function(d) {
+    return d.index == b
+  });
+  if (0 > a)
+    return {};
+  var c = {};
+  c[a] = {
+    gga: 4,
+    Oc: new gvjs_3({
+      stroke: "636363",
+      strokeWidth: 2,
+      strokeOpacity: .7
+    })
+  };
+  return c
+}
+;function gvjs_TK(a, b) {
+  gvjs_LG.call(this, a, b);
+  this.KQ = this.Um = null
+}
+gvjs_o(gvjs_TK, gvjs_LG);
+gvjs_ = gvjs_TK.prototype;
+gvjs_.C9 = function(a, b) {
+  var c = this.renderer;
+  if (1 > a.C.length)
+    return !1;
+  this.Um = b;
+  b = a.pie.Gd;
+  for (var d = a.C.length / b.length, e = 0; e < b.length; ++e) {
+    for (var f = b[e].radiusX, g = b[e].radiusY, h = b[e].cS, k = e * d, l = k + d; k < l && 180 > a.C[k].vd; )
+      gvjs_UK(this, a.C[k], f, g),
+        k += 1;
+    h && gvjs_UK(this, h, f, g);
+    for (h = l - 1; h >= k; --h)
+      gvjs_UK(this, a.C[h], f, g)
+  }
+  a.Jq && (this.KQ = c.Sa(),
+    gvjs_VK(this, a.Jq),
+    c.appendChild(this.Um, this.KQ));
+  return !0
+}
+;
+gvjs_.iY = function(a, b) {
+  if (this.Ea.O5) {
+    var c = a.square.coordinates.height
+      , d = a.square.coordinates.left + a.square.coordinates.width / 2
+      , e = a.square.coordinates.top + c / 2;
+    a = a.square.brush.clone();
+    a.mf(1);
+    gvjs_SG(this, d, e, c / 2, a, {
+      type: gvjs_4o
+    }, b)
+  } else
+    gvjs_LG.prototype.iY.call(this, a, b)
+}
+;
+function gvjs_UK(a, b, c, d) {
+  if (b.isVisible) {
+    var e = a.renderer.Sa()
+      , f = a.Ea
+      , g = f.pie.center
+      , h = b.offset;
+    if (b.dc) {
+      var k = f.pie.eE;
+      var l = b.dc
+        , m = new gvjs_SA;
+      m.move(h.x + l.gf.x, h.y + l.gf.y);
+      m.va(h.x + l.gf.x, h.y + l.gf.y + k);
+      m.Sf(h.x + g.x, h.y + g.y + k, c, d, l.de, l.vd, !0);
+      m.va(h.x + l.ei.x, h.y + l.ei.y);
+      m.Sf(h.x + g.x, h.y + g.y, c, d, l.vd, l.de, !1);
+      a.renderer.Ia(m, l.brush, e)
+    }
+    if (b.kv || b.sy)
+      k = f.pie.eE,
+        l = new gvjs_SA,
+        l.move(h.x + g.x, h.y + g.y),
+        l.va(h.x + g.x, h.y + g.y + k),
+      b.sy && (l.va(h.x + b.ei.x, h.y + b.ei.y + k),
+        l.va(h.x + b.ei.x, h.y + b.ei.y)),
+      b.kv && (l.va(h.x + b.gf.x, h.y + b.gf.y + k),
+        l.va(h.x + b.gf.x, h.y + b.gf.y)),
+        a.renderer.Ia(l, b.qQ, e);
+    l = b.highlight ? b.highlight.brush : b.brush;
+    b.rt ? 0 == b.eJ && 0 == b.gD ? a.renderer.Gl(g.x, g.y, c, d, l, e) : (m = new gvjs_SA,
+      m.move(g.x, g.y - d),
+      m.Sf(g.x, g.y, c, d, 0, 180, !0),
+      m.Sf(g.x, g.y, c, d, 180, 360, !0),
+      m.move(g.x, g.y - b.gD),
+      m.Sf(g.x, g.y, b.eJ, b.gD, 360, 180, !1),
+      m.Sf(g.x, g.y, b.eJ, b.gD, 180, 0, !1),
+      m.close(),
+      a.renderer.Ia(m, l, e)) : (m = new gvjs_SA,
+      m.move(h.x + b.fD.x, h.y + b.fD.y),
+      m.va(h.x + b.gf.x, h.y + b.gf.y),
+      m.Sf(h.x + g.x, h.y + g.y, c, d, b.de, b.vd, !0),
+      m.va(h.x + b.Uv.x, h.y + b.Uv.y),
+      m.Sf(h.x + g.x, h.y + g.y, b.eJ, b.gD, b.vd, b.de, !1),
+      a.renderer.Ia(m, l, e));
+    b.nj && f.Mfa && gvjs_WK(a, b.nj, e);
+    if (c = b.Ko) {
+      c.dc && (d = new gvjs_SA,
+        d.move(c.dc.gf.x, c.dc.gf.y),
+        d.va(c.dc.gf.x, c.dc.gf.y + k),
+        d.Sf(c.dc.di.x, c.dc.di.y + k, c.dc.radiusX, c.dc.radiusY, c.dc.de, c.dc.vd, !0),
+        d.va(c.dc.ei.x, c.dc.ei.y),
+        d.Sf(c.dc.di.x, c.dc.di.y, c.dc.radiusX, c.dc.radiusY, c.dc.vd, c.dc.de, !1),
+        a.renderer.Ia(d, c.dc.brush, e));
+      if (c.kv || c.sy)
+        d = new gvjs_SA,
+          d.move(c.eD.x, c.eD.y),
+          d.va(c.rQ.x, c.rQ.y),
+          d.va(c.rQ.x, c.rQ.y + k),
+          d.va(c.eD.x, c.eD.y + k),
+          d.va(c.eD.x, c.eD.y),
+          a.renderer.Ia(d, c.qQ, e);
+      gvjs_WK(a, c, e)
+    }
+    b.X_ && a.renderer.ce(b.text, b.U4.x + h.x, b.U4.y + h.y, b.iU.width, gvjs_2, gvjs_2, b.ja, e);
+    h = gvjs_4E([gvjs_Zp, b.index]);
+    e = e.j();
+    a.we(a.Um, h, e);
+    b.tooltip && (e = gvjs_4E([gvjs_Pd, b.index]),
+      a.nK(b.tooltip, e))
+  }
+}
+function gvjs_WK(a, b, c) {
+  if (b.rt)
+    a.renderer.Gl(b.di.x, b.di.y, b.radiusX, b.radiusY, b.brush, c);
+  else {
+    var d = new gvjs_SA;
+    d.move(b.gf.x, b.gf.y);
+    d.Sf(b.di.x, b.di.y, b.radiusX, b.radiusY, b.de, b.vd, !0);
+    a.renderer.Ia(d, b.brush, c)
+  }
+}
+function gvjs_VK(a, b) {
+  var c = gvjs_s(a.mv, a)
+    , d = gvjs_s(a.registerElement, a)
+    , e = a.renderer;
+  a = a.KQ;
+  for (var f = 0; f < b.length; ++f) {
+    var g = b[f]
+      , h = e.Sa()
+      , k = e.Sa()
+      , l = new gvjs_SA;
+    l.move(g.wp.x + .5, g.wp.y + .5);
+    l.va(g.K8 + .5, g.wp.y + .5);
+    l.va(g.K8 + .5, g.YH.y + .5);
+    l.va(g.YH.x + .5, g.YH.y + .5);
+    e.Ia(l, g.Oc, k);
+    e.Ke(g.wp.x + .5, g.wp.y + .5, g.gga, g.Bxa, k);
+    c(g.pB, h);
+    c(g.EB, h);
+    e.appendChild(a, h);
+    e.appendChild(a, k);
+    g = gvjs_4E([gvjs_zv, g.index]);
+    d(h.j(), g)
+  }
+}
+gvjs_.Dea = function(a, b) {
+  if (!gvjs_Uz(b.Jq, this.Ms.Jq)) {
+    this.renderer.qc(this.KQ);
+    var c = new gvjs_9F(2);
+    gvjs_$F(c, 0, a.Jq || {});
+    gvjs_$F(c, 1, b.Jq || {});
+    c = c.compact();
+    gvjs_VK(this, c)
+  }
+  this.VK(a);
+  this.TV(a, b)
+}
+;
+gvjs_.VK = function(a) {
+  var b = this.Ms;
+  if (b)
+    for (var c in b.C) {
+      var d = Number(c);
+      if (b.C[d].tooltip) {
+        var e = gvjs_4E([gvjs_Pd, Number(d)]);
+        gvjs_UG(this, e)
+      }
+      e = a.pie.Gd[d < a.C.length / a.pie.Gd.length ? 0 : 1];
+      gvjs_UK(this, a.C[d], e.radiusX, e.radiusY)
+    }
+}
+;
+gvjs_.TV = function(a, b) {
+  for (var c in b.C) {
+    var d = Number(c)
+      , e = new gvjs_9F(2);
+    gvjs_$F(e, 0, a.C[d]);
+    gvjs_$F(e, 1, b.C[d]);
+    var f = a.pie.Gd[d < a.C.length / a.pie.Gd.length ? 0 : 1];
+    d = f.radiusX;
+    f = f.radiusY;
+    gvjs_UK(this, e.compact(), d, f)
+  }
+}
+;
+function gvjs_XK(a, b, c, d, e) {
+  gvjs_QI.call(this, a, b, c, d, e);
+  this.Kb = b.fa(gvjs_2t, gvjs_MF);
+  this.cga = gvjs_L(b, "pieStartAngle", 0);
+  this.Ova = 0 > gvjs_L(b, gvjs_iu, 1);
+  this.Nva = gvjs_K(b, gvjs_xw, !1);
+  a = b.pb("pieSlicePercentFormat");
+  gvjs_Py(a) && (a = {
+    pattern: "#.#%"
+  });
+  this.Sua = new gvjs_gk(a);
+  b = b.pb("pieSliceValueFormat");
+  gvjs_Py(b) && (b = {
+    pattern: gvjs_Nb
+  });
+  this.mha = new gvjs_gk(b)
+}
+gvjs_o(gvjs_XK, gvjs_QI);
+gvjs_XK.prototype.nz = function() {
+  var a = this;
+  return [function() {
+    a.V.Ig = new Set([gvjs_Mw]);
+    a.V.kd = gvjs_K(a.options, "isDiff");
+    a.V.$c &= !a.V.kd;
+    a.V.kd && (a.V.Ih = a.V.Ih || {},
+      a.V.Ih.pie = a.V.Ih.pie || {},
+      a.V.Ih.pie.Kba = a.options.fa("diff.oldData.inCenter", !0),
+      a.V.Ih.pie.F_ = a.options.fa("diff.innerCircle.radiusFactor", .6));
+    for (var b = 0; b < a.lb.ca(); b++)
+      if (0 > a.lb.getValue(b, 1))
+        throw Error("Negative values are invalid for a pie chart.");
+  }
+    , gvjs_QI.prototype.nz.bind(this)]
+}
+;
+gvjs_XK.prototype.N$ = function() {
+  return gvjs_j
+}
+;
+gvjs_XK.prototype.M$ = function() {
+  return null
+}
+;
+gvjs_XK.prototype.tN = function() {
+  var a = this;
+  return [function() {
+    var b = a.ti();
+    if (a.lb.W(0) != gvjs_l)
+      throw Error("Pie chart should have a first column of type string");
+    var c = a.V;
+    var d = c.O
+      , e = a.ne.getPosition()
+      , f = null
+      , g = Math.round(1.618 * c.Dl)
+      , h = Math.round(d.width * (1 - 1 / 1.618) - g);
+    e == gvjs_$c ? (f = new gvjs_B(d.top,d.left + h,d.bottom,d.left),
+      e = new gvjs_B(d.top,d.right,d.bottom,f.right + g)) : e == gvjs_j ? (f = new gvjs_B(d.top,d.right,d.bottom,d.right - h),
+      e = new gvjs_B(d.top,f.left - g,d.bottom,d.left)) : e == gvjs_xt ? (e = new gvjs_B(d.top,d.right,d.top + 1 / 1.618 * (d.bottom - d.top - g),d.left),
+      f = new gvjs_B(e.bottom + g,d.right,d.bottom,d.left)) : e = new gvjs_B(d.top,d.right,d.bottom,d.left);
+    d = 0;
+    var k = h = Math.floor(Math.min(e.right - e.left, e.bottom - e.top) / 2);
+    g = Math.round((e.right + e.left) / 2);
+    e = Math.round((e.bottom + e.top) / 2);
+    c.$c && (k *= .8,
+      d = h / 5,
+      e -= d / 2);
+    if (c.kd) {
+      var l = {
+        radiusX: h * c.Ih.pie.F_,
+        radiusY: k * c.Ih.pie.F_
+      };
+      h = {
+        radiusX: h,
+        radiusY: k
+      };
+      c = {
+        pie: {
+          center: new gvjs_ok(g,e),
+          radiusX: h.radiusX,
+          radiusY: h.radiusY,
+          eE: d,
+          Gd: c.Ih.pie.Kba ? [l, h] : [h, l]
+        },
+        legend: f
+      }
+    } else
+      c = {
+        pie: {
+          center: new gvjs_ok(g,e),
+          radiusX: h,
+          radiusY: k,
+          eE: d,
+          Gd: [{
+            radiusX: h,
+            radiusY: k
+          }]
+        },
+        legend: f
+      };
+    gvjs_Rga(a, c);
+    f = a.ne.getPosition();
+    c.legend ? a.ne.qr(c.legend) : f == gvjs_vt ? (b = a.ne,
+      c = b.qr,
+      f = a.V,
+      e = f.height - f.O.bottom,
+      d = a.ne.Za.fontSize,
+      h = [],
+      h.push({
+        min: 2,
+        extra: [Infinity]
+      }),
+      g = h.length,
+      h.push({
+        min: d + 2,
+        extra: [Infinity]
+      }),
+      e = gvjs_nA(h, e),
+      e.length > g ? (g = f.O.bottom + e[g],
+        f = new gvjs_B(g - d,f.O.right,g,f.O.left)) : f = null,
+      c.call(b, f)) : f == gvjs_ov && gvjs_Sga(a, b.O, c, a.ne.Za)
+  }
+  ]
+}
+;
+function gvjs_YK(a, b, c) {
+  var d = a.V
+    , e = {}
+    , f = gvjs_oy(a.options, gvjs_gw, "");
+  a = b.color;
+  var g = b.qb;
+  b = b.jh;
+  if (d.$c) {
+    d = a;
+    var h = g;
+    f = b
+  } else
+    h = d = f;
+  e.Hd = new gvjs_3({
+    stroke: d,
+    strokeWidth: 1,
+    fill: a,
+    fillOpacity: null != c ? c : 1
+  });
+  e.qb = new gvjs_3({
+    stroke: h,
+    strokeWidth: 1,
+    fill: g,
+    fillOpacity: null != c ? c : 1
+  });
+  e.jh = new gvjs_3({
+    stroke: f,
+    strokeWidth: 1,
+    fill: b,
+    fillOpacity: null != c ? c : 1
+  });
+  return e
+}
+function gvjs_Rga(a, b) {
+  function c(ma, da, ea, va, Z) {
+    f.kd ? f.Vo.push({
+      id: ma,
+      text: da,
+      brush: new gvjs_3({
+        gradient: {
+          Vf: ea,
+          sf: ea,
+          tn: z[0],
+          un: z[1],
+          x1: gvjs_So,
+          y1: gvjs_Ro,
+          x2: gvjs_Ro,
+          y2: gvjs_Ro,
+          Sn: !0,
+          sp: !0
+        }
+      }),
+      index: va,
+      isVisible: Z
+    }) : f.Vo.push({
+      id: ma,
+      text: da,
+      brush: new gvjs_3({
+        fill: ea
+      }),
+      index: va,
+      isVisible: Z
+    })
+  }
+  function d(ma) {
+    var da = f.pie.Gd[ma - 1].cS
+      , ea = f.pie.Gd[0].cS;
+    1 == ma && da ? gvjs_ZK(da, r, da) : 1 < ma && (da && ea ? (gvjs_ZK(da, r, da, ea),
+      gvjs_ZK(ea, r, da, ea)) : da ? (ea = {
+      dE: "0",
+      Me: "0"
+    },
+      gvjs_ZK(da, r, da, ea)) : ea && (da = {
+      dE: "0",
+      Me: "0"
+    },
+      gvjs_ZK(ea, r, da, ea)))
+  }
+  function e(ma, da, ea, va) {
+    var Z = f.C[ma];
+    1 == da ? null != ea ? Z.wd = {
+      Nh: !!va,
+      wi: !0,
+      content: ea
+    } : gvjs_ZK(Z, r, Z) : (ma = f.C[ma - l],
+      gvjs_ZK(Z, r, Z, ma),
+      gvjs_ZK(ma, r, Z, ma))
+  }
+  var f = a.V
+    , g = a.lb
+    , h = b.pie.center
+    , k = b.pie.eE
+    , l = g.ca()
+    , m = gvjs_5F(gvjs_oy(a.options, "pieResidueSliceColor", ""))
+    , n = gvjs_YK(a, m, 1)
+    , p = gvjs_ry(a.options, "pieSliceTextStyle", {
+    bb: f.Hj,
+    fontSize: f.Dl
+  })
+    , q = gvjs_J(a.options, gvjs_hw, f.kd ? gvjs_f : gvjs_ew, gvjs_9da)
+    , r = gvjs_J(a.options, "tooltip.text", gvjs_ut, gvjs_kC)
+    , t = gvjs_ny(a.options, "sliceVisibilityThreshold", 1 / 720)
+    , u = gvjs_K(a.options, "displayTinySlicesInLegend")
+    , v = gvjs_J(a.options, "pieResidueSliceLabel", "Other")
+    , w = gvjs_ny(a.options, "pieHole", 0);
+  f.C = [];
+  f.Vo = [];
+  if (f.kd) {
+    var x = a.options.fa("diff.innerCircle.borderFactor", .01);
+    x = f.Ih.pie.F_ * (1 + x);
+    x = f.Ih.pie.Kba ? [0, x] : [x, 0];
+    var y = [!1, !0];
+    var z = [a.options.fa(gvjs_hu, .5), a.options.fa(gvjs_gu, 1)]
+  } else
+    x = [0],
+      y = [!0],
+      z = [1];
+  f.pie = {
+    center: h,
+    eE: k,
+    radiusX: b.pie.radiusX,
+    radiusY: b.pie.radiusY,
+    Gd: []
+  };
+  k = f.pie.Gd;
+  b = b.pie.Gd;
+  for (var A = b.length, B = 0, D = 0; D < A; ++D) {
+    var C = b[D]
+      , G = null
+      , J = C.radiusX;
+    C = C.radiusY;
+    for (var I = x[D], M = y[D], H = 0, Q = 0, R = 0, T = 0; T < l; T++)
+      R += g.getValue(T, D + 1) || 0;
+    for (T = 0; T < l; ++T) {
+      var O = a.Nva ? l - T - 1 : T
+        , K = 1 === A && g.$() > D + 2 && g.Jg(D + 2) === gvjs_Pd && g.W(D + 2) === gvjs_l
+        , E = f.$f && K && !(!g.getProperty(O, D + 2, gvjs_av) && !g.Bd(D + 2, gvjs_av))
+        , F = g.getValue(O, D + 1) || 0
+        , L = g.Ha(O, D + 1, a.mha)
+        , N = g.getValue(O, 0)
+        , P = g.Ha(O, 0)
+        , S = 0 === R ? 0 : Q / R
+        , U = 0 === R ? 0 : S + F / R
+        , fa = U - S >= t;
+      K = K && g.getStringValue(O, D + 2) || null;
+      fa ? Q += F : H += F;
+      var V = "slices." + B
+        , pa = a.options.fa(V + ".color", a.Kb[T % a.Kb.length]);
+      pa = gvjs_5F(pa);
+      var W = gvjs_YK(a, pa, z[D])
+        , ja = gvjs_L(a.options, V + ".offset", 0)
+        , ia = gvjs_ny(a.options, V + ".hole", w) + I
+        , Da = gvjs_ry(a.options, V + ".textStyle", p)
+        , Ea = gvjs_K(a.options, [V + gvjs_Lr, gvjs_ru], !0);
+      O = gvjs__K(a, B, O, S, U, F, L, P, fa, h, J, C, ia, ja, q, Da, pa, W, Ea);
+      f.C.push(O);
+      fa = gvjs_K(a.options, V + ".visibleInLegend", M && (fa || u));
+      c(N, P, pa.color, B, fa);
+      D == A - 1 && e(B, A, K, E);
+      B += 1
+    }
+    0 < H && (G = 1 - (0 === R ? 0 : H / R),
+      Q = H,
+      R = a.mha.Ob(H),
+      H = v,
+      G = gvjs__K(a, -1, -1, G, 1, Q, R, H, !0, h, J, C, w + I, 0, q, p, m, n, !1),
+    M && !u && c("", H, m.color, -1, !0));
+    k.push({
+      radiusX: J,
+      radiusY: C,
+      cS: G
+    });
+    D == A - 1 && d(A)
+  }
+}
+function gvjs_0K(a, b) {
+  switch (b) {
+    case gvjs_ew:
+      return a.dE;
+    case gvjs_Vd:
+      return a.Me;
+    case gvjs_ut:
+      return a.Me + " (" + a.dE + ")"
+  }
+  return ""
+}
+function gvjs__K(a, b, c, d, e, f, g, h, k, l, m, n, p, q, r, t, u, v, w) {
+  var x = a.V;
+  if (x.$c || 1 <= p)
+    p = 0;
+  var y = {}
+    , z = e - d;
+  y.value = f;
+  y.Me = g;
+  y.color = u;
+  y.Rb = v;
+  y.brush = y.Rb.Hd;
+  y.title = h;
+  y.index = b;
+  y.Yg = w;
+  y.Cs = 0 <= c ? a.lb.fj(c) : null;
+  y.isVisible = k;
+  b = m * p;
+  p *= n;
+  y.eJ = b;
+  y.gD = p;
+  y.de = 360 * d + a.cga;
+  y.vd = 360 * e + a.cga;
+  a.Ova && (c = 360 - y.de,
+    y.de = 360 - y.vd,
+    y.vd = c);
+  c = Math.PI * (y.de - 90) / 180;
+  f = Math.PI * (y.vd - 90) / 180;
+  y.dE = a.Sua.Ob(z);
+  h = "";
+  switch (r) {
+    case gvjs_ew:
+      h = y.dE;
+      break;
+    case gvjs_8c:
+      h = y.title;
+      break;
+    case gvjs_Vd:
+      h = g;
+      break;
+    case gvjs_Ix:
+      h = g + " (" + y.dE + ")"
+  }
+  y.text = h;
+  if (!k)
+    return y;
+  y.ja = t;
+  a = a.sc(y.text, t).width;
+  t = t.fontSize;
+  y.iU = new gvjs_A(a,t);
+  y.rt = 1 == z;
+  if (y.text)
+    if (y.rt)
+      y.U4 = gvjs_fA(l, new gvjs_ok(a / 2,t / 2)),
+        y.X_ = !0;
+    else {
+      z = m - t;
+      t = n - t;
+      a = y.iU;
+      a = new gvjs_A(a.width / z,a.height / t);
+      g = new gvjs_A(2 / z,2 / t);
+      k = gvjs_3I((c + f) / 2 + Math.PI, 1, 1);
+      b: {
+        r = gvjs_4I(new gvjs_ok(0,0), a);
+        h = 1;
+        u = Math.min;
+        for (v = 0; v < r.length; ++v) {
+          var A = r[v];
+          w = k.x * A.x + k.y * A.y;
+          A = w * w + 1 - (A.x * A.x + A.y * A.y);
+          0 > A ? w = null : (A = Math.sqrt(A),
+            w = [w - A, w + A]);
+          if (null === w || 0 > w[1]) {
+            r = null;
+            break b
+          }
+          h = u(h, w[1])
+        }
+        r = h
+      }
+      if (.4 > r)
+        a = null;
+      else {
+        k = k.clone();
+        k.scale(-r);
+        a = gvjs_Vfa(a, g, g);
+        b: {
+          a = gvjs_4I(k, a);
+          g = gvjs_3y(f - c, 2 * Math.PI);
+          r = 0;
+          h = g;
+          for (u = 0; u < a.length; ++u) {
+            v = gvjs_3y(Math.atan2(a[u].y, a[u].x) - c, 2 * Math.PI);
+            if (v >= g || 0 == v) {
+              a = !1;
+              break b
+            }
+            h = Math.min(v, h);
+            r = Math.max(v, r)
+          }
+          a = r - h < Math.PI
+        }
+        a = a ? k : null
+      }
+      z = a && new gvjs_ok(a.x * z,a.y * t);
+      null !== z && (y.X_ = !0,
+        y.U4 = gvjs_Ufa(l, z, new gvjs_ok(-y.iU.width / 2,-y.iU.height / 2)))
+    }
+  else
+    y.X_ = !1;
+  y.offset = gvjs_3I((c + f) / 2, m, n).scale(q);
+  q = gvjs_3I(f, m, n);
+  y.gf = gvjs_eA(l, gvjs_3I(c, m, n));
+  y.ei = gvjs_eA(l, q);
+  n = gvjs_3I(f, b, p);
+  y.fD = gvjs_eA(l, gvjs_3I(c, b, p));
+  y.Uv = gvjs_eA(l, n);
+  x.$c && 270 >= y.de && 90 <= y.vd && (n = {},
+    90 > y.de ? (n.de = 90,
+      n.gf = new gvjs_ok(l.x + m,l.y)) : (n.de = y.de,
+      n.gf = y.gf),
+    270 < y.vd ? (n.vd = 270,
+      n.ei = new gvjs_ok(l.x - m,l.y)) : (n.vd = y.vd,
+      n.ei = y.ei),
+    n.brush = y.Rb.qb,
+    y.dc = n);
+  y.kv = x.$c && .5 < d;
+  y.sy = x.$c && .5 > e;
+  if (y.kv || y.sy)
+    y.qQ = y.Rb.qb;
+  return y
+}
+function gvjs_ZK(a, b, c, d) {
+  c = gvjs_0K(c, b);
+  d && (c += "\n" + gvjs_0K(d, b));
+  a.wd = {
+    En: a.title,
+    content: c
+  }
+}
+function gvjs_Sga(a, b, c, d) {
+  var e = a.V
+    , f = e.pie.radiusX
+    , g = e.pie.radiusY
+    , h = c.pie.center
+    , k = gvjs_J(a.options, "legend.labeledValueText", gvjs_ew, gvjs_kC)
+    , l = Math.PI * (3 * (f + g) - Math.sqrt((3 * f + g) * (f + 3 * g)))
+    , m = [];
+  c = [];
+  for (var n = {}, p = 0; p < e.Vo.length; n = {
+    zM: n.zM,
+    PF: n.PF,
+    QF: n.QF,
+    AM: n.AM
+  },
+    ++p) {
+    var q = e.Vo[p];
+    if (q.isVisible) {
+      var r = void 0;
+      if (0 <= q.index)
+        r = e.C[q.index];
+      else {
+        var t = e.pie.Gd;
+        r = t[t.length - 1].cS
+      }
+      n.zM = Math.max((f + r.eJ) / 2, .75 * f);
+      n.PF = Math.max((g + r.gD) / 2, .75 * g);
+      var u = (r.vd + r.de) / 2;
+      t = gvjs_5y(u);
+      var v = gvjs_bz(f - n.zM, g - n.PF) / l * 360
+        , w = void 0
+        , x = void 0;
+      2 * v < r.vd - r.de ? (w = r.de + v,
+        x = r.vd - v,
+        180 > t ? x = Math.min(x, 180) : w = Math.max(w, 180)) : x = w = u;
+      n.QF = function(A) {
+        return function(B) {
+          return gvjs_eA(h, gvjs_3I(B, A.zM, A.PF))
+        }
+      }(n);
+      var y = function(A) {
+        return function(B) {
+          return A.QF(gvjs_6y(B - 90))
+        }
+      }(n);
+      n.AM = function(A) {
+        return function(B) {
+          return Math.asin(gvjs_0g((B - h.y) / A.PF, -1, 1))
+        }
+      }(n);
+      v = function(A) {
+        return function(B) {
+          return A.QF(A.AM(B))
+        }
+      }(n);
+      var z = function(A) {
+        return function(B) {
+          return A.QF(Math.PI - A.AM(B))
+        }
+      }(n);
+      q = {
+        oea: y(u).y,
+        aS: new gvjs_O(y(w).y,y(x).y),
+        pB: q.text,
+        EB: gvjs_0K(r, k),
+        kba: r.value,
+        index: r.index
+      };
+      180 > t ? (q.Rda = v,
+        m.push(q)) : (q.Rda = z,
+        c.push(q))
+    }
+  }
+  f = b.width / 2 - f - d.fontSize;
+  e = gvjs_RK(new gvjs_B(b.top,b.right,b.bottom,b.right - f), a.sc, 2, d, m);
+  b = gvjs_RK(new gvjs_B(b.top,b.left + f,b.bottom,b.left), a.sc, 1, d, c);
+  d = [];
+  gvjs_Me(d, e, b);
+  a.V.Jq = d
+}
+;function gvjs_1K(a, b, c) {
+  gvjs_PJ.call(this, a, b, c, gvjs_fw)
+}
+gvjs_t(gvjs_1K, gvjs_PJ);
+gvjs_1K.prototype.Gs = function(a) {
+  return this.renderer.xv(a.target)
+}
+;
+gvjs_1K.prototype.v9 = function(a, b) {
+  b = b.split("#");
+  switch (b[0]) {
+    case gvjs_Zp:
+      b = Number(b[1]),
+      0 > b || this.dispatchEvent("serie" + a, {
+        Vb: b,
+        Kk: null
+      })
+  }
+}
+;
+function gvjs_2K(a, b, c, d, e, f, g) {
+  gvjs_hK.call(this, a, b, c, d, e, g);
+  var h = gvjs_K(a, gvjs_ru, !0);
+  this.Dna = gvjs_lA(f, function(k) {
+    return gvjs_K(a, "slices." + k + gvjs_Lr, h)
+  });
+  this.Vwa = gvjs_K(a, "shouldHighlightHover", !0)
+}
+gvjs_o(gvjs_2K, gvjs_hK);
+gvjs_2K.prototype.Us = function(a, b, c) {
+  this.QX(a, b, c)
+}
+;
+gvjs_2K.prototype.xY = function(a, b) {
+  return a.equals(b, !0)
+}
+;
+function gvjs_3K(a, b) {
+  a.C = a.C || {};
+  a = a.C;
+  a[b] = a[b] || {};
+  return a[b]
+}
+gvjs_2K.prototype.QX = function(a, b, c) {
+  function d(q, r) {
+    if (null != q) {
+      if (a.kd) {
+        var t = a.C.length;
+        t = [q, (q + t / a.pie.Gd.length) % t]
+      } else
+        t = [q];
+      for (var u = !1, v = 0; v < t.length; ++v) {
+        var w = t[v];
+        null != w && e.Dna[w] && (u = u || !0,
+        a.kd || e.Vwa && gvjs_Tga(a, w, c),
+        a.Jq && (c.Jq = gvjs_Qga(a.Jq, w)))
+      }
+      r && k && u && gvjs_4K(e, f, q)
+    }
+  }
+  var e = this
+    , f = {
+    Ea: a,
+    yk: this.le.getEntries(),
+    Yv: c,
+    zk: b.gi
+  }
+    , g = b.gi.focused.wy;
+  null != g && (b.gi.focused.action = this.le.ng(g).action);
+  var h = this.Cp.u5;
+  g = h == gvjs_Jw || h == gvjs_ut;
+  var k = h == gvjs_xu || h == gvjs_ut
+    , l = this.le && 0 < f.yk.length;
+  h = gvjs_bo(b.selected);
+  l = 1 < h.length && l;
+  for (var m = 0; m < h.length; ++m) {
+    var n = h[m]
+      , p = a.pie.Gd.length;
+    n += a.C.length / p * (p - 1);
+    gvjs_Uga(a, n, c);
+    g && !l && gvjs_4K(this, f, n)
+  }
+  g && l && gvjs_Vga(this, f, h, h[h.length - 1]);
+  if (g = b.Ii)
+    c.Ii = g;
+  d(b.focused.Hb, !0);
+  d(b.legend.focused.Xc, !1)
+}
+;
+function gvjs_Tga(a, b, c) {
+  var d = a.pie
+    , e = a.C[b];
+  if (null != e.offset) {
+    c = gvjs_3K(c, b);
+    c.Ko = {};
+    b = c.Ko;
+    b.brush = new gvjs_3({
+      stroke: e.brush.fill,
+      strokeWidth: 6.5,
+      strokeOpacity: .3
+    });
+    b.di = new gvjs_z(d.center.x + e.offset.x,d.center.y + e.offset.y);
+    b.de = e.de;
+    b.vd = e.vd;
+    b.rt = e.rt;
+    (c = c.nj) && a.Mfa ? (a = c.radiusX + c.brush.strokeWidth / 2,
+      c = c.radiusY + c.brush.strokeWidth / 2) : (c = e.brush.strokeWidth / 2,
+      a = d.radiusX + c,
+      c = d.radiusY + c);
+    d = b.brush.strokeWidth / 2;
+    b.radiusX = a + d;
+    b.radiusY = c + d;
+    a = gvjs_6y(b.de - 90);
+    c = gvjs_6y(b.vd - 90);
+    b.gf = gvjs_ez(b.di, gvjs_3I(a, b.radiusX, b.radiusY));
+    b.ei = gvjs_ez(b.di, gvjs_3I(c, b.radiusX, b.radiusY));
+    var f = e.dc;
+    f && (b.dc = b.dc || {},
+      b.dc.brush = gvjs_8z(f.brush.fill, .3),
+      b.dc.di = b.di.clone(),
+      b.dc.de = f.de,
+      b.dc.vd = f.vd,
+      b.dc.radiusX = b.radiusX + d,
+      b.dc.radiusY = b.radiusY + d,
+      a = gvjs_6y(b.dc.de - 90),
+      c = gvjs_6y(b.dc.vd - 90),
+      b.dc.gf = gvjs_ez(b.dc.di, gvjs_3I(a, b.dc.radiusX, b.dc.radiusY)),
+      b.dc.ei = gvjs_ez(b.dc.di, gvjs_3I(c, b.dc.radiusX, b.dc.radiusY)));
+    b.kv = e.kv;
+    b.sy = e.sy;
+    if (b.kv || b.sy)
+      b.qQ = gvjs_8z(e.qQ.fill, .3),
+        b.pva = b.kv ? a : c,
+        e = function(g, h) {
+          return gvjs_ez(g.di, gvjs_3I(g.pva, g.radiusX + h * g.brush.strokeWidth / 2, g.radiusY + h * g.brush.strokeWidth / 2))
+        }
+        ,
+        b.eD = e(b, -1),
+        b.rQ = e(b, 1)
+  }
+}
+function gvjs_Uga(a, b, c) {
+  var d = a.pie;
+  0 < d.eE || (a = a.C[b],
+  null != a.offset && (b = gvjs_3K(c, b),
+    b.nj = {},
+    b = b.nj,
+    b.brush = gvjs_9z(a.brush.fill, 2),
+    b.di = new gvjs_z(d.center.x + a.offset.x,d.center.y + a.offset.y),
+    b.de = a.de,
+    b.vd = a.vd,
+    b.rt = a.rt,
+    a = a.brush.strokeWidth / 2 + 2.5 + b.brush.strokeWidth / 2,
+    b.radiusX = d.radiusX + a,
+    b.radiusY = d.radiusY + a,
+    d = gvjs_6y(b.vd - 90),
+    b.gf = gvjs_ez(b.di, gvjs_3I(gvjs_6y(b.de - 90), b.radiusX, b.radiusY)),
+    b.ei = gvjs_ez(b.di, gvjs_3I(d, b.radiusX, b.radiusY))))
+}
+function gvjs_4K(a, b, c) {
+  var d = gvjs_3K(b.Yv, c);
+  if (c = gvjs_fK(a.Cp, b, c, null, null))
+    d.tooltip = c,
+    b.zk && a.le.Us(c, b.zk, d.tooltip)
+}
+function gvjs_Vga(a, b, c, d) {
+  var e = gvjs_3K(b.Yv, d);
+  var f = a.Cp;
+  var g = b.Ea
+    , h = b.Ea.C[d];
+  d = gvjs_8J(g, h);
+  h = gvjs_cK(g, h);
+  c = gvjs_rga(f.es, b, c);
+  f = gvjs_kG(c, g.sc, !0, d, f.af, h, void 0, g.$f, g.bw, g.ax);
+  e.tooltip = f;
+  b.zk && a.le.Us(f, b.zk, e.tooltip)
+}
+;function gvjs_Wga(a) {
+  return Math.pow(a, 3)
+}
+function gvjs_Xga(a) {
+  return 1 - Math.pow(1 - a, 3)
+}
+function gvjs_Yga(a) {
+  return 3 * a * a - 2 * a * a * a
+}
+;var gvjs_Zga = {
+  LINEAR: gvjs_Hp,
+  sAa: gvjs_Fp,
+  YAa: gvjs_aw,
+  xAa: gvjs_cv
+};
+function gvjs__ga(a) {
+  switch (a) {
+    case gvjs_Hp:
+      return gvjs_Wx;
+    case gvjs_Fp:
+      return gvjs_Wga;
+    case gvjs_aw:
+      return gvjs_Xga;
+    case gvjs_cv:
+      return gvjs_Yga;
+    default:
+      return gvjs_Wx
+  }
+}
+function gvjs_5K(a, b, c) {
+  var d = gvjs_K(a, "animation.startup", !1);
+  b = gvjs_Oj(a, gvjs_Ws, b);
+  if (!b)
+    return null;
+  var e = gvjs_Oj(a, "animation.maxFramesPerSecond", 30);
+  a = gvjs_J(a, "animation.easing", c, gvjs_Zga);
+  return {
+    iga: d,
+    duration: b,
+    easing: gvjs__ga(a),
+    HD: e
+  }
+}
+;function gvjs_6K(a, b) {
+  this.kI = a || [];
+  gvjs_0ga(this, b)
+}
+function gvjs_7K() {
+  return function(a, b) {
+    return b === gvjs_yp && typeof a === gvjs_l && !gvjs_He(gvjs_1ga, a.toLowerCase())
+  }
+}
+function gvjs_0ga(a, b) {
+  var c = gvjs_p.WebFont;
+  0 !== a.kI.length && c ? c.load({
+    google: {
+      families: a.kI
+    },
+    active: function() {
+      b.resolve()
+    },
+    fontinactive: function() {
+      b.reject("One or more fonts could not be loaded")
+    }
+  }) : b.resolve(null)
+}
+var gvjs_1ga = [gvjs_ft, "comic sans ms", "courier new", "georgia", "impact", "times new roman", "trebuchet ms", "verdana"];
+function gvjs_2ga(a, b) {
+  this.Qv = a;
+  this.vertical = b
+}
+;function gvjs_3ga(a, b, c, d, e, f) {
+  var g = a.jd[0] ? 0 : 1
+    , h = a.wc[0] ? 0 : 1
+    , k = a.jd[g];
+  a = a.wc[h];
+  var l = k.dataType && gvjs_7H(k.dataType).toNumber
+    , m = a.dataType && gvjs_7H(a.dataType).toNumber;
+  this.ew = b;
+  this.DC = gvjs_s(function(n) {
+    return l ? l(this.ew.getHAxisValue(n, g)) : n
+  }, this);
+  this.MC = gvjs_s(function(n) {
+    return m ? m(this.ew.getVAxisValue(n, h)) : n
+  }, this);
+  b = this.ew.getChartAreaBoundingBox();
+  this.Rq = this.DC(b.left);
+  this.Sq = this.MC(b.top + b.height);
+  this.Et = this.DC(b.left + b.width);
+  this.Ft = this.MC(b.top);
+  this.YR = this.Rq;
+  this.ZR = this.Sq;
+  this.XR = this.Et - this.Rq;
+  this.WR = this.Ft - this.Sq;
+  this.scale = 1;
+  this.hta = c;
+  this.P0 = d;
+  this.Mha = e;
+  this.EQ = f
+}
+;function gvjs_8K(a, b, c, d) {
+  this.Wm = c;
+  this.Ra = a;
+  this.dj = b;
+  this.Wg = null;
+  this.gk = d;
+  this.gk.subscribe(gvjs_i, gvjs_s(this.Bq, this))
+}
+gvjs_8K.prototype.FT = function(a) {
+  this.Wg = a
+}
+;
+gvjs_8K.prototype.getState = function() {
+  return this.Ra
+}
+;
+gvjs_8K.prototype.Bq = function() {}
+;
+gvjs_8K.prototype.updateOptions = function() {
+  var a = {
+    hAxis: {
+      viewWindowMode: gvjs_su,
+      viewWindow: {}
+    },
+    vAxis: {
+      viewWindowMode: gvjs_su,
+      viewWindow: {}
+    }
+  };
+  this.Wm.Qv && (isNaN(this.Wg.Rq) || (a.hAxis.viewWindow.numericMin = this.Wg.Rq),
+  isNaN(this.Wg.Et) || (a.hAxis.viewWindow.numericMax = this.Wg.Et));
+  this.Wm.vertical && (isNaN(this.Wg.Sq) || (a.vAxis.viewWindow.numericMin = this.Wg.Sq),
+  isNaN(this.Wg.Ft) || (a.vAxis.viewWindow.numericMax = this.Wg.Ft));
+  this.Ra.gm = a
+}
+;
+function gvjs_9K(a, b) {
+  return gvjs_0g(a.x, b.left, b.left + b.width) === a.x && gvjs_0g(a.y, b.top, b.top + b.height) === a.y ? !0 : !1
+}
+;function gvjs_$K(a, b, c, d) {
+  gvjs_8K.call(this, a, b, c, d);
+  this.Dz = null
+}
+gvjs_o(gvjs_$K, gvjs_8K);
+gvjs_ = gvjs_$K.prototype;
+gvjs_.Bq = function() {
+  var a = this.gk;
+  a.subscribe(gvjs_pu, gvjs_s(this.TZ, this));
+  a.subscribe(gvjs_nu, gvjs_s(this.RZ, this));
+  a.subscribe(gvjs_ou, gvjs_s(this.SZ, this));
+  a.subscribe(gvjs_4v, gvjs_s(this.Cf, this))
+}
+;
+gvjs_.TZ = function(a) {
+  var b = this.dj().getChartAreaBoundingBox();
+  gvjs_9K(a, b) && (this.Dz = new gvjs_ok(a.x,a.y))
+}
+;
+gvjs_.RZ = function(a) {
+  this.Dz && (this.C5(a.x, a.y),
+    this.Dz.x = a.x,
+    this.Dz.y = a.y)
+}
+;
+gvjs_.SZ = function() {
+  this.Dz = null
+}
+;
+gvjs_.Cf = function(a, b) {
+  var c = this.dj().getChartAreaBoundingBox();
+  gvjs_9K(a, c) && b()
+}
+;
+gvjs_.C5 = function(a, b) {
+  var c = this.Wg;
+  if (c) {
+    var d = this.dj();
+    c.ew = d;
+    var e = this.Wm;
+    if (e.Qv) {
+      var f = c.DC(a) - c.DC(this.Dz.x)
+        , g = c.Rq - f
+        , h = c.Et - f;
+      a = Math.max(g, c.YR);
+      d = Math.min(h, c.YR + c.XR);
+      if (c.EQ && (a === g || 0 > f) && (d === h || 0 < f) || !c.EQ)
+        c.Rq = g,
+          c.Et = h
+    }
+    e.vertical && (b = c.MC(b) - c.MC(this.Dz.y),
+      e = c.Sq - b,
+      f = c.Ft - b,
+      a = Math.max(e, c.ZR),
+      d = Math.min(f, c.ZR + c.WR),
+    c.EQ && (a === e || 0 > b) && (d === f || 0 < b) || !c.EQ) && (c.Sq = e,
+      c.Ft = f);
+    this.updateOptions()
+  }
+}
+;
+function gvjs_aL(a, b, c, d) {
+  gvjs_8K.call(this, a, b, c, d);
+  this.Uw = null
+}
+gvjs_o(gvjs_aL, gvjs_8K);
+gvjs_ = gvjs_aL.prototype;
+gvjs_.Bq = function() {
+  var a = this.gk;
+  a.subscribe(gvjs_pu, gvjs_s(this.TZ, this));
+  a.subscribe(gvjs_nu, gvjs_s(this.RZ, this));
+  a.subscribe(gvjs_ou, gvjs_s(this.SZ, this));
+  a.subscribe(gvjs_4v, gvjs_s(this.Cf, this))
+}
+;
+gvjs_.TZ = function(a) {
+  var b = this.dj().getChartAreaBoundingBox();
+  gvjs_9K(a, b) && (this.Uw = new gvjs_ok(a.x,a.y))
+}
+;
+gvjs_.RZ = function(a) {
+  if (this.Uw) {
+    var b = this.dj().getChartAreaBoundingBox()
+      , c = this.Wm;
+    this.mva(a, b);
+    if (c.Qv)
+      var d = Math.min(this.Uw.x, a.x)
+        , e = Math.abs(this.Uw.x - a.x);
+    else
+      d = b.left,
+        e = b.width;
+    c.vertical ? (c = Math.min(this.Uw.y, a.y),
+      a = Math.abs(this.Uw.y - a.y)) : (c = b.top,
+      a = b.height);
+    this.getState().Ii = {
+      left: d,
+      top: c,
+      width: e,
+      height: a,
+      color: "blue",
+      opacity: .2
+    }
+  }
+}
+;
+gvjs_.SZ = function() {
+  this.Uw && (this.C5(),
+    this.Uw = null)
+}
+;
+gvjs_.Cf = function(a, b) {
+  var c = this.dj().getChartAreaBoundingBox();
+  gvjs_9K(a, c) && b()
+}
+;
+gvjs_.C5 = function() {
+  var a = this.Wm
+    , b = this.Wg
+    , c = this.dj();
+  b.ew = c;
+  var d = this.getState().Ii
+    , e = b.DC(d.left)
+    , f = b.DC(d.left + d.width);
+  c = b.MC(d.top);
+  d = b.MC(d.top + d.height);
+  if (e !== f && c !== d) {
+    var g = b.XR * b.P0;
+    if (a.Qv) {
+      var h = Math.min(e, f);
+      e = Math.max(e, f);
+      e - h < g && (e = (h + e) / 2,
+        h = e - g / 2,
+        e += g / 2);
+      b.Rq = h;
+      b.Et = e
+    }
+    g = b.WR * b.P0;
+    a.vertical && (a = Math.min(c, d),
+      c = Math.max(c, d),
+    c - a < g && (e = (a + c) / 2,
+      a = e - g / 2,
+      c = e + g / 2),
+      b.Sq = a,
+      b.Ft = c);
+    this.updateOptions()
+  }
+}
+;
+gvjs_.mva = function(a, b) {
+  a.x = gvjs_0g(a.x, b.left, b.left + b.width);
+  a.y = gvjs_0g(a.y, b.top, b.top + b.height)
+}
+;
+function gvjs_bL(a, b, c, d) {
+  gvjs_8K.call(this, a, b, c, d)
+}
+gvjs_o(gvjs_bL, gvjs_8K);
+gvjs_bL.prototype.Bq = function() {
+  this.gk.subscribe(gvjs_Aw, gvjs_s(this.Qqa, this))
+}
+;
+gvjs_bL.prototype.Qqa = function() {
+  var a = this.Wg;
+  a.scale = 1;
+  a.Rq = a.YR;
+  a.Et = a.YR + a.XR;
+  a.Sq = a.ZR;
+  a.Ft = a.ZR + a.WR;
+  this.updateOptions()
+}
+;
+function gvjs_cL(a, b, c, d) {
+  gvjs_8K.call(this, a, b, c, d)
+}
+gvjs_o(gvjs_cL, gvjs_8K);
+gvjs_cL.prototype.Bq = function() {
+  this.gk.subscribe(gvjs_Gw, gvjs_s(this.Sqa, this))
+}
+;
+gvjs_cL.prototype.Sqa = function(a, b) {
+  var c = this.Wm
+    , d = this.dj().getChartAreaBoundingBox();
+  gvjs_9K(a, d) && (b(),
+    b = this.Wg,
+    a = 0 > a.wheelDelta ? b.scale * b.Mha : b.scale / b.Mha,
+    a = gvjs_0g(a, b.P0, b.hta),
+  a !== b.scale && (b.scale = a,
+  c.Qv && (a = (b.Et + b.Rq) / 2,
+    d = b.XR * b.scale / 2,
+    b.Rq = a - d,
+    b.Et = a + d),
+  c.vertical && (c = (b.Ft + b.Sq) / 2,
+    a = b.WR * b.scale / 2,
+    b.Sq = c - a,
+    b.Ft = c + a),
+    this.updateOptions()))
+}
+;
+function gvjs_dL(a, b, c, d, e) {
+  if (c.fa(gvjs_Sd) === gvjs_fw)
+    throw Error("Cannot use explorer with a pie chart");
+  this.Ra = a;
+  this.dj = b;
+  this.m = c;
+  this.ha = d;
+  this.gk = e;
+  this.Wg = this.Wm = null;
+  this.R9 = [];
+  this.init()
+}
+gvjs_dL.prototype.Bq = function() {
+  var a = gvjs_L(this.m, "explorer.maxZoomOut", 4);
+  1 > a && (a = 1 / a);
+  var b = gvjs_L(this.m, "explorer.maxZoomIn", .25);
+  1 < b && (b = 1 / b);
+  var c = gvjs_L(this.m, "explorer.zoomDelta", 1.5)
+    , d = gvjs_K(this.m, "explorer.keepInBounds", !1);
+  this.Wg = new gvjs_3ga(this.ha,this.dj(),a,b,c,d);
+  gvjs_u(this.R9, function(e) {
+    e.FT(this.Wg)
+  }, this)
+}
+;
+gvjs_dL.prototype.init = function() {
+  var a = this.ha.jd[0] ? 0 : 1
+    , b = this.ha.wc[0] ? 0 : 1
+    , c = this.ha.jd[a]
+    , d = this.ha.wc[b];
+  a = !this.ha.jd[1 - a] && c.type === gvjs_Vd && !c.Mq;
+  b = !this.ha.wc[1 - b] && d.type === gvjs_Vd && !d.Mq;
+  d = this.m.fa(gvjs_tu).axis;
+  d === gvjs_S ? b = !1 : d === gvjs_U && (a = !1);
+  this.Wm = new gvjs_2ga(a,b);
+  b = this.R9;
+  d = this.m.fa(gvjs_uu);
+  (null == d || Array.isArray(d) && gvjs_He(d, "dragToPan")) && b.push(new gvjs_$K(this.Ra,this.dj,this.Wm,this.gk));
+  d = this.m.fa(gvjs_uu);
+  Array.isArray(d) && gvjs_He(d, "dragToZoom") && b.push(new gvjs_aL(this.Ra,this.dj,this.Wm,this.gk));
+  d = this.m.fa(gvjs_uu);
+  (null == d || Array.isArray(d) && gvjs_He(d, "rightClickToReset")) && b.push(new gvjs_bL(this.Ra,this.dj,this.Wm,this.gk));
+  d = this.m.fa(gvjs_uu);
+  Array.isArray(d) && gvjs_He(d, "pinchToZoom");
+  d = this.m.fa(gvjs_uu);
+  (null == d || Array.isArray(d) && gvjs_He(d, "scrollToZoom")) && b.push(new gvjs_cL(this.Ra,this.dj,this.Wm,this.gk));
+  this.gk.subscribe(gvjs_i, gvjs_s(this.Bq, this))
+}
+;
+function gvjs_eL(a) {
+  gvjs_F.call(this);
+  this.xz = 1;
+  this.jS = [];
+  this.qS = 0;
+  this.kl = [];
+  this.Hr = {};
+  this.Bka = !!a
+}
+gvjs_t(gvjs_eL, gvjs_F);
+gvjs_ = gvjs_eL.prototype;
+gvjs_.subscribe = function(a, b, c) {
+  var d = this.Hr[a];
+  d || (d = this.Hr[a] = []);
+  var e = this.xz;
+  this.kl[e] = a;
+  this.kl[e + 1] = b;
+  this.kl[e + 2] = c;
+  this.xz = e + 3;
+  d.push(e);
+  return e
+}
+;
+gvjs_.unsubscribe = function(a, b, c) {
+  if (a = this.Hr[a]) {
+    var d = this.kl;
+    if (a = a.find(function(e) {
+      return d[e + 1] == b && d[e + 2] == c
+    }))
+      return this.B5(a)
+  }
+  return !1
+}
+;
+gvjs_.B5 = function(a) {
+  var b = this.kl[a];
+  if (b) {
+    var c = this.Hr[b];
+    0 != this.qS ? (this.jS.push(a),
+      this.kl[a + 1] = gvjs_ke) : (c && gvjs_Ie(c, a),
+      delete this.kl[a],
+      delete this.kl[a + 1],
+      delete this.kl[a + 2])
+  }
+  return !!b
+}
+;
+gvjs_.xn = function(a, b) {
+  var c = this.Hr[a];
+  if (c) {
+    for (var d = Array(arguments.length - 1), e = 1, f = arguments.length; e < f; e++)
+      d[e - 1] = arguments[e];
+    if (this.Bka)
+      for (e = 0; e < c.length; e++) {
+        var g = c[e];
+        gvjs_4ga(this.kl[g + 1], this.kl[g + 2], d)
+      }
+    else {
+      this.qS++;
+      try {
+        for (e = 0,
+               f = c.length; e < f && !this.xf; e++)
+          g = c[e],
+            this.kl[g + 1].apply(this.kl[g + 2], d)
+      } finally {
+        if (this.qS--,
+        0 < this.jS.length && 0 == this.qS)
+          for (; c = this.jS.pop(); )
+            this.B5(c)
+      }
+    }
+    return 0 != e
+  }
+  return !1
+}
+;
+function gvjs_4ga(a, b, c) {
+  gvjs_5k(function() {
+    a.apply(b, c)
+  })
+}
+gvjs_.clear = function(a) {
+  if (a) {
+    var b = this.Hr[a];
+    b && (b.forEach(this.B5, this),
+      delete this.Hr[a])
+  } else
+    this.kl.length = 0,
+      this.Hr = {}
+}
+;
+gvjs_.Cd = function(a) {
+  if (a) {
+    var b = this.Hr[a];
+    return b ? b.length : 0
+  }
+  a = 0;
+  for (b in this.Hr)
+    a += this.Cd(b);
+  return a
+}
+;
+gvjs_.M = function() {
+  gvjs_eL.G.M.call(this);
+  this.clear();
+  this.jS.length = 0
+}
+;
+function gvjs_fL(a, b, c, d) {
+  this.m = a;
+  this.K = b;
+  this.dj = c;
+  this.ha = d;
+  this.Kna = [];
+  this.zb = null;
+  this.gk = new gvjs_eL;
+  this.init()
+}
+gvjs_fL.prototype.init = function() {
+  gvjs_r(this.m.fa(gvjs_tu)) && this.Kna.push(new gvjs_dL(this.K,this.dj,this.m,this.ha,this.gk))
+}
+;
+gvjs_fL.prototype.xn = function(a, b) {
+  var c = gvjs_5ga[a];
+  c && this.zb && !this.zb.xf && gvjs_LK(this.zb, c);
+  c = Array(arguments.length);
+  c[0] = a;
+  for (var d = 1, e = arguments.length; d < e; d++)
+    c[d] = arguments[d];
+  this.gk.xn.apply(this.gk, c)
+}
+;
+var gvjs_5ga = {
+  dragstart: 15,
+  drag: 5,
+  dragend: 5,
+  scroll: 5,
+  rightclick: 5,
+  pinch: 5,
+  pinchend: 15
+};
+function gvjs_gL(a) {
+  for (var b = gvjs_5f("thead", {}, gvjs_hL(a, gvjs_6ga)), c = [], d = a.ca(), e = {
+    SF: 0
+  }; e.SF < d; e = {
+    SF: e.SF
+  },
+         ++e.SF)
+    c.push(gvjs_hL(a, function(f) {
+      return function(g, h) {
+        g = g.Ha(f.SF, h);
+        return gvjs_5f("td", {}, g)
+      }
+    }(e)));
+  a = gvjs_5f("tbody", {}, gvjs_$f(c));
+  return gvjs_5f(gvjs_Ld, {}, gvjs_$f(b, a))
+}
+function gvjs_hL(a, b) {
+  for (var c = [], d = a.$(), e = 0; e < d; ++e)
+    "" === a.Jg(e) && c.push(b(a, e));
+  a = gvjs_$f(c);
+  return gvjs_5f("tr", {}, a)
+}
+function gvjs_6ga(a, b) {
+  a = a.Ga(b) || a.Ne(b);
+  return gvjs_5f("th", {}, a)
+}
+;function gvjs_iL(a) {
+  gvjs_Qn.call(this, a);
+  this.Xg = null;
+  this.tb = gvjs_S;
+  this.Zf = this.Tc = this.m = this.ha = this.tga = null;
+  this.RM = [];
+  this.Tf = this.ab = this.Ls = this.Ra = null;
+  this.Vk = new gvjs_H;
+  this.ea = null;
+  this.zd = new gvjs_8q(this);
+  gvjs_6x(this, this.zd);
+  this.my = this.ls = null
+}
+gvjs_o(gvjs_iL, gvjs_Qn);
+gvjs_ = gvjs_iL.prototype;
+gvjs_.M = function() {
+  this.He();
+  gvjs_E(this.Vk);
+  gvjs_E(this.ea);
+  gvjs_E(this.ls);
+  gvjs_E(this.my);
+  gvjs_Qn.prototype.M.call(this)
+}
+;
+gvjs_.us = function(a, b, c, d, e, f) {
+  if (this.Xg === gvjs_fw)
+    return gvjs_jL.prototype.us.apply(this, arguments);
+  var g = this.Xg === gvjs_4u ? new gvjs_QK(a,b,c,d,e) : new gvjs_eJ(a,b,c,d,e);
+  this.oQ(g, f);
+  return g
+}
+;
+gvjs_.oQ = function(a, b) {
+  a.init(this.Bk, b)
+}
+;
+gvjs_.hH = function(a, b, c, d, e, f, g) {
+  return this.Xg === gvjs_fw ? gvjs_jL.prototype.hH.apply(this, arguments) : new gvjs_jK(a,b,c,d,e,f,g)
+}
+;
+gvjs_.gH = function(a, b, c, d) {
+  return this.Xg === gvjs_fw ? gvjs_jL.prototype.gH.apply(this, arguments) : new gvjs_WJ(a,b,c,d)
+}
+;
+gvjs_.Wx = function(a, b) {
+  return this.Xg === gvjs_fw ? gvjs_jL.prototype.Wx.apply(this, arguments) : new gvjs_aH(a,b)
+}
+;
+gvjs_.cc = function(a, b, c, d) {
+  this.Xg = a;
+  null != b && (this.Gma = b);
+  null != c && (this.tb = c);
+  null != d && (this.tga = d)
+}
+;
+gvjs_.Mca = function(a) {
+  a && this.constructor !== gvjs_jL && (this.__proto__ ? (this.__proto__ = gvjs_jL.prototype,
+    this.constructor = gvjs_jL,
+    this.constructor.call(this, this.container)) : this.cc(gvjs_fw))
+}
+;
+gvjs_.draw = function(a, b, c) {
+  this.Mca(gvjs_r(b) && b.type === gvjs_fw);
+  gvjs_Qn.prototype.draw.call(this, a, b, c)
+}
+;
+gvjs_.Rd = function(a, b, c, d) {
+  this.Bk = a;
+  c = c || {};
+  c = gvjs_Li(gvjs_Ii(c));
+  gvjs_7ga(this, c);
+  gvjs_8ga(this, c);
+  c.orientation = c.orientation || this.tb;
+  c.theme = c.theme || this.tga;
+  this.Xg != gvjs_f && gvjs_9ga(c);
+  if (this.Xg != gvjs_fw && gvjs_Jj(c.reverseCategories)) {
+    var e = c.orientation === gvjs_U ? gvjs_Ud : gvjs_Xu;
+    c[e] = c[e] || {};
+    c[e].direction = -1;
+    delete c.reverseCategories
+  }
+  gvjs_$ga(c);
+  gvjs_iba(this.container);
+  if (!b)
+    throw Error(gvjs_as);
+  gvjs_Fe(gvjs_Ky(b.$()), function(h) {
+    return b.Jg(h) == gvjs_3v
+  }) && (c.isDiff = !0);
+  this.Cy = b.W(0) != gvjs_g ? 1 : 0;
+  this.Gi = b.ca();
+  gvjs_kL(this);
+  c = gvjs_aha(c);
+  var f = []
+    , g = gvjs_7K();
+  gvjs_u(c, function(h) {
+    f.push.apply(f, gvjs_9d(gvjs_Vz(h, g)))
+  });
+  this.cfa = c;
+  this.m = new gvjs_Aj(gvjs_Le(this.cfa));
+  this.Xg = gvjs_J(this.m, gvjs_Sd, gvjs_f, gvjs_eC);
+  this.ga = this.La(this.m);
+  this.Pa = this.getHeight(this.m);
+  c = new gvjs_A(this.ga,this.Pa);
+  e = gvjs_K(this.m, gvjs_Eu);
+  if (!this.ab || this.ab.xf)
+    try {
+      this.ab = new gvjs_3B(this.container,c,a,e)
+    } catch (h) {
+      throw Error(gvjs_As);
+    }
+  else
+    this.ab.update(c, a);
+  this.Ra = new gvjs_bG(d);
+  this.Z = b;
+  f.length && this.Lh ? (this.Lh.promise.then(function() {
+    this.ab.rl(gvjs_s(this.no, this), a)
+  }, null, this),
+    gvjs_sy(this, gvjs_s(function() {
+      this.ab.rl(gvjs_s(this.no, this), a)
+    }, this)),
+    new gvjs_6K(f,this.Lh)) : this.ab.rl(gvjs_s(this.no, this), a)
+}
+;
+function gvjs_aha(a) {
+  if (a.isStacked && a.vAxis && a.vAxis.baseline)
+    throw Error(gvjs_5r);
+  var b = a.theme || [];
+  b && !Array.isArray(b) && (b = [b]);
+  for (var c = [a], d = 0; d < b.length; d++) {
+    var e = b[d];
+    if (typeof e === gvjs_l)
+      e = gvjs_4F(e);
+    else if (gvjs_r(e))
+      e instanceof gvjs_Aj && (e = gvjs_jq(e));
+    else
+      throw Error(gvjs_ws);
+    e && c.push(e)
+  }
+  a = a.type.toLowerCase();
+  gvjs_PF[a] && c.push(gvjs_PF[a]);
+  c.push(gvjs_QF);
+  return c
+}
+gvjs_.no = function() {
+  var a = this.ab.Oa()
+    , b = this.ab.yq()
+    , c = this.m
+    , d = gvjs_s(function(e) {
+    gvjs_lL(this);
+    e = e.ti();
+    var f = new gvjs_fL(c,this.Ra,gvjs_s(this.Ql, this),e);
+    gvjs_E(this.ea);
+    this.ea = new gvjs_MK(e,this.Ra,this.Vk,this.zd,gvjs_s(this.hk, this, !0),f);
+    this.Zf = this.hH(this.m, new gvjs_A(this.ga,this.Pa), {
+      bb: e.Hj,
+      fontSize: e.Dl
+    }, e.qz, e.Ig, e.C.length, this.Zf ? this.Zf.le : void 0);
+    gvjs_bha(this);
+    this.Tc = this.Wx(b, a);
+    gvjs_cha(this, e) || (this.ha = e,
+      gvjs_mL(this),
+      gvjs_nL(this));
+    gvjs_dha(this);
+    this.zd.dispatchEvent(gvjs_i);
+    this.ea.Bq()
+  }, this);
+  this.us(this.Z, c, gvjs_s(a.me, a), this.ga, this.Pa, d)
+}
+;
+function gvjs_dha(a) {
+  var b = a.ab.Oa();
+  gvjs_Oh().Vj().setTimeout(gvjs_s(function() {
+    if (b && b.ws) {
+      var c = b.ws();
+      if (c && this.Z) {
+        var d = gvjs_gL(this.Z);
+        gvjs_cg(c, d)
+      }
+    }
+  }, a), 0)
+}
+gvjs_.Jm = gvjs_n(70);
+gvjs_.av = function(a, b) {
+  var c = new gvjs_M
+    , d = b.ca()
+    , e = b.$()
+    , f = a.W(0) != gvjs_g;
+  f && c.xd(a.W(0), a.Ga(0));
+  for (var g = f ? 1 : 0, h = g; h < e; ++h)
+    c.xd({
+      type: a.W(h),
+      label: a.Ga(h),
+      role: gvjs_3v
+    }),
+      c.xd({
+        type: b.W(h),
+        label: b.Ga(h),
+        role: gvjs_$t
+      });
+  c.Yn(d);
+  for (var k = 0; k < d; ++k) {
+    f && (h = b.getValue(k, 0),
+      c.Wb(k, 0, h));
+    var l = g;
+    for (h = g; h < e; ++h) {
+      var m = a.getValue(k, h);
+      c.Wb(k, l, m);
+      l += 1;
+      m = b.getValue(k, h);
+      c.Wb(k, l, m);
+      l += 1
+    }
+  }
+  return c
+}
+;
+function gvjs_7ga(a, b) {
+  switch (b.type) {
+    case gvjs_e:
+      a.cc(gvjs_d, gvjs_e, gvjs_S);
+      b.type = null;
+      break;
+    case gvjs_at:
+      a.cc(gvjs_d, gvjs_at, gvjs_S);
+      b.type = null;
+      break;
+    case "columns":
+      a.cc(gvjs_d, gvjs_lt, gvjs_S);
+      b.type = null;
+      break;
+    case gvjs_lt:
+      a.cc(gvjs_d, gvjs_lt, gvjs_U);
+      b.type = null;
+      break;
+    case gvjs_Dd:
+      a.cc(gvjs_Dd);
+      b.type = null;
+      break;
+    case gvjs_fw:
+      a.cc(gvjs_fw),
+        b.type = null
+  }
+  a = a.Xg;
+  a == gvjs_f && (a = null);
+  var c = b.type || gvjs_f;
+  c == gvjs_f && (c = null);
+  if (!a && !c)
+    throw Error(gvjs_zs);
+  if (a && c && a != c)
+    throw Error(gvjs_es);
+  b.type = a || c
+}
+function gvjs_8ga(a, b) {
+  if (b.type == gvjs_d) {
+    a = a.Gma;
+    a == gvjs_f && (a = null);
+    var c = b.seriesType || gvjs_f;
+    c == gvjs_f && (c = null);
+    if (a && c && a != c)
+      throw Error(gvjs_fs);
+    b.seriesType = a || c
+  }
+}
+function gvjs_9ga(a) {
+  a.hAxis = a.hAxis || {};
+  a.vAxis = a.vAxis || {};
+  var b = a.hAxis
+    , c = a.vAxis
+    , d = null;
+  switch (a.type) {
+    case gvjs_Dd:
+      d = c;
+      break;
+    case gvjs_d:
+      a.targetAxis = a.targetAxis || {},
+        d = a.targetAxis
+  }
+  d && (gvjs_oL(a, gvjs_Ov, d, gvjs_ed),
+    gvjs_oL(a, gvjs_Gv, d, gvjs_cd),
+    gvjs_oL(a, gvjs_Cv, d, gvjs_Cv));
+  b && (gvjs_oL(a, "logScaleX", b, gvjs_Cv),
+    gvjs_oL(a, "titleX", b, gvjs_fx));
+  c && gvjs_oL(a, gvjs_jx, c, gvjs_fx);
+  a.smoothLine && void 0 === a.curveType && (a.curveType = gvjs_d);
+  gvjs_oL(a, "lineSize", a, gvjs_Bv);
+  gvjs_oL(a, gvjs_ww, a, gvjs_xw);
+  a.chartArea = a.chartArea || {};
+  gvjs_oL(a, gvjs_gt, a.chartArea, gvjs_ht)
+}
+function gvjs_$ga(a) {
+  gvjs_pL(a, gvjs_gx, gvjs_hx, gvjs_ix);
+  gvjs_pL(a, gvjs_xv, gvjs_wv, gvjs_yv);
+  gvjs_qL(a.hAxis);
+  for (var b in a.hAxes)
+    gvjs_qL(a.hAxes[b]);
+  gvjs_qL(a.vAxis);
+  for (b in a.vAxes)
+    gvjs_qL(a.vAxes[b]);
+  b = a.tooltip;
+  null == b && (b = {},
+    a.tooltip = b);
+  gvjs_pL(a, gvjs_sx, gvjs_rx, gvjs_tx);
+  gvjs_oL(a, gvjs_tx, b, gvjs_bx);
+  gvjs_oL(a, "tooltipText", b, gvjs_m);
+  gvjs_oL(a, gvjs_ux, b, "trigger");
+  "hover" == b.trigger && (b.trigger = gvjs_xu);
+  b = a.legend;
+  if (null == b)
+    b = {},
+      a.legend = b;
+  else if (typeof b == gvjs_l) {
+    var c = b;
+    b = {};
+    a.legend = b;
+    b.position = c
+  }
+  gvjs_oL(a, gvjs_yv, b, gvjs_bx);
+  b = a.animation;
+  null == b ? (b = {},
+    a.animation = b) : typeof b == gvjs_g && (c = 1E3 * b,
+    b = {},
+    a.animation = b,
+    b.duration = c);
+  gvjs_oL(a, gvjs_Xs, b, "easing")
+}
+function gvjs_qL(a) {
+  if (null != a) {
+    gvjs_pL(a, "textColor", "textFontSize", gvjs_bx);
+    gvjs_pL(a, gvjs_gx, gvjs_hx, gvjs_ix);
+    a.gridlines = a.gridlines || {};
+    var b = a.gridlines
+      , c = a.numberOfSections;
+    void 0 === b.count && void 0 !== c && typeof c == gvjs_g && (b.count = c + 1);
+    a = a.gridlineColor;
+    void 0 === b.color && void 0 !== a && (b.color = a)
+  }
+}
+function gvjs_pL(a, b, c, d) {
+  a[d] = a[d] || {};
+  d = a[d];
+  gvjs_oL(a, b, d, gvjs_1);
+  gvjs_oL(a, c, d, gvjs_zp)
+}
+function gvjs_oL(a, b, c, d) {
+  void 0 !== a[b] && void 0 === c[d] && (c[d] = a[b])
+}
+gvjs_.He = function() {
+  this.ku();
+  gvjs_kL(this);
+  gvjs_lL(this);
+  gvjs_E(this.ab);
+  gvjs_li(this)
+}
+;
+function gvjs_kL(a) {
+  if (a.ea && !a.ea.xf) {
+    var b = a.ea.zb;
+    b.fq = Infinity;
+    b.Hc.stop()
+  }
+  gvjs_E(a.ea);
+  if (a.ab && !a.ab.xf) {
+    b = a.ab.Oa();
+    var c = a.ab.yq();
+    a.my = b;
+    c.clear()
+  }
+  gvjs_E(a.ls);
+  gvjs_li(a.Vk)
+}
+function gvjs_lL(a) {
+  var b = a.my || a.ab && a.ab.Oa();
+  a.my = null;
+  b && b.clear()
+}
+function gvjs_bha(a) {
+  gvjs_u(a.RM, gvjs_s(function(b) {
+    typeof b === gvjs_l ? this.th(b) : this.xh(b)
+  }, a));
+  a.RM = []
+}
+gvjs_.xh = function(a) {
+  null != this.Zf ? this.Zf.xh(a) : this.RM.push(a)
+}
+;
+function gvjs_eha(a, b) {
+  var c = new gvjs_$n;
+  c.setSelection(b);
+  b = gvjs_co(c);
+  c = !1;
+  for (var d = 0; d < b.length; d++) {
+    var e = b[d]
+      , f = e.column;
+    e = e.row;
+    f = a.ha.Jk && a.ha.Jk[f];
+    if (!f)
+      return !1;
+    var g = f.Vb, h, k;
+    null != g ? h = a.ha.C[g].points[e] : k = a.ha.$a[e];
+    if (!h && !k)
+      return !1;
+    if (f.role == gvjs_Zs) {
+      if (c)
+        return !1;
+      c = !0;
+      if (!(h || k).Bc)
+        return !1
+    }
+  }
+  return !0
+}
+gvjs_.setSelection = function(a) {
+  if (gvjs_eha(this, a)) {
+    var b = null;
+    if (this.ha.Fa != gvjs_fw) {
+      var c = new gvjs_$n;
+      c.setSelection(a);
+      c = gvjs_co(c);
+      for (var d = 0; d < c.length; d++) {
+        var e = c[d]
+          , f = this.ha.Jk[e.column];
+        if (f.role == gvjs_Zs) {
+          b = {
+            Vb: f.Vb,
+            oO: e.row
+          };
+          break
+        }
+      }
+    }
+    this.hk(!0);
+    this.Ra.selected.setSelection(a);
+    b && (this.Ra.annotations.dI = b);
+    this.hk(!1)
+  }
+}
+;
+gvjs_.hk = function(a) {
+  if (this.Ls) {
+    var b = this.Ls;
+    if (!this.Zf.xY(this.Ra, this.Ls)) {
+      var c = this.Ra.gm;
+      if (c) {
+        this.m = new gvjs_Aj(gvjs_Le(this.cfa));
+        gvjs_hq(this.m, 0, c);
+        c = this.ab.Oa();
+        var d = this.us(this.Z, this.m, gvjs_s(c.me, c), this.ga, this.Pa).ti();
+        this.ea.ha = d;
+        this.my && (this.my.clear(),
+          this.my = null);
+        this.ls.I5 && this.ls.I5(d);
+        c = gvjs_iK(this.Zf, d, this.Ra);
+        this.ha = d;
+        this.Tc.VK(this.ha);
+        gvjs_OG(this.Tc, this.ha, c);
+        this.Ra.gm = null;
+        this.Ls = this.Ra.clone()
+      } else
+        this.Ls = this.Ra.clone(),
+          c = gvjs_iK(this.Zf, this.ha, this.Ra),
+          gvjs_PG(this.Tc, this.ha, c)
+    }
+    a && this.zd.Is(b, this.Ls, this.ha.Fa, this.ha.C)
+  }
+}
+;
+gvjs_.getSelection = function() {
+  return this.Ls ? this.Ls.selected.getSelection() : []
+}
+;
+gvjs_.ng = function(a) {
+  if (this.Zf)
+    return this.Zf.ng(a)
+}
+;
+gvjs_.th = function(a) {
+  null != this.Zf ? this.Zf.th(a) : this.RM.push(a)
+}
+;
+gvjs_.dump = function() {
+  var a = this.ab.Oa();
+  return a.Poa ? a.container.innerHTML : ""
+}
+;
+function gvjs_mL(a) {
+  var b = gvjs_iK(a.Zf, a.ha, a.Ra);
+  a.Tc.Fl(a.ha, b);
+  a.Ls = a.Ra.clone()
+}
+function gvjs_nL(a) {
+  var b = a.ab.Oa()
+    , c = a.ab.yq();
+  gvjs_E(a.ls);
+  a.ls = a.gH(a.Vk, b, c, a.ha);
+  gvjs_QJ(a.ls);
+  gvjs_SJ(a.ls);
+  gvjs_TJ(a.ls)
+}
+function gvjs_cha(a, b) {
+  var c = gvjs_5K(a.m, 0, gvjs_Hp);
+  if (a.Tf) {
+    var d = a.Tf.zK;
+    a.ku()
+  } else
+    d = a.ha;
+  if (!c || !(c.iga || d && d.Fa === b.Fa) || b.Fa === gvjs_4u || b.Fa === gvjs_fw)
+    return !1;
+  if (!d) {
+    var e = gvjs_Ky(a.Z.$())
+      , f = a.Z.bf;
+    f || (f = a.Ta.Do().map(function(q) {
+      return gvjs_r(q) ? q : {
+        sourceColumn: q,
+        properties: a.Z.Rj(q)
+      }
+    }));
+    var g = b.C;
+    d = b.Jk;
+    b.Fa === gvjs_yt && (d = [{
+      role: gvjs_5c
+    }, {
+      role: gvjs_mu
+    }, {
+      role: gvjs_$t,
+      Vb: 0
+    }]);
+    var h, k;
+    gvjs_u(d, function(q, r) {
+      if (q.role === gvjs_$t || q.role === gvjs_iv) {
+        var t = gvjs_x(f[r]);
+        if (q.role === gvjs_$t) {
+          q = g[q.Vb];
+          if (q.ag)
+            return;
+          q = q.Qc || 0;
+          if (null != q) {
+            var u = b.orientation && b.orientation !== gvjs_S ? b.jd[q] : b.wc[q];
+            h = function() {
+              return u.baseline.za
+            }
+            ;
+            k = u.dataType
+          }
+        } else
+          t.role = gvjs_iv;
+        t.calc = h;
+        t.type = k;
+        e[r] = t
+      }
+    });
+    d = new gvjs_N(a.Z);
+    d.Hn(e);
+    var l = {};
+    b.jd && gvjs_w(b.jd, function(q, r) {
+      q.Tn && (l[r] = {
+        viewWindow: {
+          numericMin: q.Tn.min,
+          numericMax: q.Tn.max
+        }
+      })
+    });
+    var m = {};
+    b.wc && gvjs_w(b.wc, function(q, r) {
+      q.Tn && (m[r] = {
+        viewWindow: {
+          numericMin: q.Tn.min,
+          numericMax: q.Tn.max
+        }
+      })
+    });
+    gvjs_hq(a.m, 0, {
+      hAxes: l,
+      vAxes: m
+    });
+    var n = a.ab.Oa();
+    d = a.us(d, a.m, gvjs_s(n.me, n), a.ga, a.Pa).ti()
+  }
+  a.ha = null;
+  n = Date.now();
+  var p = a.Tf && a.Tf.iA || 0;
+  a.ku();
+  a.Tf = {
+    bua: d,
+    $J: b,
+    interpolator: new gvjs_zK(d,b),
+    zK: d,
+    startTime: n,
+    endTime: n + c.duration,
+    iA: p,
+    timer: new gvjs_IA(10),
+    oY: c.easing,
+    HD: c.HD,
+    done: !1
+  };
+  a.faa();
+  gvjs_G(a.Tf.timer, gvjs_dx, gvjs_s(a.faa, a));
+  a.Tf.timer.start();
+  a.ha = b;
+  return !0
+}
+gvjs_.faa = function() {
+  var a = this.Tf;
+  this.ha = null;
+  if (a.done)
+    this.ku(),
+      this.ha = a.$J,
+      gvjs_mL(this),
+      gvjs_nL(this),
+      this.zd.dispatchEvent(gvjs_Ys);
+  else {
+    var b = Date.now()
+      , c = (b - a.startTime) / (a.endTime - a.startTime);
+    if (1 > c) {
+      if (b - a.iA < 1E3 / this.Tf.HD)
+        return
+    } else
+      c = 1,
+        a.done = !0;
+    c = a.interpolator.interpolate(a.oY(c));
+    a.zK = c;
+    a.iA = b;
+    this.Tc.Fl(c, {});
+    this.zd.dispatchEvent("animationframefinish")
+  }
+  this.ha = a.$J
+}
+;
+gvjs_.ku = function() {
+  this.Tf && (gvjs_E(this.Tf.timer),
+    this.Tf = null)
+}
+;
+gvjs_.fZ = function() {
+  var a = this.ha.O;
+  return {
+    left: a.left,
+    top: a.top,
+    width: a.width,
+    height: a.height
+  }
+}
+;
+gvjs_.Qj = function(a) {
+  return null == this.Tc ? null : (a = this.Tc.Qj(a)) ? {
+    left: a.left,
+    top: a.top,
+    width: a.right - a.left,
+    height: a.bottom - a.top
+  } : null
+}
+;
+gvjs_.Ql = function() {
+  var a = this.ha;
+  return {
+    getChartAreaBoundingBox: gvjs_s(this.fZ, this),
+    getBoundingBox: gvjs_s(this.Qj, this),
+    getXLocation: gvjs_s(gvjs_5G, null, a),
+    getYLocation: gvjs_s(gvjs_6G, null, a),
+    getHAxisValue: gvjs_s(gvjs_7G, null, a),
+    getVAxisValue: gvjs_s(gvjs_8G, null, a),
+    getPointDatum: gvjs_s(gvjs_9G, null, a)
+  }
+}
+;
+gvjs_.pZ = gvjs_n(71);
+gvjs_.ti = function() {
+  return this.ha
+}
+;
+gvjs_.ah = function() {
+  if (!this.m || !this.ha || !this.Ra)
+    throw Error(gvjs_6r);
+  var a = new gvjs_A(this.ga,this.Pa)
+    , b = gvjs_3g(this.container).createElement(gvjs_Ob);
+  a = gvjs_1B(b, a);
+  a = new gvjs_rB(b,a);
+  a = this.Wx(new gvjs_MB(b), a);
+  var c = gvjs_iK(this.Zf, this.ha, this.Ra);
+  a.Fl(this.ha, c);
+  return b.childNodes[0].toDataURL(gvjs_bv)
+}
+;
+gvjs_.Se = null;
+function gvjs_jL(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_fw)
+}
+gvjs_o(gvjs_jL, gvjs_iL);
+gvjs_ = gvjs_jL.prototype;
+gvjs_.Mca = function() {}
+;
+gvjs_.us = function(a, b, c, d, e, f) {
+  a = new gvjs_XK(a,b,c,d,e);
+  this.oQ(a, f);
+  return a
+}
+;
+gvjs_.hH = function(a, b, c, d, e, f, g) {
+  return new gvjs_2K(a,b,c,d,e,f,g)
+}
+;
+gvjs_.gH = function(a, b, c) {
+  return new gvjs_1K(a,b,c)
+}
+;
+gvjs_.Wx = function(a, b) {
+  return new gvjs_TK(a,b)
+}
+;
+gvjs_.Jm = gvjs_n(69);
+function gvjs_rL(a) {
+  gvjs_iL.call(this, a);
+  this.cc(gvjs_d, gvjs_f, gvjs_S)
+}
+gvjs_o(gvjs_rL, gvjs_iL);
+function gvjs_fha(a) {
+  return a
+}
+function gvjs_sL(a) {
+  if (void 0 === a)
+    return gvjs_fha;
+  if (typeof a == gvjs_d)
+    return a;
+  if (typeof a == gvjs_l)
+    return function(b) {
+      return b[a]
+    }
+      ;
+  throw "Bad type for verbal.evaluator: " + a;
+}
+function gvjs_tL(a, b) {
+  var c = gvjs_sL(b);
+  return gvjs_Ee(a, function(d, e) {
+    return d + c(e)
+  }, 0)
+}
+function gvjs_uL(a, b) {
+  return gvjs_tL(a, b) / a.length
+}
+function gvjs_vL(a, b) {
+  return Math.sqrt(gvjs_wL(a, b))
+}
+function gvjs_wL(a, b) {
+  var c = gvjs_sL(b);
+  b = gvjs_uL(a, function(d) {
+    d = c(d);
+    return d * d
+  });
+  a = gvjs_uL(a, c);
+  return Math.max(b - a * a, 0)
+}
+function gvjs_xL(a, b) {
+  var c = gvjs_sL(b), d, e;
+  gvjs_u(a, function(f) {
+    var g = c(f);
+    d >= g || (d = g,
+      e = f)
+  });
+  return e
+}
+function gvjs_yL(a, b) {
+  var c = gvjs_sL(b);
+  return gvjs_xL(a, function(d) {
+    return -c(d)
+  })
+}
+var gvjs_gha = 1 / Math.sqrt(2 * Math.PI);
+function gvjs_zL(a, b, c) {
+  if (0 > c)
+    throw "Bad normal distribution: sigma = " + c + ".";
+  if (0 == c)
+    return a == b ? Infinity : 0;
+  a = (a - b) / c;
+  return gvjs_gha * Math.exp(-.5 * a * a) / c
+}
+function gvjs_AL(a, b, c) {
+  b = b || 0;
+  c = c || 1;
+  if (0 == c)
+    return a >= b ? 1 : 0;
+  if (0 != b || 1 != c)
+    return gvjs_AL((a - b) / c);
+  if (0 < a)
+    return 1 - gvjs_AL(-a);
+  var d = Math.abs(a);
+  a = Math.exp(-d * d / 2);
+  c = [.65, 4, 3, 2, 1];
+  if (37 < d)
+    return 0;
+  if (7.07106781186547 <= d) {
+    var e = 1;
+    c.forEach(function(h) {
+      e = d + h / e
+    });
+    return a / e / 2.506628274631
+  }
+  var f = 0
+    , g = 0;
+  [.0352624965998911, .700383064443688, 6.37396220353165, 33.912866078383, 112.079291497871, 221.213596169931, 220.206867912376].forEach(function(h) {
+    f = f * d + h
+  });
+  [.0883883476483184, 1.75566716318264, 16.064177579207, 86.7807322029461, 296.564248779674, 637.333633378831, 793.826512519948, 440.413735824752].forEach(function(h) {
+    g = g * d + h
+  });
+  return a * f / g
+}
+function gvjs_BL(a) {
+  this.params = a || {};
+  this.Rf = this.Vd = 0;
+  this.name = "AbstractStatsModel"
+}
+function gvjs_CL(a, b) {
+  gvjs_w(b, function(c, d) {
+    gvjs_Ty(this.params, d, c)
+  }, a)
+}
+;function gvjs_DL() {
+  this.Ot = this.GV = null
+}
+function gvjs_EL(a) {
+  var b = new gvjs_DL;
+  b.GV = a;
+  return b
+}
+function gvjs_FL(a) {
+  var b = new gvjs_DL;
+  b.Ot = a;
+  return b
+}
+function gvjs_GL(a) {
+  if (null != a.GV)
+    return a.GV;
+  throw Error("AbstractRenderer not set");
+}
+gvjs_DL.prototype.cp = gvjs_n(72);
+function gvjs_HL() {}
+;function gvjs_IL(a, b) {
+  this.pf = a;
+  this.rb = null != b && gvjs_x(b) || {}
+}
+function gvjs_JL(a, b) {
+  a = gvjs_KL(new gvjs_IL(gvjs_os), gvjs_ps, a);
+  null != b && gvjs_KL(a, gvjs_rs, b);
+  return a
+}
+function gvjs_LL(a) {
+  a = gvjs_Gi(a);
+  return new gvjs_IL(a.pf,a.rb)
+}
+gvjs_ = gvjs_IL.prototype;
+gvjs_.clone = function() {
+  return gvjs_LL(this.ie())
+}
+;
+gvjs_.equals = function(a) {
+  if (!a || this.pf != a.pf)
+    return !1;
+  var b = gvjs_Ye(this.rb);
+  return b.length !== gvjs_Ye(a.rb).length ? !1 : gvjs_Ge(gvjs_v(b, gvjs_s(function(c) {
+    return this.rb[c] === a.rb[c]
+  }, this)), gvjs_Wx)
+}
+;
+function gvjs_KL(a, b, c) {
+  a.rb[b] = c;
+  return a
+}
+gvjs_.kD = function(a) {
+  return this.pf === a.pf && gvjs_Ve(this.rb, function(b, c) {
+    return a.rb[c] === b
+  })
+}
+;
+gvjs_.type = function() {
+  return this.pf
+}
+;
+gvjs_.ie = function() {
+  return gvjs_Hi(this)
+}
+;
+function gvjs_ML() {
+  this.selected = new gvjs_$n;
+  this.Rn = this.ff = null;
+  this.Cn = new Set
+}
+gvjs_ML.prototype.clone = function() {
+  var a = new gvjs_ML;
+  a.selected = this.selected.clone();
+  a.ff = this.ff ? this.ff.clone() : null;
+  a.Rn = this.Rn ? this.Rn.clone() : null;
+  a.Cn = new Set(this.Cn);
+  return a
+}
+;
+gvjs_ML.prototype.equals = function(a) {
+  return this.selected.equals(a.selected) && (this.ff ? this.ff.equals(a.ff) : !a.ff) && (this.Rn ? this.Rn.equals(a.Rn) : !a.Rn) && gvjs_Xz(this.Cn, a.Cn)
+}
+;
+function gvjs_NL(a, b) {
+  this.bI = a;
+  this.b$ = b || null;
+  this.K = null
+}
+gvjs_NL.prototype.setState = function(a) {
+  this.K = a.clone()
+}
+;
+function gvjs_OL(a, b) {
+  if (!b)
+    return null;
+  var c = {};
+  c.row = b.rb.ROW_INDEX;
+  c.column = b.rb.COLUMN_INDEX;
+  a.b$ && gvjs_w(a.b$, function(d, e) {
+    e = b.rb[e];
+    null != e && (c[d] = e)
+  });
+  return c
+}
+gvjs_NL.prototype.Is = function(a) {
+  var b = this.K
+    , c = [];
+  a.selected.equals(b.selected) && gvjs_Xz(a.Cn, b.Cn) || c.push({
+    event: gvjs_k,
+    data: null
+  });
+  var d = a.ff;
+  b = b.ff;
+  if (!d && b || d && !d.equals(b)) {
+    var e = !!b && !!d && !b.equals(d);
+    !e && d || c.push({
+      event: gvjs_6v,
+      data: gvjs_OL(this, b)
+    });
+    !e && b || c.push({
+      event: gvjs_7v,
+      data: gvjs_OL(this, d)
+    })
+  }
+  this.K = a.clone();
+  gvjs_u(c, function(f) {
+    this.dispatchEvent(f.event, f.data)
+  }, this)
+}
+;
+gvjs_NL.prototype.dispatchEvent = function(a, b) {
+  gvjs_I(this.bI, a, b)
+}
+;
+function gvjs_PL(a, b) {
+  gvjs_F.call(this);
+  this.K = null;
+  this.Kv = b;
+  this.zb = new gvjs_KK(a);
+  gvjs_6x(this, this.zb)
+}
+gvjs_o(gvjs_PL, gvjs_F);
+gvjs_PL.prototype.setState = function(a) {
+  this.K = a
+}
+;
+gvjs_PL.prototype.sI = function() {
+  return gvjs_s(this.handleEvent, this)
+}
+;
+gvjs_PL.prototype.handleEvent = function(a, b) {
+  if (null != this.Kv) {
+    var c = !1;
+    gvjs_u(this.Kv, function(d) {
+      d.Vna(a, b) && (d = d.QG(a, b, this.K),
+        c = c || d)
+    }, this);
+    c && gvjs_LK(this.zb, 50)
+  }
+}
+;
+function gvjs_hha() {
+  this.Os = [];
+  this.Ps = [];
+  this.KN = !1
+}
+;function gvjs_QL(a) {
+  this.K = null;
+  this.nv = [];
+  this.Kv = a
+}
+gvjs_ = gvjs_QL.prototype;
+gvjs_.JG = function(a) {
+  if (this.K.equals(a))
+    return {
+      KN: !1,
+      Os: [],
+      Ps: []
+    };
+  var b = this.nv;
+  a = this.Dk(a);
+  return this.fH(a, b)
+}
+;
+gvjs_.Dk = function(a) {
+  if (null == this.Kv)
+    return [];
+  var b = gvjs_Ee(this.Kv, function(c, d) {
+    gvjs_Me(c, d.Dk(a));
+    return c
+  }, [], this);
+  this.nv = b;
+  this.K = a.clone();
+  return b
+}
+;
+gvjs_.fH = function(a, b) {
+  a = this.Nu(a);
+  var c = this.Nu(b);
+  b = gvjs_Yz(a, c);
+  a = gvjs_Yz(c, a);
+  c = new gvjs_hha;
+  c.Os = this.Aw(b);
+  c.Ps = this.Aw(a);
+  return c
+}
+;
+gvjs_.Nu = function(a) {
+  a = gvjs_v(a, function(b) {
+    return gvjs_Hi(b)
+  });
+  return new Set(a)
+}
+;
+gvjs_.Aw = function(a) {
+  a = gvjs_nj(a);
+  return gvjs_v(a, function(b) {
+    b = gvjs_Gi(b);
+    b.targets = gvjs_v(b.targets, function(c) {
+      return new gvjs_IL(c.pf,c.rb)
+    });
+    return b
+  })
+}
+;
+function gvjs_RL(a, b, c, d, e, f) {
+  gvjs_F.call(this);
+  this.Ay = a;
+  this.IO = this.state = null;
+  this.c$ = this.Ay.xq();
+  a = this.Ay.xs(e);
+  this.Ai = new gvjs_QL(a);
+  e = f(gvjs_s(this.hk, this, !0));
+  this.pi = new gvjs_PL(e,a);
+  gvjs_6x(this, this.pi);
+  this.fo = this.Ay.po(b, c, this.pi.sI(), f);
+  this.AY = new gvjs_NL(d,this.c$)
+}
+gvjs_o(gvjs_RL, gvjs_F);
+gvjs_RL.prototype.draw = function(a, b) {
+  this.state = b.clone();
+  this.pi.setState(this.state);
+  this.AY.setState(this.state);
+  b = this.Ai.Dk(this.state);
+  this.fo.draw(a, b);
+  this.IO = this.state.clone();
+  this.AY.dispatchEvent(gvjs_i, null)
+}
+;
+gvjs_RL.prototype.hk = function(a) {
+  var b = this.Ai.JG(this.state);
+  this.fo.refresh(b);
+  this.IO = this.state.clone();
+  a && this.AY.Is(this.state)
+}
+;
+gvjs_RL.prototype.setSelection = function(a) {
+  this.hk(!0);
+  this.state.selected.setSelection(a);
+  this.hk(!1)
+}
+;
+gvjs_RL.prototype.getSelection = function() {
+  var a = this
+    , b = this.IO.selected.getSelection()
+    , c = [];
+  this.IO.Cn.forEach(function(d) {
+    d = gvjs_LL(d);
+    var e = {};
+    gvjs_w(a.c$, function(f, g) {
+      g = d.rb[g];
+      null != g && (e[f] = g)
+    });
+    c.push(e)
+  });
+  gvjs_Me(b, c);
+  return b
+}
+;
+function gvjs_SL(a) {
+  gvjs_Qn.call(this, a);
+  this.fp = null
+}
+gvjs_o(gvjs_SL, gvjs_Qn);
+gvjs_ = gvjs_SL.prototype;
+gvjs_.xq = function() {
+  return null
+}
+;
+gvjs_.og = function() {}
+;
+gvjs_.po = function() {}
+;
+gvjs_.Mm = function() {}
+;
+gvjs_.Al = function() {}
+;
+gvjs_.xs = function() {
+  return null
+}
+;
+gvjs_.He = function() {
+  gvjs_E(this.fp);
+  this.fp = null
+}
+;
+gvjs_.setSelection = function(a) {
+  this.fp && this.fp.setSelection(a)
+}
+;
+gvjs_.getSelection = function() {
+  return this.fp ? this.fp.getSelection() : []
+}
+;
+function gvjs_TL(a, b, c, d, e) {
+  this.Ay = a;
+  this.renderer = b;
+  this.re = gvjs_EL(b);
+  this.zw = c;
+  this.vt = null;
+  this.Ez = gvjs_iha;
+  this.pi = d;
+  this.BB = e;
+  this.ho = null
+}
+gvjs_t(gvjs_TL, gvjs_HL);
+gvjs_ = gvjs_TL.prototype;
+gvjs_.draw = function(a) {
+  this.vt = {};
+  var b = this.renderer;
+  b.clear();
+  this.ho = this.Ay.Mm(a, this.zw);
+  a = this.ho.Tb();
+  a = b.Lm(a.width, a.height);
+  for (var c = 0; c < this.Ez.length; c++) {
+    var d = this.Ez[c]
+      , e = b.Sa();
+    b.appendChild(a, e);
+    this.vt[d] = e
+  }
+  this.ho.draw(this);
+  this.M3(a)
+}
+;
+gvjs_.$t = gvjs_n(73);
+gvjs_.refresh = function(a) {
+  this.kL(a.Ps, !1);
+  this.kL(a.Os, !0);
+  this.ho.draw(this)
+}
+;
+gvjs_.kL = function(a, b) {
+  for (var c = 0; c < a.length; c++)
+    for (var d = a[c], e = d.targets, f = 0; f < e.length; f++)
+      this.ho.nm(e[f], d.effect, b)
+}
+;
+gvjs_.M3 = function(a) {
+  var b = this.renderer;
+  b.ic(a, gvjs_3t, gvjs_Lz);
+  b.ic(a, gvjs_ld, this.BB(gvjs_s(this.handleEvent, this, gvjs_9u)));
+  b.ic(a, gvjs_kd, this.BB(gvjs_s(this.handleEvent, this, gvjs_$u)));
+  b.ic(a, gvjs_Wt, this.BB(gvjs_s(this.handleEvent, this, gvjs_Wt)))
+}
+;
+gvjs_.handleEvent = function(a, b) {
+  b.stopPropagation && b.stopPropagation();
+  b = this.renderer.xv(b.target);
+  b != gvjs_Bs && (b = gvjs_LL(b),
+    this.pi(b, a))
+}
+;
+gvjs_.Oa = function() {
+  return this.re
+}
+;
+gvjs_.we = function(a, b, c, d) {
+  null != b ? this.e3(a, b) : this.$n(a, c, d)
+}
+;
+gvjs_.$n = function(a, b, c) {
+  this.renderer.appendChild(this.vt[c], a);
+  this.renderer.kp(a, b.ie())
+}
+;
+gvjs_.e3 = function(a, b) {
+  gvjs_qh(b).replaceChild(a, b);
+  b = this.renderer.xv(b);
+  this.renderer.kp(a, b)
+}
+;
+gvjs_.Re = function(a) {
+  this.renderer.Re(a)
+}
+;
+var gvjs_iha = [gvjs_Wo, gvjs_Cw, gvjs_Bw, gvjs_Ds, gvjs_Cs];
+function gvjs_UL(a) {
+  gvjs_SL.call(this, a);
+  this.sb = null
+}
+gvjs_o(gvjs_UL, gvjs_SL);
+gvjs_ = gvjs_UL.prototype;
+gvjs_.po = function(a, b, c, d) {
+  if (null == b)
+    throw Error("Internal error: missing overlayArea");
+  a = gvjs_GL(a);
+  return new gvjs_TL(this,a,b,c,d)
+}
+;
+gvjs_.Rd = function(a, b, c) {
+  (0,
+    gvjs_D.removeAll)(this.container);
+  c = c || {};
+  var d = this.og() || {};
+  c = new gvjs_Aj([c, d]);
+  d = this.La(c);
+  var e = this.getHeight(c);
+  d = new gvjs_A(d,e);
+  e = gvjs_K(c, gvjs_Eu);
+  this.nH(d, a, e);
+  this.sb.rl(this.no.bind(this, b, c, d, a), a)
+}
+;
+gvjs_.nH = function(a, b, c) {
+  null == this.sb ? this.sb = new gvjs_3B(this.container,a,b,c) : this.sb.update(a, b)
+}
+;
+gvjs_.no = function(a, b, c, d) {
+  var e = this.sb.Oa()
+    , f = this.sb.yq();
+  c = this.Al(a, b, e.me.bind(e), c).$g();
+  gvjs_E(this.fp);
+  if (e instanceof gvjs_XA)
+    var g = gvjs_EL(e);
+  else if (e instanceof gvjs_dC)
+    g = gvjs_FL(e);
+  else
+    throw Error("Unknown renderer type");
+  this.fp = new gvjs_RL(this,g,f,this,b,d);
+  this.fp.draw(c, new gvjs_ML);
+  e.ws && (b = e.ws()) && a && (a = gvjs_gL(a),
+    gvjs_cg(b, a))
+}
+;
+gvjs_.He = function() {
+  gvjs_SL.prototype.He.call(this);
+  gvjs_E(this.sb);
+  this.sb = null
+}
+;
+gvjs_q("gviz.fw.FrameworkVisualization.convertOptions", function(a) {
+  return a || {}
+}, void 0);
+function gvjs_VL() {
+  this.cca = null;
+  this.cua = {};
+  this.LR = {};
+  this.t9 = new Set;
+  this.Qma = new Set
+}
+gvjs_VL.prototype.set = function(a, b) {
+  this.cua[a] !== b ? this.t9.add(a) : this.t9.delete(a);
+  this.cca && this.cca[a] === b || (this.Qma.add(a),
+    this.LR[a] = b)
+}
+;
+gvjs_VL.prototype.get = function(a) {
+  return this.LR[a]
+}
+;
+gvjs_VL.prototype.keys = function() {
+  return gvjs_Ye(this.LR)
+}
+;
+function gvjs_WL(a, b, c) {
+  this.pf = a;
+  this.h$ = b;
+  this.Bi = new gvjs_VL;
+  this.yn = null;
+  this.Gsa = c;
+  a === gvjs_Lp && (this.Bi.set(gvjs_np, gvjs_f),
+    this.Bi.set(gvjs_0p, gvjs_kr),
+    this.yn = new gvjs_Uq(this.ar()))
+}
+gvjs_ = gvjs_WL.prototype;
+gvjs_.Hl = gvjs_n(74);
+gvjs_.ar = function() {
+  return this.Bi.LR
+}
+;
+function gvjs_XL(a, b) {
+  a.Bi.set("x", b);
+  return a
+}
+function gvjs_YL(a, b) {
+  a.Bi.set("y", b);
+  return a
+}
+gvjs_.Ug = function(a) {
+  this.Bi.set(gvjs_Xd, a);
+  return this
+}
+;
+gvjs_.fl = function(a) {
+  this.Bi.set(gvjs_4c, a);
+  return this
+}
+;
+gvjs_.du = function(a) {
+  this.Bi.set(gvjs_m, a);
+  return this
+}
+;
+gvjs_.setRadius = function(a) {
+  this.Bi.set("radius", a);
+  return this
+}
+;
+gvjs_.rd = function(a) {
+  this.Bi.set(gvjs_0p, a);
+  this.yn && this.yn.style(gvjs_0p, a)
+}
+;
+gvjs_.hl = function(a) {
+  this.Bi.set(gvjs_8p, a);
+  this.yn && this.yn.style(gvjs_8p, a)
+}
+;
+gvjs_.Te = function(a) {
+  this.Bi.set(gvjs_np, a);
+  return this
+}
+;
+gvjs_.mf = function(a) {
+  this.Bi.set(gvjs_sp, a);
+  return this
+}
+;
+gvjs_.move = function(a, b) {
+  this.yn.move(a, b);
+  return this
+}
+;
+gvjs_.va = function(a, b) {
+  this.yn.line(a, b)
+}
+;
+gvjs_.Sf = function(a, b, c, d, e, f, g) {
+  this.yn.arc(a, b, c, d, e, f, g)
+}
+;
+gvjs_.om = function(a) {
+  this.Bi.set(gvjs_zp, a);
+  return this
+}
+;
+function gvjs_ZL(a) {
+  this.Vg = [];
+  this.ya = a;
+  this.rz = 0
+}
+gvjs_ = gvjs_ZL.prototype;
+gvjs_.Tb = function() {
+  return this.ya
+}
+;
+gvjs_.zP = gvjs_n(75);
+gvjs_.va = function(a, b, c) {
+  a = gvjs_YL(gvjs_XL(new gvjs_WL(gvjs_e,a || this.ay(),b || gvjs_Wo), c), void 0);
+  a.Bi.set("x2", void 0);
+  a.Bi.set("y2", void 0);
+  this.Vg.push(a)
+}
+;
+gvjs_.addPath = function(a, b) {
+  a = new gvjs_WL(gvjs_Lp,a || this.ay(),b || gvjs_Wo);
+  this.Vg.push(a);
+  return a
+}
+;
+gvjs_.tB = function(a, b, c, d, e, f) {
+  a = gvjs_YL(gvjs_XL((new gvjs_WL(gvjs_m,a || this.ay(),b || gvjs_Wo)).du(c), d), e).Ug(f);
+  this.Vg.push(a);
+  return a
+}
+;
+gvjs_.ay = function() {
+  var a = new gvjs_IL(gvjs_3r);
+  gvjs_KL(a, gvjs_rs, "__internal_" + this.rz);
+  this.rz += 1;
+  return a
+}
+;
+function gvjs__L(a, b) {
+  gvjs_F.call(this);
+  this.ac = a;
+  this.Ei = b
+}
+gvjs_t(gvjs__L, gvjs_F);
+var gvjs_jha = [];
+gvjs_ = gvjs__L.prototype;
+gvjs_.qd = null;
+gvjs_.Uc = null;
+gvjs_.lL = function(a) {
+  this.ac = a
+}
+;
+gvjs_.getId = function() {
+  return this.ac
+}
+;
+gvjs_.getName = function() {
+  return this.Ei
+}
+;
+gvjs_.getParent = function() {
+  return this.qd
+}
+;
+gvjs_.$v = function() {
+  return !this.ze()
+}
+;
+gvjs_.getChildren = function() {
+  return this.Uc || gvjs_jha
+}
+;
+gvjs_.Ye = function(a) {
+  return this.getChildren()[a] || null
+}
+;
+gvjs_.ze = function() {
+  return this.getChildren().length
+}
+;
+gvjs_.getHeight = function() {
+  var a = this.getChildren();
+  return gvjs_Ee(a, function(b, c) {
+    return Math.max(b, c.getHeight())
+  }, -1) + 1
+}
+;
+gvjs_.contains = function(a) {
+  do
+    a = a.getParent();
+  while (a && a != this);
+  return !!a
+}
+;
+gvjs_.VL = function(a, b) {
+  function c(d, e) {
+    !1 !== a.call(b, d, e) && gvjs_u(d.getChildren(), function(f) {
+      c(f, e + 1)
+    })
+  }
+  c(this, 0)
+}
+;
+gvjs_.find = function(a, b) {
+  var c = [];
+  this.VL(function(d) {
+    a.call(b, d) && c.push(d)
+  });
+  return c
+}
+;
+gvjs_.MB = gvjs_n(77);
+gvjs_.addChild = function(a) {
+  a.qd = this;
+  this.Uc = this.Uc || [];
+  this.Uc.push(a);
+  gvjs_6x(this, a)
+}
+;
+function gvjs_0L(a, b, c) {
+  gvjs__L.call(this, c, a);
+  this.Z = b
+}
+gvjs_o(gvjs_0L, gvjs__L);
+gvjs_ = gvjs_0L.prototype;
+gvjs_.mb = function() {
+  return this.Z
+}
+;
+function gvjs_1L(a) {
+  return a.Ha(0) || a.getName()
+}
+gvjs_.Ul = function(a) {
+  return this.BZ(this.Z.Ul, a)
+}
+;
+gvjs_.getValue = function(a) {
+  return this.BZ(this.Z.getValue, a)
+}
+;
+gvjs_.Ha = function(a) {
+  return this.BZ(this.Z.Ha, a)
+}
+;
+gvjs_.BZ = function(a, b) {
+  var c = this.getId();
+  return null != c ? (c = [c],
+    gvjs_Me(c, Array.prototype.slice.call(arguments, 1)),
+    a.apply(this.Z, c)) : null
+}
+;
+function gvjs_2L() {
+  gvjs_F.call(this);
+  this.ep = [];
+  this.uw = {}
+}
+gvjs_t(gvjs_2L, gvjs_F);
+gvjs_ = gvjs_2L.prototype;
+gvjs_.sB = function(a) {
+  var b = a.getId();
+  null != b && (this.uw[b] = a)
+}
+;
+gvjs_.getHeight = function() {
+  return gvjs_Ee(this.ep, function(a, b) {
+    return Math.max(a, b.getHeight())
+  }, -1)
+}
+;
+gvjs_.VL = function(a, b) {
+  for (var c = this.ep, d = 0; d < c.length; d++)
+    c[d].VL(a, b)
+}
+;
+gvjs_.find = function(a, b) {
+  for (var c = [], d = this.ep, e = 0; e < d.length; e++)
+    gvjs_Me(c, d[e].find(a, b));
+  return c
+}
+;
+gvjs_.MB = gvjs_n(76);
+function gvjs_3L(a, b) {
+  gvjs_2L.call(this);
+  if (2 > a.$())
+    throw Error("Data table should have at least 2 columns");
+  if (a.W(0) != gvjs_l)
+    throw Error("Column 0 must be of type string");
+  if (a.W(1) != gvjs_l)
+    throw Error("Column 1 must be of type string");
+  b = this.Kt(b);
+  for (var c = b.W9, d = b.X9, e = b.v$, f = {}, g = [], h = 0; h < a.ca(); h++)
+    if (b = a.getValue(h, 0)) {
+      var k = f[b];
+      k ? null == k.getId() && k.lL(h) : (f[b] = k = new gvjs_0L(b,a,h),
+        g.push(k));
+      var l = k.getValue(1);
+      if (l)
+        if (b = f[l],
+        b || (f[l] = b = new gvjs_0L(l,a,null),
+          g.push(b)),
+          k.getParent()) {
+          if (d)
+            throw Error("More than one row with the same id (" + k.getName() + ").");
+        } else if (k != b && !k.contains(b))
+          b.addChild(k);
+        else if (c) {
+          a = Error;
+          e = gvjs_kha;
+          g = b;
+          c = [];
+          for (b = b.getParent(); b; )
+            c.push(b),
+              b = b.getParent();
+          throw a("Data contains a cycle: " + e(this, gvjs_Ke(g, c)) + ".");
+        }
+    }
+  for (b = 0; b < g.length; b++) {
+    k = g[b];
+    if (e && null === k.getId())
+      throw Error('Failed to find row with id "' + k.getName() + '".');
+    k.getParent() ? this.sB(k) : (a = k,
+      this.ep.push(a),
+      gvjs_6x(this, a),
+      this.sB(a))
+  }
+}
+gvjs_t(gvjs_3L, gvjs_2L);
+function gvjs_kha(a, b) {
+  return gvjs_v(b, function(c) {
+    return c.getName()
+  }).toString()
+}
+gvjs_3L.prototype.Kt = function(a) {
+  var b = new gvjs_9F(2);
+  gvjs_$F(b, 0, {
+    W9: !0,
+    X9: !0,
+    v$: !0
+  });
+  null != a && gvjs_$F(b, 1, a);
+  return b.compact()
+}
+;
+function gvjs_4L(a, b, c, d, e) {
+  gvjs_2L.call(this);
+  a = a.ep;
+  for (var f = 0; f < a.length; f++) {
+    var g = gvjs_5L(this, a[f], b, c, d, e);
+    this.ep.push(g);
+    gvjs_6x(this, g);
+    this.sB(g)
+  }
+}
+gvjs_o(gvjs_4L, gvjs_2L);
+function gvjs_5L(a, b, c, d, e, f) {
+  var g = c.call(d, b)
+    , h = null != e && null != f;
+  if (h) {
+    var k = e || 0
+      , l = f || 0;
+    g.NDa = (k + l / 2 * b.ze()) % 360
+  }
+  b = b.getChildren();
+  for (f = 0; f < b.length; f++)
+    e = b[f],
+      h ? (e = gvjs_5L(a, e, c, d, k, e.$v() ? 0 : l / e.ze()),
+        k = (k + l) % 360) : e = gvjs_5L(a, e, c, d),
+      a.sB(e),
+      g.addChild(e);
+  return g
+}
+;function gvjs_6L(a, b, c) {
+  c = null != c ? gvjs_v(c, function(l) {
+    return [l, 0]
+  }) : b ? gvjs_lha : gvjs_mha;
+  var d = c.length;
+  this.oh = [];
+  for (var e = 1 + Math.floor((a - 1) / d), f = Math.ceil(a / e), g = [], h = 0; h < d; h++)
+    c[h][1] < f && g.push(c[h][0]);
+  for (h = 0; h < a; h++) {
+    var k = Math.pow(b ? .7 : .85, b ? Math.floor(h / f) : h % e);
+    this.oh[h] = gvjs_v(g[b ? h % f : Math.floor(h / e)], function(l) {
+      return ~~(k * l + 255 * (1 - k))
+    })
+  }
+}
+gvjs_6L.prototype.Tb = function() {
+  return this.oh.length
+}
+;
+gvjs_6L.prototype.ee = function(a) {
+  return "rgb(" + this.oh[a] + ")"
+}
+;
+function gvjs_7L(a, b) {
+  function c(d) {
+    d = d.toString(16);
+    1 == d.length && (d = "0" + d);
+    return d
+  }
+  a = a.oh[b];
+  return "#" + (c(a[0]) + c(a[1]) + c(a[2])).toUpperCase()
+}
+var gvjs_mha = [[[66, 133, 244], 0], [[219, 68, 55], 0], [[244, 180, 0], 0], [[15, 157, 88], 0], [[171, 71, 188], 0], [[0, 172, 193], 0], [[255, 112, 67], 0], [[158, 157, 36], 0], [[92, 107, 192], 0], [[240, 98, 146], 0], [[0, 121, 107], 0], [[194, 24, 91], 0]]
+  , gvjs_lha = [[[67, 69, 157], 6], [[83, 168, 251], 8], [[95, 150, 84], 10], [[241, 202, 58], 2], [[231, 113, 27], 5], [[135, 27, 71], 4], [[67, 116, 224], 0], [[26, 135, 99], 1], [[185, 194, 70], 9], [[228, 147, 7], 7], [[211, 54, 45], 3]];
+function gvjs_8L(a, b, c, d) {
+  this.AH = a;
+  this.LM = b;
+  this.c2 = c;
+  this.bna = d
+}
+gvjs_8L.prototype.qp = function(a) {
+  this.Oba = a
+}
+;
+gvjs_8L.prototype.CQ = function() {
+  return this.Oba
+}
+;
+gvjs_8L.prototype.Oba = !1;
+function gvjs_9L(a, b, c) {
+  this.Cl = a;
+  a = a.ca();
+  var d = b.cb("pagingButtons");
+  null === this.uda && (d = b.cb("pagingButtonsConfiguration"));
+  var e = null;
+  null !== d && (e = parseInt(d, 10) || 0);
+  var f = b.Aa("pageSize");
+  0 === f && (f = null);
+  this.e2 = gvjs_J(b, gvjs_cw, gvjs_ju) !== gvjs_ju || null != d || null != f;
+  this.Wda = d || gvjs_ub;
+  this.uda = e;
+  this.e2 && (null != f || e || (f = 10),
+  typeof f !== gvjs_g || e || (e = Math.ceil(a / f)),
+  null == f && typeof e === gvjs_g && (f = Math.ceil(a / e)));
+  this.aA = f || a;
+  this.iK = Math.ceil(a / this.aA);
+  this.foa = gvjs_L(b, "firstRowNumber", 1);
+  this.Ena = c == gvjs_qu
+}
+function gvjs_$L(a, b) {
+  a.Nm = Math.max(0, Math.min(a.iK - 1, b))
+}
+function gvjs_aM(a) {
+  for (var b = gvjs_bM(a), c = [], d = {}, e = b.start; e <= b.end; e++) {
+    var f = gvjs_cM(a, e);
+    d[f.AH] = f.c2;
+    c.push(f)
+  }
+  a.b2 = d;
+  return c
+}
+gvjs_ = gvjs_9L.prototype;
+gvjs_.AP = function() {
+  return {
+    column: this.FA,
+    ascending: !this.jD,
+    sortedIndexes: this.YE
+  }
+}
+;
+function gvjs_dM(a) {
+  return gvjs_cM(a, gvjs_bM(a).start)
+}
+function gvjs_eM(a, b) {
+  a.b2 || gvjs_aM(a);
+  a = a.b2[b];
+  return null != a ? a : -1
+}
+function gvjs_bM(a) {
+  var b = a.aA * a.Nm
+    , c = b + a.aA - 1;
+  c = Math.min(a.Cl.ca() - 1, c);
+  return new gvjs_O(b,c)
+}
+function gvjs_cM(a, b) {
+  var c = a.YE
+    , d = a.foa;
+  a = gvjs_bM(a).start;
+  return new gvjs_8L(c ? c[b] : b,b,b - a,b + d)
+}
+function gvjs_fM(a) {
+  if (a.Ena && -1 != a.FA) {
+    var b = a.Cl.bn([{
+      column: a.FA,
+      desc: a.jD
+    }])
+      , c = a.Cl.T$()
+      , d = gvjs_v(b, function(e) {
+      return c[e]
+    }, a);
+    a.Cl.pp(d);
+    a.YE = a.YE ? gvjs_v(b, function(e) {
+      return this.YE[e]
+    }, a) : b
+  } else
+    a.YE = null
+}
+gvjs_.Nm = 0;
+gvjs_.YE = null;
+gvjs_.FA = -1;
+gvjs_.jD = !1;
+gvjs_.b2 = null;
+function gvjs_gM(a, b, c) {
+  gvjs_4D.call(this, a, b || gvjs_lE.Lc(), c)
+}
+gvjs_t(gvjs_gM, gvjs_4D);
+gvjs_HD(gvjs_Hs, function() {
+  return new gvjs_gM(null)
+});
+function gvjs_hM(a) {
+  gvjs_Qn.call(this, a);
+  this.D = gvjs_Oh();
+  this.Of = new gvjs_$n;
+  this.mq = {};
+  this.VY = this.eP = this.Iy = this.XS = this.m_ = this.VS = this.Ut = null
+}
+gvjs_o(gvjs_hM, gvjs_Qn);
+gvjs_ = gvjs_hM.prototype;
+gvjs_.Rd = function(a, b, c) {
+  if (!b)
+    throw Error(gvjs_as);
+  a = this.m = new gvjs_Aj([c]);
+  this.NV = gvjs_K(a, gvjs_Us, !1);
+  this.MV = gvjs_K(a, "allowHtmlSafely", !1);
+  gvjs_K(a, "sanitizeHtml", !1);
+  this.f4 = gvjs_K(a, "showRowNumber", !1);
+  this.UT = gvjs_J(a, "sort", gvjs_qu);
+  this.Of.clear();
+  this.ra = b;
+  this.Cl = new gvjs_N(this.ra);
+  this.ge = new gvjs_9L(this.Cl,this.m,this.UT);
+  if (this.i_ = 0 < this.ra.ca()) {
+    (b = a.Aa("startPage")) && gvjs_$L(this.ge, b);
+    b = a.Aa(gvjs__w);
+    if (this.UT != gvjs_ju && null != b) {
+      c = gvjs_K(a, "sortAscending", !0);
+      var d = this.ge;
+      d.FA = b;
+      d.jD = !c;
+      gvjs_fM(d)
+    }
+    this.wJ = gvjs_dM(this.ge)
+  }
+  this.US = gvjs_L(a, "scrollLeftStartPosition", 0);
+  this.OR = Math.max(-1, gvjs_L(a, "frozenColumns", -1));
+  this.gq = gvjs_x(gvjs_nha);
+  gvjs_oha(this);
+  a = !0;
+  this.n$ && (a = gvjs_iM(this),
+    this.n$ = !1);
+  this.Qt();
+  a ? (this.D.removeNode(this.FN),
+    this.gx()) : this.rha(0)
+}
+;
+gvjs_.gx = function() {
+  gvjs_I(this, gvjs_i, null)
+}
+;
+gvjs_.AP = function() {
+  return this.ge ? this.ge.AP() : null
+}
+;
+gvjs_.Qt = function(a) {
+  var b = this.m
+    , c = this.D;
+  a || (this.YG(),
+    this.oba = gvjs_Gh(this.container));
+  this.qK = null;
+  this.ea || (this.ea = new gvjs_KA);
+  a = this.OR;
+  var d = gvjs_J(b, gvjs_Xd, "")
+    , e = gvjs_J(b, gvjs_4c, "")
+    , f = this.mq.content;
+  f || (f = c.J(gvjs_b, {
+    "class": "google-visualization-table",
+    style: "position:relative; z-index:0"
+  }),
+    this.mq.content = f,
+    c.appendChild(this.container, f));
+  gvjs_C(f, {
+    visibility: gvjs_0u,
+    "max-width": gvjs_So,
+    "max-height": gvjs_So
+  });
+  d && (d = gvjs_jM(d),
+    gvjs_C(f, {
+      width: d
+    }));
+  e && (e = gvjs_jM(e));
+  var g = this.Ut = gvjs_pha(this, f)
+    , h = this.VS = gvjs_zh(c, gvjs_Ld, null, g)[0]
+    , k = gvjs_K(b, "keepScrollPosition", !1)
+    , l = this.US
+    , m = 0;
+  k && this.Ut && (l = this.Ut.scrollLeft,
+    m = this.Ut.scrollTop);
+  gvjs_C(g, {
+    overflow: gvjs_ub,
+    "max-width": gvjs_So,
+    "max-height": gvjs_So
+  });
+  k = e && -1 === e.toString().indexOf("%");
+  d && (gvjs_C(f, {
+    width: d
+  }),
+    gvjs_C(g, {
+      width: gvjs_So
+    }),
+    gvjs_C(h, {
+      width: gvjs_So
+    }));
+  e && (gvjs_C(f, {
+    height: e
+  }),
+    d = e,
+  -1 < e.toString().indexOf("%") && (d = gvjs_So),
+    gvjs_C(g, {
+      height: d
+    }),
+    gvjs_C(h, {
+      height: d
+    }));
+  !e && 0 < this.oba.height && (e = gvjs_Gh(f).height,
+    h = gvjs_Gh(g).height,
+  e < h && gvjs_C(f, {
+    height: gvjs_So
+  }),
+    gvjs_C(g, {
+      height: gvjs_So
+    }));
+  this.Iy = null;
+  this.GI();
+  this.ge.e2 && (e = this.mq[gvjs_dw],
+  e || (e = c.J(gvjs_b),
+    gvjs_WC(e, this.gq.fja),
+    this.mq[gvjs_dw] = e,
+    h = c.J(gvjs_b),
+    gvjs_C(h, {
+      clear: gvjs_ut,
+      width: gvjs_So,
+      height: gvjs_Nr
+    }),
+    this.mq["clear-float"] = h),
+    c.qc(e),
+    gvjs_C(g, {
+      height: ""
+    }),
+    gvjs_qha(this, f),
+    c = gvjs_Gh(f).height - (new gvjs_A(e.offsetWidth,e.offsetHeight)).height,
+  0 < c && (0 < this.oba.height || k) && gvjs_C(g, {
+    height: c + gvjs_T
+  }));
+  gvjs_K(b, "rtlTable", !1) && -1 == a && (this.VS.style.direction = gvjs_Up);
+  g.scrollTop = m;
+  g.scrollLeft = l;
+  gvjs_C(f, {
+    visibility: ""
+  })
+}
+;
+gvjs_.GI = function() {
+  function a() {
+    b.XS = null;
+    var h = c.scrollTop
+      , k = h + gvjs_T
+      , l = c.scrollLeft
+      , m = l + gvjs_T;
+    f && (gvjs_VC(c, "doneScrolling"),
+      gvjs_XC(c, "scrolling"));
+    gvjs_sg ? (h != e && gvjs_u(b.Iy, function(n) {
+      gvjs_C(n, {
+        "-moz-transform": "translateY(" + (h - 1) + "px)"
+      })
+    }),
+    l != g && gvjs_u(b.eP, function(n) {
+      gvjs_C(n, {
+        "-moz-transform": "translateX(" + m + ")"
+      })
+    }),
+      gvjs_u(b.VY, function(n) {
+        gvjs_C(n, {
+          "-moz-transform": "translate3D(" + m + "," + (h - 1) + "px,0)"
+        })
+      })) : (h != e && gvjs_u(b.Iy, function(n) {
+      gvjs_C(n, {
+        top: k
+      })
+    }),
+    l != g && gvjs_u(b.eP, function(n) {
+      gvjs_C(n, {
+        left: m
+      })
+    }));
+    e = h;
+    g = l
+  }
+  var b = this, c = this.Ut, d = this.D, e, f = gvjs_J(this.m, "scrollTransition", gvjs_ju) === gvjs_qu;
+  f && (gvjs_VC(c, "scrolling"),
+    gvjs_XC(c, "doneScrolling"));
+  if (!this.Iy) {
+    var g = e = 0;
+    this.Iy = gvjs_Le(this.m_.childNodes);
+    this.eP = gvjs_Le(d.wq(gvjs_Ju, this.VS));
+    gvjs_sg && (this.VY = [],
+      gvjs_u(gvjs_Le(this.Iy), function(h) {
+        gvjs_UC(h, gvjs_Ju) && (b.VY.push(h),
+          gvjs_Ie(b.Iy, h),
+          gvjs_Ie(b.eP, h))
+      }))
+  }
+  this.XS && clearTimeout(this.XS);
+  f ? this.XS = setTimeout(a, 10) : a();
+  return !0
+}
+;
+function gvjs_pha(a, b) {
+  var c = a.D
+    , d = a.m
+    , e = a.gq
+    , f = a.ra
+    , g = gvjs_kM(f);
+  e = gvjs_rha(f, e);
+  f = !1;
+  var h = null
+    , k = a.mq["scroll-pane"];
+  k ? (f = !0,
+    h = gvjs_zh(c, gvjs_Ld, null, k)[0],
+    b = a.m_,
+    gvjs_lM(a, b, e)) : (k = a.D.J(gvjs_b, {
+    style: "position: relative;"
+  }),
+    c.appendChild(b, k),
+    a.mq["scroll-pane"] = k,
+    a.ea.o(k, gvjs_Gw, function() {
+      a.GI()
+    }),
+    b = a.m_ = gvjs_lM(a, null, e));
+  var l = d.mz(gvjs_Ku)
+    , m = a.OR + (a.f4 ? 1 : 0)
+    , n = c.getChildren(b);
+  gvjs_u(n, function(p, q) {
+    q < m && (gvjs_VC(p, gvjs_Ju),
+    l && gvjs_C(p, {
+      "background-color": l
+    }))
+  });
+  0 < m && n.length > m && gvjs_VC(n[m - 1], gvjs_qv);
+  f ? gvjs_mM(a, h, b, d, e, g) : (h = gvjs_mM(a, null, b, d, e, g),
+    c.appendChild(k, h));
+  return k
+}
+function gvjs_mM(a, b, c, d, e, f) {
+  var g = a.ra
+    , h = a.D
+    , k = a.gq;
+  if (b)
+    c = gvjs_zh(h, "tbody", null, b)[0],
+      gvjs_hh(c);
+  else {
+    b = h.J(gvjs_ss, {
+      cellspacing: "0"
+    });
+    gvjs_WC(b, k.G6);
+    var l = h.J("THEAD");
+    h.appendChild(b, l);
+    h.appendChild(l, c);
+    c = h.J(gvjs_ts);
+    h.appendChild(b, c)
+  }
+  l = new gvjs_gk({
+    fractionDigits: 0,
+    pattern: "#"
+  });
+  var m = d.mz(gvjs_Ku);
+  null == a.qK && (a.qK = a.i_ ? gvjs_aM(a.ge) : []);
+  var n = a.qK
+    , p = a.OR;
+  d = gvjs_K(d, gvjs_Vs, !0);
+  d = null != d ? d : !0;
+  for (var q = 0; q < n.length; q++) {
+    var r = 0 == q % 2
+      , t = n[q]
+      , u = t.AH
+      , v = gvjs_do(a.Of, u)
+      , w = g.Ul(u, "rowColor")
+      , x = g.Ul(u, gvjs_Db);
+    t.qp(v);
+    u = h.J(gvjs_vs);
+    x && gvjs_TC(u, x);
+    v && gvjs_WC(u, k.KM);
+    d ? gvjs_WC(u, r ? k.zV : k.K6) : gvjs_WC(u, k.zV);
+    a.ea.o(u, gvjs_gd, a.ZZ.bind(a, t));
+    a.ea.o(u, gvjs_ld, a.a_.bind(a, t));
+    a.ea.o(u, gvjs_kd, a.$Z.bind(a, t));
+    h.appendChild(c, u);
+    a.f4 && (r = h.J(gvjs_us),
+      gvjs_WC(r, k.xV),
+      gvjs_WC(r, k.D6),
+      h.appendChild(u, r),
+      h.appendChild(r, h.createTextNode(l.Ob(t.bna))),
+    w && gvjs_C(r, {
+      "background-color": w
+    }),
+    0 <= p && (gvjs_VC(r, gvjs_Ju),
+    0 === p && gvjs_VC(r, gvjs_qv),
+    m && gvjs_C(r, {
+      "background-color": m
+    })));
+    r = g.$();
+    for (v = 0; v < r; v += x) {
+      var y = t.AH
+        , z = e[v];
+      (x = g.getProperty(y, v, gvjs_Db)) && typeof x === gvjs_l && (z = gvjs_Ke(z, gvjs_kf(x).split(/\s+/)));
+      x = (x = Number(g.getProperty(y, v, "__td-colSpan"))) && Math.min(x, r - v);
+      if (!x || 1 >= x)
+        x = 1;
+      var A = h.J(gvjs_us, {
+        colSpan: x
+      });
+      gvjs_WC(A, z || []);
+      gvjs_WC(A, k.xV);
+      h.appendChild(u, A);
+      w && gvjs_C(A, {
+        "background-color": w
+      });
+      z = g.getValue(y, v);
+      var B = g.Ha(y, v);
+      null == z ? B = gvjs_jf(gvjs_gg(B)) ? "\u00a0" : B : f[v] == gvjs_zb && (B = z ? "\u2714" : "\u2717");
+      if (a.NV || a.MV) {
+        if (z = gvjs_OA(B),
+          gvjs_cg(A, z),
+          y = g.getProperty(y, v, gvjs_Jd))
+          y = gvjs_PA(String(y)),
+            A.style.cssText = gvjs_Ff(y)
+      } else
+        h.appendChild(A, h.createTextNode(B));
+      v <= p - 1 && (gvjs_VC(A, gvjs_Ju),
+      v === p - 1 && gvjs_VC(A, gvjs_qv),
+      m && gvjs_C(A, {
+        "background-color": m
+      }))
+    }
+  }
+  return b
+}
+function gvjs_lM(a, b, c) {
+  function d(q) {
+    var r = ["unsorted", "sort-descending", "sort-ascending"]
+      , t = a.ge.FA;
+    gvjs_u(q.childNodes, function(u) {
+      var v = u.index;
+      gvjs_YC(u, r);
+      if (g) {
+        var w = 0;
+        t === v && (w = a.ge.jD ? 1 : 2);
+        gvjs_VC(u, r[w])
+      }
+    })
+  }
+  var e = a.ra
+    , f = a.gq
+    , g = a.UT != gvjs_ju && 0 < e.ca();
+  if (b)
+    return d(b),
+      b;
+  b = a.D;
+  var h = e.$()
+    , k = b.J(gvjs_vs);
+  gvjs_WC(k, f.J6);
+  if (a.f4 && 0 < e.$()) {
+    var l = b.J("TH");
+    gvjs_WC(l, f.yV);
+    l.innerText = "\u00a0";
+    b.appendChild(k, l)
+  }
+  for (var m = 0; m < h; m++) {
+    l = b.J("TH", {
+      index: m
+    });
+    gvjs_WC(l, f.yV);
+    gvjs_WC(l, c[m] || []);
+    b.appendChild(k, l);
+    var n = e.Ga(m)
+      , p = l;
+    a.NV || a.MV ? gvjs__x(p, gvjs_OA(n)) : b.appendChild(p, b.createTextNode(n));
+    g && (n = b.J(gvjs_6a),
+      gvjs_WC(n, f.Dja),
+      b.appendChild(l, n),
+      l.setAttribute(gvjs_9w, 0),
+      l.setAttribute(gvjs_Bd, gvjs_Bt),
+      l.setAttribute(gvjs_et, "Sort column"));
+    a.ea.o(l, gvjs_Wt, a.raa.bind(a, m), !0);
+    a.ea.o(l, gvjs_7c, a.dqa.bind(a, m), !0)
+  }
+  d(k);
+  return k
+}
+function gvjs_qha(a, b) {
+  var c = a.D
+    , d = a.gq
+    , e = a.m.pb("pagingSymbols", {})
+    , f = e.prev;
+  e = e.next;
+  var g = a.NV || a.MV;
+  if (f)
+    if (g) {
+      var h = c.J(gvjs_6a);
+      gvjs__x(h, gvjs_OA(f))
+    } else
+      h = String(f);
+  else
+    h = c.J(gvjs_6a, {
+      alt: "previous"
+    }),
+      gvjs_WC(h, d.jja);
+  e ? g ? (f = c.J(gvjs_6a),
+    gvjs__x(f, gvjs_OA(e))) : f = String(e) : (f = c.J(gvjs_6a, {
+    alt: "next"
+  }),
+    gvjs_WC(f, d.gja));
+  gvjs_E(a.yK);
+  gvjs_E(a.aK);
+  e = a.yK = new gvjs_gM(h);
+  f = a.aK = new gvjs_gM(f);
+  e.Lw(2);
+  f.Lw(1);
+  gvjs_MA(a.ea, e, gvjs_Ss, function() {
+    gvjs_nM(this, !1)
+  }, a);
+  gvjs_MA(a.ea, f, gvjs_Ss, function() {
+    gvjs_nM(this, !0)
+  }, a);
+  gvjs_oM(a);
+  h = a.mq[gvjs_dw];
+  c.appendChild(b, h);
+  c.appendChild(b, a.mq["clear-float"]);
+  e.R(h);
+  f.R(h);
+  if (!(1 >= a.ge.iK)) {
+    var k = c.J(gvjs_b);
+    gvjs_WC(k, d.ija);
+    c.appendChild(h, k);
+    f = a.ge.iK;
+    var l = a.ge.Nm;
+    b = a.ge.uda;
+    null == b && (b = f);
+    if (null == b || 0 < b)
+      h = gvjs_pM(0, l - 1),
+        e = gvjs_pM(l + 1, f - 1),
+        e = gvjs_v(gvjs_Ke(h, l, e), function(m, n) {
+          return {
+            n: m,
+            current: l === n
+          }
+        }),
+        h = Math.max(0, h.length - Math.floor((b - 1) / 2)),
+        f = Math.min(f, h + b),
+        h = Math.max(0, f - b),
+        e = gvjs_Oe(e, h, f),
+        gvjs_u(e, function(m) {
+          var n = m.n;
+          m = c.J("A", {
+            href: "javascript:void(0)",
+            "class": m.current ? "current" : ""
+          });
+          gvjs_WC(m, d.hja);
+          m.innerText = String(Number(n) + 1);
+          gvjs_MA(this.ea, m, gvjs_Wt, function(p) {
+            p.preventDefault();
+            gvjs_qM(this, n)
+          }, this);
+          c.appendChild(k, m)
+        }, a)
+  }
+}
+function gvjs_pM(a, b) {
+  var c = [];
+  if (a + 10 > b)
+    for (; a <= b; a++)
+      c.push(a);
+  else {
+    c.push(a);
+    c.push(b);
+    for (var d = 10; a < b; )
+      a = d * Math.ceil((a + 2) / d) - 1,
+      a < b && c.push(a),
+        b = d * Math.floor(b / d) - 1,
+      a < b && c.push(b),
+        d *= 10;
+    gvjs_Qe(c)
+  }
+  return c
+}
+function gvjs_oha(a) {
+  var b = a.gq
+    , c = a.m.pb("cssClassNames");
+  c && gvjs_w(gvjs_sha, function(d, e) {
+    d = c[d];
+    gvjs_ne(d) ? b[e] = d : d && (b[e] = gvjs_kf(d).split(/\s+/))
+  })
+}
+function gvjs_nM(a, b) {
+  var c = a.ge.iK
+    , d = a.ge.Nm;
+  gvjs_qM(a, b ? Math.min(c, d + 1) : Math.max(0, d - 1))
+}
+function gvjs_qM(a, b) {
+  a.ge.e2 && (gvjs_$L(a.ge, b),
+  a.Ut && (a.US = a.Ut.scrollLeft),
+    a.Qt(!0));
+  gvjs_oM(a);
+  gvjs_I(a, gvjs_cw, {
+    page: b
+  })
+}
+function gvjs_oM(a) {
+  a: {
+    var b = a.ge;
+    switch (b.Wda) {
+      case "prev":
+        b = !1;
+        break a;
+      case "next":
+      case gvjs_ut:
+        b = !0;
+        break a;
+      default:
+        b = b.Nm != b.iK - 1
+    }
+  }
+  a.aK.Gb(b);
+  a: switch (b = a.ge,
+    b.Wda) {
+    case "next":
+      b = !1;
+      break a;
+    case "prev":
+    case gvjs_ut:
+      b = !0;
+      break a;
+    default:
+      b = 0 != b.Nm
+  }
+  a.yK.Gb(b)
+}
+function gvjs_iM(a) {
+  var b = a.FN;
+  if (!b) {
+    var c = a.container;
+    b = a.D.J(gvjs_b, {
+      style: "position: absolute; top: -5000px;",
+      "class": "google-visualization-table-loadtest"
+    }, a.D.createTextNode("\u00a0"));
+    a.D.appendChild(c, b);
+    a.FN = b
+  }
+  return "6" == gvjs_Ih(b).left
+}
+gvjs_.rha = function(a) {
+  if (10 > a)
+    if (gvjs_iM(this))
+      this.draw(this.ra, this.m);
+    else {
+      var b = 200 * a;
+      a++;
+      setTimeout(this.rha.bind(this, a), b)
+    }
+  else
+    this.D.removeNode(this.FN),
+      this.gx()
+}
+;
+gvjs_.getSelection = function() {
+  return this.Of.getSelection()
+}
+;
+gvjs_.setSelection = function(a) {
+  if (this.ra) {
+    var b = this.Of.setSelection(a);
+    a = this.qK;
+    this.wJ = gvjs_dM(this.ge);
+    for (var c = gvjs_rM(this), d, e = this.gq, f = gvjs_bo(b.An), g = 0; g < f.length; g++)
+      d = gvjs_eM(this.ge, f[g]),
+      -1 != d && (a[d].qp(!1),
+      (d = c[d]) && gvjs_YC(d, e.KM));
+    b = gvjs_bo(b.uB);
+    for (f = 0; f < b.length; f++)
+      d = gvjs_eM(this.ge, b[f]),
+      -1 != d && (a[d].qp(!0),
+      (d = c[d]) && gvjs_WC(d, e.KM))
+  }
+}
+;
+gvjs_.ZZ = function(a, b) {
+  var c = this.wJ
+    , d = a.AH;
+  var e = gvjs_ug ? b.metaKey : b.ctrlKey;
+  if (b.shiftKey) {
+    b.preventDefault();
+    var f = Math.min(a.LM, c.LM);
+    d = Math.max(a.LM, c.LM);
+    e = e ? this.Of.getSelection() : [];
+    for (var g = this.ge, h = []; f <= d; f++) {
+      var k = gvjs_cM(g, f);
+      h.push(k)
+    }
+    for (d = 0; d < h.length; d++)
+      e.push({
+        row: h[d].AH
+      })
+  } else
+    e ? (b.preventDefault(),
+      e = this.Of.getSelection(),
+      gvjs_do(this.Of, d) ? (h = new gvjs_$n,
+        h.setSelection(e),
+        h.qE(d),
+        e = h.getSelection()) : e.push({
+        row: d
+      })) : e = gvjs_do(this.Of, d) ? null : [{
+      row: d
+    }];
+  this.setSelection(e);
+  this.wJ = b.shiftKey ? c : a;
+  gvjs_I(this, gvjs_k, {})
+}
+;
+gvjs_.a_ = function(a) {
+  var b = gvjs_rM(this)
+    , c = this.gq;
+  (a = b[a.c2]) && gvjs_WC(a, c.AV)
+}
+;
+gvjs_.$Z = function(a) {
+  var b = gvjs_rM(this)
+    , c = this.gq;
+  (a = b[a.c2]) && gvjs_YC(a, c.AV)
+}
+;
+function gvjs_rM(a) {
+  return gvjs_zh(a.D, "tbody", null, a.VS)[0].childNodes
+}
+gvjs_.raa = function(a) {
+  var b = this.ge
+    , c = !b.jD;
+  c = b.FA == a ? !c : !0;
+  "event" != this.UT ? (b.FA = a,
+    b.jD = !c,
+    gvjs_fM(b),
+    gvjs_$L(this.ge, 0),
+    this.wJ = gvjs_dM(this.ge),
+  this.Ut && (this.US = this.Ut.scrollLeft),
+    this.Qt(!0),
+    gvjs_I(this, "sort", this.ge.AP())) : gvjs_I(this, "sort", {
+    column: a,
+    ascending: c,
+    sortedIndexes: null
+  })
+}
+;
+gvjs_.dqa = function(a, b) {
+  13 == b.keyCode && this.raa(a)
+}
+;
+gvjs_.YG = function() {
+  gvjs_E(this.ea);
+  this.ea = null;
+  this.D.qc(this.container);
+  gvjs_E(this.yK);
+  this.yK = null;
+  gvjs_E(this.aK);
+  this.aK = null;
+  this.mq = {}
+}
+;
+gvjs_.Jb = function() {
+  this.YG();
+  this.Of.clear();
+  this.ge = null
+}
+;
+function gvjs_jM(a) {
+  if (gvjs_jf(gvjs_gg(a)))
+    return a;
+  var b = a;
+  gvjs_Yy(a) && "0" !== String(a) && (b += gvjs_T);
+  return b
+}
+function gvjs_rha(a, b) {
+  return gvjs_v(gvjs_kM(a), function(c, d) {
+    var e = [];
+    switch (c) {
+      case gvjs_zb:
+        e = b.Yha;
+        break;
+      case gvjs_g:
+        e = b.$ha;
+        break;
+      case gvjs_Lb:
+      case gvjs_Mb:
+      case gvjs_Od:
+        e = b.Zha
+    }
+    (c = a.Bd(d, gvjs_Db)) && typeof c === gvjs_l && (e = gvjs_Ke(e, gvjs_kf(c).split(/\s+/)));
+    return e
+  })
+}
+function gvjs_kM(a) {
+  for (var b = [], c = 0; c < a.$(); c++)
+    b.push(a.W(c));
+  return b
+}
+var gvjs_nha = {
+  G6: ["google-visualization-table-table"],
+  J6: ["google-visualization-table-tr-head"],
+  zV: ["google-visualization-table-tr-even"],
+  K6: ["google-visualization-table-tr-odd"],
+  KM: ["google-visualization-table-tr-sel"],
+  AV: ["google-visualization-table-tr-over"],
+  yV: ["google-visualization-table-th", gvjs_Bp],
+  xV: ["google-visualization-table-td"],
+  $ha: ["google-visualization-table-type-number"],
+  Zha: ["google-visualization-table-type-date"],
+  Yha: ["google-visualization-table-type-bool"],
+  D6: ["google-visualization-table-seq"],
+  uBa: ["google-visualization-table-sorthdr"],
+  Dja: ["google-visualization-table-sortind"],
+  fja: ["google-visualization-table-div-page", gvjs_Bp],
+  ija: ["google-visualization-table-page-numbers"],
+  hja: ["google-visualization-table-page-number", gvjs_Bp],
+  jja: ["google-visualization-table-page-prev"],
+  gja: ["google-visualization-table-page-next"]
+}
+  , gvjs_sha = {
+  J6: "headerRow",
+  zV: "tableRow",
+  K6: "oddTableRow",
+  KM: "selectedTableRow",
+  AV: "hoverTableRow",
+  yV: "headerCell",
+  xV: "tableCell",
+  D6: "rowNumberCell"
+};
+gvjs_ = gvjs_hM.prototype;
+gvjs_.n$ = !0;
+gvjs_.FN = null;
+gvjs_.gq = null;
+gvjs_.wJ = null;
+gvjs_.ra = null;
+gvjs_.Cl = null;
+gvjs_.m = null;
+gvjs_.ge = null;
+gvjs_.qK = null;
+gvjs_.OR = -1;
+gvjs_.i_ = !1;
+gvjs_.yK = null;
+gvjs_.aK = null;
+gvjs_.US = 0;
+gvjs_.ea = null;
+function gvjs_tha(a, b) {
+  Array.isArray(b) || (b = [b]);
+  b = b.map(function(c) {
+    return typeof c === gvjs_l ? c : c.property + " " + c.duration + "s " + c.timing + " " + c.delay + "s"
+  });
+  gvjs_sM(a, b.join(","))
+}
+var gvjs_uha = gvjs_ze(function() {
+  if (gvjs_y)
+    return gvjs_Eg("10.0");
+  var a = gvjs_dh(gvjs_b)
+    , b = gvjs_tg ? "-webkit" : gvjs_sg ? "-moz" : gvjs_y ? "-ms" : gvjs_qg ? "-o" : null
+    , c = {
+    transition: gvjs_8v
+  };
+  b && (c[b + "-transition"] = gvjs_8v);
+  b = gvjs_5f(gvjs_Ob, {
+    style: c
+  });
+  gvjs_cg(a, b);
+  return "" != gvjs_qz(a.firstChild, "transition")
+});
+function gvjs_sM(a, b) {
+  gvjs_C(a, "transition", b)
+}
+;function gvjs_tM(a, b, c, d, e) {
+  gvjs_0E.call(this);
+  this.H = a;
+  this.Nk = b;
+  this.Nra = c;
+  this.j$ = d;
+  this.YA = Array.isArray(e) ? e : [e]
+}
+gvjs_t(gvjs_tM, gvjs_0E);
+gvjs_ = gvjs_tM.prototype;
+gvjs_.play = function() {
+  if (this.So())
+    return !1;
+  this.jK();
+  this.Jh("play");
+  this.startTime = gvjs_se();
+  this.K = 1;
+  if (gvjs_uha())
+    return gvjs_C(this.H, this.Nra),
+      this.tm = gvjs_pl(this.Zua, void 0, this),
+      !0;
+  this.KA(!1);
+  return !1
+}
+;
+gvjs_.Zua = function() {
+  gvjs_Dz(this.H);
+  gvjs_tha(this.H, this.YA);
+  gvjs_C(this.H, this.j$);
+  this.tm = gvjs_pl(gvjs_s(this.KA, this, !1), 1E3 * this.Nk)
+}
+;
+gvjs_.stop = function() {
+  this.So() && this.KA(!0)
+}
+;
+gvjs_.KA = function(a) {
+  gvjs_sM(this.H, "");
+  gvjs_ql(this.tm);
+  gvjs_C(this.H, this.j$);
+  this.endTime = gvjs_se();
+  this.K = 0;
+  a ? this.Jh(gvjs__p) : this.Jh(gvjs_vu);
+  this.Xz()
+}
+;
+gvjs_.M = function() {
+  this.stop();
+  gvjs_tM.G.M.call(this)
+}
+;
+gvjs_.pause = function() {}
+;
+function gvjs_uM(a, b, c, d, e) {
+  return new gvjs_tM(a,b,{
+    opacity: d
+  },{
+    opacity: e
+  },{
+    property: gvjs_Kp,
+    duration: b,
+    timing: c,
+    delay: 0
+  })
+}
+function gvjs_vM(a, b) {
+  return gvjs_uM(a, b, "ease-out", 0, 1)
+}
+function gvjs_wM(a, b) {
+  return gvjs_uM(a, b, "ease-in", 1, 0)
+}
+;

--- a/cypress/fixtures/charts/loader
+++ b/cypress/fixtures/charts/loader
@@ -1,0 +1,3770 @@
+(function() {
+    /*
+
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: Apache-2.0
+*/
+    'use strict';
+    function aa(a) {
+      var b = 0;
+      return function() {
+        return b < a.length ? {
+          done: !1,
+          value: a[b++]
+        } : {
+          done: !0
+        }
+      }
+    }
+    var ba = "function" == typeof Object.defineProperties ? Object.defineProperty : function(a, b, c) {
+        if (a == Array.prototype || a == Object.prototype)
+          return a;
+        a[b] = c.value;
+        return a
+      }
+    ;
+    function ca(a) {
+      a = ["object" == typeof globalThis && globalThis, a, "object" == typeof window && window, "object" == typeof self && self, "object" == typeof global && global];
+      for (var b = 0; b < a.length; ++b) {
+        var c = a[b];
+        if (c && c.Math == Math)
+          return c
+      }
+      throw Error("Cannot find global object");
+    }
+    var l = ca(this);
+    function p(a, b) {
+      if (b)
+        a: {
+          var c = l;
+          a = a.split(".");
+          for (var d = 0; d < a.length - 1; d++) {
+            var e = a[d];
+            if (!(e in c))
+              break a;
+            c = c[e]
+          }
+          a = a[a.length - 1];
+          d = c[a];
+          b = b(d);
+          b != d && null != b && ba(c, a, {
+            configurable: !0,
+            writable: !0,
+            value: b
+          })
+        }
+    }
+    p("Symbol", function(a) {
+      function b(h) {
+        if (this instanceof b)
+          throw new TypeError("Symbol is not a constructor");
+        return new c(d + (h || "") + "_" + e++,h)
+      }
+      function c(h, f) {
+        this.g = h;
+        ba(this, "description", {
+          configurable: !0,
+          writable: !0,
+          value: f
+        })
+      }
+      if (a)
+        return a;
+      c.prototype.toString = function() {
+        return this.g
+      }
+      ;
+      var d = "jscomp_symbol_" + (1E9 * Math.random() >>> 0) + "_"
+        , e = 0;
+      return b
+    });
+    p("Symbol.iterator", function(a) {
+      if (a)
+        return a;
+      a = Symbol("Symbol.iterator");
+      for (var b = "Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array".split(" "), c = 0; c < b.length; c++) {
+        var d = l[b[c]];
+        "function" === typeof d && "function" != typeof d.prototype[a] && ba(d.prototype, a, {
+          configurable: !0,
+          writable: !0,
+          value: function() {
+            return da(aa(this))
+          }
+        })
+      }
+      return a
+    });
+    p("Symbol.asyncIterator", function(a) {
+      return a ? a : Symbol("Symbol.asyncIterator")
+    });
+    function da(a) {
+      a = {
+        next: a
+      };
+      a[Symbol.iterator] = function() {
+        return this
+      }
+      ;
+      return a
+    }
+    function q(a) {
+      var b = "undefined" != typeof Symbol && Symbol.iterator && a[Symbol.iterator];
+      if (b)
+        return b.call(a);
+      if ("number" == typeof a.length)
+        return {
+          next: aa(a)
+        };
+      throw Error(String(a) + " is not an iterable or ArrayLike");
+    }
+    function ea(a) {
+      if (!(a instanceof Array)) {
+        a = q(a);
+        for (var b, c = []; !(b = a.next()).done; )
+          c.push(b.value);
+        a = c
+      }
+      return a
+    }
+    function r(a, b) {
+      return Object.prototype.hasOwnProperty.call(a, b)
+    }
+    var fa = "function" == typeof Object.assign ? Object.assign : function(a, b) {
+        for (var c = 1; c < arguments.length; c++) {
+          var d = arguments[c];
+          if (d)
+            for (var e in d)
+              r(d, e) && (a[e] = d[e])
+        }
+        return a
+      }
+    ;
+    p("Object.assign", function(a) {
+      return a || fa
+    });
+    var ha;
+    if ("function" == typeof Object.setPrototypeOf)
+      ha = Object.setPrototypeOf;
+    else {
+      var ia;
+      a: {
+        var ja = {
+          a: !0
+        }
+          , ka = {};
+        try {
+          ka.__proto__ = ja;
+          ia = ka.a;
+          break a
+        } catch (a) {}
+        ia = !1
+      }
+      ha = ia ? function(a, b) {
+          a.__proto__ = b;
+          if (a.__proto__ !== b)
+            throw new TypeError(a + " is not extensible");
+          return a
+        }
+        : null
+    }
+    var t = ha;
+    function la() {
+      for (var a = Number(this), b = [], c = a; c < arguments.length; c++)
+        b[c - a] = arguments[c];
+      return b
+    }
+    p("Promise", function(a) {
+      function b(f) {
+        this.g = 0;
+        this.i = void 0;
+        this.h = [];
+        this.o = !1;
+        var g = this.j();
+        try {
+          f(g.resolve, g.reject)
+        } catch (k) {
+          g.reject(k)
+        }
+      }
+      function c() {
+        this.g = null
+      }
+      function d(f) {
+        return f instanceof b ? f : new b(function(g) {
+            g(f)
+          }
+        )
+      }
+      if (a)
+        return a;
+      c.prototype.h = function(f) {
+        if (null == this.g) {
+          this.g = [];
+          var g = this;
+          this.i(function() {
+            g.l()
+          })
+        }
+        this.g.push(f)
+      }
+      ;
+      var e = l.setTimeout;
+      c.prototype.i = function(f) {
+        e(f, 0)
+      }
+      ;
+      c.prototype.l = function() {
+        for (; this.g && this.g.length; ) {
+          var f = this.g;
+          this.g = [];
+          for (var g = 0; g < f.length; ++g) {
+            var k = f[g];
+            f[g] = null;
+            try {
+              k()
+            } catch (m) {
+              this.j(m)
+            }
+          }
+        }
+        this.g = null
+      }
+      ;
+      c.prototype.j = function(f) {
+        this.i(function() {
+          throw f;
+        })
+      }
+      ;
+      b.prototype.j = function() {
+        function f(m) {
+          return function(n) {
+            k || (k = !0,
+              m.call(g, n))
+          }
+        }
+        var g = this
+          , k = !1;
+        return {
+          resolve: f(this.D),
+          reject: f(this.l)
+        }
+      }
+      ;
+      b.prototype.D = function(f) {
+        if (f === this)
+          this.l(new TypeError("A Promise cannot resolve to itself"));
+        else if (f instanceof b)
+          this.O(f);
+        else {
+          a: switch (typeof f) {
+            case "object":
+              var g = null != f;
+              break a;
+            case "function":
+              g = !0;
+              break a;
+            default:
+              g = !1
+          }
+          g ? this.C(f) : this.m(f)
+        }
+      }
+      ;
+      b.prototype.C = function(f) {
+        var g = void 0;
+        try {
+          g = f.then
+        } catch (k) {
+          this.l(k);
+          return
+        }
+        "function" == typeof g ? this.P(g, f) : this.m(f)
+      }
+      ;
+      b.prototype.l = function(f) {
+        this.u(2, f)
+      }
+      ;
+      b.prototype.m = function(f) {
+        this.u(1, f)
+      }
+      ;
+      b.prototype.u = function(f, g) {
+        if (0 != this.g)
+          throw Error("Cannot settle(" + f + ", " + g + "): Promise already settled in state" + this.g);
+        this.g = f;
+        this.i = g;
+        2 === this.g && this.G();
+        this.A()
+      }
+      ;
+      b.prototype.G = function() {
+        var f = this;
+        e(function() {
+          if (f.B()) {
+            var g = l.console;
+            "undefined" !== typeof g && g.error(f.i)
+          }
+        }, 1)
+      }
+      ;
+      b.prototype.B = function() {
+        if (this.o)
+          return !1;
+        var f = l.CustomEvent
+          , g = l.Event
+          , k = l.dispatchEvent;
+        if ("undefined" === typeof k)
+          return !0;
+        "function" === typeof f ? f = new f("unhandledrejection",{
+          cancelable: !0
+        }) : "function" === typeof g ? f = new g("unhandledrejection",{
+          cancelable: !0
+        }) : (f = l.document.createEvent("CustomEvent"),
+          f.initCustomEvent("unhandledrejection", !1, !0, f));
+        f.promise = this;
+        f.reason = this.i;
+        return k(f)
+      }
+      ;
+      b.prototype.A = function() {
+        if (null != this.h) {
+          for (var f = 0; f < this.h.length; ++f)
+            h.h(this.h[f]);
+          this.h = null
+        }
+      }
+      ;
+      var h = new c;
+      b.prototype.O = function(f) {
+        var g = this.j();
+        f.F(g.resolve, g.reject)
+      }
+      ;
+      b.prototype.P = function(f, g) {
+        var k = this.j();
+        try {
+          f.call(g, k.resolve, k.reject)
+        } catch (m) {
+          k.reject(m)
+        }
+      }
+      ;
+      b.prototype.then = function(f, g) {
+        function k(y, G) {
+          return "function" == typeof y ? function(ra) {
+              try {
+                m(y(ra))
+              } catch (sa) {
+                n(sa)
+              }
+            }
+            : G
+        }
+        var m, n, u = new b(function(y, G) {
+            m = y;
+            n = G
+          }
+        );
+        this.F(k(f, m), k(g, n));
+        return u
+      }
+      ;
+      b.prototype.catch = function(f) {
+        return this.then(void 0, f)
+      }
+      ;
+      b.prototype.F = function(f, g) {
+        function k() {
+          switch (m.g) {
+            case 1:
+              f(m.i);
+              break;
+            case 2:
+              g(m.i);
+              break;
+            default:
+              throw Error("Unexpected state: " + m.g);
+          }
+        }
+        var m = this;
+        null == this.h ? h.h(k) : this.h.push(k);
+        this.o = !0
+      }
+      ;
+      b.resolve = d;
+      b.reject = function(f) {
+        return new b(function(g, k) {
+            k(f)
+          }
+        )
+      }
+      ;
+      b.race = function(f) {
+        return new b(function(g, k) {
+            for (var m = q(f), n = m.next(); !n.done; n = m.next())
+              d(n.value).F(g, k)
+          }
+        )
+      }
+      ;
+      b.all = function(f) {
+        var g = q(f)
+          , k = g.next();
+        return k.done ? d([]) : new b(function(m, n) {
+            function u(ra) {
+              return function(sa) {
+                y[ra] = sa;
+                G--;
+                0 == G && m(y)
+              }
+            }
+            var y = []
+              , G = 0;
+            do
+              y.push(void 0),
+                G++,
+                d(k.value).F(u(y.length - 1), n),
+                k = g.next();
+            while (!k.done)
+          }
+        )
+      }
+      ;
+      return b
+    });
+    p("Object.setPrototypeOf", function(a) {
+      return a || t
+    });
+    p("WeakMap", function(a) {
+      function b(k) {
+        this.g = (g += Math.random() + 1).toString();
+        if (k) {
+          k = q(k);
+          for (var m; !(m = k.next()).done; )
+            m = m.value,
+              this.set(m[0], m[1])
+        }
+      }
+      function c() {}
+      function d(k) {
+        var m = typeof k;
+        return "object" === m && null !== k || "function" === m
+      }
+      function e(k) {
+        if (!r(k, f)) {
+          var m = new c;
+          ba(k, f, {
+            value: m
+          })
+        }
+      }
+      function h(k) {
+        var m = Object[k];
+        m && (Object[k] = function(n) {
+            if (n instanceof c)
+              return n;
+            Object.isExtensible(n) && e(n);
+            return m(n)
+          }
+        )
+      }
+      if (function() {
+        if (!a || !Object.seal)
+          return !1;
+        try {
+          var k = Object.seal({})
+            , m = Object.seal({})
+            , n = new a([[k, 2], [m, 3]]);
+          if (2 != n.get(k) || 3 != n.get(m))
+            return !1;
+          n.delete(k);
+          n.set(m, 4);
+          return !n.has(k) && 4 == n.get(m)
+        } catch (u) {
+          return !1
+        }
+      }())
+        return a;
+      var f = "$jscomp_hidden_" + Math.random();
+      h("freeze");
+      h("preventExtensions");
+      h("seal");
+      var g = 0;
+      b.prototype.set = function(k, m) {
+        if (!d(k))
+          throw Error("Invalid WeakMap key");
+        e(k);
+        if (!r(k, f))
+          throw Error("WeakMap key fail: " + k);
+        k[f][this.g] = m;
+        return this
+      }
+      ;
+      b.prototype.get = function(k) {
+        return d(k) && r(k, f) ? k[f][this.g] : void 0
+      }
+      ;
+      b.prototype.has = function(k) {
+        return d(k) && r(k, f) && r(k[f], this.g)
+      }
+      ;
+      b.prototype.delete = function(k) {
+        return d(k) && r(k, f) && r(k[f], this.g) ? delete k[f][this.g] : !1
+      }
+      ;
+      return b
+    });
+    p("Map", function(a) {
+      function b() {
+        var g = {};
+        return g.v = g.next = g.head = g
+      }
+      function c(g, k) {
+        var m = g.g;
+        return da(function() {
+          if (m) {
+            for (; m.head != g.g; )
+              m = m.v;
+            for (; m.next != m.head; )
+              return m = m.next,
+                {
+                  done: !1,
+                  value: k(m)
+                };
+            m = null
+          }
+          return {
+            done: !0,
+            value: void 0
+          }
+        })
+      }
+      function d(g, k) {
+        var m = k && typeof k;
+        "object" == m || "function" == m ? h.has(k) ? m = h.get(k) : (m = "" + ++f,
+          h.set(k, m)) : m = "p_" + k;
+        var n = g.h[m];
+        if (n && r(g.h, m))
+          for (g = 0; g < n.length; g++) {
+            var u = n[g];
+            if (k !== k && u.key !== u.key || k === u.key)
+              return {
+                id: m,
+                list: n,
+                index: g,
+                s: u
+              }
+          }
+        return {
+          id: m,
+          list: n,
+          index: -1,
+          s: void 0
+        }
+      }
+      function e(g) {
+        this.h = {};
+        this.g = b();
+        this.size = 0;
+        if (g) {
+          g = q(g);
+          for (var k; !(k = g.next()).done; )
+            k = k.value,
+              this.set(k[0], k[1])
+        }
+      }
+      if (function() {
+        if (!a || "function" != typeof a || !a.prototype.entries || "function" != typeof Object.seal)
+          return !1;
+        try {
+          var g = Object.seal({
+            x: 4
+          })
+            , k = new a(q([[g, "s"]]));
+          if ("s" != k.get(g) || 1 != k.size || k.get({
+            x: 4
+          }) || k.set({
+            x: 4
+          }, "t") != k || 2 != k.size)
+            return !1;
+          var m = k.entries()
+            , n = m.next();
+          if (n.done || n.value[0] != g || "s" != n.value[1])
+            return !1;
+          n = m.next();
+          return n.done || 4 != n.value[0].x || "t" != n.value[1] || !m.next().done ? !1 : !0
+        } catch (u) {
+          return !1
+        }
+      }())
+        return a;
+      var h = new WeakMap;
+      e.prototype.set = function(g, k) {
+        g = 0 === g ? 0 : g;
+        var m = d(this, g);
+        m.list || (m.list = this.h[m.id] = []);
+        m.s ? m.s.value = k : (m.s = {
+          next: this.g,
+          v: this.g.v,
+          head: this.g,
+          key: g,
+          value: k
+        },
+          m.list.push(m.s),
+          this.g.v.next = m.s,
+          this.g.v = m.s,
+          this.size++);
+        return this
+      }
+      ;
+      e.prototype.delete = function(g) {
+        g = d(this, g);
+        return g.s && g.list ? (g.list.splice(g.index, 1),
+        g.list.length || delete this.h[g.id],
+          g.s.v.next = g.s.next,
+          g.s.next.v = g.s.v,
+          g.s.head = null,
+          this.size--,
+          !0) : !1
+      }
+      ;
+      e.prototype.clear = function() {
+        this.h = {};
+        this.g = this.g.v = b();
+        this.size = 0
+      }
+      ;
+      e.prototype.has = function(g) {
+        return !!d(this, g).s
+      }
+      ;
+      e.prototype.get = function(g) {
+        return (g = d(this, g).s) && g.value
+      }
+      ;
+      e.prototype.entries = function() {
+        return c(this, function(g) {
+          return [g.key, g.value]
+        })
+      }
+      ;
+      e.prototype.keys = function() {
+        return c(this, function(g) {
+          return g.key
+        })
+      }
+      ;
+      e.prototype.values = function() {
+        return c(this, function(g) {
+          return g.value
+        })
+      }
+      ;
+      e.prototype.forEach = function(g, k) {
+        for (var m = this.entries(), n; !(n = m.next()).done; )
+          n = n.value,
+            g.call(k, n[1], n[0], this)
+      }
+      ;
+      e.prototype[Symbol.iterator] = e.prototype.entries;
+      var f = 0;
+      return e
+    });
+    function ma(a, b) {
+      a instanceof String && (a += "");
+      var c = 0
+        , d = !1
+        , e = {
+        next: function() {
+          if (!d && c < a.length) {
+            var h = c++;
+            return {
+              value: b(h, a[h]),
+              done: !1
+            }
+          }
+          d = !0;
+          return {
+            done: !0,
+            value: void 0
+          }
+        }
+      };
+      e[Symbol.iterator] = function() {
+        return e
+      }
+      ;
+      return e
+    }
+    p("Array.prototype.values", function(a) {
+      return a ? a : function() {
+        return ma(this, function(b, c) {
+          return c
+        })
+      }
+    });
+    p("Array.prototype.keys", function(a) {
+      return a ? a : function() {
+        return ma(this, function(b) {
+          return b
+        })
+      }
+    });
+    function v(a, b, c) {
+      if (null == a)
+        throw new TypeError("The 'this' value for String.prototype." + c + " must not be null or undefined");
+      if (b instanceof RegExp)
+        throw new TypeError("First argument to String.prototype." + c + " must not be a regular expression");
+      return a + ""
+    }
+    p("String.prototype.endsWith", function(a) {
+      return a ? a : function(b, c) {
+        var d = v(this, b, "endsWith");
+        void 0 === c && (c = d.length);
+        c = Math.max(0, Math.min(c | 0, d.length));
+        for (var e = b.length; 0 < e && 0 < c; )
+          if (d[--c] != b[--e])
+            return !1;
+        return 0 >= e
+      }
+    });
+    function na(a, b, c) {
+      a instanceof String && (a = String(a));
+      for (var d = a.length, e = 0; e < d; e++) {
+        var h = a[e];
+        if (b.call(c, h, e, a))
+          return {
+            J: e,
+            N: h
+          }
+      }
+      return {
+        J: -1,
+        N: void 0
+      }
+    }
+    p("Array.prototype.find", function(a) {
+      return a ? a : function(b, c) {
+        return na(this, b, c).N
+      }
+    });
+    p("String.prototype.startsWith", function(a) {
+      return a ? a : function(b, c) {
+        var d = v(this, b, "startsWith")
+          , e = d.length
+          , h = b.length;
+        c = Math.max(0, Math.min(c | 0, d.length));
+        for (var f = 0; f < h && c < e; )
+          if (d[c++] != b[f++])
+            return !1;
+        return f >= h
+      }
+    });
+    p("Number.isFinite", function(a) {
+      return a ? a : function(b) {
+        return "number" !== typeof b ? !1 : !isNaN(b) && Infinity !== b && -Infinity !== b
+      }
+    });
+    p("String.prototype.repeat", function(a) {
+      return a ? a : function(b) {
+        var c = v(this, null, "repeat");
+        if (0 > b || 1342177279 < b)
+          throw new RangeError("Invalid count value");
+        b |= 0;
+        for (var d = ""; b; )
+          if (b & 1 && (d += c),
+            b >>>= 1)
+            c += c;
+        return d
+      }
+    });
+    p("Array.from", function(a) {
+      return a ? a : function(b, c, d) {
+        c = null != c ? c : function(g) {
+          return g
+        }
+        ;
+        var e = []
+          , h = "undefined" != typeof Symbol && Symbol.iterator && b[Symbol.iterator];
+        if ("function" == typeof h) {
+          b = h.call(b);
+          for (var f = 0; !(h = b.next()).done; )
+            e.push(c.call(d, h.value, f++))
+        } else
+          for (h = b.length,
+                 f = 0; f < h; f++)
+            e.push(c.call(d, b[f], f));
+        return e
+      }
+    });
+    p("String.prototype.trimLeft", function(a) {
+      function b() {
+        return this.replace(/^[\s\xa0]+/, "")
+      }
+      return a || b
+    });
+    p("String.prototype.trimStart", function(a) {
+      return a || String.prototype.trimLeft
+    });
+    p("Object.is", function(a) {
+      return a ? a : function(b, c) {
+        return b === c ? 0 !== b || 1 / b === 1 / c : b !== b && c !== c
+      }
+    });
+    p("Array.prototype.includes", function(a) {
+      return a ? a : function(b, c) {
+        var d = this;
+        d instanceof String && (d = String(d));
+        var e = d.length;
+        c = c || 0;
+        for (0 > c && (c = Math.max(c + e, 0)); c < e; c++) {
+          var h = d[c];
+          if (h === b || Object.is(h, b))
+            return !0
+        }
+        return !1
+      }
+    });
+    p("String.prototype.includes", function(a) {
+      return a ? a : function(b, c) {
+        return -1 !== v(this, b, "includes").indexOf(b, c || 0)
+      }
+    });
+    p("Math.trunc", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        if (isNaN(b) || Infinity === b || -Infinity === b || 0 === b)
+          return b;
+        var c = Math.floor(Math.abs(b));
+        return 0 > b ? -c : c
+      }
+    });
+    function oa(a) {
+      a = Math.trunc(a) || 0;
+      0 > a && (a += this.length);
+      if (!(0 > a || a >= this.length))
+        return this[a]
+    }
+    p("Array.prototype.at", function(a) {
+      return a ? a : oa
+    });
+    p("Array.prototype.copyWithin", function(a) {
+      function b(c) {
+        c = Number(c);
+        return Infinity === c || -Infinity === c ? c : c | 0
+      }
+      return a ? a : function(c, d, e) {
+        var h = this.length;
+        c = b(c);
+        d = b(d);
+        e = void 0 === e ? h : b(e);
+        c = 0 > c ? Math.max(h + c, 0) : Math.min(c, h);
+        d = 0 > d ? Math.max(h + d, 0) : Math.min(d, h);
+        e = 0 > e ? Math.max(h + e, 0) : Math.min(e, h);
+        if (c < d)
+          for (; d < e; )
+            d in this ? this[c++] = this[d++] : (delete this[c++],
+              d++);
+        else
+          for (e = Math.min(e, h + d - c),
+                 c += e - d; e > d; )
+            --e in this ? this[--c] = this[e] : delete this[--c];
+        return this
+      }
+    });
+    p("Array.prototype.entries", function(a) {
+      return a ? a : function() {
+        return ma(this, function(b, c) {
+          return [b, c]
+        })
+      }
+    });
+    p("Array.prototype.fill", function(a) {
+      return a ? a : function(b, c, d) {
+        var e = this.length || 0;
+        0 > c && (c = Math.max(0, e + c));
+        if (null == d || d > e)
+          d = e;
+        d = Number(d);
+        0 > d && (d = Math.max(0, e + d));
+        for (c = Number(c || 0); c < d; c++)
+          this[c] = b;
+        return this
+      }
+    });
+    p("Array.prototype.findIndex", function(a) {
+      return a ? a : function(b, c) {
+        return na(this, b, c).J
+      }
+    });
+    p("Array.prototype.flat", function(a) {
+      return a ? a : function(b) {
+        b = void 0 === b ? 1 : b;
+        var c = [];
+        Array.prototype.forEach.call(this, function(d) {
+          Array.isArray(d) && 0 < b ? (d = Array.prototype.flat.call(d, b - 1),
+            c.push.apply(c, d)) : c.push(d)
+        });
+        return c
+      }
+    });
+    p("Array.prototype.flatMap", function(a) {
+      return a ? a : function(b, c) {
+        var d = [];
+        Array.prototype.forEach.call(this, function(e, h) {
+          e = b.call(c, e, h, this);
+          Array.isArray(e) ? d.push.apply(d, e) : d.push(e)
+        });
+        return d
+      }
+    });
+    p("Array.of", function(a) {
+      return a ? a : function(b) {
+        return Array.from(arguments)
+      }
+    });
+    p("globalThis", function(a) {
+      return a || l
+    });
+    p("Math.acosh", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        return Math.log(b + Math.sqrt(b * b - 1))
+      }
+    });
+    p("Math.asinh", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        if (0 === b)
+          return b;
+        var c = Math.log(Math.abs(b) + Math.sqrt(b * b + 1));
+        return 0 > b ? -c : c
+      }
+    });
+    p("Math.log1p", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        if (.25 > b && -.25 < b) {
+          for (var c = b, d = 1, e = b, h = 0, f = 1; h != e; )
+            c *= b,
+              f *= -1,
+              e = (h = e) + f * c / ++d;
+          return e
+        }
+        return Math.log(1 + b)
+      }
+    });
+    p("Math.atanh", function(a) {
+      if (a)
+        return a;
+      var b = Math.log1p;
+      return function(c) {
+        c = Number(c);
+        return (b(c) - b(-c)) / 2
+      }
+    });
+    p("Math.cbrt", function(a) {
+      return a ? a : function(b) {
+        if (0 === b)
+          return b;
+        b = Number(b);
+        var c = Math.pow(Math.abs(b), 1 / 3);
+        return 0 > b ? -c : c
+      }
+    });
+    p("Math.clz32", function(a) {
+      return a ? a : function(b) {
+        b = Number(b) >>> 0;
+        if (0 === b)
+          return 32;
+        var c = 0;
+        0 === (b & 4294901760) && (b <<= 16,
+          c += 16);
+        0 === (b & 4278190080) && (b <<= 8,
+          c += 8);
+        0 === (b & 4026531840) && (b <<= 4,
+          c += 4);
+        0 === (b & 3221225472) && (b <<= 2,
+          c += 2);
+        0 === (b & 2147483648) && c++;
+        return c
+      }
+    });
+    p("Math.cosh", function(a) {
+      if (a)
+        return a;
+      var b = Math.exp;
+      return function(c) {
+        c = Number(c);
+        return (b(c) + b(-c)) / 2
+      }
+    });
+    p("Math.expm1", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        if (.25 > b && -.25 < b) {
+          for (var c = b, d = 1, e = b, h = 0; h != e; )
+            c *= b / ++d,
+              e = (h = e) + c;
+          return e
+        }
+        return Math.exp(b) - 1
+      }
+    });
+    p("Math.fround", function(a) {
+      if (a)
+        return a;
+      if ("function" !== typeof Float32Array)
+        return function(c) {
+          return c
+        }
+          ;
+      var b = new Float32Array(1);
+      return function(c) {
+        b[0] = c;
+        return b[0]
+      }
+    });
+    p("Math.hypot", function(a) {
+      return a ? a : function(b) {
+        if (2 > arguments.length)
+          return arguments.length ? Math.abs(arguments[0]) : 0;
+        var c, d, e;
+        for (c = e = 0; c < arguments.length; c++)
+          e = Math.max(e, Math.abs(arguments[c]));
+        if (1E100 < e || 1E-100 > e) {
+          if (!e)
+            return e;
+          for (c = d = 0; c < arguments.length; c++) {
+            var h = Number(arguments[c]) / e;
+            d += h * h
+          }
+          return Math.sqrt(d) * e
+        }
+        for (c = d = 0; c < arguments.length; c++)
+          h = Number(arguments[c]),
+            d += h * h;
+        return Math.sqrt(d)
+      }
+    });
+    p("Math.imul", function(a) {
+      return a ? a : function(b, c) {
+        b = Number(b);
+        c = Number(c);
+        var d = b & 65535
+          , e = c & 65535;
+        return d * e + ((b >>> 16 & 65535) * e + d * (c >>> 16 & 65535) << 16 >>> 0) | 0
+      }
+    });
+    p("Math.log10", function(a) {
+      return a ? a : function(b) {
+        return Math.log(b) / Math.LN10
+      }
+    });
+    p("Math.log2", function(a) {
+      return a ? a : function(b) {
+        return Math.log(b) / Math.LN2
+      }
+    });
+    p("Math.sign", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        return 0 === b || isNaN(b) ? b : 0 < b ? 1 : -1
+      }
+    });
+    p("Math.sinh", function(a) {
+      if (a)
+        return a;
+      var b = Math.exp;
+      return function(c) {
+        c = Number(c);
+        return 0 === c ? c : (b(c) - b(-c)) / 2
+      }
+    });
+    p("Math.tanh", function(a) {
+      return a ? a : function(b) {
+        b = Number(b);
+        if (0 === b)
+          return b;
+        var c = Math.exp(-2 * Math.abs(b));
+        c = (1 - c) / (1 + c);
+        return 0 > b ? -c : c
+      }
+    });
+    p("Number.EPSILON", function() {
+      return Math.pow(2, -52)
+    });
+    p("Number.MAX_SAFE_INTEGER", function() {
+      return 9007199254740991
+    });
+    p("Number.MIN_SAFE_INTEGER", function() {
+      return -9007199254740991
+    });
+    p("Number.isInteger", function(a) {
+      return a ? a : function(b) {
+        return Number.isFinite(b) ? b === Math.floor(b) : !1
+      }
+    });
+    p("Number.isNaN", function(a) {
+      return a ? a : function(b) {
+        return "number" === typeof b && isNaN(b)
+      }
+    });
+    p("Number.isSafeInteger", function(a) {
+      return a ? a : function(b) {
+        return Number.isInteger(b) && Math.abs(b) <= Number.MAX_SAFE_INTEGER
+      }
+    });
+    p("Number.parseFloat", function(a) {
+      return a || parseFloat
+    });
+    p("Number.parseInt", function(a) {
+      return a || parseInt
+    });
+    p("Object.entries", function(a) {
+      return a ? a : function(b) {
+        var c = [], d;
+        for (d in b)
+          r(b, d) && c.push([d, b[d]]);
+        return c
+      }
+    });
+    p("Object.fromEntries", function(a) {
+      return a ? a : function(b) {
+        var c = {};
+        if (!(Symbol.iterator in b))
+          throw new TypeError("" + b + " is not iterable");
+        b = b[Symbol.iterator].call(b);
+        for (var d = b.next(); !d.done; d = b.next()) {
+          d = d.value;
+          if (Object(d) !== d)
+            throw new TypeError("iterable for fromEntries should yield objects");
+          c[d[0]] = d[1]
+        }
+        return c
+      }
+    });
+    p("Reflect", function(a) {
+      return a ? a : {}
+    });
+    p("Object.getOwnPropertySymbols", function(a) {
+      return a ? a : function() {
+        return []
+      }
+    });
+    p("Reflect.ownKeys", function(a) {
+      return a ? a : function(b) {
+        var c = []
+          , d = Object.getOwnPropertyNames(b);
+        b = Object.getOwnPropertySymbols(b);
+        for (var e = 0; e < d.length; e++)
+          ("jscomp_symbol_" == d[e].substring(0, 14) ? b : c).push(d[e]);
+        return c.concat(b)
+      }
+    });
+    p("Object.getOwnPropertyDescriptors", function(a) {
+      return a ? a : function(b) {
+        for (var c = {}, d = Reflect.ownKeys(b), e = 0; e < d.length; e++)
+          c[d[e]] = Object.getOwnPropertyDescriptor(b, d[e]);
+        return c
+      }
+    });
+    p("Object.values", function(a) {
+      return a ? a : function(b) {
+        var c = [], d;
+        for (d in b)
+          r(b, d) && c.push(b[d]);
+        return c
+      }
+    });
+    p("Object.hasOwn", function(a) {
+      return a ? a : function(b, c) {
+        return Object.prototype.hasOwnProperty.call(b, c)
+      }
+    });
+    p("Promise.allSettled", function(a) {
+      function b(d) {
+        return {
+          status: "fulfilled",
+          value: d
+        }
+      }
+      function c(d) {
+        return {
+          status: "rejected",
+          reason: d
+        }
+      }
+      return a ? a : function(d) {
+        var e = this;
+        d = Array.from(d, function(h) {
+          return e.resolve(h).then(b, c)
+        });
+        return e.all(d)
+      }
+    });
+    p("Promise.prototype.finally", function(a) {
+      return a ? a : function(b) {
+        return this.then(function(c) {
+          return Promise.resolve(b()).then(function() {
+            return c
+          })
+        }, function(c) {
+          return Promise.resolve(b()).then(function() {
+            throw c;
+          })
+        })
+      }
+    });
+    var pa = "function" == typeof Object.create ? Object.create : function(a) {
+        function b() {}
+        b.prototype = a;
+        return new b
+      }
+    ;
+    function qa(a, b) {
+      a.prototype = pa(b.prototype);
+      a.prototype.constructor = a;
+      if (t)
+        t(a, b);
+      else
+        for (var c in b)
+          if ("prototype" != c)
+            if (Object.defineProperties) {
+              var d = Object.getOwnPropertyDescriptor(b, c);
+              d && Object.defineProperty(a, c, d)
+            } else
+              a[c] = b[c];
+      a.T = b.prototype
+    }
+    p("AggregateError", function(a) {
+      function b(c, d) {
+        d = Error(d);
+        "stack"in d && (this.stack = d.stack);
+        this.errors = c;
+        this.message = d.message
+      }
+      if (a)
+        return a;
+      qa(b, Error);
+      b.prototype.name = "AggregateError";
+      return b
+    });
+    p("Promise.any", function(a) {
+      return a ? a : function(b) {
+        b = b instanceof Array ? b : Array.from(b);
+        return Promise.all(b.map(function(c) {
+          return Promise.resolve(c).then(function(d) {
+            throw d;
+          }, function(d) {
+            return d
+          })
+        })).then(function(c) {
+          throw new AggregateError(c,"All promises were rejected");
+        }, function(c) {
+          return c
+        })
+      }
+    });
+    p("Reflect.apply", function(a) {
+      if (a)
+        return a;
+      var b = Function.prototype.apply;
+      return function(c, d, e) {
+        return b.call(c, d, e)
+      }
+    });
+    var ta = function() {
+      function a() {
+        function c() {}
+        new c;
+        Reflect.construct(c, [], function() {});
+        return new c instanceof c
+      }
+      if ("undefined" != typeof Reflect && Reflect.construct) {
+        if (a())
+          return Reflect.construct;
+        var b = Reflect.construct;
+        return function(c, d, e) {
+          c = b(c, d);
+          e && Reflect.setPrototypeOf(c, e.prototype);
+          return c
+        }
+      }
+      return function(c, d, e) {
+        void 0 === e && (e = c);
+        e = pa(e.prototype || Object.prototype);
+        return Function.prototype.apply.call(c, e, d) || e
+      }
+    }();
+    p("Reflect.construct", function() {
+      return ta
+    });
+    p("Reflect.defineProperty", function(a) {
+      return a ? a : function(b, c, d) {
+        try {
+          Object.defineProperty(b, c, d);
+          var e = Object.getOwnPropertyDescriptor(b, c);
+          return e ? e.configurable === (d.configurable || !1) && e.enumerable === (d.enumerable || !1) && ("value"in e ? e.value === d.value && e.writable === (d.writable || !1) : e.get === d.get && e.set === d.set) : !1
+        } catch (h) {
+          return !1
+        }
+      }
+    });
+    p("Reflect.deleteProperty", function(a) {
+      return a ? a : function(b, c) {
+        if (!r(b, c))
+          return !0;
+        try {
+          return delete b[c]
+        } catch (d) {
+          return !1
+        }
+      }
+    });
+    p("Reflect.getOwnPropertyDescriptor", function(a) {
+      return a || Object.getOwnPropertyDescriptor
+    });
+    p("Reflect.getPrototypeOf", function(a) {
+      return a || Object.getPrototypeOf
+    });
+    function ua(a, b) {
+      for (; a; ) {
+        var c = Reflect.getOwnPropertyDescriptor(a, b);
+        if (c)
+          return c;
+        a = Reflect.getPrototypeOf(a)
+      }
+    }
+    p("Reflect.get", function(a) {
+      return a ? a : function(b, c, d) {
+        if (2 >= arguments.length)
+          return b[c];
+        var e = ua(b, c);
+        if (e)
+          return e.get ? e.get.call(d) : e.value
+      }
+    });
+    p("Reflect.has", function(a) {
+      return a ? a : function(b, c) {
+        return c in b
+      }
+    });
+    p("Reflect.isExtensible", function(a) {
+      return a ? a : "function" == typeof Object.isExtensible ? Object.isExtensible : function() {
+        return !0
+      }
+    });
+    p("Reflect.preventExtensions", function(a) {
+      return a ? a : "function" != typeof Object.preventExtensions ? function() {
+          return !1
+        }
+        : function(b) {
+          Object.preventExtensions(b);
+          return !Object.isExtensible(b)
+        }
+    });
+    p("Reflect.set", function(a) {
+      return a ? a : function(b, c, d, e) {
+        var h = ua(b, c);
+        return h ? h.set ? (h.set.call(3 < arguments.length ? e : b, d),
+          !0) : h.writable && !Object.isFrozen(b) ? (b[c] = d,
+          !0) : !1 : Reflect.isExtensible(b) ? (b[c] = d,
+          !0) : !1
+      }
+    });
+    p("Reflect.setPrototypeOf", function(a) {
+      return a ? a : t ? function(b, c) {
+          try {
+            return t(b, c),
+              !0
+          } catch (d) {
+            return !1
+          }
+        }
+        : null
+    });
+    p("Set", function(a) {
+      function b(c) {
+        this.g = new Map;
+        if (c) {
+          c = q(c);
+          for (var d; !(d = c.next()).done; )
+            this.add(d.value)
+        }
+        this.size = this.g.size
+      }
+      if (function() {
+        if (!a || "function" != typeof a || !a.prototype.entries || "function" != typeof Object.seal)
+          return !1;
+        try {
+          var c = Object.seal({
+            x: 4
+          })
+            , d = new a(q([c]));
+          if (!d.has(c) || 1 != d.size || d.add(c) != d || 1 != d.size || d.add({
+            x: 4
+          }) != d || 2 != d.size)
+            return !1;
+          var e = d.entries()
+            , h = e.next();
+          if (h.done || h.value[0] != c || h.value[1] != c)
+            return !1;
+          h = e.next();
+          return h.done || h.value[0] == c || 4 != h.value[0].x || h.value[1] != h.value[0] ? !1 : e.next().done
+        } catch (f) {
+          return !1
+        }
+      }())
+        return a;
+      b.prototype.add = function(c) {
+        c = 0 === c ? 0 : c;
+        this.g.set(c, c);
+        this.size = this.g.size;
+        return this
+      }
+      ;
+      b.prototype.delete = function(c) {
+        c = this.g.delete(c);
+        this.size = this.g.size;
+        return c
+      }
+      ;
+      b.prototype.clear = function() {
+        this.g.clear();
+        this.size = 0
+      }
+      ;
+      b.prototype.has = function(c) {
+        return this.g.has(c)
+      }
+      ;
+      b.prototype.entries = function() {
+        return this.g.entries()
+      }
+      ;
+      b.prototype.values = function() {
+        return this.g.values()
+      }
+      ;
+      b.prototype.keys = b.prototype.values;
+      b.prototype[Symbol.iterator] = b.prototype.values;
+      b.prototype.forEach = function(c, d) {
+        var e = this;
+        this.g.forEach(function(h) {
+          return c.call(d, h, h, e)
+        })
+      }
+      ;
+      return b
+    });
+    p("String.prototype.at", function(a) {
+      return a ? a : oa
+    });
+    p("String.prototype.codePointAt", function(a) {
+      return a ? a : function(b) {
+        var c = v(this, null, "codePointAt")
+          , d = c.length;
+        b = Number(b) || 0;
+        if (0 <= b && b < d) {
+          b |= 0;
+          var e = c.charCodeAt(b);
+          if (55296 > e || 56319 < e || b + 1 === d)
+            return e;
+          b = c.charCodeAt(b + 1);
+          return 56320 > b || 57343 < b ? e : 1024 * (e - 55296) + b + 9216
+        }
+      }
+    });
+    p("String.fromCodePoint", function(a) {
+      return a ? a : function(b) {
+        for (var c = "", d = 0; d < arguments.length; d++) {
+          var e = Number(arguments[d]);
+          if (0 > e || 1114111 < e || e !== Math.floor(e))
+            throw new RangeError("invalid_code_point " + e);
+          65535 >= e ? c += String.fromCharCode(e) : (e -= 65536,
+            c += String.fromCharCode(e >>> 10 & 1023 | 55296),
+            c += String.fromCharCode(e & 1023 | 56320))
+        }
+        return c
+      }
+    });
+    p("String.prototype.matchAll", function(a) {
+      return a ? a : function(b) {
+        if (b instanceof RegExp && !b.global)
+          throw new TypeError("RegExp passed into String.prototype.matchAll() must have global tag.");
+        var c = new RegExp(b,b instanceof RegExp ? void 0 : "g")
+          , d = this
+          , e = !1
+          , h = {
+          next: function() {
+            if (e)
+              return {
+                value: void 0,
+                done: !0
+              };
+            var f = c.exec(d);
+            if (!f)
+              return e = !0,
+                {
+                  value: void 0,
+                  done: !0
+                };
+            "" === f[0] && (c.lastIndex += 1);
+            return {
+              value: f,
+              done: !1
+            }
+          }
+        };
+        h[Symbol.iterator] = function() {
+          return h
+        }
+        ;
+        return h
+      }
+    });
+    function va(a, b) {
+      a = void 0 !== a ? String(a) : " ";
+      return 0 < b && a ? a.repeat(Math.ceil(b / a.length)).substring(0, b) : ""
+    }
+    p("String.prototype.padEnd", function(a) {
+      return a ? a : function(b, c) {
+        var d = v(this, null, "padStart");
+        return d + va(c, b - d.length)
+      }
+    });
+    p("String.prototype.padStart", function(a) {
+      return a ? a : function(b, c) {
+        var d = v(this, null, "padStart");
+        return va(c, b - d.length) + d
+      }
+    });
+    p("String.raw", function(a) {
+      return a ? a : function(b, c) {
+        if (null == b)
+          throw new TypeError("Cannot convert undefined or null to object");
+        for (var d = b.raw, e = d.length, h = "", f = 0; f < e; ++f)
+          h += d[f],
+          f + 1 < e && f + 1 < arguments.length && (h += String(arguments[f + 1]));
+        return h
+      }
+    });
+    p("String.prototype.replaceAll", function(a) {
+      return a ? a : function(b, c) {
+        if (b instanceof RegExp && !b.global)
+          throw new TypeError("String.prototype.replaceAll called with a non-global RegExp argument.");
+        return b instanceof RegExp ? this.replace(b, c) : this.replace(new RegExp(String(b).replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, "\\$1").replace(/\x08/g, "\\x08"),"g"), c)
+      }
+    });
+    p("String.prototype.trimRight", function(a) {
+      function b() {
+        return this.replace(/[\s\xa0]+$/, "")
+      }
+      return a || b
+    });
+    p("String.prototype.trimEnd", function(a) {
+      return a || String.prototype.trimRight
+    });
+    function w(a) {
+      return a ? a : oa
+    }
+    p("Int8Array.prototype.at", w);
+    p("Uint8Array.prototype.at", w);
+    p("Uint8ClampedArray.prototype.at", w);
+    p("Int16Array.prototype.at", w);
+    p("Uint16Array.prototype.at", w);
+    p("Int32Array.prototype.at", w);
+    p("Uint32Array.prototype.at", w);
+    p("Float32Array.prototype.at", w);
+    p("Float64Array.prototype.at", w);
+    function x(a) {
+      return a ? a : Array.prototype.copyWithin
+    }
+    p("Int8Array.prototype.copyWithin", x);
+    p("Uint8Array.prototype.copyWithin", x);
+    p("Uint8ClampedArray.prototype.copyWithin", x);
+    p("Int16Array.prototype.copyWithin", x);
+    p("Uint16Array.prototype.copyWithin", x);
+    p("Int32Array.prototype.copyWithin", x);
+    p("Uint32Array.prototype.copyWithin", x);
+    p("Float32Array.prototype.copyWithin", x);
+    p("Float64Array.prototype.copyWithin", x);
+    function z(a) {
+      return a ? a : Array.prototype.fill
+    }
+    p("Int8Array.prototype.fill", z);
+    p("Uint8Array.prototype.fill", z);
+    p("Uint8ClampedArray.prototype.fill", z);
+    p("Int16Array.prototype.fill", z);
+    p("Uint16Array.prototype.fill", z);
+    p("Int32Array.prototype.fill", z);
+    p("Uint32Array.prototype.fill", z);
+    p("Float32Array.prototype.fill", z);
+    p("Float64Array.prototype.fill", z);
+    p("WeakSet", function(a) {
+      function b(c) {
+        this.g = new WeakMap;
+        if (c) {
+          c = q(c);
+          for (var d; !(d = c.next()).done; )
+            this.add(d.value)
+        }
+      }
+      if (function() {
+        if (!a || !Object.seal)
+          return !1;
+        try {
+          var c = Object.seal({})
+            , d = Object.seal({})
+            , e = new a([c]);
+          if (!e.has(c) || e.has(d))
+            return !1;
+          e.delete(c);
+          e.add(d);
+          return !e.has(c) && e.has(d)
+        } catch (h) {
+          return !1
+        }
+      }())
+        return a;
+      b.prototype.add = function(c) {
+        this.g.set(c, !0);
+        return this
+      }
+      ;
+      b.prototype.has = function(c) {
+        return this.g.has(c)
+      }
+      ;
+      b.prototype.delete = function(c) {
+        return this.g.delete(c)
+      }
+      ;
+      return b
+    });
+    var A = this || self;
+    function B(a) {
+      a = a.split(".");
+      for (var b = A, c = 0; c < a.length; c++)
+        if (b = b[a[c]],
+        null == b)
+          return null;
+      return b
+    }
+    function wa(a) {
+      var b = typeof a;
+      return "object" == b && null != a || "function" == b
+    }
+    function xa(a, b, c) {
+      return a.call.apply(a.bind, arguments)
+    }
+    function ya(a, b, c) {
+      if (!a)
+        throw Error();
+      if (2 < arguments.length) {
+        var d = Array.prototype.slice.call(arguments, 2);
+        return function() {
+          var e = Array.prototype.slice.call(arguments);
+          Array.prototype.unshift.apply(e, d);
+          return a.apply(b, e)
+        }
+      }
+      return function() {
+        return a.apply(b, arguments)
+      }
+    }
+    function C(a, b, c) {
+      Function.prototype.bind && -1 != Function.prototype.bind.toString().indexOf("native code") ? C = xa : C = ya;
+      return C.apply(null, arguments)
+    }
+    function D(a, b) {
+      a = a.split(".");
+      var c = A;
+      a[0]in c || "undefined" == typeof c.execScript || c.execScript("var " + a[0]);
+      for (var d; a.length && (d = a.shift()); )
+        a.length || void 0 === b ? c[d] && c[d] !== Object.prototype[d] ? c = c[d] : c = c[d] = {} : c[d] = b
+    }
+    function E(a, b) {
+      function c() {}
+      c.prototype = b.prototype;
+      a.T = b.prototype;
+      a.prototype = new c;
+      a.prototype.constructor = a;
+      a.U = function(d, e, h) {
+        for (var f = Array(arguments.length - 2), g = 2; g < arguments.length; g++)
+          f[g - 2] = arguments[g];
+        return b.prototype[e].apply(d, f)
+      }
+    }
+    function za(a) {
+      return a
+    }
+    ;function F(a, b) {
+      if (Error.captureStackTrace)
+        Error.captureStackTrace(this, F);
+      else {
+        var c = Error().stack;
+        c && (this.stack = c)
+      }
+      a && (this.message = String(a));
+      void 0 !== b && (this.cause = b)
+    }
+    E(F, Error);
+    F.prototype.name = "CustomError";
+    function H(a, b) {
+      this.g = a === Aa && b || "";
+      this.h = Ba
+    }
+    H.prototype.K = !0;
+    H.prototype.I = function() {
+      return this.g
+    }
+    ;
+    function Ca(a) {
+      return a instanceof H && a.constructor === H && a.h === Ba ? a.g : "type_error:Const"
+    }
+    function I(a) {
+      return new H(Aa,a)
+    }
+    var Ba = {}
+      , Aa = {};
+    var Da = {
+      "gstatic.com": {
+        loader: I("https://www.gstatic.com/charts/%{version}/loader.js"),
+        debug: I("https://www.gstatic.com/charts/debug/%{version}/js/jsapi_debug_%{package}_module.js"),
+        debug_i18n: I("https://www.gstatic.com/charts/debug/%{version}/i18n/jsapi_debug_i18n_%{package}_module__%{language}.js"),
+        compiled: I("https://www.gstatic.com/charts/%{version}/js/jsapi_compiled_%{package}_module.js"),
+        compiled_i18n: I("https://www.gstatic.com/charts/%{version}/i18n/jsapi_compiled_i18n_%{package}_module__%{language}.js"),
+        css: I("https://www.gstatic.com/charts/%{version}/css/%{subdir}/%{filename}"),
+        css2: I("https://www.gstatic.com/charts/%{version}/css/%{subdir1}/%{subdir2}/%{filename}"),
+        third_party: I("https://www.gstatic.com/charts/%{version}/third_party/%{subdir}/%{filename}"),
+        third_party2: I("https://www.gstatic.com/charts/%{version}/third_party/%{subdir1}/%{subdir2}/%{filename}"),
+        third_party_gen: I("https://www.gstatic.com/charts/%{version}/third_party/%{subdir}/%{filename}")
+      },
+      "gstatic.cn": {
+        loader: I("https://www.gstatic.cn/charts/%{version}/loader.js"),
+        debug: I("https://www.gstatic.cn/charts/debug/%{version}/js/jsapi_debug_%{package}_module.js"),
+        debug_i18n: I("https://www.gstatic.cn/charts/debug/%{version}/i18n/jsapi_debug_i18n_%{package}_module__%{language}.js"),
+        compiled: I("https://www.gstatic.cn/charts/%{version}/js/jsapi_compiled_%{package}_module.js"),
+        compiled_i18n: I("https://www.gstatic.cn/charts/%{version}/i18n/jsapi_compiled_i18n_%{package}_module__%{language}.js"),
+        css: I("https://www.gstatic.cn/charts/%{version}/css/%{subdir}/%{filename}"),
+        css2: I("https://www.gstatic.cn/charts/%{version}/css/%{subdir1}/%{subdir2}/%{filename}"),
+        third_party: I("https://www.gstatic.cn/charts/%{version}/third_party/%{subdir}/%{filename}"),
+        third_party2: I("https://www.gstatic.cn/charts/%{version}/third_party/%{subdir1}/%{subdir2}/%{filename}"),
+        third_party_gen: I("https://www.gstatic.cn/charts/%{version}/third_party/%{subdir}/%{filename}")
+      }
+    }
+      , Ea = ["default"];
+    var Fa = {
+      "chrome-frame": {
+        versions: {
+          "1.0.0": {
+            uncompressed: "CFInstall.js",
+            compressed: "CFInstall.min.js"
+          },
+          "1.0.1": {
+            uncompressed: "CFInstall.js",
+            compressed: "CFInstall.min.js"
+          },
+          "1.0.2": {
+            uncompressed: "CFInstall.js",
+            compressed: "CFInstall.min.js"
+          }
+        },
+        aliases: {
+          1: "1.0.2",
+          "1.0": "1.0.2"
+        }
+      },
+      swfobject: {
+        versions: {
+          "2.1": {
+            uncompressed: "swfobject_src.js",
+            compressed: "swfobject.js"
+          },
+          "2.2": {
+            uncompressed: "swfobject_src.js",
+            compressed: "swfobject.js"
+          }
+        },
+        aliases: {
+          2: "2.2"
+        }
+      },
+      "ext-core": {
+        versions: {
+          "3.1.0": {
+            uncompressed: "ext-core-debug.js",
+            compressed: "ext-core.js"
+          },
+          "3.0.0": {
+            uncompressed: "ext-core-debug.js",
+            compressed: "ext-core.js"
+          }
+        },
+        aliases: {
+          3: "3.1.0",
+          "3.0": "3.0.0",
+          "3.1": "3.1.0"
+        }
+      },
+      scriptaculous: {
+        versions: {
+          "1.8.3": {
+            uncompressed: "scriptaculous.js",
+            compressed: "scriptaculous.js"
+          },
+          "1.9.0": {
+            uncompressed: "scriptaculous.js",
+            compressed: "scriptaculous.js"
+          },
+          "1.8.1": {
+            uncompressed: "scriptaculous.js",
+            compressed: "scriptaculous.js"
+          },
+          "1.8.2": {
+            uncompressed: "scriptaculous.js",
+            compressed: "scriptaculous.js"
+          }
+        },
+        aliases: {
+          1: "1.9.0",
+          "1.8": "1.8.3",
+          "1.9": "1.9.0"
+        }
+      },
+      webfont: {
+        versions: {
+          "1.0.12": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.13": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.14": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.15": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.10": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.11": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.27": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.28": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.29": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.23": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.24": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.25": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.26": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.21": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.22": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.3": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.4": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.5": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.6": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.9": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.16": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.17": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.0": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.18": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.1": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.19": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          },
+          "1.0.2": {
+            uncompressed: "webfont_debug.js",
+            compressed: "webfont.js"
+          }
+        },
+        aliases: {
+          1: "1.0.29",
+          "1.0": "1.0.29"
+        }
+      },
+      jqueryui: {
+        versions: {
+          "1.8.17": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.16": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.15": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.14": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.4": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.13": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.5": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.12": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.6": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.11": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.7": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.10": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.8": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.9": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.6.0": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.7.0": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.5.2": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.0": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.7.1": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.5.3": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.1": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.7.2": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.8.2": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          },
+          "1.7.3": {
+            uncompressed: "jquery-ui.js",
+            compressed: "jquery-ui.min.js"
+          }
+        },
+        aliases: {
+          1: "1.8.17",
+          "1.5": "1.5.3",
+          "1.6": "1.6.0",
+          "1.7": "1.7.3",
+          "1.8": "1.8.17",
+          "1.8.3": "1.8.4"
+        }
+      },
+      mootools: {
+        versions: {
+          "1.3.0": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.2.1": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.1.2": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.4.0": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.3.1": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.2.2": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.4.1": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.3.2": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.2.3": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.4.2": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.2.4": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.2.5": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          },
+          "1.1.1": {
+            uncompressed: "mootools.js",
+            compressed: "mootools-yui-compressed.js"
+          }
+        },
+        aliases: {
+          1: "1.1.2",
+          "1.1": "1.1.2",
+          "1.2": "1.2.5",
+          "1.3": "1.3.2",
+          "1.4": "1.4.2",
+          "1.11": "1.1.1"
+        }
+      },
+      yui: {
+        versions: {
+          "2.8.0r4": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          },
+          "2.9.0": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          },
+          "2.8.1": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          },
+          "2.6.0": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          },
+          "2.7.0": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          },
+          "3.3.0": {
+            uncompressed: "build/yui/yui.js",
+            compressed: "build/yui/yui-min.js"
+          },
+          "2.8.2r1": {
+            uncompressed: "build/yuiloader/yuiloader.js",
+            compressed: "build/yuiloader/yuiloader-min.js"
+          }
+        },
+        aliases: {
+          2: "2.9.0",
+          "2.6": "2.6.0",
+          "2.7": "2.7.0",
+          "2.8": "2.8.2r1",
+          "2.8.0": "2.8.0r4",
+          "2.8.2": "2.8.2r1",
+          "2.9": "2.9.0",
+          3: "3.3.0",
+          "3.3": "3.3.0"
+        }
+      },
+      prototype: {
+        versions: {
+          "1.6.1.0": {
+            uncompressed: "prototype.js",
+            compressed: "prototype.js"
+          },
+          "1.6.0.2": {
+            uncompressed: "prototype.js",
+            compressed: "prototype.js"
+          },
+          "1.7.0.0": {
+            uncompressed: "prototype.js",
+            compressed: "prototype.js"
+          },
+          "1.6.0.3": {
+            uncompressed: "prototype.js",
+            compressed: "prototype.js"
+          }
+        },
+        aliases: {
+          1: "1.7.0.0",
+          "1.6": "1.6.1.0",
+          "1.6.0": "1.6.0.3",
+          "1.6.1": "1.6.1.0",
+          "1.7": "1.7.0.0",
+          "1.7.0": "1.7.0.0"
+        }
+      },
+      jquery: {
+        versions: {
+          "1.2.3": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.2.6": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.3.0": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.3.1": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.3.2": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.4.0": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.4.1": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.4.2": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.4.3": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.4.4": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.5.0": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.5.1": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.5.2": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.6.0": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.6.1": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.6.2": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.6.3": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.6.4": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.7.0": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          },
+          "1.7.1": {
+            uncompressed: "jquery.js",
+            compressed: "jquery.min.js"
+          }
+        },
+        aliases: {
+          1: "1.7.1",
+          "1.2": "1.2.6",
+          "1.3": "1.3.2",
+          "1.4": "1.4.4",
+          "1.5": "1.5.2",
+          "1.6": "1.6.4",
+          "1.7": "1.7.1"
+        }
+      },
+      dojo: {
+        versions: {
+          "1.3.0": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.4.0": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.3.1": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.5.0": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.4.1": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.3.2": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.2.3": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.6.0": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.5.1": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.7.0": {
+            uncompressed: "dojo/dojo.js.uncompressed.js",
+            compressed: "dojo/dojo.js"
+          },
+          "1.6.1": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.4.3": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.7.1": {
+            uncompressed: "dojo/dojo.js.uncompressed.js",
+            compressed: "dojo/dojo.js"
+          },
+          "1.7.2": {
+            uncompressed: "dojo/dojo.js.uncompressed.js",
+            compressed: "dojo/dojo.js"
+          },
+          "1.2.0": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          },
+          "1.1.1": {
+            uncompressed: "dojo/dojo.xd.js.uncompressed.js",
+            compressed: "dojo/dojo.xd.js"
+          }
+        },
+        aliases: {
+          1: "1.6.1",
+          "1.1": "1.1.1",
+          "1.2": "1.2.3",
+          "1.3": "1.3.2",
+          "1.4": "1.4.3",
+          "1.5": "1.5.1",
+          "1.6": "1.6.1",
+          "1.7": "1.7.2"
+        }
+      }
+    };
+    var Ga = {
+      af: !0,
+      am: !0,
+      az: !0,
+      ar: !0,
+      arb: "ar",
+      bg: !0,
+      bn: !0,
+      ca: !0,
+      cs: !0,
+      cmn: "zh",
+      da: !0,
+      de: !0,
+      el: !0,
+      en: !0,
+      en_gb: !0,
+      es: !0,
+      es_419: !0,
+      et: !0,
+      eu: !0,
+      fa: !0,
+      fi: !0,
+      fil: !0,
+      fr: !0,
+      fr_ca: !0,
+      gl: !0,
+      ka: !0,
+      gu: !0,
+      he: "iw",
+      hi: !0,
+      hr: !0,
+      hu: !0,
+      hy: !0,
+      id: !0,
+      "in": "id",
+      is: !0,
+      it: !0,
+      iw: !0,
+      ja: !0,
+      ji: "yi",
+      jv: !1,
+      jw: "jv",
+      km: !0,
+      kn: !0,
+      ko: !0,
+      lo: !0,
+      lt: !0,
+      lv: !0,
+      ml: !0,
+      mn: !0,
+      mo: "ro",
+      mr: !0,
+      ms: !0,
+      nb: "no",
+      ne: !0,
+      nl: !0,
+      no: !0,
+      pl: !0,
+      pt: "pt_br",
+      pt_br: !0,
+      pt_pt: !0,
+      ro: !0,
+      ru: !0,
+      si: !0,
+      sk: !0,
+      sl: !0,
+      sr: !0,
+      sv: !0,
+      sw: !0,
+      swh: "sw",
+      ta: !0,
+      te: !0,
+      th: !0,
+      tl: "fil",
+      tr: !0,
+      uk: !0,
+      ur: !0,
+      vi: !0,
+      yi: !1,
+      zh: "zh_cn",
+      zh_cn: !0,
+      zh_hk: !0,
+      zh_tw: !0,
+      zsm: "ms",
+      zu: !0
+    };
+    var Ha = {
+      1: "1.0",
+      "1.0": "current",
+      "1.1": "upcoming",
+      "1.2": "testing",
+      41: "pre-45",
+      42: "pre-45",
+      43: "pre-45",
+      44: "pre-45",
+      46: "46.1",
+      "46.1": "46.2",
+      48: "48.1",
+      current: "51",
+      upcoming: "52"
+    };
+    var Ia;
+    function J(a, b) {
+      this.g = b === Ja ? a : ""
+    }
+    J.prototype.toString = function() {
+      return this.g + ""
+    }
+    ;
+    J.prototype.K = !0;
+    J.prototype.I = function() {
+      return this.g.toString()
+    }
+    ;
+    function Ka(a) {
+      return a instanceof J && a.constructor === J ? a.g : "type_error:TrustedResourceUrl"
+    }
+    function La(a, b) {
+      var c = Ca(a);
+      if (!Ma.test(c))
+        throw Error("Invalid TrustedResourceUrl format: " + c);
+      a = c.replace(Na, function(d, e) {
+        if (!Object.prototype.hasOwnProperty.call(b, e))
+          throw Error('Found marker, "' + e + '", in format string, "' + c + '", but no valid label mapping found in args: ' + JSON.stringify(b));
+        d = b[e];
+        return d instanceof H ? Ca(d) : encodeURIComponent(String(d))
+      });
+      return Oa(a)
+    }
+    var Na = /%{(\w+)}/g
+      , Ma = RegExp("^((https:)?//[0-9a-z.:[\\]-]+/|/[^/\\\\]|[^:/\\\\%]+/|[^:/\\\\%]*[?#]|about:blank#)", "i")
+      , Pa = /^([^?#]*)(\?[^#]*)?(#[\s\S]*)?/;
+    function Qa(a, b, c) {
+      a = La(a, b);
+      a = Pa.exec(Ka(a).toString());
+      b = a[3] || "";
+      return Oa(a[1] + Ra("?", a[2] || "", c) + Ra("#", b))
+    }
+    var Ja = {};
+    function Oa(a) {
+      if (void 0 === Ia) {
+        var b = null;
+        var c = A.trustedTypes;
+        if (c && c.createPolicy) {
+          try {
+            b = c.createPolicy("goog#html", {
+              createHTML: za,
+              createScript: za,
+              createScriptURL: za
+            })
+          } catch (d) {
+            A.console && A.console.error(d.message)
+          }
+          Ia = b
+        } else
+          Ia = b
+      }
+      a = (b = Ia) ? b.createScriptURL(a) : a;
+      return new J(a,Ja)
+    }
+    function Ra(a, b, c) {
+      if (null == c)
+        return b;
+      if ("string" === typeof c)
+        return c ? a + encodeURIComponent(c) : "";
+      for (var d in c)
+        if (Object.prototype.hasOwnProperty.call(c, d)) {
+          var e = c[d];
+          e = Array.isArray(e) ? e : [e];
+          for (var h = 0; h < e.length; h++) {
+            var f = e[h];
+            null != f && (b || (b = a),
+              b += (b.length > a.length ? "&" : "") + encodeURIComponent(d) + "=" + encodeURIComponent(String(f)))
+          }
+        }
+      return b
+    }
+    ;var Sa = Array.prototype.some ? function(a, b) {
+        return Array.prototype.some.call(a, b, void 0)
+      }
+      : function(a, b) {
+        for (var c = a.length, d = "string" === typeof a ? a.split("") : a, e = 0; e < c; e++)
+          if (e in d && b.call(void 0, d[e], e, a))
+            return !0;
+        return !1
+      }
+    ;
+    function Ta() {}
+    ;function Ua(a, b) {
+      for (var c in a)
+        b.call(void 0, a[c], c, a)
+    }
+    var Va = "constructor hasOwnProperty isPrototypeOf propertyIsEnumerable toLocaleString toString valueOf".split(" ");
+    function Wa(a, b) {
+      for (var c, d, e = 1; e < arguments.length; e++) {
+        d = arguments[e];
+        for (c in d)
+          a[c] = d[c];
+        for (var h = 0; h < Va.length; h++)
+          c = Va[h],
+          Object.prototype.hasOwnProperty.call(d, c) && (a[c] = d[c])
+      }
+    }
+    ;var Xa, Ya = B("CLOSURE_FLAGS"), Za = Ya && Ya[610401301];
+    Xa = null != Za ? Za : !1;
+    function $a() {
+      var a = A.navigator;
+      return a && (a = a.userAgent) ? a : ""
+    }
+    var K, ab = A.navigator;
+    K = ab ? ab.userAgentData || null : null;
+    function bb(a, b) {
+      a: {
+        var c = (a.ownerDocument && a.ownerDocument.defaultView || A).document;
+        if (c.querySelector && (c = c.querySelector("script[nonce]")) && (c = c.nonce || c.getAttribute("nonce")) && cb.test(c))
+          break a;
+        c = ""
+      }
+      c && a.setAttribute("nonce", c);
+      a.src = Ka(b)
+    }
+    var cb = /^[\w+/_-]+[=]{0,2}$/;
+    var db = RegExp("^(?:([^:/?#.]+):)?(?://(?:([^\\\\/?#]*)@)?([^\\\\/?#]*?)(?::([0-9]+))?(?=[\\\\/?#]|$))?([^?#]+)?(?:\\?([^#]*))?(?:#([\\s\\S]*))?$");
+    function eb(a, b) {
+      if (a) {
+        a = a.split("&");
+        for (var c = 0; c < a.length; c++) {
+          var d = a[c].indexOf("=")
+            , e = null;
+          if (0 <= d) {
+            var h = a[c].substring(0, d);
+            e = a[c].substring(d + 1)
+          } else
+            h = a[c];
+          b(h, e ? decodeURIComponent(e.replace(/\+/g, " ")) : "")
+        }
+      }
+    }
+    ;function L(a) {
+      this.g = this.o = this.j = "";
+      this.u = null;
+      this.m = this.h = "";
+      this.l = !1;
+      var b;
+      a instanceof L ? (this.l = a.l,
+        fb(this, a.j),
+        this.o = a.o,
+        this.g = a.g,
+        gb(this, a.u),
+        this.h = a.h,
+        hb(this, ib(a.i)),
+        this.m = a.m) : a && (b = String(a).match(db)) ? (this.l = !1,
+        fb(this, b[1] || "", !0),
+        this.o = M(b[2] || ""),
+        this.g = M(b[3] || "", !0),
+        gb(this, b[4]),
+        this.h = M(b[5] || "", !0),
+        hb(this, b[6] || "", !0),
+        this.m = M(b[7] || "")) : (this.l = !1,
+        this.i = new N(null,this.l))
+    }
+    L.prototype.toString = function() {
+      var a = []
+        , b = this.j;
+      b && a.push(O(b, jb, !0), ":");
+      var c = this.g;
+      if (c || "file" == b)
+        a.push("//"),
+        (b = this.o) && a.push(O(b, jb, !0), "@"),
+          a.push(encodeURIComponent(String(c)).replace(/%25([0-9a-fA-F]{2})/g, "%$1")),
+          c = this.u,
+        null != c && a.push(":", String(c));
+      if (c = this.h)
+        this.g && "/" != c.charAt(0) && a.push("/"),
+          a.push(O(c, "/" == c.charAt(0) ? kb : lb, !0));
+      (c = this.i.toString()) && a.push("?", c);
+      (c = this.m) && a.push("#", O(c, mb));
+      return a.join("")
+    }
+    ;
+    L.prototype.resolve = function(a) {
+      var b = new L(this)
+        , c = !!a.j;
+      c ? fb(b, a.j) : c = !!a.o;
+      c ? b.o = a.o : c = !!a.g;
+      c ? b.g = a.g : c = null != a.u;
+      var d = a.h;
+      if (c)
+        gb(b, a.u);
+      else if (c = !!a.h) {
+        if ("/" != d.charAt(0))
+          if (this.g && !this.h)
+            d = "/" + d;
+          else {
+            var e = b.h.lastIndexOf("/");
+            -1 != e && (d = b.h.slice(0, e + 1) + d)
+          }
+        e = d;
+        if (".." == e || "." == e)
+          d = "";
+        else if (-1 != e.indexOf("./") || -1 != e.indexOf("/.")) {
+          d = 0 == e.lastIndexOf("/", 0);
+          e = e.split("/");
+          for (var h = [], f = 0; f < e.length; ) {
+            var g = e[f++];
+            "." == g ? d && f == e.length && h.push("") : ".." == g ? ((1 < h.length || 1 == h.length && "" != h[0]) && h.pop(),
+            d && f == e.length && h.push("")) : (h.push(g),
+              d = !0)
+          }
+          d = h.join("/")
+        } else
+          d = e
+      }
+      c ? b.h = d : c = "" !== a.i.toString();
+      c ? hb(b, ib(a.i)) : c = !!a.m;
+      c && (b.m = a.m);
+      return b
+    }
+    ;
+    function fb(a, b, c) {
+      a.j = c ? M(b, !0) : b;
+      a.j && (a.j = a.j.replace(/:$/, ""))
+    }
+    function gb(a, b) {
+      if (b) {
+        b = Number(b);
+        if (isNaN(b) || 0 > b)
+          throw Error("Bad port number " + b);
+        a.u = b
+      } else
+        a.u = null
+    }
+    function hb(a, b, c) {
+      b instanceof N ? (a.i = b,
+        nb(a.i, a.l)) : (c || (b = O(b, ob)),
+        a.i = new N(b,a.l))
+    }
+    function M(a, b) {
+      return a ? b ? decodeURI(a.replace(/%25/g, "%2525")) : decodeURIComponent(a) : ""
+    }
+    function O(a, b, c) {
+      return "string" === typeof a ? (a = encodeURI(a).replace(b, pb),
+      c && (a = a.replace(/%25([0-9a-fA-F]{2})/g, "%$1")),
+        a) : null
+    }
+    function pb(a) {
+      a = a.charCodeAt(0);
+      return "%" + (a >> 4 & 15).toString(16) + (a & 15).toString(16)
+    }
+    var jb = /[#\/\?@]/g
+      , lb = /[#\?:]/g
+      , kb = /[#\?]/g
+      , ob = /[#\?@]/g
+      , mb = /#/g;
+    function N(a, b) {
+      this.h = this.g = null;
+      this.i = a || null;
+      this.j = !!b
+    }
+    function P(a) {
+      a.g || (a.g = new Map,
+        a.h = 0,
+      a.i && eb(a.i, function(b, c) {
+        a.add(decodeURIComponent(b.replace(/\+/g, " ")), c)
+      }))
+    }
+    N.prototype.add = function(a, b) {
+      P(this);
+      this.i = null;
+      a = Q(this, a);
+      var c = this.g.get(a);
+      c || this.g.set(a, c = []);
+      c.push(b);
+      this.h += 1;
+      return this
+    }
+    ;
+    function qb(a, b) {
+      P(a);
+      b = Q(a, b);
+      a.g.has(b) && (a.i = null,
+        a.h -= a.g.get(b).length,
+        a.g.delete(b))
+    }
+    function rb(a, b) {
+      P(a);
+      b = Q(a, b);
+      return a.g.has(b)
+    }
+    N.prototype.forEach = function(a, b) {
+      P(this);
+      this.g.forEach(function(c, d) {
+        c.forEach(function(e) {
+          a.call(b, e, d, this)
+        }, this)
+      }, this)
+    }
+    ;
+    function sb(a, b) {
+      P(a);
+      var c = [];
+      if ("string" === typeof b)
+        rb(a, b) && (c = c.concat(a.g.get(Q(a, b))));
+      else
+        for (a = Array.from(a.g.values()),
+               b = 0; b < a.length; b++)
+          c = c.concat(a[b]);
+      return c
+    }
+    N.prototype.set = function(a, b) {
+      P(this);
+      this.i = null;
+      a = Q(this, a);
+      rb(this, a) && (this.h -= this.g.get(a).length);
+      this.g.set(a, [b]);
+      this.h += 1;
+      return this
+    }
+    ;
+    N.prototype.get = function(a, b) {
+      if (!a)
+        return b;
+      a = sb(this, a);
+      return 0 < a.length ? String(a[0]) : b
+    }
+    ;
+    N.prototype.toString = function() {
+      if (this.i)
+        return this.i;
+      if (!this.g)
+        return "";
+      for (var a = [], b = Array.from(this.g.keys()), c = 0; c < b.length; c++) {
+        var d = b[c]
+          , e = encodeURIComponent(String(d));
+        d = sb(this, d);
+        for (var h = 0; h < d.length; h++) {
+          var f = e;
+          "" !== d[h] && (f += "=" + encodeURIComponent(String(d[h])));
+          a.push(f)
+        }
+      }
+      return this.i = a.join("&")
+    }
+    ;
+    function ib(a) {
+      var b = new N;
+      b.i = a.i;
+      a.g && (b.g = new Map(a.g),
+        b.h = a.h);
+      return b
+    }
+    function Q(a, b) {
+      b = String(b);
+      a.j && (b = b.toLowerCase());
+      return b
+    }
+    function nb(a, b) {
+      b && !a.j && (P(a),
+        a.i = null,
+        a.g.forEach(function(c, d) {
+          var e = d.toLowerCase();
+          if (d != e && (qb(this, d),
+            qb(this, e),
+          0 < c.length)) {
+            this.i = null;
+            d = this.g;
+            var h = d.set;
+            e = Q(this, e);
+            var f = c.length;
+            if (0 < f) {
+              for (var g = Array(f), k = 0; k < f; k++)
+                g[k] = c[k];
+              f = g
+            } else
+              f = [];
+            h.call(d, e, f);
+            this.h += c.length
+          }
+        }, a));
+      a.j = b
+    }
+    ;function tb(a, b) {
+      Ua(b, function(c, d) {
+        c && "object" == typeof c && c.K && (c = c.I());
+        "style" == d ? a.style.cssText = c : "class" == d ? a.className = c : "for" == d ? a.htmlFor = c : ub.hasOwnProperty(d) ? a.setAttribute(ub[d], c) : 0 == d.lastIndexOf("aria-", 0) || 0 == d.lastIndexOf("data-", 0) ? a.setAttribute(d, c) : a[d] = c
+      })
+    }
+    var ub = {
+      cellpadding: "cellPadding",
+      cellspacing: "cellSpacing",
+      colspan: "colSpan",
+      frameborder: "frameBorder",
+      height: "height",
+      maxlength: "maxLength",
+      nonce: "nonce",
+      role: "role",
+      rowspan: "rowSpan",
+      type: "type",
+      usemap: "useMap",
+      valign: "vAlign",
+      width: "width"
+    };
+    function vb(a, b) {
+      b = String(b);
+      "application/xhtml+xml" === a.contentType && (b = b.toLowerCase());
+      return a.createElement(b)
+    }
+    function wb(a) {
+      this.g = a || A.document || document
+    }
+    ;function xb() {}
+    ;function yb(a, b) {
+      this.i = a;
+      this.j = b;
+      this.h = 0;
+      this.g = null
+    }
+    yb.prototype.get = function() {
+      if (0 < this.h) {
+        this.h--;
+        var a = this.g;
+        this.g = a.next;
+        a.next = null
+      } else
+        a = this.i();
+      return a
+    }
+    ;
+    function zb(a, b) {
+      a.j(b);
+      100 > a.h && (a.h++,
+        b.next = a.g,
+        a.g = b)
+    }
+    ;var Ab;
+    function Bb() {
+      var a = A.MessageChannel;
+      "undefined" === typeof a && "undefined" !== typeof window && window.postMessage && window.addEventListener && -1 == $a().indexOf("Presto") && (a = function() {
+          var e = vb(document, "IFRAME");
+          e.style.display = "none";
+          document.documentElement.appendChild(e);
+          var h = e.contentWindow;
+          e = h.document;
+          e.open();
+          e.close();
+          var f = "callImmediate" + Math.random()
+            , g = "file:" == h.location.protocol ? "*" : h.location.protocol + "//" + h.location.host;
+          e = C(function(k) {
+            if (("*" == g || k.origin == g) && k.data == f)
+              this.port1.onmessage()
+          }, this);
+          h.addEventListener("message", e, !1);
+          this.port1 = {};
+          this.port2 = {
+            postMessage: function() {
+              h.postMessage(f, g)
+            }
+          }
+        }
+      );
+      if ("undefined" !== typeof a && (Xa && K && 0 < K.brands.length || -1 == $a().indexOf("Trident") && -1 == $a().indexOf("MSIE"))) {
+        var b = new a
+          , c = {}
+          , d = c;
+        b.port1.onmessage = function() {
+          if (void 0 !== c.next) {
+            c = c.next;
+            var e = c.H;
+            c.H = null;
+            e()
+          }
+        }
+        ;
+        return function(e) {
+          d.next = {
+            H: e
+          };
+          d = d.next;
+          b.port2.postMessage(0)
+        }
+      }
+      return function(e) {
+        A.setTimeout(e, 0)
+      }
+    }
+    ;function Cb(a) {
+      A.setTimeout(function() {
+        throw a;
+      }, 0)
+    }
+    ;function Db() {
+      this.h = this.g = null
+    }
+    Db.prototype.add = function(a, b) {
+      var c = Eb.get();
+      c.set(a, b);
+      this.h ? this.h.next = c : this.g = c;
+      this.h = c
+    }
+    ;
+    function Fb() {
+      var a = Gb
+        , b = null;
+      a.g && (b = a.g,
+        a.g = a.g.next,
+      a.g || (a.h = null),
+        b.next = null);
+      return b
+    }
+    var Eb = new yb(function() {
+        return new Hb
+      }
+      ,function(a) {
+        return a.reset()
+      }
+    );
+    function Hb() {
+      this.next = this.g = this.h = null
+    }
+    Hb.prototype.set = function(a, b) {
+      this.h = a;
+      this.g = b;
+      this.next = null
+    }
+    ;
+    Hb.prototype.reset = function() {
+      this.next = this.g = this.h = null
+    }
+    ;
+    var Ib, Jb = !1, Gb = new Db;
+    function Kb(a, b) {
+      Ib || Lb();
+      Jb || (Ib(),
+        Jb = !0);
+      Gb.add(a, b)
+    }
+    function Lb() {
+      if (A.Promise && A.Promise.resolve) {
+        var a = A.Promise.resolve(void 0);
+        Ib = function() {
+          a.then(Mb)
+        }
+      } else
+        Ib = function() {
+          var b = Mb;
+          "function" !== typeof A.setImmediate || A.Window && A.Window.prototype && (Xa && K && 0 < K.brands.length || -1 == $a().indexOf("Edge")) && A.Window.prototype.setImmediate == A.setImmediate ? (Ab || (Ab = Bb()),
+            Ab(b)) : A.setImmediate(b)
+        }
+    }
+    function Mb() {
+      for (var a; a = Fb(); ) {
+        try {
+          a.h.call(a.g)
+        } catch (b) {
+          Cb(b)
+        }
+        zb(Eb, a)
+      }
+      Jb = !1
+    }
+    ;function Nb(a) {
+      if (!a)
+        return !1;
+      try {
+        return !!a.$goog_Thenable
+      } catch (b) {
+        return !1
+      }
+    }
+    ;function R(a) {
+      this.g = 0;
+      this.o = void 0;
+      this.j = this.h = this.i = null;
+      this.l = this.m = !1;
+      if (a != Ta)
+        try {
+          var b = this;
+          a.call(void 0, function(c) {
+            S(b, 2, c)
+          }, function(c) {
+            S(b, 3, c)
+          })
+        } catch (c) {
+          S(this, 3, c)
+        }
+    }
+    function Ob() {
+      this.next = this.i = this.h = this.j = this.g = null;
+      this.l = !1
+    }
+    Ob.prototype.reset = function() {
+      this.i = this.h = this.j = this.g = null;
+      this.l = !1
+    }
+    ;
+    var Pb = new yb(function() {
+        return new Ob
+      }
+      ,function(a) {
+        a.reset()
+      }
+    );
+    function Qb(a, b, c) {
+      var d = Pb.get();
+      d.j = a;
+      d.h = b;
+      d.i = c;
+      return d
+    }
+    R.prototype.then = function(a, b, c) {
+      return Rb(this, "function" === typeof a ? a : null, "function" === typeof b ? b : null, c)
+    }
+    ;
+    R.prototype.$goog_Thenable = !0;
+    R.prototype.cancel = function(a) {
+      if (0 == this.g) {
+        var b = new T(a);
+        Kb(function() {
+          Sb(this, b)
+        }, this)
+      }
+    }
+    ;
+    function Sb(a, b) {
+      if (0 == a.g)
+        if (a.i) {
+          var c = a.i;
+          if (c.h) {
+            for (var d = 0, e = null, h = null, f = c.h; f && (f.l || (d++,
+            f.g == a && (e = f),
+              !(e && 1 < d))); f = f.next)
+              e || (h = f);
+            e && (0 == c.g && 1 == d ? Sb(c, b) : (h ? (d = h,
+            d.next == c.j && (c.j = d),
+              d.next = d.next.next) : Tb(c),
+              Ub(c, e, 3, b)))
+          }
+          a.i = null
+        } else
+          S(a, 3, b)
+    }
+    function Vb(a, b) {
+      a.h || 2 != a.g && 3 != a.g || Wb(a);
+      a.j ? a.j.next = b : a.h = b;
+      a.j = b
+    }
+    function Rb(a, b, c, d) {
+      var e = Qb(null, null, null);
+      e.g = new R(function(h, f) {
+          e.j = b ? function(g) {
+              try {
+                var k = b.call(d, g);
+                h(k)
+              } catch (m) {
+                f(m)
+              }
+            }
+            : h;
+          e.h = c ? function(g) {
+              try {
+                var k = c.call(d, g);
+                void 0 === k && g instanceof T ? f(g) : h(k)
+              } catch (m) {
+                f(m)
+              }
+            }
+            : f
+        }
+      );
+      e.g.i = a;
+      Vb(a, e);
+      return e.g
+    }
+    R.prototype.A = function(a) {
+      this.g = 0;
+      S(this, 2, a)
+    }
+    ;
+    R.prototype.B = function(a) {
+      this.g = 0;
+      S(this, 3, a)
+    }
+    ;
+    function S(a, b, c) {
+      if (0 == a.g) {
+        a === c && (b = 3,
+          c = new TypeError("Promise cannot resolve to itself"));
+        a.g = 1;
+        a: {
+          var d = c
+            , e = a.A
+            , h = a.B;
+          if (d instanceof R) {
+            Vb(d, Qb(e || Ta, h || null, a));
+            var f = !0
+          } else if (Nb(d))
+            d.then(e, h, a),
+              f = !0;
+          else {
+            if (wa(d))
+              try {
+                var g = d.then;
+                if ("function" === typeof g) {
+                  Xb(d, g, e, h, a);
+                  f = !0;
+                  break a
+                }
+              } catch (k) {
+                h.call(a, k);
+                f = !0;
+                break a
+              }
+            f = !1
+          }
+        }
+        f || (a.o = c,
+          a.g = b,
+          a.i = null,
+          Wb(a),
+        3 != b || c instanceof T || Yb(a, c))
+      }
+    }
+    function Xb(a, b, c, d, e) {
+      function h(k) {
+        g || (g = !0,
+          d.call(e, k))
+      }
+      function f(k) {
+        g || (g = !0,
+          c.call(e, k))
+      }
+      var g = !1;
+      try {
+        b.call(a, f, h)
+      } catch (k) {
+        h(k)
+      }
+    }
+    function Wb(a) {
+      a.m || (a.m = !0,
+        Kb(a.u, a))
+    }
+    function Tb(a) {
+      var b = null;
+      a.h && (b = a.h,
+        a.h = b.next,
+        b.next = null);
+      a.h || (a.j = null);
+      return b
+    }
+    R.prototype.u = function() {
+      for (var a; a = Tb(this); )
+        Ub(this, a, this.g, this.o);
+      this.m = !1
+    }
+    ;
+    function Ub(a, b, c, d) {
+      if (3 == c && b.h && !b.l)
+        for (; a && a.l; a = a.i)
+          a.l = !1;
+      if (b.g)
+        b.g.i = null,
+          Zb(b, c, d);
+      else
+        try {
+          b.l ? b.j.call(b.i) : Zb(b, c, d)
+        } catch (e) {
+          $b.call(null, e)
+        }
+      zb(Pb, b)
+    }
+    function Zb(a, b, c) {
+      2 == b ? a.j.call(a.i, c) : a.h && a.h.call(a.i, c)
+    }
+    function Yb(a, b) {
+      a.l = !0;
+      Kb(function() {
+        a.l && $b.call(null, b)
+      })
+    }
+    var $b = Cb;
+    function T(a) {
+      F.call(this, a)
+    }
+    E(T, F);
+    T.prototype.name = "cancel";
+    /*
+
+ Copyright 2005, 2007 Bob Ippolito. All Rights Reserved.
+ Copyright The Closure Library Authors.
+ SPDX-License-Identifier: MIT
+*/
+    function U(a, b) {
+      this.l = [];
+      this.D = a;
+      this.C = b || null;
+      this.j = this.i = !1;
+      this.h = void 0;
+      this.A = this.G = this.o = !1;
+      this.m = 0;
+      this.g = null;
+      this.u = 0
+    }
+    E(U, xb);
+    U.prototype.cancel = function(a) {
+      if (this.i)
+        this.h instanceof U && this.h.cancel();
+      else {
+        if (this.g) {
+          var b = this.g;
+          delete this.g;
+          a ? b.cancel(a) : (b.u--,
+          0 >= b.u && b.cancel())
+        }
+        this.D ? this.D.call(this.C, this) : this.A = !0;
+        this.i || (a = new V(this),
+          ac(this),
+          W(this, !1, a))
+      }
+    }
+    ;
+    U.prototype.B = function(a, b) {
+      this.o = !1;
+      W(this, a, b)
+    }
+    ;
+    function W(a, b, c) {
+      a.i = !0;
+      a.h = c;
+      a.j = !b;
+      bc(a)
+    }
+    function ac(a) {
+      if (a.i) {
+        if (!a.A)
+          throw new cc(a);
+        a.A = !1
+      }
+    }
+    function dc(a, b, c, d) {
+      a.l.push([b, c, d]);
+      a.i && bc(a)
+    }
+    U.prototype.then = function(a, b, c) {
+      var d, e, h = new R(function(f, g) {
+          e = f;
+          d = g
+        }
+      );
+      dc(this, e, function(f) {
+        f instanceof V ? h.cancel() : d(f);
+        return ec
+      }, this);
+      return h.then(a, b, c)
+    }
+    ;
+    U.prototype.$goog_Thenable = !0;
+    function fc(a) {
+      return Sa(a.l, function(b) {
+        return "function" === typeof b[1]
+      })
+    }
+    var ec = {};
+    function bc(a) {
+      if (a.m && a.i && fc(a)) {
+        var b = a.m
+          , c = gc[b];
+        c && (A.clearTimeout(c.g),
+          delete gc[b]);
+        a.m = 0
+      }
+      a.g && (a.g.u--,
+        delete a.g);
+      b = a.h;
+      for (var d = c = !1; a.l.length && !a.o; ) {
+        var e = a.l.shift()
+          , h = e[0]
+          , f = e[1];
+        e = e[2];
+        if (h = a.j ? f : h)
+          try {
+            var g = h.call(e || a.C, b);
+            g === ec && (g = void 0);
+            void 0 !== g && (a.j = a.j && (g == b || g instanceof Error),
+              a.h = b = g);
+            if (Nb(b) || "function" === typeof A.Promise && b instanceof A.Promise)
+              d = !0,
+                a.o = !0
+          } catch (k) {
+            b = k,
+              a.j = !0,
+            fc(a) || (c = !0)
+          }
+      }
+      a.h = b;
+      d && (g = C(a.B, a, !0),
+        d = C(a.B, a, !1),
+        b instanceof U ? (dc(b, g, d),
+          b.G = !0) : b.then(g, d));
+      c && (b = new hc(b),
+        gc[b.g] = b,
+        a.m = b.g)
+    }
+    function cc() {
+      F.call(this)
+    }
+    E(cc, F);
+    cc.prototype.message = "Deferred has already fired";
+    cc.prototype.name = "AlreadyCalledError";
+    function V() {
+      F.call(this)
+    }
+    E(V, F);
+    V.prototype.message = "Deferred was canceled";
+    V.prototype.name = "CanceledError";
+    function hc(a) {
+      this.g = A.setTimeout(C(this.i, this), 0);
+      this.h = a
+    }
+    hc.prototype.i = function() {
+      delete gc[this.g];
+      throw this.h;
+    }
+    ;
+    var gc = {};
+    function ic(a) {
+      var b;
+      return (b = (a || document).getElementsByTagName("HEAD")) && 0 !== b.length ? b[0] : a.documentElement
+    }
+    function jc() {
+      if (this && this.L) {
+        var a = this.L;
+        a && "SCRIPT" == a.tagName && kc(a, !0, this.M)
+      }
+    }
+    function kc(a, b, c) {
+      null != c && A.clearTimeout(c);
+      a.onload = function() {}
+      ;
+      a.onerror = function() {}
+      ;
+      a.onreadystatechange = function() {}
+      ;
+      b && window.setTimeout(function() {
+        a && a.parentNode && a.parentNode.removeChild(a)
+      }, 0)
+    }
+    function lc(a, b) {
+      var c = "Jsloader error (code #" + a + ")";
+      b && (c += ": " + b);
+      F.call(this, c);
+      this.code = a
+    }
+    E(lc, F);
+    /*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+*/
+    function mc(a) {
+      return Qa(a.format, a.R, a.X || {})
+    }
+    function nc(a) {
+      var b = {
+        timeout: 3E4,
+        attributes: {
+          async: !1,
+          defer: !1
+        }
+      }
+        , c = b.document || document
+        , d = Ka(a).toString()
+        , e = vb((new wb(c)).g, "SCRIPT")
+        , h = {
+        L: e,
+        M: void 0
+      }
+        , f = new U(jc,h)
+        , g = null
+        , k = null != b.timeout ? b.timeout : 5E3;
+      0 < k && (g = window.setTimeout(function() {
+        kc(e, !0);
+        var m = new lc(1,"Timeout reached for loading script " + d);
+        ac(f);
+        W(f, !1, m)
+      }, k),
+        h.M = g);
+      e.onload = e.onreadystatechange = function() {
+        e.readyState && "loaded" != e.readyState && "complete" != e.readyState || (kc(e, b.V || !1, g),
+          ac(f),
+          W(f, !0, null))
+      }
+      ;
+      e.onerror = function() {
+        kc(e, !0, g);
+        var m = new lc(0,"Error while loading script " + d);
+        ac(f);
+        W(f, !1, m)
+      }
+      ;
+      h = b.attributes || {};
+      Wa(h, {
+        type: "text/javascript",
+        charset: "UTF-8"
+      });
+      tb(e, h);
+      bb(e, a);
+      ic(c).appendChild(e);
+      return f
+    }
+    function oc(a, b, c) {
+      c = c || {};
+      a = Qa(a, b, c);
+      var d = nc(a);
+      return new Promise(function(e) {
+          dc(d, e, null)
+        }
+      )
+    }
+    ;/*
+
+ Copyright 2021 Google LLC
+ This code is released under the MIT license.
+ SPDX-License-Identifier: MIT
+
+*/
+    function pc() {
+      return new Promise(function(a) {
+          "undefined" === typeof window || "complete" === document.readyState ? a() : window.addEventListener ? (document.addEventListener("DOMContentLoaded", a, !0),
+            window.addEventListener("load", a, !0)) : window.attachEvent ? window.attachEvent("onload", a) : "function" !== typeof window.onload ? window.onload = a : window.onload = function(b) {
+            if (window.onload)
+              window.onload(b);
+            a()
+          }
+        }
+      )
+    }
+    ;var X = "", Y = "", qc, Z, rc = null, sc;
+    function tc(a) {
+      var b = a, c, d = a.match(/^testing-/);
+      d && (b = b.replace(/^testing-/, ""));
+      a = b;
+      do {
+        if (b === Ha[b])
+          throw Error("Infinite loop in version mapping: " + b);
+        (c = Ha[b]) && (b = c)
+      } while (c);
+      c = (d ? "testing-" : "") + b;
+      a = "pre-45" == b ? a : c;
+      return {
+        version: a,
+        S: c
+      }
+    }
+    function uc(a) {
+      var b = Da[sc].loader
+        , c = tc(a);
+      return oc(b, {
+        version: c.S
+      }).then(function() {
+        var d = B("google.charts.loader.versionSpecific.load") || B("google.charts.loader.VersionSpecific.load") || B("google.charts.loader.publicLoad") || B("google.charts.versionSpecific.load");
+        if (!d)
+          throw Error("Bad version: " + a);
+        rc = function(e) {
+          e = d(c.version, e);
+          if (null == e || null == e.then) {
+            var h = B("google.charts.loader.publicSetOnLoadCallback") || B("google.charts.versionSpecific.setOnLoadCallback");
+            e = new Promise(function(f) {
+                h(f)
+              }
+            );
+            e.then = h
+          }
+          return e
+        }
+      })
+    }
+    function vc(a) {
+      "string" === typeof a && (a = [a]);
+      Array.isArray(a) && 0 !== a.length || (a = Ea);
+      var b = [];
+      a.forEach(function(c) {
+        c = c.toLowerCase();
+        b = b.concat(c.split(/[\s,]+\s*/))
+      });
+      return b
+    }
+    function wc(a) {
+      a = a || "";
+      for (var b = a.replace(/-/g, "_").toLowerCase(); "string" === typeof b; )
+        a = b,
+          b = Ga[b],
+        b === a && (b = !1);
+      b || (a.match(/_[^_]+$/) ? (a = a.replace(/_[^_]+$/, ""),
+        a = wc(a)) : a = "en");
+      return a
+    }
+    function xc(a) {
+      a = a || "";
+      "" !== X && X !== a && (console.warn(" Attempting to load version '" + a + "' of Google Charts, but the previously loaded '" + (X + "' will be used instead.")),
+        a = X);
+      return X = a || ""
+    }
+    function yc(a) {
+      a = a || "";
+      "" !== Y && Y !== a && (console.warn(" Attempting to load Google Charts for language '" + a + "', but the previously loaded '" + (Y + "' will be used instead.")),
+        a = Y);
+      "en" === a && (a = "");
+      return Y = a || ""
+    }
+    function zc(a) {
+      var b = {}, c;
+      for (c in a)
+        b[c] = a[c];
+      return b
+    }
+    function Ac(a, b) {
+      b = zc(b);
+      b.domain = sc;
+      b.callback = Bc(b.callback);
+      a = xc(a);
+      var c = b.language;
+      c = yc(wc(c));
+      b.language = c;
+      if (!qc) {
+        if (b.enableUrlSettings && window.URLSearchParams)
+          try {
+            a = (new URLSearchParams(top.location.search)).get("charts-version") || a
+          } catch (d) {
+            console.info("Failed to get charts-version from top URL", d)
+          }
+        qc = uc(a)
+      }
+      b.packages = vc(b.packages);
+      return Z = qc.then(function() {
+        return rc(b)
+      })
+    }
+    function Cc(a) {
+      if (!Z)
+        throw Error("Must call google.charts.load before google.charts.setOnLoadCallback");
+      return a ? Z.then(a) : Z
+    }
+    D("google.charts.safeLoad", function(a) {
+      return Dc(Object.assign({}, a, {
+        safeMode: !0
+      }))
+    });
+    function Dc() {
+      var a = la.apply(0, arguments)
+        , b = 0;
+      "visualization" === a[b] && b++;
+      var c = "current";
+      if ("string" === typeof a[b] || "number" === typeof a[b])
+        c = String(a[b]),
+          b++;
+      var d = {};
+      wa(a[b]) && (d = a[b]);
+      return Ac(c, d)
+    }
+    D("google.charts.load", Dc);
+    D("google.charts.setOnLoadCallback", Cc);
+    var Ec = I("https://maps.googleapis.com/maps/api/js?jsapiRedirect=true")
+      , Fc = I("https://maps-api-ssl.google.com/maps?jsapiRedirect=true&file=googleapi");
+    function Gc(a, b, c) {
+      console.warn("Loading Maps API with the jsapi loader is deprecated.");
+      c = c || {};
+      a = c.key || c.client;
+      var d = c.libraries
+        , e = function(g) {
+        for (var k = {}, m = 0; m < g.length; m++) {
+          var n = g[m];
+          k[n[0]] = n[1]
+        }
+        return k
+      }(c.other_params ? c.other_params.split("&").map(function(g) {
+        return g.split("=")
+      }) : [])
+        , h = Object.assign({}, {
+        key: a,
+        W: d
+      }, e)
+        , f = "2" === b ? Fc : Ec;
+      Z = new Promise(function(g) {
+          var k = Bc(c && c.callback);
+          oc(f, {}, h).then(k).then(g)
+        }
+      )
+    }
+    var Hc = I("https://www.gstatic.com/inputtools/js/ita/inputtools_3.js");
+    function Ic(a, b, c) {
+      wa(c) && c.packages ? (Array.isArray(c.packages) ? c.packages : [c.packages]).includes("inputtools") ? (console.warn('Loading "elements" with the jsapi loader is deprecated.\nPlease load ' + (Hc + " directly.")),
+        Z = new Promise(function(d) {
+            var e = Bc(c && c.callback);
+            oc(Hc, {}, {}).then(e).then(d)
+          }
+        )) : console.error('Loading "elements" other than "inputtools" is unsupported.') : console.error("google.load of elements was invoked without specifying packages")
+    }
+    var Jc = I("https://ajax.googleapis.com/ajax/libs/%{module}/%{version}/%{file}");
+    function Kc(a, b) {
+      var c;
+      do {
+        if (a === b[a])
+          throw Error("Infinite loop in version mapping for version " + a);
+        (c = b[a]) && (a = c)
+      } while (c);
+      return a
+    }
+    function Lc(a, b, c) {
+      var d = Fa[a];
+      if (d) {
+        b = Kc(b, d.aliases);
+        d = d.versions[b];
+        if (!d)
+          throw Error("Unknown version, " + b + ", of " + a + ".");
+        var e = {
+          module: a,
+          version: b || "",
+          file: d.compressed
+        };
+        b = Ka(mc({
+          format: Jc,
+          R: e
+        })).toString();
+        console.warn("Loading modules with the jsapi loader is deprecated.\nPlease load " + (a + " directly from " + b + "."));
+        Z = new Promise(function(h) {
+            var f = Bc(c && c.callback);
+            oc(Jc, e).then(f).then(h)
+          }
+        )
+      } else
+        setTimeout(function() {
+          throw Error('Module "' + a + '" is not supported.');
+        }, 0)
+    }
+    function Bc(a) {
+      return function() {
+        if ("function" === typeof a)
+          a();
+        else if ("string" === typeof a && "" !== a)
+          try {
+            var b = B(a);
+            if ("function" !== typeof b)
+              throw Error("Type of '" + a + "' is " + typeof b + ".");
+            b()
+          } catch (c) {
+            throw Error("Callback of " + a + " failed with: " + c);
+          }
+      }
+    }
+    function Mc() {
+      var a = la.apply(0, arguments);
+      switch (a[0]) {
+        case "maps":
+          Gc.apply(null, ea(a));
+          break;
+        case "elements":
+          Ic.apply(null, ea(a));
+          break;
+        case "visualization":
+          Dc.apply(null, ea(a));
+          break;
+        default:
+          Lc.apply(null, ea(a))
+      }
+    }
+    D("google.loader.LoadFailure", !1);
+    if (sc)
+      console.warn("Google Charts loader.js should only be loaded once.");
+    else {
+      Y = X = "";
+      rc = Z = qc = null;
+      B("google.load") || (D("google.load", Mc),
+        D("google.setOnLoadCallback", Cc));
+      var Nc = document.getElementsByTagName("script")
+        , Oc = (document.currentScript || Nc[Nc.length - 1]).getAttribute("src")
+        , Pc = new L(Oc)
+        , Qc = Pc.g;
+      sc = Qc = Qc.match(/^www\.gstatic\.cn/) ? "gstatic.cn" : "gstatic.com";
+      var Rc = new N(Pc.i.toString())
+        , Sc = Rc.get("callback");
+      if ("string" === typeof Sc) {
+        var Tc = Bc(Sc);
+        pc().then(Tc)
+      }
+      var Uc = Rc.get("autoload");
+      if ("string" === typeof Uc)
+        try {
+          if ("" !== Uc)
+            for (var Vc = JSON.parse(Uc).modules, Wc = 0; Wc < Vc.length; Wc++) {
+              var Xc = Vc[Wc];
+              Mc(Xc.name, Xc.version, Xc)
+            }
+        } catch (a) {
+          throw Error("Autoload failed with: " + a);
+        }
+    }
+    ;
+  }
+).call(this);

--- a/cypress/fixtures/queries/chart-data-response.json
+++ b/cypress/fixtures/queries/chart-data-response.json
@@ -1,0 +1,100 @@
+{
+  "head" : {
+    "vars" : [
+      "country",
+      "temperature"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "2"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "1"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "3"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "11"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "50"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "1"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "12"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "123"
+        }
+      }
+    ]
+  }
+}

--- a/cypress/steps/google-charts-config-steps.ts
+++ b/cypress/steps/google-charts-config-steps.ts
@@ -1,0 +1,33 @@
+export class GoogleChartsConfigSteps {
+  static getConfigDialog() {
+    return cy.get('.google-visualization-charteditor-dialog');
+  }
+
+  static selectPieChart() {
+    this.getConfigDialog().find('#google-visualization-charteditor-thumbnail-piechart').click();
+    // Wait explicitly without condition because the selected chart preview is generic and we can
+    // not distinguish the preview in any way and also the preview element is always present in the
+    // dialog but the chart is rendered with a bit of delay.
+    cy.wait(1000);
+  }
+
+  static selectLineChart() {
+    this.getConfigDialog().find('#google-visualization-charteditor-thumbnail-linechart').click();
+    // Wait explicitly without condition because the selected chart preview is generic and we can
+    // not distinguish the preview in any way and also the preview element is always present in the
+    // dialog but the chart is rendered with a bit of delay.
+    cy.wait(1000);
+  }
+
+  static getConfirmSelectedChartButton() {
+    return this.getConfigDialog().find('[name=ok]');
+  }
+
+  static confirmSelectedChart() {
+    this.getConfirmSelectedChartButton().click();
+  }
+
+  static getPieChartPreview() {
+    return this.getConfigDialog().find('#google-visualization-charteditor-preview-div-chart');
+  }
+}

--- a/cypress/steps/pages/yasr-charts-plugin-page-steps.ts
+++ b/cypress/steps/pages/yasr-charts-plugin-page-steps.ts
@@ -1,0 +1,6 @@
+export class YasrChartsPluginPageSteps {
+
+  static visit() {
+    cy.visit('/pages/yasr-chart-plugin');
+  }
+}

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -60,7 +60,7 @@ export class YasqeSteps {
   static executeQuery(index = 0) {
     this.getExecuteQueryButton(index).click();
     LoaderSteps.getLoader(index).should('not.be.visible');
-    // Wait a wile for the response information to be present.
+    // Wait a while for the response information to be present.
     YasrSteps.getResponseInfo(index)
       .should('not.have.class', 'hidden')
       .should('not.have.class', 'empty')

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -200,4 +200,24 @@ export class YasrSteps {
   static getEmptyResultElement() {
     return cy.get('.yasr_response_chip.empty');
   }
+
+  static openChartsTab() {
+    this.getYasr().find('.select_charts').click();
+  }
+
+  static getGoogleChartConfigButton() {
+    return this.getYasr().find('#openChartConfigBtn');
+  }
+
+  static openGoogleChartsConfig() {
+    this.getGoogleChartConfigButton().click();
+  }
+
+  static getGoogleDataTable() {
+    return this.getYasr().find('.google-visualization-table-table');
+  }
+
+  static getGoogleChartVisualization() {
+    return this.getYasr().find('.yasr_results svg');
+  }
 }

--- a/cypress/stubs/charts-stubs.ts
+++ b/cypress/stubs/charts-stubs.ts
@@ -1,0 +1,104 @@
+export class ChartsStubs {
+
+  static stubLoader() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/loader.js'
+    }, {fixture: '/charts/loader'})
+  }
+
+  static stub_jsapi_compiled_annotatedtimeline_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_annotatedtimeline_module.js'
+    }, {fixture: '/charts/jsapi_compiled_annotatedtimeline_module'})
+  }
+
+  static stub_jsapi_compiled_annotationchart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_annotationchart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_annotationchart_module'})
+  }
+
+  static stub_jsapi_compiled_charteditor_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_charteditor_module.js'
+    }, {fixture: '/charts/jsapi_compiled_charteditor_module'})
+  }
+
+  static stub_jsapi_compiled_controls_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_controls_module.js'
+    }, {fixture: '/charts/jsapi_compiled_controls_module'})
+  }
+
+  static stub_jsapi_compiled_corechart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_corechart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_corechart_module'})
+  }
+
+  static stub_jsapi_compiled_default_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_default_module.js'
+    }, {fixture: '/charts/jsapi_compiled_default_module'})
+  }
+
+  static stub_jsapi_compiled_flashui_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_flashui_module.js'
+    }, {fixture: '/charts/jsapi_compiled_flashui_module'})
+  }
+
+  static stub_jsapi_compiled_gauge_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_gauge_module.js'
+    }, {fixture: '/charts/jsapi_compiled_gauge_module'})
+  }
+
+  static stub_jsapi_compiled_geo_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_geo_module.js'
+    }, {fixture: '/charts/jsapi_compiled_geo_module'})
+  }
+
+  static stub_jsapi_compiled_geochart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_geochart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_geochart_module'})
+  }
+
+  static stub_jsapi_compiled_graphics_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_graphics_module.js'
+    }, {fixture: '/charts/jsapi_compiled_graphics_module'})
+  }
+
+  static stub_jsapi_compiled_imagechart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_imagechart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_imagechart_module'})
+  }
+
+  static stub_jsapi_compiled_motionchart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_motionchart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_motionchart_module'})
+  }
+
+  static stub_jsapi_compiled_orgchart_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_orgchart_module.js'
+    }, {fixture: '/charts/jsapi_compiled_orgchart_module'})
+  }
+
+  static stub_jsapi_compiled_table_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_table_module.js'
+    }, {fixture: '/charts/jsapi_compiled_table_module'})
+  }
+
+  static stub_jsapi_compiled_ui_module() {
+    cy.intercept({
+      url: 'https://www.gstatic.com/charts/51/js/jsapi_compiled_ui_module.js'
+    }, {fixture: '/charts/jsapi_compiled_ui_module'})
+  }
+}

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -59,6 +59,10 @@ export class QueryStubs {
     }).as('updaeResponse');
   }
 
+  static stubChartDataQuery() {
+    cy.intercept('/repositories/chart-data', {fixture: '/queries/chart-data-response.json'}).as('chart-data-request');
+  }
+
   static stubQueryResults(queryDescription: QueryStubDescription) {
     const resultType = queryDescription.resultType;
     const pageSize = queryDescription.pageSize;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -208,6 +208,22 @@
       .yasr_response_chip {
         min-height: 50px;
         background-color: $color-onto-table-header-background;
+
+        #openChartConfigBtn {
+          color: #333;
+          background-color: #fff;
+          border: 1px solid #ccc;
+          text-align: center;
+          vertical-align: middle;
+          cursor: pointer;
+          padding: 6px 12px;
+          user-select: none;
+        }
+
+        #openChartConfigBtn:hover {
+          background-color: #ebebeb;
+          border-color: #adadad;
+        }
       }
 
       .pageSizeWrapper, .switch {
@@ -253,8 +269,7 @@
 
       /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
       .dataTable tbody td div.uri-cell:hover .resource-copy-link, .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
-      .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link
-      {
+      .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link {
         display: inline;
         padding-left: 10px;
         padding-right: 10px;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -27,6 +27,7 @@ import {YasqeButtonType} from '../../models/yasqe-button-name';
 import {YasqeService} from '../../services/yasqe/yasqe-service';
 import {YasrService} from '../../services/yasr/yasr-service';
 import {PivotTablePlugin} from '../../plugins/yasr/pivot-table-plugin';
+import {ChartsPlugin} from "../../plugins/yasr/charts-plugin";
 
 /**
  * This is the custom web component which is adapter for the yasgui library. It allows as to
@@ -734,6 +735,7 @@ export class OntotextYasguiWebComponent {
       const yasguiConfiguration = this.yasguiConfigurationBuilder.build(externalConfiguration);
       // * Build a yasgui instance using the configuration
       YasrService.registerPlugin(PivotTablePlugin.PLUGIN_NAME, PivotTablePlugin as any);
+      YasrService.registerPlugin(ChartsPlugin.PLUGIN_NAME, ChartsPlugin as any);
       this.ontotextYasgui = this.yasguiBuilder.build(this.hostElement, yasguiConfiguration);
       this.afterInit();
     }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -108,6 +108,8 @@
   "yasr.plugin_control.plugin.name.response": "Raw response",
   "yasr.plugin_control.plugin.name.table": "Table",
   "yasr.plugin_control.plugin.name.pivot-table": "Pivot Table",
+  "yasr.plugin_control.plugin.name.charts": "Charts",
+  "yasr.plugin_control.plugin.charts.config.button": "Chart Config",
   "yasr.plugin_control.shows_view.btn.aria_label": "Shows {{name}} view",
   "yasr.plugin_control.response_chip.timestamp.minutes_ago": "minutes ago",
   "yasr.plugin_control.response_chip.timestamp.moments_ago": "moments ago",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -108,6 +108,8 @@
   "yasr.plugin_control.plugin.name.response": "Réponse brute",
   "yasr.plugin_control.plugin.name.table": "Tableau",
   "yasr.plugin_control.plugin.name.pivot-table": "Table de pivotement",
+  "yasr.plugin_control.plugin.name.charts": "Graphiques",
+  "yasr.plugin_control.plugin.charts.config.button": "Configuration du graphique",
   "yasr.plugin_control.shows_view.btn.aria_label": "Affiche la vue {{name}}",
   "yasr.plugin_control.response_chip.timestamp.minutes_ago": "minutes",
   "yasr.plugin_control.response_chip.timestamp.moments_ago": "il y a quelques instants",

--- a/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
+++ b/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
@@ -1,7 +1,9 @@
-function getOntotextYasgui(componentId) {
+function getOntotextYasgui(componentId, endpoint = "/repositories/test-repo") {
   let ontoElement = document.querySelector("ontotext-yasgui");
   ontoElement.config = {
-    endpoint: "/repositories/test-repo",
+    endpoint: () => {
+      return endpoint;
+    },
     prefixes: getPrefixes(),
     componentId
   };

--- a/ontotext-yasgui-web-component/src/models/yasr-plugin.ts
+++ b/ontotext-yasgui-web-component/src/models/yasr-plugin.ts
@@ -10,20 +10,22 @@ export interface YasrPlugin {
   priority: number;
 
   /**
-   * Checks if the plugin can render the response.
-   */
-  canHandleResults(): boolean;
-
-  /**
    * A unique string of plugin. It will be used for translation of plugin name.
    * For instance: if name is "test-plugin" then the translation label key will be "yasr.plugin_control.plugin.name.test-plugin";
    */
   label: string;
 
   /**
+   * Checks if the plugin can render the response.
+   */
+  canHandleResults(): boolean;
+
+  /**
    * It is called during the initialization of the plugin.
    */
   initialize?(): Promise<void>;
+
+  download?(filename?: string): DownloadInfo | undefined;
 
   /**
    * It is called during the destruction of the plugin.
@@ -38,4 +40,14 @@ export interface YasrPlugin {
   draw(persistentConfig: any, runtimeConfig?: any): Promise<void> | void;
 
   getIcon(): Element | undefined;
+}
+
+export interface DownloadInfo {
+  contentType: string;
+  /**
+   * File contents as a string or a data url
+   */
+  getData: () => string;
+  filename: string;
+  title: string;
 }

--- a/ontotext-yasgui-web-component/src/pages/fake-server.js
+++ b/ontotext-yasgui-web-component/src/pages/fake-server.js
@@ -5,6 +5,10 @@ module.exports = function (req, res, next) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(queryResponse));
+  } else if (req.url === '/repositories/chart-data') {
+    // custom response overriding the dev server
+    res.writeHead(200, {"Content-Type": "application/json"});
+    res.end(JSON.stringify(chartDataResponse));
   } else if (req.url.endsWith('/repositories/test-repo/namespaces')) {
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(namespacesResponse));
@@ -123,6 +127,7 @@ const localNamesResponse = {
     "description": "http://www.w3.org/ns/ldp#Non<b>RDF</b>Source"
   }]
 }
+
 const namespacesResponse = {
   "head": {
     "vars": [
@@ -245,6 +250,107 @@ const namespacesResponse = {
     ]
   }
 };
+
+const chartDataResponse = {
+  "head" : {
+    "vars" : [
+      "country",
+      "temperature"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "2"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "1"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "3"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "11"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book1"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "50"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "1"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "12"
+        }
+      },
+      {
+        "country" : {
+          "type" : "uri",
+          "value" : "http://example/book2"
+        },
+        "temperature" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "123"
+        }
+      }
+    ]
+  }
+}
 
 const queryResponse = {
   "head": {

--- a/ontotext-yasgui-web-component/src/pages/yasr-chart-plugin/index.html
+++ b/ontotext-yasgui-web-component/src/pages/yasr-chart-plugin/index.html
@@ -7,9 +7,10 @@
 
     <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
     <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
-    <script src="js/main.js" defer></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
+    <script src="./yasr-chart-plugin/main.js" defer></script>
   </head>
-  <body>|
+  <body>
   <a href="/pages/default-view">default-view</a> |
   <a href="/pages/actions">actions</a> |
   <a href="/pages/languages">languages</a> |
@@ -23,6 +24,7 @@
   <a href="/pages/autocomplete">autocomplete</a> |
   <a href="/pages/keyboard-shortcuts">keyboard-shortcuts</a> |
   <hr/>
+
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>
 </html>

--- a/ontotext-yasgui-web-component/src/pages/yasr-chart-plugin/main.js
+++ b/ontotext-yasgui-web-component/src/pages/yasr-chart-plugin/main.js
@@ -1,0 +1,1 @@
+getOntotextYasgui('yasr-plugins', '/repositories/chart-data');

--- a/ontotext-yasgui-web-component/src/plugins/yasr/charts-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/charts-plugin.ts
@@ -44,8 +44,8 @@ export class ChartsPlugin implements YasrPlugin {
     });
   }
 
-  // @ts-ignore
   download?(filename?: string): DownloadInfo | undefined {
+    console.log('download', filename);
     return;
   }
 
@@ -229,7 +229,7 @@ export class ChartsPlugin implements YasrPlugin {
         case 'http://www.w3.org/2001/XMLSchema#gDay':
         case 'http://www.w3.org/2001/XMLSchema#gMonth':
           return Number(binding.value);
-        case 'http://www.w3.org/2001/XMLSchema#date':
+        case 'http://www.w3.org/2001/XMLSchema#date': {
           // the date function does not parse -any- date (including most xsd dates!)
           // datetime and time seem to be fine though.
           // so, first try our custom parser. if that does not work, try the regular date parser anyway
@@ -237,6 +237,8 @@ export class ChartsPlugin implements YasrPlugin {
           if (date) {
             return date;
           }
+          break;
+        }
         case 'http://www.w3.org/2001/XMLSchema#dateTime':
           return new Date(binding.value);
         case 'http://www.w3.org/2001/XMLSchema#time':

--- a/ontotext-yasgui-web-component/src/services/utils/sparql-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/sparql-utils.ts
@@ -16,7 +16,7 @@ export class SparqlUtils {
    *   }
    * </pre>
    */
-  static uriToPrefixWithLocalName(uri: string, prefixes: { [label: string]: string }): string {
+  static uriToPrefixWithLocalName(uri: string, prefixes: Record<string, string>): string {
     for (const prefixLabel in prefixes) {
       const prefix = prefixes[prefixLabel];
       if (uri.indexOf(prefix) == 0) {
@@ -24,5 +24,12 @@ export class SparqlUtils {
       }
     }
     return uri;
+  }
+
+  static mapPrefixesToNamespaces(prefixes: Record<string, string>): Record<string, string> {
+    return Object.keys(prefixes).reduce<Record<string, string>>((acc, key) => {
+      acc[prefixes[key]] = key;
+      return acc;
+    }, {});
   }
 }

--- a/ontotext-yasgui-web-component/src/services/utils/svg-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/svg-util.ts
@@ -4,18 +4,14 @@ export class SvgUtil {
   }
 
   static getPivotTableIconSvgTag(): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
-                <rect width="48" height="48" fill="white" fill-opacity="0.01"/>
-                <path  fill="white" stroke="#000000" stroke-width="4" d="M42.0004 4H6.00005C4.89546 4 4.00002 4.89546 4.00005 6.00005L4.00104 42.0001C4.00107 43.1046 4.8965 44 6.00104 44H42.0004C43.105 44 44.0004 43.1046 44.0004 42V6C44.0004 4.89543 43.105 4 42.0004 4Z"/>
-                <path d="M20.0088 34.0083H33.5005V20.0083" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M24.5 38.5L23 37L20 34L23 31L24.5 29.5" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M29 24.5L30.5 23L33.5 20L36.5 23L38 24.5" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M14 4L14 44" stroke="black" stroke-width="4" stroke-linecap="round"/>
-                <path d="M4 14.0378L44 14" stroke="black" stroke-width="4" stroke-linecap="round"/>
-                <path d="M8 4H28" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M8 44H28" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M44 8V18" stroke="#000000" stroke-width="4" stroke-linecap="round"/>
-                <path d="M4 8L4 18" stroke="#000000" stroke-width="4" stroke-linecap="round"/>
-            </svg>`
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+        <path d="M400-640v-200h360q33 0 56.5 23.5T840-760v120H400ZM200-120q-33 0-56.5-23.5T120-200v-360h200v440H200Zm-80-520v-120q0-33 23.5-56.5T200-840h120v200H120ZM520-80 360-240l160-160 56 56-62 64h86q33 0 56.5-23.5T680-360v-88l-64 64-56-56 160-160 160 160-56 56-64-64v88q0 66-47 113t-113 47h-86l62 64-56 56Z"/>
+      </svg>`;
+  }
+
+  static getYasrChartPluginIcon(): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+        <path d="M200-120q-33 0-56.5-23.5T120-200v-640h80v640h640v80H200Zm40-120v-360h160v360H240Zm200 0v-560h160v560H440Zm200 0v-200h160v200H640Z"/>
+      </svg>`;
   }
 }


### PR DESCRIPTION
## What
Implemented and integrated yasr google charts plugin.

## Why
The old yasr had this plugin included, but with the new version it is removed from yasr and is not open source anymore.

## How
Implemented a new Charts plugin which wraps the google charts library and it's editor allowing customizations of the charts. The new plugin is registered in the yasr and some initial tests are implemeneted as well.