### PR TITLE
GDB-8247 improve styling of yasr table results

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -263,14 +263,21 @@
       }
 
       .literal-cell {
+        word-break: break-word !important;
         overflow-wrap: break-word;
         -webkit-hyphens: auto;
         -moz-hyphens: auto;
         hyphens: auto;
+
+        p {
+          // needed in order for the ellipsis to work
+          display: inline;
+        }
       }
 
       /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
-      .dataTable tbody td div.uri-cell:hover .resource-copy-link, .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
+      .dataTable tbody td div.uri-cell:hover .resource-copy-link,
+      .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
       .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link {
         display: inline;
         padding-left: 10px;

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -126,7 +126,8 @@ export class YasrService {
 
   // @ts-ignore
   private static getLiteralCellContent(binding: Parser.BindingValue): string {
-    return `<div lang="${YasrService.getLang(binding, 'xx')}" class="literal-cell"><p class="nonUri">${this.getLiteralAsString(binding, true)}</p></div>`;
+    const literalAsString = this.getLiteralAsString(binding, true);
+    return `<div lang="${YasrService.getLang(binding, 'xx')}" class="literal-cell"><p title='${literalAsString}' class="nonUri">${literalAsString}</p></div>`;
   }
 
   //@ts-ignore


### PR DESCRIPTION
## What
Improve styling of yasr table results.

## Why
Cells holding literal values were not styled correctly to apply the ellipsis which resulted in value being cut off.

## How
Improved the styling of the paragraphs inside literal cells in order for the ellipsis to work and also applied a title attribute to them so that when the value gets truncated, the user to still be able to see the whole value.