### PR TITLE
GDB-9308: When I rename a tab name I should be able to save the changes with "Enter" key

### DIFF
--- a/cypress/e2e/editor-actions/rename-tab.spec.cy.ts
+++ b/cypress/e2e/editor-actions/rename-tab.spec.cy.ts
@@ -46,6 +46,19 @@ describe('Rename tab functionality', () => {
     // Then I expect the tab name has been renamed.
     YasguiSteps.getTabName(0).should('have.text', 'New Value');
   });
+
+  it('should rename the tab when I click on enter key', () => {
+    // When I open the tab name editor,
+    YasguiSteps.getTabName(0).should('have.text', 'Unnamed');
+    YasguiSteps.dblClickTab(0);
+    // and change tab name,
+    EditableTabElement.getValueInput().invoke('val', '').type('New Value');
+    // and press the enter keyboard key.
+    EditableTabElement.pressEnter();
+
+    // Then I expect the tab name has been renamed.
+    YasguiSteps.getTabName(0).should('have.text', 'New Value');
+  });
 });
 
 const openTabNameEditor = (tabName: string) => {

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -71,6 +71,10 @@ export class EditableTabElement {
     EditableTabElement.getSaveButton().click();
   }
 
+  static pressEnter() {
+    cy.get('body').type('{enter}');
+  }
+
   static getCancelButton() {
     return cy.get('.cancel-btn');
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -73,6 +73,13 @@ export class OntotextEditableTextField {
     }
   }
 
+  @Listen('keydown', {target: "document"})
+  keydownListener(ev: KeyboardEvent) {
+    if (ev.key === 'Enter') {
+      this.save();
+    }
+  }
+
   /**
    * Initializes the field that holds edited value when component is loaded.
    */

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -75,7 +75,7 @@ export class OntotextEditableTextField {
 
   @Listen('keydown', {target: "document"})
   keydownListener(ev: KeyboardEvent) {
-    if (ev.key === 'Enter') {
+    if (this.edit && ev.key === 'Enter') {
       this.save();
     }
   }
@@ -116,12 +116,12 @@ export class OntotextEditableTextField {
    * Saves the value of text field and emits "valueChanged" event with the new value.
    */
   private save(): void {
-    if (this.value === this.editedValue) {
-      return;
-    }
+    const isValueChanged = this.value === this.editedValue;
     this.value = this.editedValue;
     this.edit = false;
-    this.valueChanged.emit(this.value);
+    if (isValueChanged) {
+      this.valueChanged.emit(this.value);
+    }
   }
 
   /**


### PR DESCRIPTION
## What
When renaming a tab and pressing the "Enter" key, the tab name is not persisted.

## Why
This functionality was not implemented.

## How
Added a listener for the 'keydown' event that saves the tab name if the pressed key is "Enter."