### PR TITLE
GDB-9004 add a hint to autocomplete dropdown

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -739,16 +739,16 @@ export class OntotextYasguiWebComponent {
   }
 
   registerEventHandlers():void {
-    let hint =  HtmlElementsUtil.createAutocompleteHintElement(this.translationService.translate('yasqe.autocomplete.hint'));
+    const hint =  HtmlElementsUtil.createAutocompleteHintElement(this.translationService.translate('yasqe.autocomplete.hint'));
 
     this.ontotextYasgui.getInstance().on('autocompletionShown', (_instance, _tab, _widget) => {
       const elRect = document.querySelector('.CodeMirror-hints').getBoundingClientRect();
       document.body.appendChild(hint);
-      let top = `${elRect.top - 20}px`;
+      const topPosition = elRect.top - 20;
       let leftPosition = elRect.right - hint.offsetWidth;
       // move it additionally 40px on the right to prevent overlapping with the current cursor position
       leftPosition = leftPosition < elRect.left ? elRect.left + 40 : leftPosition - 12
-      hint.style.top = top;
+      hint.style.top = `${topPosition}px`;
       hint.style.left = `${leftPosition}px`;
     });
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -738,6 +738,25 @@ export class OntotextYasguiWebComponent {
     this.ontotextYasguiService.postConstruct(this.hostElement, this.ontotextYasgui.getConfig());
   }
 
+  registerEventHandlers():void {
+    let hint =  HtmlElementsUtil.createAutocompleteHintElement(this.translationService.translate('yasqe.autocomplete.hint'));
+
+    this.ontotextYasgui.getInstance().on('autocompletionShown', (_instance, _tab, _widget) => {
+      const elRect = document.querySelector('.CodeMirror-hints').getBoundingClientRect();
+      document.body.appendChild(hint);
+      let top = `${elRect.top - 20}px`;
+      let leftPosition = elRect.right - hint.offsetWidth;
+      // move it additionally 40px on the right to prevent overlapping with the current cursor position
+      leftPosition = leftPosition < elRect.left ? elRect.left + 40 : leftPosition - 12
+      hint.style.top = top;
+      hint.style.left = `${leftPosition}px`;
+    });
+
+    this.ontotextYasgui.getInstance().on('autocompletionClose', (_instance, _tab) => {
+      hint.parentNode && hint.parentNode.removeChild(hint);
+    });
+  }
+
   private destroy(): void {
     if (this.ontotextYasgui) {
       this.ontotextYasgui.destroy();
@@ -762,6 +781,7 @@ export class OntotextYasguiWebComponent {
       YasrService.registerPlugin(PivotTablePlugin.PLUGIN_NAME, PivotTablePlugin as any);
       YasrService.registerPlugin(ChartsPlugin.PLUGIN_NAME, ChartsPlugin as any);
       this.ontotextYasgui = this.yasguiBuilder.build(this.hostElement, yasguiConfiguration);
+      this.registerEventHandlers();
       this.afterInit();
     }
   }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -46,6 +46,7 @@
   "yasqe.action.share.btn.tooltip": "Share your query",
   "yasqe.action.share.error.general_message": "An error has occurred",
   "yasqe.action.shorten.btn.label": "Shorten",
+  "yasqe.autocomplete.hint": "Hint: \"abC\" matches \"abC*\", \"ab c*\" and \"ab-c*\"",
   "yasqe.autocomplete.notification.info.help_info_message": "Press Alt+Enter to autocomplete",
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Nothing to autocomplete yet!",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Failed fetching suggestions...",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -46,6 +46,7 @@
   "yasqe.action.share.btn.tooltip": "Partagez votre requête",
   "yasqe.action.share.error.general_message": "An error has occurred",
   "yasqe.action.shorten.btn.label": "Raccourcir",
+  "yasqe.autocomplete.hint": "Indice: \"abC\" correspond à \"abC*\", \"ab c*\" et \"ab-c*\".",
   "yasqe.autocomplete.notification.info.help_info_message": "Appuyez sur Alt+Entrée pour l'autocomplétion.",
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Rien à autocompléter encore !",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Échec de la récupération des suggestions...",

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasgui.ts
@@ -8,4 +8,6 @@ export class Yasgui {
   addTab: (setActive: boolean, partialTabConfig?: any, opts?: any) => Tab;
 
   destroy: () => void;
+
+  on: (event, handler) => void;
 }

--- a/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
@@ -50,4 +50,16 @@ export class HtmlElementsUtil {
       }
     });
   }
+
+  static createAutocompleteHintElement(text: string): HTMLElement {
+    let hint =  document.createElement('span');
+    hint.innerHTML = text;
+    hint.style.fontSize = '12px';
+    hint.style.color = "gray";
+    hint.style.backgroundColor = 'white';
+    hint.style.position = 'absolute';
+    hint.style.zIndex = '3';
+    hint.style.paddingLeft = 12 + 'px';
+    return hint;
+  }
 }

--- a/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
@@ -52,7 +52,7 @@ export class HtmlElementsUtil {
   }
 
   static createAutocompleteHintElement(text: string): HTMLElement {
-    let hint =  document.createElement('span');
+    const hint =  document.createElement('span');
     hint.innerHTML = text;
     hint.style.fontSize = '12px';
     hint.style.color = "gray";


### PR DESCRIPTION
## What
Add a hint to autocomplete dropdown menu.

## Why
This would allow the user to better use the autocomplete functionality. Also this is present in the current workbench.

## How
Hook into autocomplete show/hide events fired by the yasgui and rendered the hint component above the autocomplete dropdown.