### PR TITLE
GDB-7789 put yasr toolbar info message in separate tag to allow customization on client side

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -210,7 +210,7 @@ export class ExtendedYasr extends Yasr {
       ? this.getUpdateTypeQueryResponseInfo()
       : this.getQueryTypeQueryResponseInfo();
     const resultTimeInfo = this.getResultTimeMessage(responseTime, queryFinishedTime);
-    responseInfoElement.innerHTML = `${warningIcon} ${resultInfo} ${resultTimeInfo}`;
+    responseInfoElement.innerHTML = `<span class="response-info-message">${warningIcon} ${resultInfo} ${resultTimeInfo}</span>`;
   }
 
   private getCountResultMessage(bindings: any[]): string {

--- a/yasgui-patches/2023-11-08-GDB-7789_put_yasr_toolbar_info_message_in_separate_tag_to_allow_customization_on_client.patch
+++ b/yasgui-patches/2023-11-08-GDB-7789_put_yasr_toolbar_info_message_in_separate_tag_to_allow_customization_on_client.patch
@@ -1,0 +1,17 @@
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 9e0f320f6b5f9437cea8a131ed56238f4636d369)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 7a29c271ae557a93de1d7740a5e492cd547a6ae8)
+@@ -210,7 +210,7 @@
+       ? this.getUpdateTypeQueryResponseInfo()
+       : this.getQueryTypeQueryResponseInfo();
+     const resultTimeInfo = this.getResultTimeMessage(responseTime, queryFinishedTime);
+-    responseInfoElement.innerHTML = `${warningIcon} ${resultInfo} ${resultTimeInfo}`;
++    responseInfoElement.innerHTML = `<span class="response-info-message">${warningIcon} ${resultInfo} ${resultTimeInfo}</span>`;
+   }
+ 
+   private getCountResultMessage(bindings: any[]): string {


### PR DESCRIPTION
## What
Put yasr toolbar info message in separate tag to allow customization on client side

## Why
On the client side this message can't be moved separately if we put other elements in this section like the chart config button for example.

## How
* Wrap the info message in its own tag with a css class to allow easier customization.