### PR TITLE
GDB-7789 allow download of chart plugin data

### DIFF
--- a/cypress/e2e/yasr/toolbar/yasr-toolbar.spec.cy.ts
+++ b/cypress/e2e/yasr/toolbar/yasr-toolbar.spec.cy.ts
@@ -3,12 +3,12 @@ import {YasrCustomElementSteps} from '../../../steps/yasr-custom-element-steps';
 import {YasqeSteps} from '../../../steps/yasqe-steps';
 import {YasrSteps} from '../../../steps/yasr-steps';
 
-describe('Configuration of yasr toolbar custom element.', () => {
+describe('YASR toolbar', () => {
   beforeEach(() => {
     YasrCustomElementPageSteps.visit();
   });
 
-  it('should display a custom button configured by user .', {
+  it('Should display a custom button configured by user', {
     retries: {
       runMode: 1,
       openMode: 0
@@ -31,16 +31,18 @@ describe('Configuration of yasr toolbar custom element.', () => {
     YasrCustomElementSteps.getElementCreatedAfterButtonClicked().should('be.visible');
   });
 
-  it('should elements be ordered', () => {
-    // When I visit a page with "ontotext-yasgui-web-component",
-    // and configured a yasr toolbar button.
-    // When I execute a query, so yasr (yasr toolbar) to be visible.
+  it('Should render ordered plugins', () => {
+    // Given I have opened a page with a yasgui and configured yasr toolbar button.
+    // When I execute a query, so yasr toolbar to become visible.
     YasqeSteps.executeQuery();
 
     YasrCustomElementSteps.getYasrToolbarElement(0).contains('Download as');
+    // hidden pivot table download button
     YasrCustomElementSteps.getYasrToolbarElement(1).should('have.class', 'hidden');
-    YasrCustomElementSteps.getYasrToolbarElement(2).contains('Second described Element that have to be first');
-    YasrCustomElementSteps.getYasrToolbarElement(3).contains('Custom button');
+    // hidden chart download button
+    YasrCustomElementSteps.getYasrToolbarElement(2).should('have.class', 'hidden');
+    YasrCustomElementSteps.getYasrToolbarElement(3).contains('Second described Element that have to be first');
+    YasrCustomElementSteps.getYasrToolbarElement(4).contains('Custom button');
 
     // When I open "Pivot Table" tab.
     YasrSteps.openPivotPluginTab();
@@ -48,7 +50,9 @@ describe('Configuration of yasr toolbar custom element.', () => {
     // Then I expect pivot download button to be visible download
     YasrCustomElementSteps.getYasrToolbarElement(0).should('have.class', 'hidden');
     YasrCustomElementSteps.getYasrToolbarElement(1).contains('Get HTML snippet to embed results on a web page');
-    YasrCustomElementSteps.getYasrToolbarElement(2).contains('Second described Element that have to be first');
-    YasrCustomElementSteps.getYasrToolbarElement(3).contains('Custom button');
+    // hidden chart download button
+    YasrCustomElementSteps.getYasrToolbarElement(2).should('have.class', 'hidden');
+    YasrCustomElementSteps.getYasrToolbarElement(3).contains('Second described Element that have to be first');
+    YasrCustomElementSteps.getYasrToolbarElement(4).contains('Custom button');
   });
 });

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -5,6 +5,7 @@
 @import "src/css/icons";
 @import 'src/css/external/tippy';
 @import 'src/css/pivottable-plugin';
+@import 'src/css/charts-plugin';
 
 :host {
   display: block;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -27,7 +27,7 @@ import {YasqeButtonType} from '../../models/yasqe-button-name';
 import {YasqeService} from '../../services/yasqe/yasqe-service';
 import {YasrService} from '../../services/yasr/yasr-service';
 import {PivotTablePlugin} from '../../plugins/yasr/pivot-table/pivot-table-plugin';
-import {ChartsPlugin} from "../../plugins/yasr/charts-plugin";
+import {ChartsPlugin} from "../../plugins/yasr/charts/charts-plugin";
 
 /**
  * This is the custom web component which is adapter for the yasgui library. It allows as to

--- a/ontotext-yasgui-web-component/src/css/charts-plugin.scss
+++ b/ontotext-yasgui-web-component/src/css/charts-plugin.scss
@@ -1,0 +1,16 @@
+.yasr {
+  .chart-download-as-button {
+    font-size: 16px;
+    font-weight: 400;
+    padding: 5px 16px;
+    line-height: 1.25;
+    border: none;
+    outline: none;
+    color: #fff;
+    cursor: pointer;
+    background-color: #e84e0f;
+    .chart-download-as-button-label {
+      padding-left: 8px;
+    }
+  }
+}

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -135,6 +135,7 @@
   "yasr.plugin_control.download_as.table.dropdown.label": "Get HTML snippet to embed results on a web page",
   "yasr.plugin_control.download_as.pivot_table.dropdown.label": "Get HTML snippet to embed results on a web page",
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Get HTML snippet to embed results on a web page",
+  "yasr.plugin_control.download_as.charts.dropdown.label": "Get HTML snippet to embed results on a web page",
   "yasr.plugin_control.download_as.sparql_results_json.label": "JSON",
   "yasr.plugin_control.download_as.sparql_results_json_ld.label": "JSON-LD",
   "yasr.plugin_control.download_as.sparql_results_ndjson_ld.label": "NDJSON-LD",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -135,6 +135,7 @@
   "yasr.plugin_control.download_as.table.dropdown.label": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.plugin_control.download_as.pivot_table.dropdown.label": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
+  "yasr.plugin_control.download_as.charts.dropdown.label": "Obtenir un extrait HTML pour intégrer les résultats dans une page web",
   "yasr.plugin_control.download_as.sparql_results_json.label": "JSON",
   "yasr.plugin_control.download_as.sparql_results_json_ld.label": "JSON-LD",
   "yasr.plugin_control.download_as.sparql_results_ndjson_ld.label": "NDJSON-LD",

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -214,7 +214,7 @@ export interface ExternalYasguiConfiguration {
   defaultPlugin: string
 
   /**
-   * Describes the order of how plugins will be displayed.
+   * Describes the order of how YASR plugins will be displayed.
    * For example: ["extended_table", "response"]
    */
   pluginOrder: string[]

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -191,7 +191,7 @@ export interface YasguiConfiguration {
       defaultPlugin: string,
 
       /**
-       * Describes the order of how plugins will be displayed.
+       * Describes the order of how YASR plugins will be displayed.
        * For example: ["extended_table", "response"]
        */
       pluginOrder: string[],
@@ -307,6 +307,6 @@ export const defaultYasqeConfig: Record<string, any> = {
 
 export const defaultYasrConfig: Record<string, any> = {
   defaultPlugin: 'extended_table',
-  pluginOrder: ["extended_table", "response"],
+  pluginOrder: ['extended_table', 'extended_response', 'pivot-table-plugin', 'charts'],
   showQueryLoader: true,
 }

--- a/ontotext-yasgui-web-component/src/models/yasr-toolbar-plugin.ts
+++ b/ontotext-yasgui-web-component/src/models/yasr-toolbar-plugin.ts
@@ -1,3 +1,5 @@
+import {Yasr} from "./yasr";
+
 /**
  * An interface for elements that can be plugged into yasr toolbar.
  * These elements will be sorted depends on {@link YasrToolbarPlugin#getOrder};
@@ -9,7 +11,6 @@ export interface YasrToolbarPlugin {
    *
    * @param yasr - the parent yasr of toolbar.
    */
-  //@ts-ignore
   createElement(yasr: Yasr): HTMLElement;
 
   /**
@@ -18,7 +19,6 @@ export interface YasrToolbarPlugin {
    * @param element - the element created in {@link YasrToolbarPlugin#createElement}.
    * @param yasr - the parent yasr of toolbar.
    */
-  //@ts-ignore
   updateElement(element: HTMLElement, yasr: Yasr): void;
 
   /**
@@ -34,6 +34,5 @@ export interface YasrToolbarPlugin {
    * @param element - the element created in {@link YasrToolbarPlugin#createElement}.
    * @param yasr - the parent yasr of toolbar.
    */
-  //@ts-ignore
   destroy(element: HTMLElement, yasr: Yasr): void;
 }

--- a/ontotext-yasgui-web-component/src/models/yasr.ts
+++ b/ontotext-yasgui-web-component/src/models/yasr.ts
@@ -1,0 +1,26 @@
+/**
+ * This is our internal Yasr type interface used only for typing convenience.
+ * We can't use the exported types from the YASGUI because the library has it's own build than ours
+ * and our component doesn't see their types.
+ */
+export interface Yasr {
+  yasqe: any;
+
+  results: any;
+
+  config: any;
+
+  storePluginConfig: any;
+
+  resultsContainer: any;
+
+  resultsEl: any;
+
+  translationService: any;
+
+  getSelectedPlugin: any;
+
+  getSelectedPluginName: any;
+
+  getPrefixes: any;
+}

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -19,6 +19,7 @@ import {PaginationYasrToolbarPlugin} from '../../yasr/toolbar/pagination-yasr-to
 import {YasqeMode} from '../../../models/yasqe-mode';
 import {TimeFormattingService} from '../../utils/time-formatting-service';
 import {PivotTableDownloadPlugin} from '../../yasr/toolbar/pivot-table-download-plugin';
+import {ChartDownloadPlugin} from "../../yasr/toolbar/chart-download-plugin";
 
 /**
  * Builder for yasgui configuration.
@@ -108,6 +109,7 @@ export class YasguiConfigurationBuilder {
       const downloadAsYasrToolbarPlugin = new DownloadAsYasrToolbarPlugin(this.serviceFactory, externalConfiguration.pluginsConfigurations);
       yasrToolbarElements.push(downloadAsYasrToolbarPlugin);
       yasrToolbarElements.push(new PivotTableDownloadPlugin());
+      yasrToolbarElements.push(new ChartDownloadPlugin());
     }
 
     if (config.yasguiConfig.paginationOn) {

--- a/ontotext-yasgui-web-component/src/services/yasr/toolbar/chart-download-plugin.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/toolbar/chart-download-plugin.ts
@@ -1,0 +1,45 @@
+import {YasrToolbarPlugin} from '../../../models/yasr-toolbar-plugin';
+import {DownloadInfo} from '../../../models/yasr-plugin';
+import {ChartsPlugin} from "../../../plugins/yasr/charts/charts-plugin";
+import {Yasr} from "../../../models/yasr";
+import {HtmlUtil} from "../../utils/html-util";
+
+export class ChartDownloadPlugin implements YasrToolbarPlugin {
+  createElement(yasr: Yasr): HTMLElement {
+    const downloadAsElement = document.createElement('button');
+    downloadAsElement.className = 'chart-download-as-button icon-download';
+    downloadAsElement.onclick = this.onClick(yasr);
+    this.updateElement(downloadAsElement, yasr);
+    return downloadAsElement;
+  }
+
+  updateElement(element: HTMLElement, yasr: Yasr): void {
+    // if we don't have a configuration for that plugin or no results are present we hide the button.
+    element.classList.toggle('hidden', !yasr.results || ChartsPlugin.PLUGIN_NAME !== yasr.getSelectedPluginName());
+    element.innerHTML = `<span class="chart-download-as-button-label">${yasr.translationService.translate('yasr.plugin_control.download_as.charts.dropdown.label')}</span>`;
+  }
+
+  getOrder(): number {
+    return 0;
+  }
+
+  destroy(_element: HTMLElement, _yasr: Yasr): void {
+    // destroy it
+  }
+
+  private onClick(yasr: Yasr): () => void {
+    return () => {
+      if (!yasr.results) {
+        return;
+      }
+
+      const selectedPlugin = yasr.getSelectedPlugin();
+      if (ChartsPlugin.PLUGIN_NAME === selectedPlugin.label) {
+        const downloadInfo: DownloadInfo = selectedPlugin.download();
+        if (downloadInfo) {
+          HtmlUtil.downloadStringAsFile(downloadInfo.getData(), downloadInfo.filename, downloadInfo.contentType);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Introduce download for chart plugin when datatable is rendered in csv format and svg snippet when chart is rendered.

## Why
This would allow users to export the result from the quer in the respective format or as svg for embedding in some html page.

## How
* Implemented a plugin for the download operation in yasr toolbar.
* Implemented the download method to extract and return the appropriate data for download depending on what visualization is selected in the chart plugin.