### PR TITLE
GDB-8993 preserve cursor position when query is set in the editor

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -223,6 +223,8 @@ export class OntotextYasguiWebComponent {
 
   /**
    * Allows the client to set a query in the current opened tab.
+   * The cursor position is preserved.
+   *
    * @param query The query that should be set in the current focused tab.
    */
   @Method()

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -47,8 +47,14 @@ export class OntotextYasgui {
     return this.yasgui?.getTab().getYasqe();
   }
 
+  /**
+   * Sets a query value in the editor by preserving the cursor position.
+   * @param query The query value to be set.
+   */
   setQuery(query: string): void {
+    const cursor = this.yasgui.getTab().getYasqe().getDoc().getCursor();
     this.yasgui.getTab().getYasqe().setValue(query);
+    this.yasgui.getTab().getYasqe().getDoc().setCursor(cursor);
   }
 
   query(): Promise<any> {


### PR DESCRIPTION
## What
Preserve cursor position when query is set in the editor.

## Why
There was a bug where when the setQuery method was invoked, the query was set in the editor but this was resetting the cursor to initial position in the beginning of the editor.

## How
Applied a fix where the cursor position is stored locally and after setting the query it's then restored to its previous position.