### PR TITLE
GDB-8994 GDB-9114 improve yasr styling

### DIFF
--- a/ontotext-yasgui-web-component/src/components/dropdown/dropdown.scss
+++ b/ontotext-yasgui-web-component/src/components/dropdown/dropdown.scss
@@ -23,9 +23,9 @@
   .ontotext-dropdown-menu-item {
     display: block;
     text-decoration: none;
-    font-size: 1.2em;
+    font-size: 1rem;
     font-weight: 400;
-    padding: 0.2em 0.5em;
+    padding: .5em 1.2em;
     color: $color-onto-white;
     background-color: $color-ontotext-orange;
   }

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
@@ -14,7 +14,7 @@
   background-color: #fff;
 
   .saved-queries-popup {
-    height: 250px;
+    max-height: 250px;
     width: 300px;
     overflow-y: scroll;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## What
* Fix download as menu styling for consistency with old yasgui.
* Reposition yasqe action buttons to prevent overlapping with the vertical scrollbar when it's present in the yasqe.

## Why
* The dropdown menu items padding and font size were left default as in the ontotext yasgui component which resulted in different menu and menu items size.
* Yasqe buttons were placed too close to the right-side border of the editor which led to overlapping between the vertical scrollbar and the run query button.

## How
* Overriding the menu items padding and font-size properties.
* Increased the space between the buttons and the right-side editor border