### PR TITLE
GDB-9002 center keyboard shortcut descriptions

### DIFF
--- a/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.scss
@@ -31,7 +31,7 @@
   }
 
   .keyboard-shortcut-description-item-label {
-    width: 40%;
+    width: 50%;
     text-align: end;
     font-size: 14px;
   }
@@ -44,7 +44,7 @@
   }
 
   .keyboard-shortcut-description-item-description {
-    width: 60%;
+    width: 50%;
     font-size: 20px;
   }
 


### PR DESCRIPTION
## What
Center keyboard shortcut descriptions in their dialog.

## Why
For better perceiving and consistency with current workbench.

## How
Changed the column widths in the dialog styles.