### PR TITLE
GDB-8643 handle repository change

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -494,6 +494,7 @@ export class Tab extends EventEmitter {
     );
   };
   handleYasqeQuery = (yasqe: Yasqe, req: superagent.SuperAgentRequest) => {
+    this.yasr?.hideWarning();
     const message = yasqe.isUpdateQuery()
       ? this.yasgui.translationService.translate("loader.message.query.editor.executing.update")
       : this.yasgui.translationService.translate("loader.message.query.editor.evaluating.query");

--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -456,6 +456,11 @@ export class Yasgui extends EventEmitter {
     }
     return this._tabs[tabId];
   }
+
+  public emitTabChange(tab: Tab) {
+    this.emit("tabChange", this, tab);
+  }
+
   public restoreLastTab() {
     const config = this.persistentConfig.retrieveLastClosedTab();
     if (config) {

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -95,7 +95,7 @@ export class Yasr extends EventEmitter {
     }
   }
 
-  public showWarning(message: string) {
+  public showWarning(message: string, type: "warning" | "error" | "success" = "warning", noButton = false) {
     this.hideWarning();
     if (message) {
         const alertBoxEl = document.createElement('alert-box');
@@ -104,7 +104,9 @@ export class Yasr extends EventEmitter {
         // @ts-ignore
         alertBoxEl.isVisible = true;
         // @ts-ignore
-        alertBoxEl.type = 'warning';
+        alertBoxEl.type = type;
+        // @ts-ignore
+        alertBoxEl.noButton = noButton;
         this.rootEl.prepend(alertBoxEl);
     }
   }
@@ -220,8 +222,13 @@ export class Yasr extends EventEmitter {
   public draw() {
     this.updateHelpButton();
     this.updateResponseInfo();
+    this.hideWarning();
     if (!this.results) {
       this.hideLoader();
+      addClass(this.headerEl, "hidden");
+      addClass(this.resultsEl, "hidden");
+      addClass(this.fallbackInfoEl, "hidden");
+      this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
       return;
     }
     this.updatePluginSelectorNames();

--- a/cypress/e2e/view-configurations.spec.cy.ts
+++ b/cypress/e2e/view-configurations.spec.cy.ts
@@ -6,147 +6,150 @@ import {QueryStubs} from "../stubs/query-stubs";
 
 describe('View configurations', () => {
 
-   beforeEach(() => {
-      QueryStubs.stubDefaultQueryResponse();
-      ViewConfigurationsPageSteps.visit();
-      cy.clearLocalStorage('yasgui_config');
-      cy.clearLocalStorage('prefixes');
-   });
+  beforeEach(() => {
+    QueryStubs.stubDefaultQueryResponse();
+    ViewConfigurationsPageSteps.visit();
+    cy.clearLocalStorage('yasgui_config');
+    cy.clearLocalStorage('prefixes');
+  });
 
-   describe('View mode', () => {
+  describe('View mode', () => {
 
-      it('Should render all tabs by default', () => {
-         // GIVEN: "view-configurations" page is visited.
+    it('Should render all tabs by default', () => {
+      // GIVEN: "view-configurations" page is visited.
+      // When I haven't executed any query.
+      YasrSteps.getResultHeader().should('be.hidden');
+      // When I execute a query.
+      YasqeSteps.executeQuery();
+      // THEN: all components of yasgui, yasr, yasqe have to be visible.
+      YasqeSteps.getQueryTabs().should('be.visible');
+      YasrSteps.getResultHeader().should('be.visible');
+    });
 
-         // THEN: all components of yasgui, yasr, yasqe have to be visible.
-         YasqeSteps.getQueryTabs().should('be.visible');
-         YasrSteps.getResultHeader().should('be.visible');
-      });
+    it('Should hide query tabs', () => {
+      // GIVEN: "view-configurations" page is visited.
+      YasqeSteps.executeQuery();
+      // WHEN: set configuration property "showEditorTabs" to false.
+      ViewConfigurationsPageSteps.hideEditorTabs();
 
-      it('Should hide query tabs', () => {
-         // GIVEN: "view-configurations" page is visited.
+      // THEN: only query tabs have to be invisible.
+      YasqeSteps.getQueryTabs().should('not.be.visible');
+      YasrSteps.getResultHeader().should('be.visible');
 
-         // WHEN: set configuration property "showEditorTabs" to false.
-         ViewConfigurationsPageSteps.hideEditorTabs();
+      // WHEN: set configuration property "showEditorTabs" to true.
+      ViewConfigurationsPageSteps.showEditorTabs();
 
-         // THEN: only query tabs have to be invisible.
-         YasqeSteps.getQueryTabs().should('not.be.visible');
-         YasrSteps.getResultHeader().should('be.visible');
+      // THEN: all components of yasgui, yasr, yasqe have to be visible.
+      YasqeSteps.getQueryTabs().should('be.visible');
+      YasrSteps.getResultHeader().should('be.visible');
+    });
 
-         // WHEN: set configuration property "showEditorTabs" to true.
-         ViewConfigurationsPageSteps.showEditorTabs();
+    it('Should hide result tabs', () => {
+      // GIVEN: "view-configurations" page is visited.
 
-         // THEN: all components of yasgui, yasr, yasqe have to be visible.
-         YasqeSteps.getQueryTabs().should('be.visible');
-         YasrSteps.getResultHeader().should('be.visible');
-      });
+      // WHEN: set configuration property "showResultTabs" to false.
+      ViewConfigurationsPageSteps.hideResultTabs();
 
-      it('Should hide result tabs', () => {
-         // GIVEN: "view-configurations" page is visited.
+      // THEN: results tab have to not be visible.
+      YasqeSteps.getQueryTabs().should('be.visible');
+      YasrSteps.getExtendedTableTab().should('not.be.visible');
+      YasrSteps.getResponseTableTab().should('not.be.visible');
 
-         // WHEN: set configuration property "showResultTabs" to false.
-         ViewConfigurationsPageSteps.hideResultTabs();
+      // WHEN: set configuration property "showResultTabs" to true.
+      ViewConfigurationsPageSteps.showResultTabs();
+      YasqeSteps.executeQuery();
+      // THEN: all components of yasgui, yasr, yasqe have to be visible.
+      YasqeSteps.getQueryTabs().should('be.visible');
+      YasrSteps.getResultHeader().should('be.visible');
+    });
+  });
 
-         // THEN: results tab have to not be visible.
-         YasqeSteps.getQueryTabs().should('be.visible');
-         YasrSteps.getExtendedTableTab().should('not.be.visible');
-         YasrSteps.getResponseTableTab().should('not.be.visible');
+  describe('Query configurations', () => {
 
-         // WHEN: set configuration property "showResultTabs" to true.
-         ViewConfigurationsPageSteps.showResultTabs();
+    it('Should set query passed through "initialQuery" configuration', () => {
+      // GIVEN: "view-configurations" page is visited.
 
-         // THEN: all components of yasgui, yasr, yasqe have to be visible.
-         YasqeSteps.getQueryTabs().should('be.visible');
-         YasrSteps.getResultHeader().should('be.visible');
-      });
-   });
+      // WHEN: set 'initial_query' value to configuration "initialQuery"
+      ViewConfigurationsPageSteps.setInitialQuery();
 
-   describe('Query configurations', () => {
+      // THEN: 'initial_query' have to be set in the query editor.
+      YasqeSteps.getEditor().contains('initial_query');
+    });
 
-      it('Should set query passed through "initialQuery" configuration', () => {
-         // GIVEN: "view-configurations" page is visited.
+    it('Should set default query', () => {
+      // GIVEN: "view-configurations" page is visited.
 
-         // WHEN: set 'initial_query' value to configuration "initialQuery"
-         ViewConfigurationsPageSteps.setInitialQuery();
+      // WHEN: set 'default_query' value to configuration "query".
+      ViewConfigurationsPageSteps.setDefaultQuery();
+      // AND: open a new tab.
+      YasguiSteps.openANewTab();
 
-         // THEN: 'initial_query' have to be set in the query editor.
-         YasqeSteps.getEditor().contains('initial_query');
-      });
+      // THEN: 'default_query' have to be set in the query editor.
+      YasqeSteps.getEditor().contains('default_query');
+    });
 
-      it('Should set default query', () => {
-         // GIVEN: "view-configurations" page is visited.
+    it('Should fire event when query is executed', () => {
+      // GIVEN: "view-configurations" page is visited.
 
-         // WHEN: set 'default_query' value to configuration "query".
-         ViewConfigurationsPageSteps.setDefaultQuery();
-         // AND: open a new tab.
-         YasguiSteps.openANewTab();
+      // WHEN: execute an query
+      YasqeSteps.executeQuery();
 
-         // THEN: 'default_query' have to be set in the query editor.
-         YasqeSteps.getEditor().contains('default_query');
-      });
+      // THEN: an event "queryExecuted" have to be fired
+      // AND: a new element in dom have to be added.
+      ViewConfigurationsPageSteps.getQueryRanInfo().should('be.visible');
+    });
+  });
 
-      it('Should fire event when query is executed', () => {
-         // GIVEN: "view-configurations" page is visited.
+  describe('Control bar', () => {
 
-         // WHEN: execute an query
-         YasqeSteps.executeQuery();
+    it('Should control bar not be visible with default configuration', () => {
+      // WHEN: "view-configurations" page is visited.
 
-         // THEN: an event "queryExecuted" have to be fired
-         // AND: a new element in dom have to be added.
-         ViewConfigurationsPageSteps.getQueryRanInfo().should('be.visible');
-      });
-   });
+      // THEN: an event "queryExecuted" have to be fired
+      // AND: a new element in dom have to be added.
+      YasqeSteps.getControlBar().should('not.be.visible');
+    });
 
-   describe('Control bar', () => {
+    it('Should control bar be visible', () => {
+      // When I configure control panel to be visible.
+      ViewConfigurationsPageSteps.showControlBar();
 
-      it('Should control bar not be visible with default configuration', () => {
-         // WHEN: "view-configurations" page is visited.
+      // Then I expected control panel to not be visible.
+      YasqeSteps.getControlBar().should('be.visible');
 
-         // THEN: an event "queryExecuted" have to be fired
-         // AND: a new element in dom have to be added.
-         YasqeSteps.getControlBar().should('not.be.visible');
-      });
+    });
 
-      it('Should control bar be visible', () => {
-         // When I configure control panel to be visible.
-         ViewConfigurationsPageSteps.showControlBar();
+    it('Should control bar not be visible', () => {
+      // When I configure control panel to be visible.
+      ViewConfigurationsPageSteps.showControlBar();
 
-         // Then I expected control panel to not be visible.
-         YasqeSteps.getControlBar().should('be.visible');
+      // And I change configuration of control panel to not be visible.
+      ViewConfigurationsPageSteps.hideControlBar();
 
-      });
+      // Then I expected control panel to be visible.
+      YasqeSteps.getControlBar().should('not.be.visible');
+    });
 
-      it('Should control bar not be visible', () => {
-         // When I configure control panel to be visible.
-         ViewConfigurationsPageSteps.showControlBar();
+    it("Should control bar not be visible when is turned of and new tab is opened", () => {
+      // When control bar is hidden
+      ViewConfigurationsPageSteps.hideControlBar();
 
-         // And I change configuration of control panel to not be visible.
-         ViewConfigurationsPageSteps.hideControlBar();
+      // And I open a new query tab
+      YasguiSteps.openANewTab();
 
-         // Then I expected control panel to be visible.
-         YasqeSteps.getControlBar().should('not.be.visible');
-      });
+      // Then I expect control bar to be not visible in the new tab
+      YasqeSteps.getControlBar().should('not.be.visible');
+    });
 
-      it("Should control bar not be visible when is turned of and new tab is opened", () => {
-         // When control bar is hidden
-         ViewConfigurationsPageSteps.hideControlBar();
+    it("Should control bar not be visible when is turned of and new tab is opened", () => {
+      // When control bar is configured to be enabled.
+      ViewConfigurationsPageSteps.showControlBar();
 
-         // And I open a new query tab
-         YasguiSteps.openANewTab();
+      // And I open a new query tab
+      YasguiSteps.openANewTab();
 
-         // Then I expect control bar to be not visible in the new tab
-         YasqeSteps.getControlBar().should('not.be.visible');
-      });
-
-      it("Should control bar not be visible when is turned of and new tab is opened", () => {
-         // When control bar is configured to be enabled.
-         ViewConfigurationsPageSteps.showControlBar();
-
-         // And I open a new query tab
-         YasguiSteps.openANewTab();
-
-         // Then I expect control bar to be visible in the new tab
-         YasqeSteps.getControlBar().should('be.visible');
-      });
-   });
+      // Then I expect control bar to be visible in the new tab
+      YasqeSteps.getControlBar().should('be.visible');
+    });
+  });
 });

--- a/cypress/e2e/yasr/plugins/charts/configure-charts.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/charts/configure-charts.spec.cy.ts
@@ -32,6 +32,7 @@ describe('Plugin: Charts', () => {
 
   it('Should render results in a datatable by default', () => {
     // When I open the yasr charts tab
+    YasqeSteps.executeQuery();
     YasrSteps.openChartsTab();
     // Then I should not see results
     YasrSteps.getRawResults().should('be.empty');
@@ -47,6 +48,7 @@ describe('Plugin: Charts', () => {
   });
 
   it('Should be able to configure a chart', () => {
+    YasqeSteps.executeQuery();
     configurePieChart();
     // Then I expect to see the pie chart rendered in the results
     YasrSteps.getGoogleChartVisualization().should('be.visible');
@@ -57,6 +59,7 @@ describe('Plugin: Charts', () => {
   });
 
   it('Should persist chart data and configuration', () => {
+    YasqeSteps.executeQuery();
     // Given I have configured a pie chart
     configurePieChart();
     // When I switch to another renderer

--- a/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/raw/plugin-raw-response.spec.cy.ts
@@ -17,11 +17,11 @@ describe('Plugin: Raw response', () => {
       openMode: 0
     }
   }, () => {
-    // When I open the raw response tab
-    YasrSteps.openRawResponseTab();
-    YasrSteps.getRawResults().should('not.be.visible');
+    // Given I have opened the page
     // And I run a query
     YasqeSteps.executeQuery();
+    // When I open the raw response tab
+    YasrSteps.openRawResponseTab();
     // Then I expect to see the raw JSON response
     YasrSteps.getRawResults().should('be.visible');
     YasrSteps.getShowAllRawResponseButton().should('be.visible');
@@ -37,11 +37,12 @@ describe('Plugin: Raw response', () => {
   });
 
   it('should be able to download response in two formats', () => {
+    // Given I have opened the page
+    // And I executed a query which returns results.
+    YasqeSteps.executeQuery();
     // When I open the raw response tab
     YasrSteps.openRawResponseTab();
-    // When execute a query which returns results.
-    YasqeSteps.executeQuery();
-    // And dropdown is opened.
+    // And I open the download as dropdown.
     DownloadAsPageSteps.openDownloadAsDropdown();
     // Then I expect to have only one option
     DownloadAsPageSteps.getDownloadAsOptions().should('have.length', 2);

--- a/cypress/steps/pages/public-api-page-steps.ts
+++ b/cypress/steps/pages/public-api-page-steps.ts
@@ -54,4 +54,8 @@ export class PublicApiPageSteps {
   static switchToYasrMode() {
     cy.get('#switchToYasrMode').click();
   }
+
+  static resetResults() {
+    cy.get('#resetResults').click();
+  }
 }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -32,6 +32,10 @@ export namespace Components {
          */
         "message": string;
         /**
+          * Configures if the close button in the alert should be displayed or not. Default is <code>false</code>
+         */
+        "noButton": boolean;
+        /**
           * Configures if the icon in the alert should be displayed or not. Default is <code>true</code>
          */
         "noIcon": boolean;
@@ -186,6 +190,11 @@ export namespace Components {
           * @param renderingMode - specifies the new view mode of the component when the query is executed.
          */
         "query": (renderingMode?: RenderingMode) => Promise<any>;
+        /**
+          * Clears the results of the query.
+          * @param refreshYasr - if true, the YASR component will be refreshed.
+         */
+        "resetResults": (refreshYasr: boolean) => Promise<any>;
         /**
           * A configuration model related with all the saved queries actions.
          */
@@ -413,6 +422,10 @@ declare namespace LocalJSX {
           * The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed.
          */
         "message"?: string;
+        /**
+          * Configures if the close button in the alert should be displayed or not. Default is <code>false</code>
+         */
+        "noButton"?: boolean;
         /**
           * Configures if the icon in the alert should be displayed or not. Default is <code>true</code>
          */

--- a/ontotext-yasgui-web-component/src/components/alert-box/alert-box.tsx
+++ b/ontotext-yasgui-web-component/src/components/alert-box/alert-box.tsx
@@ -29,6 +29,12 @@ export class AlertBox {
    */
   @Prop() noIcon = true;
 
+/**
+   * Configures if the close button in the alert should be displayed or not.
+   * Default is <code>false</code>
+   */
+  @Prop() noButton = false;
+
   /**
    * Controls the visibility of the alert.
    * Default is <code>true</code>
@@ -45,7 +51,7 @@ export class AlertBox {
     return (
       <Host>
         {this.isVisible && <div class={classList}>
-          <a class="close-button" onClick={(evt) => this.onClose(evt)}>&times;</a>
+          {!this.noButton && <a class="close-button" onClick={(evt) => this.onClose(evt)}>&times;</a>}
           <div class="message">{this.message}</div>
         </div>}
       </Host>);

--- a/ontotext-yasgui-web-component/src/components/alert-box/readme.md
+++ b/ontotext-yasgui-web-component/src/components/alert-box/readme.md
@@ -11,11 +11,12 @@ Implementation of dismissible alert box component which can be configured.
 
 ## Properties
 
-| Property  | Attribute | Description                                                                                                          | Type                                                     | Default     |
-| --------- | --------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------- |
-| `message` | `message` | The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed. | `string`                                                 | `undefined` |
-| `noIcon`  | `no-icon` | Configures if the icon in the alert should be displayed or not. Default is <code>true</code>                         | `boolean`                                                | `true`      |
-| `type`    | `type`    | Defines the alert type which is represented by different color, background and icon. Default is <code>"info"</code>. | `"danger" \| "help" \| "info" \| "success" \| "warning"` | `'info'`    |
+| Property   | Attribute   | Description                                                                                                          | Type                                                     | Default     |
+| ---------- | ----------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ----------- |
+| `message`  | `message`   | The message which should be displayed in the alert. If the message is not provided, then the alert is not displayed. | `string`                                                 | `undefined` |
+| `noButton` | `no-button` | Configures if the close button in the alert should be displayed or not. Default is <code>false</code>                | `boolean`                                                | `false`     |
+| `noIcon`   | `no-icon`   | Configures if the icon in the alert should be displayed or not. Default is <code>true</code>                         | `boolean`                                                | `true`      |
+| `type`     | `type`      | Defines the alert type which is represented by different color, background and icon. Default is <code>"info"</code>. | `"danger" \| "help" \| "info" \| "success" \| "warning"` | `'info'`    |
 
 
 ----------------------------------------------

--- a/ontotext-yasgui-web-component/src/components/loader-component/loader-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/loader-component/loader-component.tsx
@@ -92,11 +92,13 @@ export class LoaderComponent {
     return (
       <Host class='ontotext-yasgui-loader hidden'>
         <slot>
+          {!this.hidden &&
           <div class='loader-component'>
             <div innerHTML={SvgUtil.getLoaderSvgTag(this.size)}></div>
             <div>{this.message} {this.queryProgress}</div>
             <div>{this.additionalMessage}</div>
           </div>
+          }
         </slot>
       </Host>
     );

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -372,6 +372,18 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
+   * Clears the results of the query.
+   * @param refreshYasr - if true, the YASR component will be refreshed.
+   */
+  @Method()
+  resetResults(refreshYasr: boolean): Promise<any> {
+    return this.getOntotextYasgui()
+      .then((ontotextYasgui) => {
+        ontotextYasgui.resetResults(refreshYasr);
+      });
+  }
+
+  /**
    * Checks whether the query has been modified after the initialization of the YASQE editor.
    */
   @Method()

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -180,6 +180,16 @@ Type: `Promise<any>`
 
 
 
+### `resetResults(refreshYasr: boolean) => Promise<any>`
+
+Clears the results of the query.
+
+#### Returns
+
+Type: `Promise<any>`
+
+
+
 ### `setQuery(query: string) => Promise<void>`
 
 Allows the client to set a query in the current opened tab.

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -51,6 +51,7 @@
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Nothing to autocomplete yet!",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Failed fetching suggestions...",
   "yasqe.check_syntax.error.invalid_line.prefix": "This line is invalid. Expected: ",
+  "yasr.noresults.box.info": "No results from previous run. Click Run or press Ctrl/Cmd-Enter to execute the current query or update.",
   "yasr.fallback.box.info.for_more_info": "for more information.",
   "yasr.fallback.box.info.info_message": "Could not render results with the {{selectedPluginName}} plugin, the results currently are rendered with the {{selectedPluginName}} plugin.",
   "yasqe.keyboard_shortcuts.btn.label": "keyboard shortcuts",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -51,6 +51,7 @@
   "yasqe.autocomplete.notification.info.nothing_to_autocomplete": "Rien à autocompléter encore !",
   "yasqe.autocomplete.notification.error.failed_fetching_suggestions": "Échec de la récupération des suggestions...",
   "yasqe.check_syntax.error.invalid_line.prefix": "Cette ligne n'est pas valide. Attendu: ",
+  "yasr.noresults.box.info": "Aucun résultat de l'exécution précédente. Cliquez sur Exécuter ou appuyez sur Ctrl/Cmd-Enter pour exécuter la requête ou la mise à jour en cours.",
   "yasr.fallback.box.info.for_more_info": "pour plus d'informations.",
   "yasr.fallback.box.info.info_message": "Impossible de rendre les résultats avec le plugin {{selectedPluginName}}, les résultats sont actuellement rendus avec le plugin {{selectedPluginName}}.",
   "yasqe.keyboard_shortcuts.btn.label": "raccourcis clavier",

--- a/ontotext-yasgui-web-component/src/index.html
+++ b/ontotext-yasgui-web-component/src/index.html
@@ -11,6 +11,7 @@
   </head>
   <body>|
   <a href="/pages/default-view">default-view</a> |
+  <a href="/pages/public-api">public-api</a> |
   <a href="/pages/actions">actions</a> |
   <a href="/pages/languages">languages</a> |
   <a href="/pages/multiple-instances">multiple-instances</a> |

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -65,9 +65,10 @@ export interface ExternalYasguiConfiguration {
 
   /**
    * The sparql endpoint which will be used when a query request is made.
-   * It is important to note that if the endpoint configuration is passed as string, it will be persisted when first time initializes
-   * the instance with specific {@link ExternalYasguiConfiguration#componentId}. Subsequent query executions will
-   * use the endpoint stored in the persistence regardless if the configuration is changed. If the endpoint is defined as a function, it will be called before each query execution.
+   * It is important to note that if the endpoint configuration is passed as string, it will be persisted when first
+   * time initializes the instance with specific {@link ExternalYasguiConfiguration#componentId}. Subsequent query
+   * executions will use the endpoint stored in the persistence regardless if the configuration is changed. If the
+   * endpoint is defined as a function, it will be called before each query execution.
    */
   // @ts-ignore
   endpoint: string | ((yasgui: Yasgui) => string);
@@ -79,7 +80,8 @@ export interface ExternalYasguiConfiguration {
 
   /**
    * Key -> value translations as JSON. If the language is supported, then not needed to pass all label values.
-   * If pass a new language then all label's values have to be present, otherwise they will be translated to the default English language.
+   * If pass a new language then all label's values have to be present, otherwise they will be translated to the default
+   * English language.
    * Example:
    * {
    *   en: {
@@ -140,9 +142,9 @@ export interface ExternalYasguiConfiguration {
    * 4. request configuration: endpoint, headers, method and so on;
    * 5. opened tabs;
    * 5. which tab is active.
-   * The <code>componentId</code> configuration options defines uniqueness of this persistent state. Passed value will be used to generate
-   * the key which will be used into browser local store. For example if value is "123" then the key will be "yasgui__123".
-   * Default value is "ontotext-yasgui-config".
+   * The <code>componentId</code> configuration options defines uniqueness of this persistent state. Passed value will
+   * be used to generate the key which will be used into browser local store. For example if value is "123" then the key
+   * will be "yasgui__123". Default value is "ontotext-yasgui-config".
    */
   componentId: string;
 
@@ -221,8 +223,8 @@ export interface ExternalYasguiConfiguration {
   pluginOrder: string[]
 
   /**
-   * Map with configuration of given plugin. The key of map is the name of a plugin. The value is any object which fields are supported by
-   * the plugin configuration.
+   * Map with configuration of given plugin. The key of map is the name of a plugin. The value is any object which
+   * fields are supported by the plugin configuration.
    */
   pluginsConfigurations: Map<string, any>;
 
@@ -237,12 +239,14 @@ export interface ExternalYasguiConfiguration {
   paginationOn: boolean;
 
   /**
-   * A flag that controls creation of "Download as" dropdown. When false, the dropdown will not be created. Default value is true.
+   * A flag that controls creation of "Download as" dropdown. When false, the dropdown will not be created.
+   * Default value is true.
    */
   downloadAsOn: boolean;
 
   /**
-   * Maximum length of response which will be persisted. If response is bigger it will not be persisted in browser local store.
+   * Maximum length of response which will be persisted. If response is bigger it will not be persisted in browser local
+   * store.
    * Default value is 100000.
    */
   maxPersistentResponseSize: number;
@@ -259,19 +263,21 @@ export interface ExternalYasguiConfiguration {
   isVirtualRepository?: boolean;
 
   /**
-   * This function will be called before the update query be executed. The client can abort execution of query for some reason and can
-   * provide a message or label key for the reason of aborting.
+   * This function will be called before the update query be executed. The client can abort execution of query for some
+   * reason and can provide a message or label key for the reason of aborting.
    */
   beforeUpdateQuery?: (query: string, tabId: string) => Promise<BeforeUpdateQueryResult>,
 
   /**
-   * This function will be called before and after execution of an update query. Depends on results a corresponding result message info will be generated.
+   * This function will be called before and after execution of an update query. Depends on results a corresponding
+   * result message info will be generated.
    */
   getRepositoryStatementsCount?: () => Promise<number>,
 
   /**
-   * If this function is present, then an "Abort query" button wil be displayed when a query is running. If the  button is clicked then
-   * this function will be invoked after the abort operation was triggered. The button will be visible until "ontotext-yasgui-web-component" client resolve returned promise.
+   * If this function is present, then an "Abort query" button wil be displayed when a query is running. If the  button
+   * is clicked then this function will be invoked after the abort operation was triggered. The button will be visible
+   * until "ontotext-yasgui-web-component" client resolve returned promise.
    * @param req - the running request.
    */
   onQueryAborted?: (req) => Promise<void>;

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -68,6 +68,23 @@ export class OntotextYasgui {
     this.yasgui.getTab().getYasqe().abortQuery();
   }
 
+  /**
+   * Removes the sparql results from the in-memory persistence json object. Then it emits a tab change event to apply
+   * the changes in the storage.
+   * @param refreshYasr If true, the yasr will be refreshed.
+   */
+  resetResults(refreshYasr = false): void {
+    Object.values(this.yasgui.persistentConfig?.persistedJson?.tabConfig).forEach((tab: any) => {
+      tab.yasr.response = null
+    });
+    Object.values(this.yasgui._tabs).forEach((tab: any) => {
+      this.yasgui.emitTabChange(tab);
+    });
+    if (refreshYasr) {
+      this.yasgui.getTab().getYasr().refresh();
+    }
+  }
+
   getQuery(): string {
     return this.yasgui.getTab().getYasqe().getValue();
   }

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasgui.ts
@@ -1,13 +1,14 @@
 import {Tab} from './tab';
 
 export class Yasgui {
+  persistentConfig: any;
+  _tabs: Tab[];
+
   getTab: (tabId?: string) => Tab;
   getTabByNameAndQuery: (queryName: string, query: string) => Tab;
   selectTabId: (tabId: string) => void;
-
   addTab: (setActive: boolean, partialTabConfig?: any, opts?: any) => Tab;
-
   destroy: () => void;
-
   on: (event, handler) => void;
+  emitTabChange: (tab: Tab) => void;
 }

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasr.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasr.ts
@@ -8,6 +8,7 @@ import {Yasqe} from './yasqe';
 export interface Yasr {
 
   yasqe: Yasqe;
+  storage: any;
 
   persistentJson: {
     yasr: {
@@ -48,4 +49,5 @@ export interface Yasr {
 
   showWarning: (message: string) => void;
   hideWarning: () => void;
+  refresh: () => void;
 }

--- a/ontotext-yasgui-web-component/src/pages/public-api/index.html
+++ b/ontotext-yasgui-web-component/src/pages/public-api/index.html
@@ -25,6 +25,7 @@
   <button id="switchToYasguiMode" onclick="changeRenderMode('mode-yasgui')">Switch to YASGUI Mode</button>
   <button id="switchToYasqeMode" onclick="changeRenderMode('mode-yasqe')">Switch to YASQE Mode</button>
   <button id="switchToYasrMode" onclick="changeRenderMode('mode-yasr')">Switch to YASR Mode</button>
+  <button id="resetResults" onclick="resetResults()">reset results</button>
   <hr/>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/public-api/main.js
+++ b/ontotext-yasgui-web-component/src/pages/public-api/main.js
@@ -11,3 +11,7 @@ function changeActionButtonVisibility(actionButtonName, hide) {
 function changeRenderMode(renderMode) {
   ontoElement.changeRenderMode(renderMode);
 }
+
+function resetResults() {
+  ontoElement.resetResults();
+}

--- a/yasgui-patches/2024-01-17-GDB-8643_allow_yasr_results_to_be_cleared_and_to_show_a_warning_message_when_there_are_no_results.patch
+++ b/yasgui-patches/2024-01-17-GDB-8643_allow_yasr_results_to_be_cleared_and_to_show_a_warning_message_when_there_are_no_results.patch
@@ -1,0 +1,80 @@
+Subject: [PATCH] Extend the showWarning function in yasr to allow more fine grain tuning of how exactly the warning should be configured. And make use of it during the yasr initialization when no results are present.
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision cac26677ae6d0da5ee4b8d38bc5bbcf0bf86c463)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 2f4d621de6dfaffc935002a1f724b99e32c98ad1)
+@@ -494,6 +494,7 @@
+     );
+   };
+   handleYasqeQuery = (yasqe: Yasqe, req: superagent.SuperAgentRequest) => {
++    this.yasr?.hideWarning();
+     const message = yasqe.isUpdateQuery()
+       ? this.yasgui.translationService.translate("loader.message.query.editor.executing.update")
+       : this.yasgui.translationService.translate("loader.message.query.editor.evaluating.query");
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision cac26677ae6d0da5ee4b8d38bc5bbcf0bf86c463)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision 2f4d621de6dfaffc935002a1f724b99e32c98ad1)
+@@ -456,6 +456,11 @@
+     }
+     return this._tabs[tabId];
+   }
++
++  public emitTabChange(tab: Tab) {
++    this.emit("tabChange", this, tab);
++  }
++
+   public restoreLastTab() {
+     const config = this.persistentConfig.retrieveLastClosedTab();
+     if (config) {
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision cac26677ae6d0da5ee4b8d38bc5bbcf0bf86c463)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 2f4d621de6dfaffc935002a1f724b99e32c98ad1)
+@@ -95,7 +95,7 @@
+     }
+   }
+ 
+-  public showWarning(message: string) {
++  public showWarning(message: string, type: "warning" | "error" | "success" = "warning", noButton = false) {
+     this.hideWarning();
+     if (message) {
+         const alertBoxEl = document.createElement('alert-box');
+@@ -104,7 +104,9 @@
+         // @ts-ignore
+         alertBoxEl.isVisible = true;
+         // @ts-ignore
+-        alertBoxEl.type = 'warning';
++        alertBoxEl.type = type;
++        // @ts-ignore
++        alertBoxEl.noButton = noButton;
+         this.rootEl.prepend(alertBoxEl);
+     }
+   }
+@@ -220,8 +222,13 @@
+   public draw() {
+     this.updateHelpButton();
+     this.updateResponseInfo();
++    this.hideWarning();
+     if (!this.results) {
+       this.hideLoader();
++      addClass(this.headerEl, "hidden");
++      addClass(this.resultsEl, "hidden");
++      addClass(this.fallbackInfoEl, "hidden");
++      this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
+       return;
+     }
+     this.updatePluginSelectorNames();


### PR DESCRIPTION
## What
Expose method for reseting the results rendered in yasgui.

## Why
This is needed for situations where for example as in the workbench the repository can be switched and then the results visible in the yasgui would become irrelevant.

## How
* Expose method in the yasgui component which can be used to trigger the results reset.
* Implemeneted the logic in the yasgui and yasr components where the results are removed from the persistence in memory and the tab change is triggered in order to propagate the changes to the storage.