### PR TITLE
GDB-9335: Disable column resizing.

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -23,6 +23,7 @@ const DEFAULT_PAGE_SIZE = 50;
 export interface PluginConfig {
   openIriInNewWindow: boolean;
   tableConfig: DataTables.Settings;
+  maxResizableResultsColumns: number;
 }
 
 export interface PersistentConfig {
@@ -72,10 +73,11 @@ export default class Table implements Plugin<PluginConfig> {
     this.yasr = yasr;
     //TODO read options from constructor
     this.translationService = this.yasr.config.translationService;
-    this.config = Table.defaults;
+    this.config = { ...Table.defaults, maxResizableResultsColumns: this.getMaxResizibleColumns() };
   }
   public static defaults: PluginConfig = {
     openIriInNewWindow: true,
+    maxResizableResultsColumns: 19,
     tableConfig: {
       dom: "tip", //  tip: Table, Page Information and Pager, change to ipt for showing pagination on top
       pageLength: DEFAULT_PAGE_SIZE, //default page length
@@ -210,6 +212,10 @@ export default class Table implements Plugin<PluginConfig> {
       pageLength: -1,
       data: rows,
       columns: columns,
+      // DataTables will only render the rows that are initially visible on the page.
+      deferRender: true,
+      // // Switch off the pagination.
+      paging: false,
       // Switched off for optimization purposes.
       // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
       autoWidth: false,
@@ -226,18 +232,27 @@ export default class Table implements Plugin<PluginConfig> {
     this.dataTable = $(this.tableEl).DataTable(dtConfig);
     this.tableEl.style.removeProperty("width");
     this.tableEl.style.width = this.tableEl.clientWidth + "px";
-    // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
-    // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
-    // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
-    setTimeout(() => {
-      this.tableResizer = new ColumnResizer.default(this.tableEl, {
-        partialRefresh: true,
-        onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
-        headerOnly: false,
-        // Ask for this
-        disabledColumns: this.persistentConfig.compact ? [] : [0],
-      });
-    }, 0);
+
+    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+    const maxResizableResultsColumns = this.persistentConfig.compact
+      ? this.config.maxResizableResultsColumns - 1
+      : this.config.maxResizableResultsColumns;
+
+    if (columns.length <= maxResizableResultsColumns) {
+      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+      setTimeout(() => {
+        this.tableResizer = new ColumnResizer.default(this.tableEl, {
+          partialRefresh: true,
+          onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+          headerOnly: false,
+          disabledColumns: this.persistentConfig.compact ? [] : [0],
+        });
+      }, 0);
+    } else {
+      addClass(this.tableEl, "fixedColumns");
+    }
     // DataTables uses the rendered style to decide the widths of columns.
     // Before a draw remove the ellipseTable styling
     if (this.persistentConfig.isEllipsed !== false) {
@@ -359,7 +374,8 @@ export default class Table implements Plugin<PluginConfig> {
     this.tableEllipseSwitch.type = "checkbox";
     ellipseSwitchComponent.appendChild(this.tableEllipseSwitch);
     // isEllipsed should be unchecked by default
-    this.tableEllipseSwitch.defaultChecked = this.persistentConfig.isEllipsed !== undefined ? this.persistentConfig.isEllipsed : false;
+    this.tableEllipseSwitch.defaultChecked =
+      this.persistentConfig.isEllipsed !== undefined ? this.persistentConfig.isEllipsed : false;
     this.tableControls.appendChild(ellipseToggleWrapper);
 
     // Compact switch
@@ -373,6 +389,7 @@ export default class Table implements Plugin<PluginConfig> {
     toggleWrapper.appendChild(switchComponent);
     this.tableCompactSwitch = document.createElement("input");
     switchComponent.addEventListener("change", this.handleSetCompactToggle);
+    addClass(this.tableCompactSwitch, "row-number-switch");
     this.tableCompactSwitch.type = "checkbox";
     switchComponent.appendChild(this.tableCompactSwitch);
     this.tableCompactSwitch.defaultChecked = !!this.persistentConfig.compact;
@@ -440,6 +457,16 @@ export default class Table implements Plugin<PluginConfig> {
       window.removeEventListener("resize", this.tableResizer.onResize);
       this.tableResizer = undefined;
     }
+  }
+  private getMaxResizibleColumns(): number {
+    let maxResizableResultsColumns = Table.defaults.maxResizableResultsColumns;
+    if (this.yasr.config.externalPluginsConfigurations) {
+      const pluginConfiguration = this.yasr.config.externalPluginsConfigurations.get("table");
+      if (pluginConfiguration) {
+        maxResizableResultsColumns = pluginConfiguration.maxResizableResultsColumns;
+      }
+    }
+    return maxResizableResultsColumns;
   }
   destroy() {
     this.removeControls();

--- a/cypress/e2e-flaky/yasr/plugins/table/copy-link-dialog.spec.cy.ts
+++ b/cypress/e2e-flaky/yasr/plugins/table/copy-link-dialog.spec.cy.ts
@@ -1,13 +1,13 @@
-import {YasrTablePluginSteps} from '../../../../steps/yasr-table-plugin-steps';
 import {QueryStubDescription, QueryStubs} from '../../../../stubs/query-stubs';
 import {YasqeSteps} from '../../../../steps/yasqe-steps';
 import {YasrSteps} from '../../../../steps/yasr-steps';
+import {YasrPluginPageSteps} from '../../../../steps/pages/yasr-plugin-page-steps';
 
 describe('Plugin: Table', () => {
 
   beforeEach(() => {
     // Given I visit a page with "ontotex-yasgui-web-component" in it.
-    YasrTablePluginSteps.visit();
+    YasrPluginPageSteps.visit();
   });
 
   context('Copy resource link dialog', () => {

--- a/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
@@ -1,14 +1,14 @@
 import {QueryStubs} from '../../../../stubs/query-stubs';
-import {YasrTablePluginSteps} from '../../../../steps/yasr-table-plugin-steps';
 import {YasqeSteps} from '../../../../steps/yasqe-steps';
 import {YasrSteps} from '../../../../steps/yasr-steps';
 import {DownloadAsPageSteps} from "../../../../steps/download-as-page-steps";
+import {YasrPluginPageSteps} from '../../../../steps/pages/yasr-plugin-page-steps';
 
 describe('Plugin: Raw response', () => {
   beforeEach(() => {
     QueryStubs.stubDefaultQueryResponse();
     // Given I visit a page with "ontotex-yasgui-web-component" in it.
-    YasrTablePluginSteps.visit();
+    YasrPluginPageSteps.visit();
   });
 
   it('should be able to render raw response', {

--- a/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
@@ -5,12 +5,13 @@ import DefaultViewPageSteps from '../../../../steps/default-view-page-steps';
 import {YasrSteps} from '../../../../steps/yasr-steps';
 import {PaginationPageSteps} from '../../../../steps/pages/pagination-page-steps';
 import {PaginationSteps} from '../../../../steps/pagination-steps';
+import {YasrPluginPageSteps} from '../../../../steps/pages/yasr-plugin-page-steps';
 
 describe('Plugin: Table', () => {
 
   beforeEach(() => {
     // Given I visit a page with "ontotex-yasgui-web-component" in it.
-    YasrTablePluginSteps.visit();
+    YasrPluginPageSteps.visit();
   });
 
   describe('Result info message', () => {

--- a/cypress/e2e/yasr/plugins/table/resize-columns.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/resize-columns.spec.cy.ts
@@ -1,0 +1,32 @@
+import {YasrPluginPageSteps} from '../../../../steps/pages/yasr-plugin-page-steps';
+import {YasqeSteps} from '../../../../steps/yasqe-steps';
+import {YasrSteps} from '../../../../steps/yasr-steps';
+
+describe('YASR columns resizable functionality', () => {
+  beforeEach(() => {
+    YasrPluginPageSteps.visit();
+  });
+
+  it('Should disabled column resizing if there are more columns than configured', () => {
+    // When execute a query that returns results with few columns.
+    YasqeSteps.executeQuery();
+
+    // I expect columns to be resizable,
+    YasrSteps.getResultTableHeaderResizableElement().should('have.length.greaterThan', 0);
+    // regardless if row number column is visible.
+    YasrSteps.toggleCompactView()
+    YasrSteps.getResultTableHeaderResizableElement().should('have.length.greaterThan', 0);
+    YasrSteps.toggleCompactView();
+
+    // When I configure the component not to be resizable when the number of result columns is less than the specified configuration value,
+    YasrPluginPageSteps.configureSmallResizableColumns();
+    // and execute a query.
+    YasqeSteps.executeQuery();
+
+    // Then I expect the columns not be resizable.
+    YasrSteps.getResultTableHeaderResizableElement().should('have.length', 0);
+    // regardless if row number is visible.
+    YasrSteps.toggleCompactView();
+    YasrSteps.getResultTableHeaderResizableElement().should('have.length', 0);
+  });
+});

--- a/cypress/steps/pages/yasr-plugin-page-steps.ts
+++ b/cypress/steps/pages/yasr-plugin-page-steps.ts
@@ -1,0 +1,10 @@
+export class YasrPluginPageSteps {
+
+  static visit() {
+    cy.visit('/pages/yasr-plugins');
+  }
+
+  static configureSmallResizableColumns() {
+    cy.get('#configureSmallResizableColumns').click();
+  }
+}

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -220,4 +220,16 @@ export class YasrSteps {
   static getGoogleChartVisualization() {
     return this.getYasr().find('.yasr_results svg');
   }
+
+  static getResultTableHeaderResizableElement(yasrIndex = 0) {
+    return YasrSteps.getYasr(yasrIndex).get('.grip-resizable');
+  }
+
+  static getHideRowNumbersCheckbox() {
+    return YasrSteps.getYasr(0).find('.row-number-switch');
+  }
+
+  static toggleCompactView() {
+    YasrSteps.getHideRowNumbersCheckbox().click();
+  }
 }

--- a/cypress/steps/yasr-table-plugin-steps.ts
+++ b/cypress/steps/yasr-table-plugin-steps.ts
@@ -1,7 +1,4 @@
 export class YasrTablePluginSteps {
-   static visit() {
-      cy.visit('/pages/yasr-plugins');
-   }
 
    static getEmptyResult() {
       return cy.get('.dataTables_empty');

--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -101,6 +101,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
 - **showEditorTabs**: If the query editor tabs should be rendered or not;
 - **showResultTabs**: If the results tabs should be rendered or not;
 - **showResultInfo**: If the result information header of YASR should be rendered or not;
+- **maxResizableResultsColumns**: The maximum count of columns in YASR that can be resized. When there are too many columns, YASR may slow down and frequently crash the browser. The default value is 19.
 - **showQueryLoader**: Flag that controls displaying the loader during the run query process. Default value is true;
 - **showToolbar**: If the toolbar with render mode buttons should be rendered or not;
 - **yasqePluginButtons**: Plugin definitions configurations for yasqe action buttons; 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -269,11 +269,14 @@
 
     /* Make the datatable horizontally scrollable when there is not enough space to fit the columns */
     .dataTables_wrapper {
-      width: 100%;
-      overflow-x: auto;
-
       table.dataTable {
-        table-layout: auto;
+        table-layout: fixed;
+      }
+
+      table.dataTable.fixedColumns {
+        tr td:not(:first-child), tr th:not(:first-child) {
+          width: 100px;
+        }
       }
     }
 

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -287,6 +287,12 @@ export interface ExternalYasguiConfiguration {
   getCellContent: (binding: Parser.BindingValue, prefixes?: Prefixes) => string;
 
   /**
+   * The maximum count of columns in YASR that can be resized. When there are too many columns, YASR may slow down and frequently
+   * crash the browser. The default value is 19.
+   */
+  maxResizableResultsColumns: number;
+
+  /**
    * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
    */
   sparqlResponse: string | undefined;

--- a/ontotext-yasgui-web-component/src/pages/yasr-plugins/index.html
+++ b/ontotext-yasgui-web-component/src/pages/yasr-plugins/index.html
@@ -13,6 +13,7 @@
   <body>
   <hr/>
   <button id="attachMessageHandler" onclick="attachMessageHandler()">Attach message handler</button>
+  <button id="configureSmallResizableColumns" onclick="configureSmallResizableColumns()">Configure small resizable columns</button>
 
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
+++ b/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
@@ -11,3 +11,10 @@ function attachMessageHandler() {
     }
   });
 }
+
+function configureSmallResizableColumns() {
+  ontoElement.config = {
+    ...ontoElement.config,
+    maxResizableResultsColumns: 3
+  }
+}

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -28,7 +28,15 @@ export class YasrService {
   static getPluginsConfigurations(externalConfiguration: ExternalYasguiConfiguration): Map<string, any> {
     const pluginsConfigurations = new Map<string, any>();
     this.addExtendedTableConfiguration(externalConfiguration, pluginsConfigurations);
+    this.addTableConfiguration(externalConfiguration, pluginsConfigurations);
     return pluginsConfigurations;
+  }
+
+  private static addTableConfiguration(externalConfiguration: ExternalYasguiConfiguration, pluginsConfigurations: Map<string, any>): void {
+    const configuration = {
+      maxResizableResultsColumns: externalConfiguration.maxResizableResultsColumns ? externalConfiguration.maxResizableResultsColumns : 19,
+    };
+    pluginsConfigurations.set('table', configuration);
   }
 
   private static addExtendedTableConfiguration(externalConfiguration: ExternalYasguiConfiguration, pluginsConfigurations: Map<string, any>) {

--- a/yasgui-patches/2024-01-15-GDB-9335_disable_column_resizing.patch
+++ b/yasgui-patches/2024-01-15-GDB-9335_disable_column_resizing.patch
@@ -1,0 +1,117 @@
+Subject: [PATCH] GDB-9335: Disable column resizing.
+---
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision f9663bc786e66103152a0c3bf8ba2dce93d82b18)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision ed01b0b679e777dad4b113589a2eb180175ec9b4)
+@@ -23,6 +23,7 @@
+ export interface PluginConfig {
+   openIriInNewWindow: boolean;
+   tableConfig: DataTables.Settings;
++  maxResizableResultsColumns: number;
+ }
+ 
+ export interface PersistentConfig {
+@@ -72,10 +73,11 @@
+     this.yasr = yasr;
+     //TODO read options from constructor
+     this.translationService = this.yasr.config.translationService;
+-    this.config = Table.defaults;
++    this.config = { ...Table.defaults, maxResizableResultsColumns: this.getMaxResizibleColumns() };
+   }
+   public static defaults: PluginConfig = {
+     openIriInNewWindow: true,
++    maxResizableResultsColumns: 19,
+     tableConfig: {
+       dom: "tip", //  tip: Table, Page Information and Pager, change to ipt for showing pagination on top
+       pageLength: DEFAULT_PAGE_SIZE, //default page length
+@@ -210,6 +212,10 @@
+       pageLength: -1,
+       data: rows,
+       columns: columns,
++      // DataTables will only render the rows that are initially visible on the page.
++      deferRender: true,
++      // // Switch off the pagination.
++      paging: false,
+       // Switched off for optimization purposes.
+       // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+       autoWidth: false,
+@@ -226,18 +232,27 @@
+     this.dataTable = $(this.tableEl).DataTable(dtConfig);
+     this.tableEl.style.removeProperty("width");
+     this.tableEl.style.width = this.tableEl.clientWidth + "px";
+-    // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+-    // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+-    // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+-    setTimeout(() => {
+-      this.tableResizer = new ColumnResizer.default(this.tableEl, {
+-        partialRefresh: true,
+-        onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+-        headerOnly: false,
+-        // Ask for this
+-        disabledColumns: this.persistentConfig.compact ? [] : [0],
+-      });
+-    }, 0);
++
++    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
++    const maxResizableResultsColumns = this.persistentConfig.compact
++      ? this.config.maxResizableResultsColumns - 1
++      : this.config.maxResizableResultsColumns;
++
++    if (columns.length <= maxResizableResultsColumns) {
++      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
++      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
++      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
++      setTimeout(() => {
++        this.tableResizer = new ColumnResizer.default(this.tableEl, {
++          partialRefresh: true,
++          onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
++          headerOnly: false,
++          disabledColumns: this.persistentConfig.compact ? [] : [0],
++        });
++      }, 0);
++    } else {
++      addClass(this.tableEl, "fixedColumns");
++    }
+     // DataTables uses the rendered style to decide the widths of columns.
+     // Before a draw remove the ellipseTable styling
+     if (this.persistentConfig.isEllipsed !== false) {
+@@ -359,7 +374,8 @@
+     this.tableEllipseSwitch.type = "checkbox";
+     ellipseSwitchComponent.appendChild(this.tableEllipseSwitch);
+     // isEllipsed should be unchecked by default
+-    this.tableEllipseSwitch.defaultChecked = this.persistentConfig.isEllipsed !== undefined ? this.persistentConfig.isEllipsed : false;
++    this.tableEllipseSwitch.defaultChecked =
++      this.persistentConfig.isEllipsed !== undefined ? this.persistentConfig.isEllipsed : false;
+     this.tableControls.appendChild(ellipseToggleWrapper);
+ 
+     // Compact switch
+@@ -373,6 +389,7 @@
+     toggleWrapper.appendChild(switchComponent);
+     this.tableCompactSwitch = document.createElement("input");
+     switchComponent.addEventListener("change", this.handleSetCompactToggle);
++    addClass(this.tableCompactSwitch, "row-number-switch");
+     this.tableCompactSwitch.type = "checkbox";
+     switchComponent.appendChild(this.tableCompactSwitch);
+     this.tableCompactSwitch.defaultChecked = !!this.persistentConfig.compact;
+@@ -441,6 +458,16 @@
+       this.tableResizer = undefined;
+     }
+   }
++  private getMaxResizibleColumns(): number {
++    let maxResizableResultsColumns = Table.defaults.maxResizableResultsColumns;
++    if (this.yasr.config.externalPluginsConfigurations) {
++      const pluginConfiguration = this.yasr.config.externalPluginsConfigurations.get("table");
++      if (pluginConfiguration) {
++        maxResizableResultsColumns = pluginConfiguration.maxResizableResultsColumns;
++      }
++    }
++    return maxResizableResultsColumns;
++  }
+   destroy() {
+     this.removeControls();
+     this.destroyResizer();


### PR DESCRIPTION
## What
Disabled column resizing.

## Why
Column resizing functionality is slow and memory-consuming. If there are many cells to be displayed, the browser starts working slowly and frequently crashes.

## How
The column resizer has been displayed.