### PR TITLE
GDB-9245 refactor yasgui layout to work properly when horizontal ordering is selected

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -493,20 +493,53 @@
     }
   }
 
+  /* On horizontal orientation we make yasqe and yasr to have 50% width and make them float left
+   in order to make them appear next to each other.*/
   &.orientation-horizontal {
 
     .yasgui {
       display: grid;
+      position: relative;
 
-      .tabPanel > div {
-        display: grid;
-        grid-template-columns: 0 1fr 1fr;
-        position: relative;
+      /* Contract the tabs list because we move the yasr container up to the yasgui top border in
+      order to have the yasqe and yasr tabs be aligned properly.*/
+      .tabsList {
+        width: 50%;
+      }
+
+      .tabPanel {
+        /* unset the position in order to allow yasr container which is absolute positioned to be
+        top aligned to the closest relative positioned parent which must be the yasgui */
+        position: unset;
+      }
+
+      .tabPanel > div:after {
+        content: "";
+        display: table;
+        clear: both;
+      }
+
+      .tabPanel .yasqe {
+        padding-right: 15px;
       }
 
       // this targets the yasqe container
       .tabPanel > div > div:nth-of-type(2) {
-        padding-right: 15px;
+        float: left;
+        width: 50%;
+        /* make it absolute in order to allow proper resizing when there is a query with long lines
+        inside the editor*/
+        position: absolute;
+      }
+
+      // this targets the yasr container
+      .tabPanel > div > div:nth-of-type(3) {
+        float: left;
+        width: 50%;
+        /* move yasr container up to the yasgui top border in order to align the tabs of the yasqe and yasr */
+        position: absolute;
+        top: 0;
+        right: 0;
       }
     }
   }


### PR DESCRIPTION
## What
Refactor yasgui layout to work properly when horizontal ordering is selected.

## Why
When horizontal ordering is selected, yasqe and yasr should be aligned next to each other and both span 50% of the screen width even if there is a  query containing very long lines.

## How
* Made the yasqe and yasr be floated in the left and span 50% of the screen width. This replaces the old approach which aligned them using grid layout which doesn't seem to work and scale properly.
* Also made the yasr container be absolute positioned and aligned top along with the yasgui's top border in order to align the yasr and yasqe tabs pproperly.