### PR TITLE
GDB-9146: The button Visual in tab Pivot table and Google tab should have a distance with the button GET HTML

### DIFF
--- a/Yasgui/packages/yasr/src/main.scss
+++ b/Yasgui/packages/yasr/src/main.scss
@@ -163,8 +163,8 @@
   .yasr-toolbar {
     display: flex;
     .yasr-toolbar-element {
-      padding-left: 10px;
-      padding-right: 10px;
+      margin-left: 6px;
+      margin-right: 6px;
     }
   }
 }


### PR DESCRIPTION
## What
There is no space between the "Visual" button and the "Get HTML snippets..." button in the "Pivot Table" and "Charts" plugins.

## Why
This issue is caused by incorrect styling.

## How
Margins on the left and right of the "yasr-toolbar-element" elements have been added to resolve the spacing problem.