### PR TITLE
GDB-9151 fix sizing of the code editor

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -58,6 +58,11 @@
 
   .yasgui {
 
+    /* prevent overlapping of the query text with the yasqe action buttons on the right side of the editor */
+    .CodeMirror-code {
+      width: 89%;
+    }
+
     .yasqe-fullscreen .CodeMirror {
       position: fixed;
       top: 0;


### PR DESCRIPTION
## What
When screen resolution is changed the editor can shrink in width and it might happen that the query inside the editor be overlapped by the action buttons on the right.

## Why
Improving the usability and user perception.

## How
Set width of the code editor in percentage.