### PR TITLE
GDB-8247 fix literal cell content building

### DIFF
--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -180,7 +180,7 @@ export class YasrService {
   }
 
   private static addWorldBreakTagAfterSpecialCharacters(text) {
-    return text.replace(/([_:/-](?![_:\/-]|sup>))/g, "$1<wbr>");
+    return text.replace(/([_:/-](?![_:/-]|sup>))/g, "$1<wbr>");
   }
 
   private static addWorldBreakTagBeforeSpecialCharacters(text) {

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -180,7 +180,7 @@ export class YasrService {
   }
 
   private static addWorldBreakTagAfterSpecialCharacters(text) {
-    return text.replace(/([_:/-](?![_:/-]))/g, "$1<wbr>");
+    return text.replace(/([_:/-](?![_:\/-]|sup>))/g, "$1<wbr>");
   }
 
   private static addWorldBreakTagBeforeSpecialCharacters(text) {


### PR DESCRIPTION
## What
Fix literal cell content building.

## Why
Currently the function which processes the literal values uses a regex which incorrectly inserts <wbr> tags inside the </sup> tags which breaks the html.

## How
Fix the regex to prevent inserting the <wbr> tag in such places.