### PR TITLE
GDB-9143: Fixes an issue with the resizing of YASR table columns.

### DIFF
--- a/yasgui-patches/2024-01-03-GDB-9143_Fixes_an_issue_with_the_resizing_of_YASR_table_columns.patch
+++ b/yasgui-patches/2024-01-03-GDB-9143_Fixes_an_issue_with_the_resizing_of_YASR_table_columns.patch
@@ -1,0 +1,52 @@
+Subject: [PATCH] GDB-9143: YASGUI -  It should be possible to expand and collapse the columns of each row
+---
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision d1a5aeb76d72c0f2afcba2d1f30c52b40e7cc37d)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision a68e20b50d2191effaa9dd5b0f62f9c2dd5a68ff)
+@@ -56,6 +56,7 @@
+           onResize?: () => void;
+           partialRefresh?: boolean;
+           headerOnly?: boolean;
++          disabledColumns?: number[];
+         }) => void;
+         onResize: () => {};
+       }
+@@ -225,11 +226,18 @@
+     this.dataTable = $(this.tableEl).DataTable(dtConfig);
+     this.tableEl.style.removeProperty("width");
+     this.tableEl.style.width = this.tableEl.clientWidth + "px";
+-    this.tableResizer = new ColumnResizer.default(this.tableEl, {
+-      partialRefresh: true,
+-      onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+-      headerOnly: false,
+-    });
++    // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
++    // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
++    // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
++    setTimeout(() => {
++      this.tableResizer = new ColumnResizer.default(this.tableEl, {
++        partialRefresh: true,
++        onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
++        headerOnly: false,
++        // Ask for this
++        disabledColumns: this.persistentConfig.compact ? [] : [0],
++      });
++    }, 0);
+     // DataTables uses the rendered style to decide the widths of columns.
+     // Before a draw remove the ellipseTable styling
+     if (this.persistentConfig.isEllipsed !== false) {
+@@ -254,7 +262,8 @@
+           disable: false,
+           partialRefresh: true,
+           onResize: this.setEllipsisHandlers,
+-          headerOnly: true,
++          headerOnly: false,
++          disabledColumns: this.persistentConfig.compact ? [] : [0],
+         });
+         // Re-add the ellipsis
+         addClass(this.tableEl, "ellipseTable");


### PR DESCRIPTION
## What
When the YASR "Table" plugin renders a SPARQL query result the column resizing does not work until a column header is clicked.

## Why
The table columns are not rendered before the table-resizer is initialized.

## How
The initialization of the table resizer has been wrapped in a setTimeout, ensuring that the resizer will render after the result table is rendered.

### Additional work
Configures the table resizer to exclude resizing the column number.