### PR TITLE
GDB-7790: There missing values in CSV export

### DIFF
--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-download-util.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-download-util.ts
@@ -130,6 +130,7 @@ export class PivotTableDownloadUtil {
     if (PivotTableDownloadUtil.needToQuoteString(value, config)) {
       return `"${value}"`;
     }
+    return value;
   }
 
   private static toCSVFormat(data: string[][], config: TableToCsvConfiguration): string {


### PR DESCRIPTION
## What
Values that don't have to be escaped missed in exported CSV file.

## Why
Missed return statement in function that have to escape values.

## How
The return statement has been added.