### PR TITLE
GDB-8997 move chart config button in the beginning of the yasr header

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -208,6 +208,27 @@
         }
       }
 
+      .chart-config-control {
+        align-self: center;
+        padding-left: 10px;
+      }
+
+      #openChartConfigBtn, #openPivotTableChartConfigBtn {
+        color: #333;
+        background-color: #fff;
+        border: 1px solid #ccc;
+        text-align: center;
+        vertical-align: middle;
+        cursor: pointer;
+        padding: 6px 12px;
+        user-select: none;
+      }
+
+      #openChartConfigBtn:hover, #openPivotTableChartConfigBtn {
+        background-color: #ebebeb;
+        border-color: #adadad;
+      }
+
       .yasr_external_ref_btn, .yasr_downloadIcon {
         display: none;
       }
@@ -222,22 +243,6 @@
 
         .response-info-message {
           white-space: normal;
-        }
-
-        #openChartConfigBtn, #openPivotTableChartConfigBtn {
-          color: #333;
-          background-color: #fff;
-          border: 1px solid #ccc;
-          text-align: center;
-          vertical-align: middle;
-          cursor: pointer;
-          padding: 6px 12px;
-          user-select: none;
-        }
-
-        #openChartConfigBtn:hover, #openPivotTableChartConfigBtn {
-          background-color: #ebebeb;
-          border-color: #adadad;
         }
       }
 

--- a/ontotext-yasgui-web-component/src/plugins/yasr/charts/charts-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/charts/charts-plugin.ts
@@ -220,8 +220,12 @@ export class ChartsPlugin implements YasrPlugin {
     openConfigButton.addEventListener('click', () => {
       this.chartEditor.openDialog(this.wrapper, {});
     });
-    const infoContainer = this.yasr.resultsEl.parentElement.querySelector('.yasr_header .yasr_response_chip');
-    infoContainer.prepend(openConfigButton);
+    // Wrap it in a div so that it can be easily styled without clashing with the header layout styles
+    const buttonWrapper = document.createElement('div');
+    buttonWrapper.classList.add('chart-config-control');
+    buttonWrapper.prepend(openConfigButton);
+    const infoContainer = this.yasr.resultsEl.parentElement.querySelector('.yasr_header .space_element');
+    infoContainer.insertAdjacentElement('beforebegin', buttonWrapper);
   }
 
   private static getGoogleTypeForBinding(binding): string | null {

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -282,8 +282,12 @@ export class PivotTablePlugin implements YasrPlugin {
       // @ts-ignore
       $(this.yasr.rootEl.querySelector(`.${PivotTablePlugin.PLUGIN_NAME}`)).find('div[dir="ltr"]').dblclick();
     });
-    const infoContainer = this.yasr.resultsEl.parentElement.querySelector('.yasr_header .yasr_response_chip');
-    infoContainer.prepend(openConfigButton);
+    // Wrap it in a div so that it can be easily styled without clashing with the header layout styles
+    const buttonWrapper = document.createElement('div');
+    buttonWrapper.classList.add('chart-config-control');
+    buttonWrapper.prepend(openConfigButton);
+    const infoContainer = this.yasr.resultsEl.parentElement.querySelector('.yasr_header .space_element');
+    infoContainer.insertAdjacentElement('beforebegin', buttonWrapper);
   }
 
   private toPivotTablePersistentConfig(pivotUIOptions): PivotTablePersistentConfig {


### PR DESCRIPTION
## What
Move chart config button in the beginning of the yasr header.

## Why
After yasr header reorganization these buttons were left unchanged which was wrong because in the current workbench they appear in the beginning of the header.

## How
Put buttons in container and append it in the beginning of the yasr header.