### PR TITLE
GDB-9145 visual graph cannot open via sparql view

### DIFF
--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -35,7 +35,7 @@ export class PivotTablePlugin implements YasrPlugin {
   initialize(): Promise<void> {
     return new Promise(resolve => {
       HtmlUtil.loadCss('https://pivottable.js.org/dist/pivot.css');
-      HtmlUtil.loadJavaScript('https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js');
+      HtmlUtil.loadJavaScript('https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js');
       HtmlUtil.loadJavaScript('https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js');
       HtmlUtil.loadJavaScript('https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js');
       HtmlUtil.loadJavaScript('https://www.gstatic.com/charts/loader.js');

--- a/yasgui-patches/2023-11-28-GDB-9146_missing_space_between_yasr_toolbar_elements.patch
+++ b/yasgui-patches/2023-11-28-GDB-9146_missing_space_between_yasr_toolbar_elements.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] GDB-9146: The button Visual in tab Pivot table and Google tab should have a distance with the button GET HTML
+---
+Index: Yasgui/packages/yasr/src/main.scss
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/main.scss b/Yasgui/packages/yasr/src/main.scss
+--- a/Yasgui/packages/yasr/src/main.scss	(revision 41930b7327006ae83feccb880d7e865264136632)
++++ b/Yasgui/packages/yasr/src/main.scss	(revision 2d3061e97f4da6da06fdad1f6a0468e3cd991767)
+@@ -163,8 +163,8 @@
+   .yasr-toolbar {
+     display: flex;
+     .yasr-toolbar-element {
+-      padding-left: 10px;
+-      padding-right: 10px;
++      margin-left: 6px;
++      margin-right: 6px;
+     }
+   }
+ }


### PR DESCRIPTION
## What
Increase the d3 version.

## Why
WB increased the version of the d3 library, causing a problem with the ontotext-yasgui-web-component version.

## How
The d3 library version was increased.

## Additional work
Added "2023-11-28-GDB-9146_missing_space_between_yasr_toolbar_elements.patch" patch because, the changes made for GDB-9146 issue has changes inside original yasgui, they were merged without to creating of a patch for that changes.
