### PR TITLE
GDB-7790: There is render error when Google chart render selected

### DIFF
--- a/cypress/e2e/yasr/plugins/pivot-table/pivot-table-plugin.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/pivot-table/pivot-table-plugin.spec.cy.ts
@@ -42,7 +42,7 @@ describe('Pivot table plugin', () => {
     PivotTableSteps.verifyColVariable(2, 'A new book');
   });
 
-  it.only('Should persist pivot table and configuration', () => {
+  it('Should persist pivot table and configuration', () => {
     // When I am on page with ontotext-web-component on it,
     // and execute a query
     YasqeSteps.executeQuery();


### PR DESCRIPTION
## What
Frequently, an error "Cannot read properties of undefined (reading 'arrayToDataTable')" occurs when a Google chart render is selected, and the page is refreshed.

## Why
The Google visualization module loads asynchronously to the pivot table plugin code. When a Google chart render is selected and the pivot table try to render result before visualization module loaded the exception is thrown.

## How
The code has been modified to wait for the Google visualization module to load before rendering results if the selected render is a Google chart.

Additional work:
Optimized the loading of the Google visualization module. Added a check to ensure the module is not loaded again.