### PR TITLE
GDB-7790: There is render error when Google chart render selected

### DIFF
--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -52,16 +52,22 @@ export class PivotTablePlugin implements YasrPlugin {
 
   draw(persistentConfig: PivotTablePersistentConfig, _runtimeConfig?: any): Promise<void> | void {
     // @ts-ignore
-    // If the render is not a Google chart or the Google visualization module has already been loaded, we can draw the plugin synchronously.
-    if (!persistentConfig || !this.isGoogleChartRender(persistentConfig.rendererName) || google.visualization) {
+    // if Google module visualization is loaded then we can continue with drawing.
+    if (google.visualization) {
       this.drawPivotTable(persistentConfig);
     } else {
       // @ts-ignore
       google.load("visualization", "1", {packages: ["corechart", "charteditor"]});
-      // @ts-ignore
-      google.setOnLoadCallback(() => {
+      // If the render is a Google chart we have to wait the module to be loaded.
+      if (persistentConfig && this.isGoogleChartRender(persistentConfig.rendererName)) {
+        // @ts-ignore
+        google.setOnLoadCallback(() => {
+          this.drawPivotTable(persistentConfig);
+        });
+      } else {
+        // If the render is not a Google chart or the Google we can continue with drawing.
         this.drawPivotTable(persistentConfig);
-      });
+      }
     }
   }
 


### PR DESCRIPTION
## What
When chosen render is table after refreshing a Google chart is selected then the error is thrown.

## Why
There is not properly written code when to wait for the Google visualisation module loaded.

## How
The code has been fixed.