### PR TITLE
GDB-9118 hide all yasr plugin tabs if configured via showResultTabs

### DIFF
--- a/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
+++ b/ontotext-yasgui-web-component/src/components/dropdown/dropdown.tsx
@@ -70,7 +70,6 @@ export class Dropdown {
   private onSelect(value: string) {
     this.open = false;
     this.valueChanged.emit(new InternalDropdownValueSelectedEvent(value));
-    console.log('selected', value);
   }
 
   private toggleComponent(): void {

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -45,7 +45,8 @@ export class OntotextYasguiService {
   }
 
   private static initResultTabs(hostElement: HTMLElement, config: YasguiConfiguration): void {
-    const pluginTabsElementsSelectors = ['.select_extended_table', '.select_extended_response'];
+    // TODO: this can be improved by getting the registered plugins directly from the yasr instead of hard-coding them here
+    const pluginTabsElementsSelectors = ['.select_extended_table', '.select_extended_response', '.select_charts', '.select_pivot-table-plugin'];
     HtmlElementsUtil.toggleHiddenByCondition(hostElement, pluginTabsElementsSelectors, () => !config.showResultTabs);
   }
 


### PR DESCRIPTION
## What
When `showResultTabs` flag is set to `false` then all yasr plugins should be hidden.

## Why
There are some integration points where only the yasr results table renderer is displayed and no tabs should be visible. In the latest version of this component were introduced two new yasr plugins: charts and pivot table. These two plugins were not registered in the service which used to hide them when the flag is falsy.

## How
Added the plugins in the list where they are shown or hidden conditionally.