### PR TITLE
GDB-9267 position the query button at the bottom of the editor

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -87,6 +87,12 @@
           display: none;
         }
 
+        // Position the query button at the bottom right corner of the editor.
+        yasgui-tooltip:last-of-type {
+          position: absolute;
+          bottom: 32px;
+        }
+
         .yasqe_queryButton {
           width: unset;
           height: unset;


### PR DESCRIPTION
## What
Position the query button at the bottom of the editor.

## Why
For consistency with the current workbench.

## How
Applied css to absolutely position the button at the bottom which allows it to stay there even when the editor gets resized.