### PR TITLE
GDB-8189: Different Behavior on "Delete Current Line" Keyboard Shortc…

### DIFF
--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -50,8 +50,11 @@ export class KeyboardShortcutService {
     keyboardShortcut.keyboardShortcuts.push('Cmd-K');
     //@ts-ignore
     keyboardShortcut.executeFunction = (yasqe: Yasqe) => {
-      //@ts-ignore
-      Yasqe.defaults.extraKeys['Shift-Ctrl-K'](yasqe);
+      const lineNumber = yasqe.getDoc().getCursor().line;
+      //delete current line including the linebreak after
+      return yasqe.getDoc().replaceRange("",
+        {ch: 0, line: lineNumber},
+        {ch: 0, line: lineNumber + 1});
     };
     return keyboardShortcut;
   }


### PR DESCRIPTION
## What
The function executed when the keyboard shortcut is pressed deletes the current line and moves the cursor to the line before it. This differs from the current behaviour of WB.

## Why
This behavior is the default in the new YASGUI implementation.

## How
Modified the function to delete only the current line without moving the cursor.