### PR TITLE
GDB-7790: Add "Chart Config" button when a chart render is chosen

### DIFF
--- a/cypress/e2e/yasr/plugins/pivot-table/pivot-table-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/pivot-table/pivot-table-plugin.spec.cy.ts
@@ -3,6 +3,8 @@ import {YasqeSteps} from '../../../../steps/yasqe-steps';
 import {YasrSteps} from '../../../../steps/yasr-steps';
 import {PivotTableStubs} from '../../../../stubs/pivot-table-stubs';
 import {PivotTableSteps} from '../../../../steps/pivot-table-steps';
+import {KeyboardShortcutPageSteps} from '../../../../steps/pages/keyboard-shortcut-page-steps';
+import {YasrChartsPluginPageSteps} from '../../../../steps/pages/yasr-charts-plugin-page-steps';
 
 describe('Pivot table plugin', () => {
   beforeEach(() => {
@@ -35,6 +37,51 @@ describe('Pivot table plugin', () => {
     PivotTableSteps.getUnusedVariable('o').drag(PivotTableSteps.COLS_CONTAINER_SELECTOR, {force: true});
 
     // Then I expect result to be shown into result area table
+    PivotTableSteps.getResultArea().should('be.visible');
+    PivotTableSteps.verifyRowVariable(0, 'http://example/book1');
+    PivotTableSteps.verifyColVariable(2, 'A new book');
+  });
+
+  it.only('Should persist pivot table and configuration', () => {
+    // When I am on page with ontotext-web-component on it,
+    // and execute a query
+    YasqeSteps.executeQuery();
+
+    // Then I expect the "Pivot table" tab to be visible.
+    YasrSteps.getPivotTablePluginTab().should('be.visible');
+
+    // When I open "Pivot Table" plugin
+    YasrSteps.openPivotPluginTab();
+
+    // Then I expect to see the pivot table
+    PivotTableSteps.getPivotTableUIPlugin().should('be.visible');
+
+    // When I drag the subject into rows container
+    PivotTableSteps.getUnusedVariable('s').drag(PivotTableSteps.ROWS_CONTAINER_SELECTOR, {force: true});
+    // and drag object into columns container
+    PivotTableSteps.getUnusedVariable('o').drag(PivotTableSteps.COLS_CONTAINER_SELECTOR, {force: true});
+
+    // Then I expect result to be shown into result area table
+    PivotTableSteps.getResultArea().should('be.visible');
+    PivotTableSteps.verifyRowVariable(0, 'http://example/book1');
+    PivotTableSteps.verifyColVariable(2, 'A new book');
+
+    // When switch to another render
+    YasrSteps.openRawResponseTab();
+    // and then returns to the "Pivot table" render.
+    YasrSteps.openPivotPluginTab();
+
+    // Then I expect table to be rendered again
+    PivotTableSteps.getResultArea().should('be.visible');
+    PivotTableSteps.verifyRowVariable(0, 'http://example/book1');
+    PivotTableSteps.verifyColVariable(2, 'A new book');
+
+    // When I go to another view.
+    YasrChartsPluginPageSteps.visit();
+    // and go back to previous page
+    DefaultViewPageSteps.visit();
+
+    // Then I expect table to be rendered again
     PivotTableSteps.getResultArea().should('be.visible');
     PivotTableSteps.verifyRowVariable(0, 'http://example/book1');
     PivotTableSteps.verifyColVariable(2, 'A new book');

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -210,7 +210,7 @@
         min-height: 50px;
         background-color: $color-onto-table-header-background;
 
-        #openChartConfigBtn {
+        #openChartConfigBtn, #openPivotTableChartConfigBtn {
           color: #333;
           background-color: #fff;
           border: 1px solid #ccc;
@@ -221,7 +221,7 @@
           user-select: none;
         }
 
-        #openChartConfigBtn:hover {
+        #openChartConfigBtn:hover, #openPivotTableChartConfigBtn {
           background-color: #ebebeb;
           border-color: #adadad;
         }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -112,6 +112,7 @@
   "yasr.plugin_control.plugin.name.pivot-table-plugin.columns": "Columns",
   "yasr.plugin_control.plugin.name.pivot-table-plugin.cells": "Cells",
   "yasr.plugin_control.plugin.name.pivot-table-plugin.rows": "Rows",
+  "yasr.plugin_control.plugin.pivot-table-plugin.charts.config.button": "Chart Config",
   "yasr.plugin_control.plugin.name.charts": "Charts",
   "yasr.plugin_control.plugin.charts.config.button": "Chart Config",
   "yasr.plugin_control.shows_view.btn.aria_label": "Shows {{name}} view",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -112,6 +112,7 @@
   "yasr.plugin_control.plugin.name.pivot-table-plugin.columns": "Colonnes",
   "yasr.plugin_control.plugin.name.pivot-table-plugin.cells": "Cellules",
   "yasr.plugin_control.plugin.name.pivot-table-plugin.rows": "Lignes",
+  "yasr.plugin_control.plugin.pivot-table-plugin.charts.config.button": "Configuration du graphique",
   "yasr.plugin_control.plugin.name.charts": "Graphiques",
   "yasr.plugin_control.plugin.charts.config.button": "Configuration du graphique",
   "yasr.plugin_control.shows_view.btn.aria_label": "Affiche la vue {{name}}",

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -211,14 +211,50 @@ export class PivotTablePlugin implements YasrPlugin {
     icon.classList.add('pivottable-plugin-variable-icon');
     icon.innerHTML = SvgUtil.getPivotTableValueIcon();
     variableElement.insertBefore(icon, dropdownElement);
-
-    //SvgUtil.getPivotTableValueIcon()
   }
 
   private onRefresh(): (pivotUIOptions) => void  {
     return (pivotUIOptions) => {
+      if (pivotUIOptions) {
+        switch (pivotUIOptions.rendererName) {
+          case PivotTableRendererName.BAR_CHART:
+          case PivotTableRendererName.LINE_CHART:
+          case PivotTableRendererName.STACKED_BAR_CHART:
+          case PivotTableRendererName.AREA_CHART:
+          case PivotTableRendererName.SCATTER_CHART:
+            this.addChartConfigButton();
+            break;
+          default:
+            this.removeChartConfigButton();
+        }
+      }
+      // FIX ME: When a chart renderer is selected and configured using the Google Chart Editor (by double-clicking on the SVG or clicking on 'Chart Config'),
+      // the configuration is not persisted.
       this.yasr.storePluginConfig(PivotTablePlugin.PLUGIN_NAME, this.toPivotTablePersistentConfig(pivotUIOptions));
     }
+  }
+
+  private removeChartConfigButton() {
+    const element = this.yasr.resultsEl.parentElement.querySelector('#openPivotTableChartConfigBtn');
+    if (!element) {
+      return;
+    }
+    element.remove();
+  }
+
+  private addChartConfigButton() {
+    if (this.yasr.resultsEl.parentElement.querySelector('#openPivotTableChartConfigBtn')) {
+      return;
+    }
+    const openConfigButton = document.createElement('button');
+    openConfigButton.id = 'openPivotTableChartConfigBtn';
+    openConfigButton.innerHTML = this.translationService.translate("yasr.plugin_control.plugin.charts.config.button");
+    openConfigButton.addEventListener('click', () => {
+      // @ts-ignore
+      $(this.yasr.rootEl.querySelector(`.${PivotTablePlugin.PLUGIN_NAME}`)).find('div[dir="ltr"]').dblclick();
+    });
+    const infoContainer = this.yasr.resultsEl.parentElement.querySelector('.yasr_header .yasr_response_chip');
+    infoContainer.prepend(openConfigButton);
   }
 
   private toPivotTablePersistentConfig(pivotUIOptions): PivotTablePersistentConfig {


### PR DESCRIPTION
## What
A "Chart Config" button has been added.

## Why
This will provide an opportunity to configure the chart visualization of the response. This will provide an opportunity to configure the chart visualization of the response.

## How
A "Chart Config" button has been added. When the button is clicked, a Google chart editor for configuring the selected chart is opened.