### PR TITLE
GDB-8247 properly break literal values in yasr table

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -263,16 +263,11 @@
       }
 
       .literal-cell {
-        word-break: break-word !important;
+        word-break: normal !important;
         overflow-wrap: break-word;
         -webkit-hyphens: auto;
         -moz-hyphens: auto;
         hyphens: auto;
-
-        p {
-          // needed in order for the ellipsis to work
-          display: inline;
-        }
       }
 
       /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
@@ -302,7 +297,8 @@
         border: none;
         background-color: transparent;
         padding: 0;
-        margin: 0
+        margin: 0;
+        white-space: pre-wrap;
       }
 
       .dataTable td div.triple-cell .triple-close:hover .resource-copy-link {

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -126,8 +126,7 @@ export class YasrService {
 
   // @ts-ignore
   private static getLiteralCellContent(binding: Parser.BindingValue): string {
-    const literalAsString = this.getLiteralAsString(binding, true);
-    return `<div lang="${YasrService.getLang(binding, 'xx')}" class="literal-cell"><p title='${literalAsString}' class="nonUri">${literalAsString}</p></div>`;
+    return `<div lang="${YasrService.getLang(binding, 'xx')}" class="literal-cell"><p class="nonUri">${this.getLiteralAsString(binding, true)}</p></div>`;
   }
 
   //@ts-ignore


### PR DESCRIPTION
## What
Properly break literal values on new lines in yasr table when string too wide to accommodate on a single line.

## Why
This is the way how literal values are rendered in the graphdb yasr

## How
* Changed the word-break to normal and added a white-space pre-wrap to allow browser to break the text properly