### PR TITLE
GDB-9230 remove chart config button when changing yasr tabs

### DIFF
--- a/ontotext-yasgui-web-component/src/models/yasr.ts
+++ b/ontotext-yasgui-web-component/src/models/yasr.ts
@@ -14,6 +14,8 @@ export interface Yasr {
 
   resultsContainer: any;
 
+  rootEl: any;
+
   resultsEl: any;
 
   translationService: any;

--- a/ontotext-yasgui-web-component/src/plugins/yasr/charts/charts-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/charts/charts-plugin.ts
@@ -124,6 +124,8 @@ export class ChartsPlugin implements YasrPlugin {
   destroy(): void {
     // @ts-ignore
     google.visualization.events.removeListener(this.chartEditorOkHandler);
+    const configButtonWrapper = this.yasr.rootEl.querySelector('.yasr_header .chart-config-control');
+    configButtonWrapper?.remove();
   }
 
   private drawChart() {

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -103,6 +103,8 @@ export class PivotTablePlugin implements YasrPlugin {
 
   destroy(): void {
     // TODO remove all listeners if any.
+    const configButtonWrapper = this.yasr.rootEl.querySelector('.yasr_header .chart-config-control');
+    configButtonWrapper?.remove();
   }
 
   download(_filename?: string): DownloadInfo | undefined {


### PR DESCRIPTION
## What
Remove the chart config button when changing yasr tabs

## Why
Chart config button remains visible when changing from google chart or pivot table to some of the other yasr tabs which should not happen.

## How
Extended the destroy function in the google chart and pivot table plugins to remove the button.