### PR TITLE
GDB-9147 introduce an alert box component

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -5,6 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { AlertBoxType } from "./components/alert-box/alert-box";
 import { TranslationService } from "./services/translation.service";
 import { ConfirmationDialogConfig } from "./components/confirmation-dialog/confirmation-dialog";
 import { CopyLinkDialogConfig, CopyLinkObserver } from "./components/copy-link-dialog/copy-link-dialog";
@@ -21,6 +22,23 @@ import { OutputEvent } from "./models/output-events/output-event";
 import { YasqeButtonType } from "./models/yasqe-button-name";
 import { ShareQueryDialogConfig } from "./components/share-query-dialog/share-query-dialog";
 export namespace Components {
+    /**
+     * Implementation of dismissible alert box component which can be configured.
+     */
+    interface AlertBox {
+        /**
+          * The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed.
+         */
+        "message": string;
+        /**
+          * Configures if the icon in the alert should be displayed or not. Default is <code>true</code>
+         */
+        "noIcon": boolean;
+        /**
+          * Defines the alert type which is represented by different color, background and icon. Default is <code>"info"</code>.
+         */
+        "type": AlertBoxType;
+    }
     interface ConfirmationDialog {
         "config": ConfirmationDialogConfig;
         "translationService": TranslationService;
@@ -224,6 +242,15 @@ export interface ShareQueryDialogCustomEvent<T> extends CustomEvent<T> {
     target: HTMLShareQueryDialogElement;
 }
 declare global {
+    /**
+     * Implementation of dismissible alert box component which can be configured.
+     */
+    interface HTMLAlertBoxElement extends Components.AlertBox, HTMLStencilElement {
+    }
+    var HTMLAlertBoxElement: {
+        prototype: HTMLAlertBoxElement;
+        new (): HTMLAlertBoxElement;
+    };
     interface HTMLConfirmationDialogElement extends Components.ConfirmationDialog, HTMLStencilElement {
     }
     var HTMLConfirmationDialogElement: {
@@ -331,6 +358,7 @@ declare global {
         new (): HTMLYasguiTooltipElement;
     };
     interface HTMLElementTagNameMap {
+        "alert-box": HTMLAlertBoxElement;
         "confirmation-dialog": HTMLConfirmationDialogElement;
         "copy-link-dialog": HTMLCopyLinkDialogElement;
         "copy-resource-link-button": HTMLCopyResourceLinkButtonElement;
@@ -349,6 +377,23 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * Implementation of dismissible alert box component which can be configured.
+     */
+    interface AlertBox {
+        /**
+          * The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed.
+         */
+        "message"?: string;
+        /**
+          * Configures if the icon in the alert should be displayed or not. Default is <code>true</code>
+         */
+        "noIcon"?: boolean;
+        /**
+          * Defines the alert type which is represented by different color, background and icon. Default is <code>"info"</code>.
+         */
+        "type"?: AlertBoxType;
+    }
     interface ConfirmationDialog {
         "config"?: ConfirmationDialogConfig;
         /**
@@ -547,6 +592,7 @@ declare namespace LocalJSX {
         "showOnClick"?: false;
     }
     interface IntrinsicElements {
+        "alert-box": AlertBox;
         "confirmation-dialog": ConfirmationDialog;
         "copy-link-dialog": CopyLinkDialog;
         "copy-resource-link-button": CopyResourceLinkButton;
@@ -568,6 +614,10 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * Implementation of dismissible alert box component which can be configured.
+             */
+            "alert-box": LocalJSX.AlertBox & JSXBase.HTMLAttributes<HTMLAlertBoxElement>;
             "confirmation-dialog": LocalJSX.ConfirmationDialog & JSXBase.HTMLAttributes<HTMLConfirmationDialogElement>;
             "copy-link-dialog": LocalJSX.CopyLinkDialog & JSXBase.HTMLAttributes<HTMLCopyLinkDialogElement>;
             "copy-resource-link-button": LocalJSX.CopyResourceLinkButton & JSXBase.HTMLAttributes<HTMLCopyResourceLinkButtonElement>;

--- a/ontotext-yasgui-web-component/src/components/alert-box/alert-box.scss
+++ b/ontotext-yasgui-web-component/src/components/alert-box/alert-box.scss
@@ -1,0 +1,22 @@
+.alert-box {
+  position: relative;
+  margin: 10px 0;
+
+  .close-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+    font-size: 21px;
+    font-weight: 700;
+    line-height: 1;
+    color: #8a6d3b;
+    opacity: .2;
+
+    &:hover {
+      text-decoration: none;
+      color: #000;
+      opacity: .5;
+    }
+  }
+}

--- a/ontotext-yasgui-web-component/src/components/alert-box/alert-box.tsx
+++ b/ontotext-yasgui-web-component/src/components/alert-box/alert-box.tsx
@@ -1,0 +1,53 @@
+import {Component, h, Host, Prop, State} from '@stencil/core';
+
+export type AlertBoxType = 'info' | 'warning' | 'help' | 'danger' | 'success';
+
+/**
+ * Implementation of dismissible alert box component which can be configured.
+ */
+@Component({
+  tag: 'alert-box',
+  styleUrl: 'alert-box.scss',
+  shadow: false,
+})
+export class AlertBox {
+  /**
+   * Defines the alert type which is represented by different color, background and icon.
+   * Default is <code>"info"</code>.
+   */
+  @Prop() type: AlertBoxType = 'info';
+
+  /**
+   * The message which should be displayed in the alert. If the message is not provided, then the
+   * alert is not displayed.
+   */
+  @Prop() message: string;
+
+  /**
+   * Configures if the icon in the alert should be displayed or not.
+   * Default is <code>true</code>
+   */
+  @Prop() noIcon = true;
+
+  /**
+   * Controls the visibility of the alert.
+   * Default is <code>true</code>
+   */
+  @State() isVisible = true;
+
+  onClose(evt: MouseEvent): void {
+    evt.stopPropagation();
+    this.isVisible = !this.isVisible;
+  }
+
+  render() {
+    const classList = `alert-box alert alert-${this.type} ${this.noIcon && 'no-icon'}`;
+    return (
+      <Host>
+        {this.isVisible && <div class={classList}>
+          <a class="close-button" onClick={(evt) => this.onClose(evt)}>&times;</a>
+          <div class="message">{this.message}</div>
+        </div>}
+      </Host>);
+  }
+}

--- a/ontotext-yasgui-web-component/src/components/alert-box/readme.md
+++ b/ontotext-yasgui-web-component/src/components/alert-box/readme.md
@@ -1,0 +1,23 @@
+# alert-box
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Implementation of dismissible alert box component which can be configured.
+
+## Properties
+
+| Property  | Attribute | Description                                                                                                          | Type                                                     | Default     |
+| --------- | --------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------- |
+| `message` | `message` | The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed. | `string`                                                 | `undefined` |
+| `noIcon`  | `no-icon` | Configures if the icon in the alert should be displayed or not. Default is <code>true</code>                         | `boolean`                                                | `true`      |
+| `type`    | `type`    | Defines the alert type which is represented by different color, background and icon. Default is <code>"info"</code>. | `"danger" \| "help" \| "info" \| "success" \| "warning"` | `'info'`    |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
## What
Introduce an alert box component which can be used in the yasgui.

## Why
There cases where there is a need to render such alert box. For example rendering warnings inside yasr when some plugin has some errors to show.

## How
Implemented a new component.