### PR TITLE
GDB-8995 rendering mode should be switched to yasgui when query is run

### DIFF
--- a/cypress/e2e/before-execute-query.spec.cy.ts
+++ b/cypress/e2e/before-execute-query.spec.cy.ts
@@ -15,7 +15,7 @@ describe('Before execute query functionality', () => {
     BeforeExecuteQueryPageSteps.setupErrorResult();
     YasqeSteps.clearEditor();
     YasqeSteps.writeInEditor('INSERT DATA {<https://swapi.co/vocabulary/#planet> <http://www.w3.org/2000/01/rdf-schema#label> "Test name".\n<https://swapi.co/vocabulary/#planet> <http://www.w3.org/2000/01/rdf-schema#label> "Test name two".\n}');
-    YasqeSteps.executeQueryWithoutWaiteResult();
+    YasqeSteps.executeQueryWithoutWaitResult();
 
     // Then I expect to see an error message.
     ErrorPluginSteps.getErrorPluginBody().contains('Before Update Query Error Result.');

--- a/cypress/e2e/editor-actions/abort-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/abort-query.spec.cy.ts
@@ -13,7 +13,7 @@ describe('Abort query', () => {
     // When I visit a page with "ontotext-yasgui-web-component" in it,
     // and execute a query that takes a long time.
     QueryStubs.stubDefaultQueryResponse(1000);
-    YasqeSteps.executeQueryWithoutWaiteResult();
+    YasqeSteps.executeQueryWithoutWaitResult();
 
     // Then I expect to an "Abort query" button to be displayed,
     YasqeSteps.getAbortQueryButton().should('exist');

--- a/cypress/e2e/editor-actions/execute-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/execute-query.spec.cy.ts
@@ -23,7 +23,7 @@ describe('Execute query action', () => {
   it('Should display a progress indicator during query execution', () => {
     QueryStubs.stubDefaultQueryResponse(2000);
     ActionsPageSteps.visit();
-    YasqeSteps.executeQueryWithoutWaiteResult();
+    YasqeSteps.executeQueryWithoutWaitResult();
     YasqeSteps.getTabWithProgressBar().should('exist');
   });
 
@@ -82,7 +82,7 @@ describe('Execute query action', () => {
     KeyboardShortcutPageSteps.setVirtualRepository();
     YasqeSteps.clearEditor();
     YasqeSteps.writeInEditor("INSERT DATA { ontogen:name rdf:label \"Test name\"");
-    YasqeSteps.executeQueryWithoutWaiteResult();
+    YasqeSteps.executeQueryWithoutWaitResult();
 
     // Then I expect the query don't run,
     YasrSteps.getResultsTable().should('not.exist');

--- a/cypress/e2e/view-modes.spec.cy.ts
+++ b/cypress/e2e/view-modes.spec.cy.ts
@@ -32,7 +32,6 @@ describe('View modes', () => {
         // Then Only yasqe should be visible
         YasqeSteps.getYasqe().should('be.visible');
         YasguiSteps.getTabs().should('have.length', 1);
-        YasqeSteps.executeQueryWithoutWaiteResult();
         // And yasr should be hidden
         YasrSteps.getYasr().should('not.be.visible');
         // And I expect that render yasqe in the toolbar to be selected
@@ -48,6 +47,20 @@ describe('View modes', () => {
         // And the height css property will be removed to allow yasqe expand only to the with not
         // occupied by yasr
         YasqeSteps.getCodeMirrorEl().should('have.attr', 'style', '');
+    });
+
+    it('Should switch to yasgui mode when query is executed', () => {
+      // When I configure mode-yasqe
+      ViewModePageSteps.switchToModeYasqe();
+      // Then Only yasqe should be visible
+      YasqeSteps.getYasqe().should('be.visible');
+      YasrSteps.getYasr().should('not.be.visible');
+      // When I run a query
+      YasqeSteps.executeQueryWithoutWaitResult();
+      // Then I expect rendering mode to be switched back to yasgui
+      YasqeSteps.getYasqe().should('be.visible');
+      YasrSteps.getYasr().should('be.visible');
+      ToolbarPageSteps.isYasguiModeSelected();
     });
 
     it('Should render mode-yasr', () => {

--- a/cypress/e2e/yasgui-toolbar.spec.cy.ts
+++ b/cypress/e2e/yasgui-toolbar.spec.cy.ts
@@ -64,7 +64,7 @@ describe('Yasgui Toolbar', () => {
         // Then yasqe should be visible
         YasqeSteps.getYasqe().should('be.visible');
         YasguiSteps.getTabs().should('have.length', 1);
-        YasqeSteps.executeQueryWithoutWaiteResult();
+        YasqeSteps.executeQueryWithoutWaitResult();
         // And yasr should be not visible
         YasrSteps.getYasr().should('not.be.visible');
         // And only yasqe button have to be selected

--- a/cypress/e2e/yasgui-toolbar.spec.cy.ts
+++ b/cypress/e2e/yasgui-toolbar.spec.cy.ts
@@ -57,14 +57,13 @@ describe('Yasgui Toolbar', () => {
         ToolbarPageSteps.getToolbar().should('be.visible');
     });
 
-    it.only('Should render mode-yasqe', () => {
+    it('Should render mode-yasqe', () => {
         ToolbarPageSteps.visit();
         // When I switch to mode-yasqe
         ToolbarPageSteps.switchToModeYasqe();
         // Then yasqe should be visible
         YasqeSteps.getYasqe().should('be.visible');
         YasguiSteps.getTabs().should('have.length', 1);
-        YasqeSteps.executeQueryWithoutWaitResult();
         // And yasr should be not visible
         YasrSteps.getYasr().should('not.be.visible');
         // And only yasqe button have to be selected

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -67,7 +67,7 @@ export class YasqeSteps {
       .should('be.visible');
   }
 
-  static executeQueryWithoutWaiteResult(index = 0) {
+  static executeQueryWithoutWaitResult(index = 0) {
     this.getExecuteQueryButton(index).click();
   }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -240,6 +240,7 @@ export class OntotextYasguiWebComponent {
   query(): Promise<any> {
     return this.getOntotextYasgui()
       .then((ontotextYasgui) => {
+        console.log('run query', );
         return ontotextYasgui.query();
       });
   }
@@ -566,6 +567,7 @@ export class OntotextYasguiWebComponent {
 
   @Listen('internalQueryEvent')
   onQuery(event: CustomEvent<InternalQueryEvent>): void {
+    this.changeRenderMode(RenderingMode.YASGUI);
     this.output.emit(toOutputEvent(event));
   }
 


### PR DESCRIPTION
## What
Rendering mode should be switched to yasgui when query is run.

## Why
This is the expected behavior and the workbench works this way. The user would expect when executing a query to see the results even if he previously switched to editor only mode.

## How
* Switch the rendering mode from the internal query run event.
* Added test and fixed a typo in some of the test steps.