### PR TITLE
GDB-9308: cancel tab renaming

### DIFF
--- a/cypress/e2e/editor-actions/rename-tab.spec.cy.ts
+++ b/cypress/e2e/editor-actions/rename-tab.spec.cy.ts
@@ -34,6 +34,19 @@ describe('Rename tab functionality', () => {
     verifyEditorClosed('New Value');
   });
 
+  it('should not save changed name of tab when "Escape" button is pressed', () => {
+    YasguiSteps.getTabName(0).should('have.text', 'Unnamed');
+    // When I open a tab name editor,
+    openTabNameEditor('Unnamed');
+    // and change the name of the tab,
+    EditableTabElement.getValueInput().invoke('val', '').type('New Value');
+    // and click on cancel button
+    EditableTabElement.pressEscape();
+
+    // Then I expect the tab name do not be changed,
+    verifyEditorClosed('Unnamed');
+  });
+
   it('should rename tab when click on save button', () => {
     // When I open the tab name editor,
     YasguiSteps.getTabName(0).should('have.text', 'Unnamed');

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -75,6 +75,10 @@ export class EditableTabElement {
     cy.get('body').type('{enter}');
   }
 
+  static pressEscape() {
+    cy.get('body').type('{esc}');
+  }
+
   static getCancelButton() {
     return cy.get('.cancel-btn');
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -75,8 +75,14 @@ export class OntotextEditableTextField {
 
   @Listen('keydown', {target: "document"})
   keydownListener(ev: KeyboardEvent) {
-    if (this.edit && ev.key === 'Enter') {
+    if (!this.edit) {
+      return;
+    }
+
+    if ('Enter' === ev.key) {
       this.save();
+    } else if ('Escape' === ev.key) {
+      this.cancel();
     }
   }
 


### PR DESCRIPTION
## What
Cancel tab renaming when the 'Escape' key is pressed.

## Why
There is such behaviour in the old implementation.

## How
Added a listener for the "Escape" button press event, canceling tab renaming when the event is fired.