### PR TITLE
GDB-8645: Keyboard shortcuts differences between old implementation

### DIFF
--- a/Yasgui/packages/utils/src/index.ts
+++ b/Yasgui/packages/utils/src/index.ts
@@ -58,6 +58,8 @@ export function getAsValue<E, A>(valueOrFn: E | ((arg: A) => E), arg: A): E {
   return valueOrFn;
 }
 
+type TranslationCallback = (translation: string) => void;
+
 export class TranslationService {
   private static _INSTANCE: TranslationService;
 
@@ -70,6 +72,15 @@ export class TranslationService {
 
   translate(key: string, _parameters?: TranslationParameter[]): string {
     return key;
+  }
+
+  onTranslate(
+    messageLabelKey: string,
+    translationCallback: TranslationCallback = () => {},
+    _translationParameter: TranslationParameter[] = []
+  ) {
+    translationCallback(messageLabelKey);
+    return () => {};
   }
 }
 

--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts
@@ -127,10 +127,7 @@ export class Completer extends EventEmitter {
       return false;
     }
     if (!this.config.autoShow) {
-      this.yasqe.showNotification(
-        this.config.name,
-        this.yasqe.translationService.translate("yasqe.autocomplete.notification.info.help_info_message")
-      );
+      this.yasqe.showNotification(this.config.name, "yasqe.autocomplete.notification.info.help_info_message");
     }
     this.emit("validPosition", this);
     return true;
@@ -334,10 +331,7 @@ export const fetchFromLov = (
   var reqProtocol = window.location.protocol.indexOf("http") === 0 ? "https://" : "http://";
   const notificationKey = "autocomplete_" + type;
   if (!token || !token.string || token.string.trim().length == 0) {
-    yasqe.showNotification(
-      notificationKey,
-      yasqe.translationService.translate("yasqe.autocomplete.notification.info.nothing_to_autocomplete")
-    );
+    yasqe.showNotification(notificationKey, "yasqe.autocomplete.notification.info.nothing_to_autocomplete");
     return Promise.resolve([]);
   }
   // //if notification bar is there, show a loader
@@ -362,10 +356,7 @@ export const fetchFromLov = (
         return [];
       },
       (_e) => {
-        yasqe.showNotification(
-          notificationKey,
-          yasqe.translationService.translate("yasqe.autocomplete.notification.error.failed_fetching_suggestions")
-        );
+        yasqe.showNotification(notificationKey, "yasqe.autocomplete.notification.error.failed_fetching_suggestions");
       }
     );
 };

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -106,6 +106,7 @@ export class Yasqe extends CodeMirror {
   public readonly eventService: EventService;
   private readonly isVirtualRepository: boolean;
   private readonly tabId: string;
+  private subscriptions: any[] = [];
   constructor(parent: HTMLElement, conf: PartialConfig = {}) {
     super();
     if (!parent) throw new Error("No parent passed as argument. Dont know where to draw YASQE");
@@ -997,9 +998,9 @@ export class Yasqe extends CodeMirror {
   /**
    * Shows notification
    * @param key reference to the notification
-   * @param message the message to display
+   * @param messageLabelKey the message label key to display
    */
-  public showNotification(key: string, message: string) {
+  public showNotification(key: string, messageLabelKey: string) {
     if (!this.notificationEls[key]) {
       // We create one wrapper for each notification, since there is no interactivity with the container (yet) we don't need to keep a reference
       const notificationContainer = document.createElement("div");
@@ -1017,7 +1018,12 @@ export class Yasqe extends CodeMirror {
     }
     const el = this.notificationEls[key];
     addClass(el, "active");
-    el.innerText = message;
+
+    this.subscriptions.push(
+      this.translationService.onTranslate(messageLabelKey, (translation) => {
+        el.innerText = translation;
+      })
+    );
   }
   /**
    * Hides notification
@@ -1184,6 +1190,7 @@ export class Yasqe extends CodeMirror {
   }
 
   public destroy() {
+    this.subscriptions.forEach((subscription) => subscription());
     //  Abort running query;
     this.abortQuery();
     this.unregisterEventListeners();

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -157,7 +157,7 @@ export namespace Components {
          */
         "savedQueryConfig"?: SavedQueryConfig;
         /**
-          * Allows the client to set a query in the current opened tab.
+          * Allows the client to set a query in the current opened tab. The cursor position is preserved.
           * @param query The query that should be set in the current focused tab.
          */
         "setQuery": (query: string) => Promise<void>;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -173,6 +173,7 @@ Type: `Promise<any>`
 ### `setQuery(query: string) => Promise<void>`
 
 Allows the client to set a query in the current opened tab.
+The cursor position is preserved.
 
 #### Returns
 

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -46,7 +46,7 @@
   "yasqe.action.share.btn.tooltip": "Share your query",
   "yasqe.action.share.error.general_message": "An error has occurred",
   "yasqe.action.shorten.btn.label": "Shorten",
-  "yasqe.autocomplete.notification.info.help_info_message": "Press CTRL - <spacebar> to autocomplete.",
+  "yasqe.autocomplete.notification.info.help_info_message": "Press Alt+Enter to autocomplete",
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Nothing to autocomplete yet!",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Failed fetching suggestions...",
   "yasqe.check_syntax.error.invalid_line.prefix": "This line is invalid. Expected: ",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -46,7 +46,7 @@
   "yasqe.action.share.btn.tooltip": "Partagez votre requête",
   "yasqe.action.share.error.general_message": "An error has occurred",
   "yasqe.action.shorten.btn.label": "Raccourcir",
-  "yasqe.autocomplete.notification.info.help_info_message": "Appuyez sur CTRL - <spacebar> pour l'autocomplétion.",
+  "yasqe.autocomplete.notification.info.help_info_message": "Appuyez sur Alt+Entrée pour l'autocomplétion.",
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Rien à autocompléter encore !",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Échec de la récupération des suggestions...",
   "yasqe.check_syntax.error.invalid_line.prefix": "Cette ligne n'est pas valide. Attendu: ",

--- a/yasgui-patches/2023-12-5_Fixes_Translation_of_Autocomplete_Hint_When_Language_is_Changed.patch
+++ b/yasgui-patches/2023-12-5_Fixes_Translation_of_Autocomplete_Hint_When_Language_is_Changed.patch
@@ -1,0 +1,129 @@
+Subject: [PATCH] Fixes Translation of Autocomplete Hint When Language is Changed
+---
+Index: Yasgui/packages/utils/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/utils/src/index.ts b/Yasgui/packages/utils/src/index.ts
+--- a/Yasgui/packages/utils/src/index.ts	(revision fb9368561b3f184482ac77c281a41cf32f7db3f3)
++++ b/Yasgui/packages/utils/src/index.ts	(revision 87a8f3dd6e69dc0aabfac210c0ae8554569f6eb4)
+@@ -58,6 +58,8 @@
+   return valueOrFn;
+ }
+ 
++type TranslationCallback = (translation: string) => void;
++
+ export class TranslationService {
+   private static _INSTANCE: TranslationService;
+ 
+@@ -71,6 +73,15 @@
+   translate(key: string, _parameters?: TranslationParameter[]): string {
+     return key;
+   }
++
++  onTranslate(
++    messageLabelKey: string,
++    translationCallback: TranslationCallback = () => {},
++    _translationParameter: TranslationParameter[] = []
++  ) {
++    translationCallback(messageLabelKey);
++    return () => {};
++  }
+ }
+ 
+ export class TimeFormattingService {
+Index: Yasgui/packages/yasqe/src/autocompleters/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/autocompleters/index.ts b/Yasgui/packages/yasqe/src/autocompleters/index.ts
+--- a/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision fb9368561b3f184482ac77c281a41cf32f7db3f3)
++++ b/Yasgui/packages/yasqe/src/autocompleters/index.ts	(revision 87a8f3dd6e69dc0aabfac210c0ae8554569f6eb4)
+@@ -127,10 +127,7 @@
+       return false;
+     }
+     if (!this.config.autoShow) {
+-      this.yasqe.showNotification(
+-        this.config.name,
+-        this.yasqe.translationService.translate("yasqe.autocomplete.notification.info.help_info_message")
+-      );
++      this.yasqe.showNotification(this.config.name, "yasqe.autocomplete.notification.info.help_info_message");
+     }
+     this.emit("validPosition", this);
+     return true;
+@@ -334,10 +331,7 @@
+   var reqProtocol = window.location.protocol.indexOf("http") === 0 ? "https://" : "http://";
+   const notificationKey = "autocomplete_" + type;
+   if (!token || !token.string || token.string.trim().length == 0) {
+-    yasqe.showNotification(
+-      notificationKey,
+-      yasqe.translationService.translate("yasqe.autocomplete.notification.info.nothing_to_autocomplete")
+-    );
++    yasqe.showNotification(notificationKey, "yasqe.autocomplete.notification.info.nothing_to_autocomplete");
+     return Promise.resolve([]);
+   }
+   // //if notification bar is there, show a loader
+@@ -362,10 +356,7 @@
+         return [];
+       },
+       (_e) => {
+-        yasqe.showNotification(
+-          notificationKey,
+-          yasqe.translationService.translate("yasqe.autocomplete.notification.error.failed_fetching_suggestions")
+-        );
++        yasqe.showNotification(notificationKey, "yasqe.autocomplete.notification.error.failed_fetching_suggestions");
+       }
+     );
+ };
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision fb9368561b3f184482ac77c281a41cf32f7db3f3)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 87a8f3dd6e69dc0aabfac210c0ae8554569f6eb4)
+@@ -106,6 +106,7 @@
+   public readonly eventService: EventService;
+   private readonly isVirtualRepository: boolean;
+   private readonly tabId: string;
++  private subscriptions: any[] = [];
+   constructor(parent: HTMLElement, conf: PartialConfig = {}) {
+     super();
+     if (!parent) throw new Error("No parent passed as argument. Dont know where to draw YASQE");
+@@ -997,9 +998,9 @@
+   /**
+    * Shows notification
+    * @param key reference to the notification
+-   * @param message the message to display
++   * @param messageLabelKey the message label key to display
+    */
+-  public showNotification(key: string, message: string) {
++  public showNotification(key: string, messageLabelKey: string) {
+     if (!this.notificationEls[key]) {
+       // We create one wrapper for each notification, since there is no interactivity with the container (yet) we don't need to keep a reference
+       const notificationContainer = document.createElement("div");
+@@ -1017,7 +1018,12 @@
+     }
+     const el = this.notificationEls[key];
+     addClass(el, "active");
+-    el.innerText = message;
++
++    this.subscriptions.push(
++      this.translationService.onTranslate(messageLabelKey, (translation) => {
++        el.innerText = translation;
++      })
++    );
+   }
+   /**
+    * Hides notification
+@@ -1184,6 +1190,7 @@
+   }
+ 
+   public destroy() {
++    this.subscriptions.forEach((subscription) => subscription());
+     //  Abort running query;
+     this.abortQuery();
+     this.unregisterEventListeners();


### PR DESCRIPTION
## What
- Changed the translation of autocomplete hint "Press CTRL - <spacebar> to autocomplete." to "Press Alt+Enter to autocomplete";
- The TranslationService has been extended with a new "onTranslate" functions. It gives opportunity to service clients to subscribe to translation changes. The calling of "onTranslate" function will subscribe the caller for translation of given label. When the translation changed the caller will be notified with new translation;
- When the language is changed, the autocomplete label does not update.

## Why
- To be same as old Yasgui;
- Until now we don't have functionality to change labels dynamically. When we want to change the translations we just refresh all components. Which is slowly and not effective way to do that;
- We don't have dynamically changing of translation. We did it with reload of YASGUI, but autocomplete hint is not part of component redrowing and that's why the message not changed.

## How
- The label has been changed;
- The new added method has three parameters. The "messageLabelKey" and "translationParameter" is used for translation. The "translationCallback" is callback function that is called upon subscription and the language is changed;
- The code that set message is refactoring to use the new functionality of translation service. When the hint element is initialized a subscription to translation changes is added, and when it is occurred the hint element is updated with, the new value.