### PR TITLE
GDB-9231 prevent tab duplication when saved query is selected

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -416,13 +416,19 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
-   * Handler for the event fired when the saved query is selected from the saved queries list.
+   * Handles the event fired when the saved query is selected from the saved queries list. Tries to
+   * find a tab with the same name and query inside and opens it. Otherwise opens a new tab with
+   * provided parameters.
    */
   @Listen('internalSaveQuerySelectedEvent')
   savedQuerySelectedHandler(event: CustomEvent<SaveQueryData>) {
     const queryData: SaveQueryData = event.detail;
     this.showSavedQueriesPopup = false;
-    this.ontotextYasgui.createNewTab(queryData.queryName, queryData.query);
+    this.openTab({
+      queryName: queryData.queryName,
+      query: queryData.query,
+      owner: undefined
+    });
   }
 
   /**


### PR DESCRIPTION
## What
Prevent tab duplication when saved query is selected.

## Why
When a saved query is selected from the menu, then a new tab is opened each time instead of focusing on the existing opened tab with the same name and query inside. This is unexpected behavior.

## How
Just used the openTab method which has the ability to properly resolve this behavior instead of opening a new tab.