### PR TITLE
GDB-8995 refactor yasgui component layout to work properly when rendering mode or orientation are changed

### DIFF
--- a/cypress/e2e/view-modes.spec.cy.ts
+++ b/cypress/e2e/view-modes.spec.cy.ts
@@ -38,6 +38,16 @@ describe('View modes', () => {
         // And I expect that render yasqe in the toolbar to be selected
         ToolbarPageSteps.showToolbar();
         ToolbarPageSteps.isYasqeModeSelected();
+        // And yasqe should have set a height css property to expand it to a full width
+        YasqeSteps.getCodeMirrorEl().should('have.attr', 'style').and('match', /height:/);
+        // When I select the yasgui mode again
+        ViewModePageSteps.switchToModeYasgui();
+        // Then I expect that yasqe and yasr will be both visible
+        YasqeSteps.getYasqe().should('be.visible');
+        YasrSteps.getYasr().should('be.visible');
+        // And the height css property will be removed to allow yasqe expand only to the with not
+        // occupied by yasr
+        YasqeSteps.getCodeMirrorEl().should('have.attr', 'style', '');
     });
 
     it('Should render mode-yasr', () => {
@@ -69,8 +79,16 @@ describe('View modes', () => {
         YasguiSteps.isHorizontalOrientation();
         // And the toolbar orientation button should be set to horizontal
         ToolbarPageSteps.isHorizontalOrientation();
-        // When I switch to vertical orientation
+        // And yasqe should have set a height css property to expand it to a full width
+        YasqeSteps.getCodeMirrorEl().should('have.attr', 'style').and('match', /height:/);
+        // When I switch to yasqe mode
+        ViewModePageSteps.switchToModeYasqe();
+        // And yasqe should have set a height css property to expand it to a full width
+        YasqeSteps.getCodeMirrorEl().should('have.attr', 'style').and('match', /height:/);
+        // When I switch orientation to vertical
         ViewModePageSteps.switchToVerticalOrientation();
+        // And yasqe should have set a height css property to expand it to a full width
+        YasqeSteps.getCodeMirrorEl().should('have.attr', 'style').and('match', /height:/);
         // Then I expect yasqe and yasr to be placed on top of each other
         YasguiSteps.isVerticalOrientation();
         // And the toolbar orientation button should be set to horizontal

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -260,6 +260,10 @@ export class YasqeSteps {
     this.getExpandResultsOverSameAsButton().click();
   }
 
+  static getCodeMirrorEl() {
+    return this.getEditor().find('.CodeMirror');
+  }
+
   static getCodeMirror() {
     return this.getEditor().find('.CodeMirror').then(($el) => {
       // @ts-ignore

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -180,6 +180,11 @@ export class OntotextYasguiWebComponent {
   @State() isVerticalOrientation = true;
 
   /**
+   * Holds the rendering mode currently applied to the yasgui component.
+   */
+  @State() renderingMode = this.getRenderMode();
+
+  /**
    * Flag controlling the visibility of the save query dialog.
    */
   @State() showSaveQueryDialog = false;
@@ -212,7 +217,7 @@ export class OntotextYasguiWebComponent {
   changeRenderMode(newRenderMode): Promise<void> {
     return this.getOntotextYasgui()
       .then(() => {
-        VisualisationUtils.changeRenderMode(this.hostElement, newRenderMode);
+        VisualisationUtils.changeRenderMode(this.hostElement, newRenderMode, this.getOrientationMode());
       });
   }
 
@@ -369,6 +374,7 @@ export class OntotextYasguiWebComponent {
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {
         ontotextYasgui.refresh();
+        VisualisationUtils.setYasqeFullHeight(this.renderingMode, VisualisationUtils.resolveOrientation(this.isVerticalOrientation));
       });
   }
 
@@ -587,7 +593,7 @@ export class OntotextYasguiWebComponent {
 
   private changeOrientation() {
     this.isVerticalOrientation = !this.isVerticalOrientation;
-    VisualisationUtils.toggleLayoutOrientation(this.hostElement, this.isVerticalOrientation);
+    VisualisationUtils.toggleLayoutOrientation(this.hostElement, this.isVerticalOrientation, this.renderingMode);
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {
         ontotextYasgui.refresh();
@@ -710,6 +716,11 @@ export class OntotextYasguiWebComponent {
     });
   }
 
+  private changeRenderingMode(mode: RenderingMode): void {
+    this.renderingMode = mode;
+    VisualisationUtils.changeRenderMode(this.hostElement, mode, this.isVerticalOrientation);
+  }
+
   private isOntotextYasguiInitialiazed(): boolean {
     return !!this.ontotextYasgui && !!this.ontotextYasgui.getInstance();
   }
@@ -774,15 +785,15 @@ export class OntotextYasguiWebComponent {
       <Host class={classList}>
         <div class="yasgui-toolbar hidden">
           <button class="yasgui-btn btn-mode-yasqe"
-                  onClick={() => VisualisationUtils.changeRenderMode(this.hostElement, RenderingMode.YASQE)}>
+                  onClick={() => this.changeRenderingMode(RenderingMode.YASQE)}>
             {this.translationService.translate('yasgui.toolbar.mode_yasqe.btn.label')}
           </button>
           <button class="yasgui-btn btn-mode-yasgui"
-                  onClick={() => VisualisationUtils.changeRenderMode(this.hostElement, RenderingMode.YASGUI)}>
+                  onClick={() => this.changeRenderingMode(RenderingMode.YASGUI)}>
             {this.translationService.translate('yasgui.toolbar.mode_yasgui.btn.label')}
           </button>
           <button class="yasgui-btn btn-mode-yasr"
-                  onClick={() => VisualisationUtils.changeRenderMode(this.hostElement, RenderingMode.YASR)}>
+                  onClick={() => this.changeRenderingMode(RenderingMode.YASR)}>
             {this.translationService.translate('yasgui.toolbar.mode_yasr.btn.label')}
           </button>
           <yasgui-tooltip

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -1,4 +1,4 @@
-import {YasguiConfiguration} from '../../models/yasgui-configuration';
+import {Orientation, YasguiConfiguration} from '../../models/yasgui-configuration';
 import {VisualisationUtils} from '../utils/visualisation-utils';
 import {HtmlElementsUtil} from '../utils/html-elements-util';
 import {TranslationService} from '../translation.service';
@@ -57,7 +57,7 @@ export class OntotextYasguiService {
 
   private static initButtonsStyling(hostElement: HTMLElement, config: YasguiConfiguration): void {
     // Initialize render buttons styling.
-    VisualisationUtils.changeRenderMode(hostElement, config.render);
+    VisualisationUtils.changeRenderMode(hostElement, config.render, config.orientation === Orientation.VERTICAL);
 
     // Initialize orientation button styling.
     const orientation = config.orientation;


### PR DESCRIPTION
## What
Refactor yasgui component layout to work properly when rendering mode or orientation are changed.

## Why
When switching to vertical layout yasqe should span the entire height of the viewport. Same should happen also when the yasqe mode (editor only) mode is selected.

## How
* Refactored the component to call an utility function which is capable of calculating the possible height which the yasqe could have and applying it.
* Introduced a renderingMode state property which holds the actual rendering mode. This was needed in order to allow getting the actual value instead of resolving the one that comes from the config.
* Extended the tests to cover some ot the corner cases related with this functionality.