### PR TITLE
GDB-8984: Style Changes for "Add New Tab" Button and Context Menu

### DIFF
--- a/Yasgui/packages/yasgui/src/TabElements.ts
+++ b/Yasgui/packages/yasgui/src/TabElements.ts
@@ -283,10 +283,10 @@ export class TabList {
 
     this.addTabEl = document.createElement("div");
     this.addTabEl.setAttribute("role", "presentation");
+    this.addTabEl.className = "create-tab-tab";
 
     const addTabLink = document.createElement("button");
     addTabLink.className = "addTab";
-    addTabLink.textContent = "+";
     const addTabLabel = this.yasgui.translationService.translate("yasgui.tab_list.add_tab.btn.label");
     addTabLink.title = addTabLabel;
     addTabLink.setAttribute("aria-label", addTabLabel);
@@ -300,6 +300,9 @@ export class TabList {
     addTabLink.addEventListener("blur", () => {
       addTabLink.setAttribute("tabindex", "0"); // maintains tabability
     });
+    const icon = document.createElement("i");
+    icon.className = "icon-plus";
+    addTabLink.prepend(icon);
     this.addTabEl.appendChild(addTabLink);
     this._tabsListEl.appendChild(this.addTabEl);
     this.tabContextMenu = TabContextMenu.get(

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -176,42 +176,78 @@
     }
 
 
-    .tabsList .tab {
-      border: 1px solid #eeeeee;
-      margin-right: 0.2em;
-      margin-top: 0.2em;
-      padding: 8px;
+    .tabsList {
+      .tab {
+        border: 1px solid #eeeeee;
+        margin-right: 0.2em;
+        margin-top: 0.2em;
+        padding: 8px;
 
-      .closeTab {
-        margin-left: 10px;
-        display: inline-block;
-      }
+        .closeTab {
+          margin-left: 10px;
+          display: inline-block;
+        }
 
-      .closeTab:hover {
-        cursor: pointer;
-        color: $color-ontotext-orange-dark;
+        .closeTab:hover {
+          cursor: pointer;
+          color: $color-ontotext-orange-dark;
 
-        .icon-close {
+          .icon-close {
+            transform: scale(1.1);
+          }
+        }
+
+        .closeTab i::before {
+          display: inline-block;
+        }
+
+        .closeTab:hover i::before {
           transform: scale(1.1);
+        }
+
+        .editable-text-field-wrapper:focus {
+          outline: none;
+        }
+
+        // Overrides the YASGUI style that hides the input of the tab rename input.
+        .editable-text-field {
+          display: inline-block;
+          border: 1px solid $color-onto-grey;
         }
       }
 
-      .closeTab i::before {
-        display: inline-block;
+      .create-tab-tab {
+        margin-top: 0.2em;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background-color: #eeeeee;
+      }
+      .addTab {
+        color: #000042;
+        margin: 0;
+        padding: 0.5em 1em;
+        transform: none;
+        &:hover {
+          color: $color-ontotext-orange-dark;
+          i {
+            transform: scale(1.1);
+          }
+        }
       }
 
-      .closeTab:hover i::before {
-        transform: scale(1.1);
-      }
+      .context-menu {
+        color: #003663
+      ;
+        background-color: #FFFFFF;
 
-      .editable-text-field-wrapper:focus {
-        outline: none;
-      }
+        .context-menu-list {
+          margin: 0;
+        }
 
-      // Overrides the YASGUI style that hides the input of the tab rename input.
-      .editable-text-field {
-        display: inline-block;
-        border: 1px solid $color-onto-grey;
+        .context-menu-item:hover {
+          background-color: #0000001a;
+        }
       }
     }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -223,13 +223,16 @@
         align-items: center;
         background-color: #eeeeee;
       }
+
       .addTab {
         color: #000042;
         margin: 0;
         padding: 0.5em 1em;
         transform: none;
+
         &:hover {
           color: $color-ontotext-orange-dark;
+
           i {
             transform: scale(1.1);
           }
@@ -237,8 +240,7 @@
       }
 
       .context-menu {
-        color: #003663
-      ;
+        color: #003663;
         background-color: #FFFFFF;
 
         .context-menu-list {


### PR DESCRIPTION
## What
- The "Add New Tab" button differs from the one in Workbench;
- The Context menu styling does not match any style in workbench.

## Why
- The "Add New Tab" button previously had the default YASGUI styling and had not been customized.
- The styling was default for the new YASGUI and had not been modified.

## How
- Changed styling of the "Add new tab button";
- The style has been changed to look like left side menu.