### PR TITLE
GDB-8646: save query changes on refresh

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -164,6 +164,10 @@ export namespace Components {
          */
         "hideYasqeActionButton": (yasqeActionButtonNames: YasqeButtonType | YasqeButtonType[]) => Promise<void>;
         /**
+          * Checks whether the query has been modified after the initialization of the YASQE editor.
+         */
+        "isQueryDirty": () => Promise<boolean>;
+        /**
           * Checks if query is valid.
          */
         "isQueryValid": () => Promise<boolean>;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -369,6 +369,15 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
+   * Checks whether the query has been modified after the initialization of the YASQE editor.
+   */
+  @Method()
+  isQueryDirty(): Promise<boolean> {
+    return this.getOntotextYasgui()
+      .then((ontotextYasgui) => ontotextYasgui.isQueryDirty());
+  }
+
+  /**
    * There are rendering problems when the window size is changed. To address this, we added a listener to the window resize event.
    * When the event occurs, we refresh the component to recalculate and resolve the rendering issues.
    */
@@ -378,6 +387,16 @@ export class OntotextYasguiWebComponent {
       .then((ontotextYasgui) => {
         ontotextYasgui.refresh();
         VisualisationUtils.setYasqeFullHeight(this.renderingMode, VisualisationUtils.resolveOrientation(this.isVerticalOrientation));
+      });
+  }
+
+  @Listen('beforeunload', {target: 'window'})
+  onBeforeunloadHandler() {
+    this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        if (ontotextYasgui.isQueryDirty()) {
+          ontotextYasgui.saveQuery();
+        }
       });
   }
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -138,6 +138,16 @@ Type: `Promise<void>`
 
 
 
+### `isQueryDirty() => Promise<boolean>`
+
+Checks whether the query has been modified after the initialization of the YASQE editor.
+
+#### Returns
+
+Type: `Promise<boolean>`
+
+
+
 ### `isQueryValid() => Promise<boolean>`
 
 Checks if query is valid.

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -72,6 +72,14 @@ export class OntotextYasgui {
     return this.yasgui.getTab().getYasqe().getValue();
   }
 
+  saveQuery(): void {
+    this.getInstance().getTab().getYasqe().emit('blur');
+  }
+
+  isQueryDirty(): boolean {
+    return !this.getYasqe().getDoc().isClean();
+  }
+
   isQueryValid(): boolean {
     return this.yasgui.getTab().getYasqe().queryValid;
   }

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
@@ -71,6 +71,7 @@ export class Doc {
 
   replaceRange: (replacement: string | string[], from: Cursor, to?: Cursor, origin?: string) => void;
   getLine: (line: number) => string;
+  isClean: () => boolean;
 }
 
 export class Cursor {


### PR DESCRIPTION
## What
When I edit the query and refresh the page without execute the query, the query is not persisted.

## Why
This functionality was not present in the new YASGUI version.

## How
Added a "beforeunload" event handler. When the event occurs, the YASQE is triggered to execute the query persistence.