### PR TITLE
GDB-9115: Fixed randomly invisible buttons of copy link buttons.

### DIFF
--- a/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.scss
@@ -24,6 +24,22 @@
     margin-right: 10px;
   }
 
+  .copy-button, .cancel-button {
+      display: inline-block;
+      font-weight: 400;
+      line-height: 1.25;
+      text-align: center;
+      white-space: nowrap;
+      vertical-align: middle;
+      cursor: pointer;
+      user-select: none;
+      border: 1px solid transparent;
+      outline: none;
+      padding: .5rem 1rem;
+      font-size: 1rem;
+      border-radius: 0;
+  }
+
   @include primaryButton;
   @include secondaryButton;
 }

--- a/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/copy-link-dialog/copy-link-dialog.tsx
@@ -71,7 +71,7 @@ export class CopyLinkDialog {
     // If not placed inside a setTimeout, the shareLink input is not selected for some reason.
     setTimeout(() => {
       this.shareLink.select();
-    });
+    }, 100);
   }
 
   private static fallbackCopyTextToClipboard(text: string): void {

--- a/ontotext-yasgui-web-component/src/components/ontotext-dialog-web-component/ontotext-dialog-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-dialog-web-component/ontotext-dialog-web-component.scss
@@ -47,7 +47,6 @@
       border: none;
       outline: none;
       cursor: pointer;
-      transition: all .15s ease-out;
 
       &:hover, &:focus {
         font-weight: bold;
@@ -65,22 +64,5 @@
     justify-content: flex-end;
     padding: 15px;
     border-top: 1px solid #e5e5e5;
-
-    button {
-      display: inline-block;
-      font-weight: 400;
-      line-height: 1.25;
-      text-align: center;
-      white-space: nowrap;
-      vertical-align: middle;
-      cursor: pointer;
-      user-select: none;
-      border: 1px solid transparent;
-      outline: none;
-      padding: .5rem 1rem;
-      font-size: 1rem;
-      border-radius: 0;
-      transition: all .15s ease-out;
-    }
   }
 }


### PR DESCRIPTION
## What
The buttons in the "Copy link" dialog were frequently clickable and fully functional but not visible.

## Why
The problem was caused by a transition set on the buttons with "transition: all .15s ease-out," making the buttons invisible. This issue occurred only in Chrome.

## How
Removed the problematic transition property.

### Additional work
Moved the styling for the cancel and copy buttons from "Ontotext-dialog-web-component.scss" to "copy-link-dialog.scss. Both buttons are part of the copy link dialog, and their styling should be in this component instead of the generic one.