### PR TITLE
Expose a new configuration

### DIFF
--- a/cypress/e2e/keyboard-shortcuts.spec.cy.ts
+++ b/cypress/e2e/keyboard-shortcuts.spec.cy.ts
@@ -32,7 +32,7 @@ describe('Keyboard Shortcuts', () => {
     it('should open dialog with information only for readonly keyboard shortcuts actions', () => {
       // When I visit a page with "ontotext-yasgui-web-component" in it,
       // and component is configured to be read only
-      KeyboardShortcutPageSteps.hideRunButton();
+      KeyboardShortcutPageSteps.removeExecutableShortcuts();
 
       // Then I expect to see the "keyboard shortcuts" button in it.
       KeyboardShortcutSteps.getInfoDialogButton().should('be.visible');
@@ -190,7 +190,7 @@ describe('Keyboard Shortcuts', () => {
     it('should not trigger "EXECUTE_QUERY_OR_UPDATE" action when run button is hidden', () => {
       // Given: I visit a page with "ontotext-yasgui-web-component" in it,
       // and a query is typed.
-      KeyboardShortcutPageSteps.hideRunButton();
+      KeyboardShortcutPageSteps.removeExecutableShortcuts();
 
       // When press the "Run query button" keyboard shortcut.
       KeyboardShortcutSteps.clickOnRunQueryShortcut();

--- a/cypress/steps/pages/keyboard-shortcut-page-steps.ts
+++ b/cypress/steps/pages/keyboard-shortcut-page-steps.ts
@@ -11,7 +11,7 @@ export class KeyboardShortcutPageSteps {
     cy.get('#setVirtualRepo').realClick();
   }
 
-  static hideRunButton() {
-    cy.get('#hideRunButton').click();
+  static removeExecutableShortcuts() {
+    cy.get('#removeExecutableShortcuts').click();
   }
 }

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -122,6 +122,28 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - **sameAs**: the value of "sameAs" parameter when a query is executed. Default value is true.
 - **immutableSameAs**: if set to true, the 'sameAs' value cannot be changed. Default value is false.
 - **language**: the language being used when the component is initialized. Default value is "en".
+- **keyboardShortcutConfiguration**: This is an object with key-value pairs. The key is the name of the keyboard shortcut, and the value is
+  a boolean that controls whether the shortcut should be visible. The shortcut will be visible if it is not set in the configuration or is
+  set with a value of true. All possible values for the keys are:
+  - trigger_autocompletion
+  - delete_current_line
+  - comment_selected_line
+  - copy_line_down
+  - copy_line_up
+  - auto_format_selected_line
+  - indent_current_line_more
+  - indent_current_line_less
+  - execute_query_or_update
+  - execute_explain_plan_for_query
+  - execute_chat_gpt_explain_plan_for_query
+  - create_tab
+  - create_save_query
+  - switch_next_tab
+  - switch_previous_tab
+  - closes_all_tabs
+  - full_screen
+  - esc
+
 
 ## Developers guide
 

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -84,6 +84,8 @@
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.description": "Switch to previous tab",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "[Ctrl|Cmd]-Shift-F4",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.description": "Closes all the tabs except the current one",
+  "yasqe.keyboard_shortcuts.dialog.item.execute_chat_gpt_explain_plan_for_query.label": "Alt-[Ctrl|Cmd]-Enter",
+  "yasqe.keyboard_shortcuts.dialog.item.execute_chat_gpt_explain_plan_for_query.description": "Explain query/result using ChatGPT",
   "yasqe.keyboard_shortcuts.dialog.item.full_screen.label": "[Ctrl|Cmd]-Alt-F",
   "yasqe.keyboard_shortcuts.dialog.item.full_screen.description": "Full screen/exit full screen",
   "yasqe.keyboard_shortcuts.dialog.item.explain_exit_fullscreen.message": "[Ctrl|Cmd]-Alt-F or Esc to exit full screen.",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -84,6 +84,8 @@
   "yasqe.keyboard_shortcuts.dialog.item.switch_previous_tab.description": "Passer à l'onglet suivant",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.label": "[Ctrl|Cmd]-Shift-F4",
   "yasqe.keyboard_shortcuts.dialog.item.closes_all_tabs.description": "Ferme tous les onglets sauf celui en cours",
+  "yasqe.keyboard_shortcuts.dialog.item.execute_chat_gpt_explain_plan_for_query.label": "Alt-[Ctrl|Cmd]-Enter",
+  "yasqe.keyboard_shortcuts.dialog.item.execute_chat_gpt_explain_plan_for_query.description": "Expliquer la requête/résultat avec ChatGPT",
   "yasqe.keyboard_shortcuts.dialog.item.full_screen.label": "[Ctrl|Cmd]-Alt-F",
   "yasqe.keyboard_shortcuts.dialog.item.full_screen.description": "Plein écran/Quitter le plein écran",
   "yasqe.keyboard_shortcuts.dialog.item.explain_exit_fullscreen.message": "[Ctrl|Cmd]-Alt-F ou Échap pour quitter le mode plein écran.",

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -3,6 +3,7 @@ import {Prefixes} from '../../../Yasgui/packages/yasr';
 import {BeforeUpdateQueryResult} from './before-update-query-result';
 import {YasrToolbarPlugin} from './yasr-toolbar-plugin';
 import {YasqeMode} from './yasqe-mode';
+import {KeyboardShortcutName} from './keyboard-shortcut-description';
 
 export interface ExternalYasguiConfiguration {
   // ***********************************************************
@@ -289,6 +290,12 @@ export interface ExternalYasguiConfiguration {
    * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
    */
   sparqlResponse: string | undefined;
+
+  /**
+   * Configuration that controls which keyboard shortcuts are enabled.
+   *
+   */
+  keyboardShortcutConfiguration: Record<KeyboardShortcutName, boolean>[];
 }
 
 export type AutocompleteLoader = () => any;

--- a/ontotext-yasgui-web-component/src/models/keyboard-shortcut-description.ts
+++ b/ontotext-yasgui-web-component/src/models/keyboard-shortcut-description.ts
@@ -35,4 +35,4 @@ export enum EXPLAIN_PLAN_TYPE {
   CHAT_GPT_EXPLAIN = 'gpt'
 }
 
-export type CreateKeyboardShortCutFunction = () => KeyboardShortcutDescription;
+export type CreateKeyboardShortcutFunction = () => KeyboardShortcutDescription;

--- a/ontotext-yasgui-web-component/src/models/keyboard-shortcut-description.ts
+++ b/ontotext-yasgui-web-component/src/models/keyboard-shortcut-description.ts
@@ -1,8 +1,11 @@
+import {Yasqe} from './yasgui/yasqe';
+
+export type KeyboardExecuteFunction = (yasqe: Yasqe) => void;
+
 export class KeyboardShortcutDescription {
 
   NAME: KeyboardShortcutName;
   keyboardShortcuts: string[] = [];
-  //@ts-ignore
   executeFunction: (yasqe: Yasqe) => void
 }
 
@@ -31,3 +34,5 @@ export enum EXPLAIN_PLAN_TYPE {
   EXPLAIN= 'explain',
   CHAT_GPT_EXPLAIN = 'gpt'
 }
+
+export type CreateKeyboardShortCutFunction = () => KeyboardShortcutDescription;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -5,6 +5,7 @@ import {BeforeUpdateQueryResult} from './before-update-query-result';
 import {YasrToolbarPlugin} from './yasr-toolbar-plugin';
 import {EventService} from '../services/event-service';
 import {TimeFormattingService} from '../services/utils/time-formatting-service';
+import {KeyboardShortcutName} from './keyboard-shortcut-description';
 
 export interface YasguiConfiguration {
   // ***********************************************************
@@ -67,6 +68,12 @@ export interface YasguiConfiguration {
    * Registered yasqe autocomplete handlers. Every handler is mapped by its name.
    */
   yasqeAutocomplete?: Record<string, AutocompleteLoader>;
+
+  /**
+   * Configuration that controls which keyboard shortcuts are enabled.
+   *
+   */
+  keyboardShortcutConfiguration?: Record<KeyboardShortcutName, boolean>[];
 
   // ***********************************************************
   //
@@ -276,6 +283,10 @@ export const defaultYasguiConfig: Record<string, any> = {
   immutableSameAs: false,
   pageSize: 10,
   paginationOn: true,
+  keyboardShortcutConfiguration: {
+    execute_explain_plan_for_query: false,
+    execute_chat_gpt_explain_plan_for_query: false
+  },
   getRepositoryStatementsCount: () => Promise.resolve(),
   beforeUpdateQuery: () => Promise.resolve({}),
   headers: () => {

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/index.html
@@ -12,7 +12,7 @@
   </head>
   <body>
   <button id="setVirtualRepo" onclick="setVirtualRepository()">Set Virtual Repository</button>
-  <button id="hideRunButton" onclick="hideRunButton()">Hide Run button</button>
+  <button id="removeExecutableShortcuts" onclick="removeExecutableShortcuts()">Remove the executable shortcuts</button>
   <hr>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
 

--- a/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
+++ b/ontotext-yasgui-web-component/src/pages/keyboard-shortcuts/main.js
@@ -1,4 +1,15 @@
-let ontoElement = getOntotextYasgui();
+let ontoElement = document.querySelector("ontotext-yasgui");
+ontoElement.config = {
+  keyboardShortcutConfiguration: {
+    execute_explain_plan_for_query: true,
+    execute_chat_gpt_explain_plan_for_query: true,
+  },
+  endpoint: () => {
+    return "/repositories/test-repo";
+  },
+  prefixes: getPrefixes(),
+  componentId: 'keyboard-shortcut'
+};
 
 ontoElement.addEventListener('output', (evt) => {
   if ('notificationMessage' === evt.detail.TYPE) {
@@ -6,10 +17,19 @@ ontoElement.addEventListener('output', (evt) => {
   }
 });
 
-function hideRunButton() {
+function removeExecutableShortcuts() {
   ontoElement.config = {
     ...ontoElement.config,
-    showQueryButton: false
+    keyboardShortcutConfiguration: {
+      execute_query_or_update: false,
+      execute_explain_plan_for_query: false,
+      execute_chat_gpt_explain_plan_for_query: false,
+      create_tab: false,
+      create_save_query: false,
+      switch_next_tab: false,
+      switch_previous_tab: false,
+      closes_all_tabs: false,
+    }
   };
 }
 

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -1,5 +1,5 @@
 import {
-  CreateKeyboardShortCutFunction,
+  CreateKeyboardShortcutFunction,
   EXPLAIN_PLAN_TYPE,
   KeyboardShortcutDescription,
   KeyboardShortcutName
@@ -18,7 +18,7 @@ export class KeyboardShortcutService {
     const keyboardShortcutDescriptions = [];
     const insertAll = !config.keyboardShortcutConfiguration || config.keyboardShortcutConfiguration.length < 1;
     KeyboardShortcutService.keyboardShortcutNameToFactoryFunction
-      .forEach((factoryFunction: CreateKeyboardShortCutFunction, keyboardShortcutName: KeyboardShortcutName) => {
+      .forEach((factoryFunction: CreateKeyboardShortcutFunction, keyboardShortcutName: KeyboardShortcutName) => {
         if (insertAll || config.keyboardShortcutConfiguration[keyboardShortcutName] === undefined || config.keyboardShortcutConfiguration[keyboardShortcutName]) {
           keyboardShortcutDescriptions.push(factoryFunction());
         }
@@ -269,8 +269,8 @@ export class KeyboardShortcutService {
     return keyboardShortcut;
   }
 
-  private static initAllKeyboardShortcuts(): Map<string, CreateKeyboardShortCutFunction> {
-    const keyboardShortcuts = new Map<string, CreateKeyboardShortCutFunction>();
+  private static initAllKeyboardShortcuts(): Map<string, CreateKeyboardShortcutFunction> {
+    const keyboardShortcuts = new Map<string, CreateKeyboardShortcutFunction>();
     keyboardShortcuts.set(KeyboardShortcutName.TRIGGER_AUTOCOMPLETION, KeyboardShortcutService.createTriggerAutocomplete);
     keyboardShortcuts.set(KeyboardShortcutName.DELETE_CURRENT_LINE, KeyboardShortcutService.createDeleteCurrentLine);
     keyboardShortcuts.set(KeyboardShortcutName.COMMENT_SELECTED_LINE, KeyboardShortcutService.createCommentCurrentLine);

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -1,4 +1,9 @@
-import {EXPLAIN_PLAN_TYPE, KeyboardShortcutDescription, KeyboardShortcutName} from '../models/keyboard-shortcut-description';
+import {
+  CreateKeyboardShortCutFunction,
+  EXPLAIN_PLAN_TYPE,
+  KeyboardShortcutDescription,
+  KeyboardShortcutName
+} from '../models/keyboard-shortcut-description';
 import {YasguiConfiguration} from '../models/yasgui-configuration';
 import {YasqeButtonName} from '../models/yasqe-button-name';
 import {YasqeService} from './yasqe/yasqe-service';
@@ -6,28 +11,18 @@ import {Yasqe} from '../models/yasgui/yasqe';
 import {IndentSelection} from '../models/yasgui/indent-selection';
 
 export class KeyboardShortcutService {
+
+  private static keyboardShortcutNameToFactoryFunction = KeyboardShortcutService.initAllKeyboardShortcuts();
+
   static initKeyboardShortcutMapping = (config: YasguiConfiguration): KeyboardShortcutDescription[] => {
     const keyboardShortcutDescriptions = [];
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createTriggerAutocomplete());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createDeleteCurrentLine());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createCommentCurrentLine());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createCopyLineDown());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createCopyLineUp());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createAutoFormat());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createIndentMore());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createIndentLess());
-    if (config.yasguiConfig.yasqe.showQueryButton) {
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteQuery());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteExplainPlanForQuery());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createExecuteChatGPTExplainPlanForQuery());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createCreateTab());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSavedQuery());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToNextTab());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createSwitchToPreviousTab());
-      keyboardShortcutDescriptions.push(KeyboardShortcutService.createCloseAllTabs());
-    }
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createF11());
-    keyboardShortcutDescriptions.push(KeyboardShortcutService.createEscape());
+    const insertAll = !config.keyboardShortcutConfiguration || config.keyboardShortcutConfiguration.length < 1;
+    KeyboardShortcutService.keyboardShortcutNameToFactoryFunction
+      .forEach((factoryFunction: CreateKeyboardShortCutFunction, keyboardShortcutName: KeyboardShortcutName) => {
+        if (insertAll || config.keyboardShortcutConfiguration[keyboardShortcutName] === undefined || config.keyboardShortcutConfiguration[keyboardShortcutName]) {
+          keyboardShortcutDescriptions.push(factoryFunction());
+        }
+      });
     return keyboardShortcutDescriptions;
   };
 
@@ -253,7 +248,7 @@ export class KeyboardShortcutService {
     return keyboardShortcut;
   }
 
-  private static createF11(): KeyboardShortcutDescription {
+  private static createFullScreen(): KeyboardShortcutDescription {
     const keyboardShortcut = new KeyboardShortcutDescription()
     keyboardShortcut.NAME = KeyboardShortcutName.FULL_SCREEN;
     keyboardShortcut.keyboardShortcuts.push('Ctrl-Alt-F');
@@ -272,5 +267,28 @@ export class KeyboardShortcutService {
       yasqe.leaveFullScreen();
     };
     return keyboardShortcut;
+  }
+
+  private static initAllKeyboardShortcuts(): Map<string, CreateKeyboardShortCutFunction> {
+    const keyboardShortcuts = new Map<string, CreateKeyboardShortCutFunction>();
+    keyboardShortcuts.set(KeyboardShortcutName.TRIGGER_AUTOCOMPLETION, KeyboardShortcutService.createTriggerAutocomplete);
+    keyboardShortcuts.set(KeyboardShortcutName.DELETE_CURRENT_LINE, KeyboardShortcutService.createDeleteCurrentLine);
+    keyboardShortcuts.set(KeyboardShortcutName.COMMENT_SELECTED_LINE, KeyboardShortcutService.createCommentCurrentLine);
+    keyboardShortcuts.set(KeyboardShortcutName.COPY_LINE_DOWN, KeyboardShortcutService.createCopyLineDown);
+    keyboardShortcuts.set(KeyboardShortcutName.COPY_LINE_UP, KeyboardShortcutService.createCopyLineUp);
+    keyboardShortcuts.set(KeyboardShortcutName.AUTO_FORMAT_SELECTED_LINE, KeyboardShortcutService.createAutoFormat);
+    keyboardShortcuts.set(KeyboardShortcutName.INDENT_CURRENT_LINE_MORE, KeyboardShortcutService.createIndentMore);
+    keyboardShortcuts.set(KeyboardShortcutName.INDENT_CURRENT_LINE_LESS, KeyboardShortcutService.createIndentLess);
+    keyboardShortcuts.set(KeyboardShortcutName.EXECUTE_QUERY_OR_UPDATE, KeyboardShortcutService.createExecuteQuery);
+    keyboardShortcuts.set(KeyboardShortcutName.EXECUTE_EXPLAIN_PLAN_FOR_QUERY, KeyboardShortcutService.createExecuteExplainPlanForQuery);
+    keyboardShortcuts.set(KeyboardShortcutName.EXECUTE_CHAT_GPT_EXPLAIN_PLAN_FOR_QUERY, KeyboardShortcutService.createExecuteChatGPTExplainPlanForQuery);
+    keyboardShortcuts.set(KeyboardShortcutName.CREATE_TAB, KeyboardShortcutService.createCreateTab);
+    keyboardShortcuts.set(KeyboardShortcutName.CREATE_SAVE_QUERY, KeyboardShortcutService.createSavedQuery);
+    keyboardShortcuts.set(KeyboardShortcutName.SWITCH_NEXT_TAB, KeyboardShortcutService.createSwitchToNextTab);
+    keyboardShortcuts.set(KeyboardShortcutName.SWITCH_PREVIOUS_TAB, KeyboardShortcutService.createSwitchToPreviousTab);
+    keyboardShortcuts.set(KeyboardShortcutName.CLOSES_ALL_TABS, KeyboardShortcutService.createCloseAllTabs);
+    keyboardShortcuts.set(KeyboardShortcutName.FULL_SCREEN, KeyboardShortcutService.createFullScreen);
+    keyboardShortcuts.set(KeyboardShortcutName.ESC, KeyboardShortcutService.createEscape);
+    return keyboardShortcuts;
   }
 }

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -41,6 +41,9 @@ export class YasguiConfigurationBuilder {
    */
   build(externalConfiguration: ExternalYasguiConfiguration): YasguiConfiguration {
     const config: YasguiConfiguration = {};
+
+    config.keyboardShortcutConfiguration = Object.assign({}, defaultYasguiConfig.keyboardShortcutConfiguration, externalConfiguration.keyboardShortcutConfiguration);
+
     // prepare the adapter config
     config.render = externalConfiguration.render || defaultOntotextYasguiConfig.render;
     config.orientation = externalConfiguration.orientation || defaultOntotextYasguiConfig.orientation;


### PR DESCRIPTION
## What
Expose a new configuration that controls which keyboard shortcuts are active.

## Why
Not all keyboard shortcut functions are related to ontotext-yasgui-web-component, there are two that are specific to WB. With this configuration, other client will have the opportunity to disable them.

## How
Exposed a new configuration to the clients of the component.