### PR TITLE
GDB-9310: Long yasqe screen with useless buttons in SQL table configuration

### DIFF
--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -472,6 +472,7 @@ export class Yasqe extends CodeMirror {
       runButtonTooltip.setAttribute("placement", "top");
       this.queryBtn = document.createElement("button");
       runButtonTooltip.appendChild(this.queryBtn);
+      addClass(runButtonTooltip, "yasqe_tooltip_queryButton");
       this.queryBtn.innerText = this.translationService.translate("yasqe.action.run_query.btn.label");
       addClass(this.queryBtn, "yasqe_queryButton");
 

--- a/cypress/e2e/view-modes.spec.cy.ts
+++ b/cypress/e2e/view-modes.spec.cy.ts
@@ -107,4 +107,19 @@ describe('View modes', () => {
         // And the toolbar orientation button should be set to horizontal
         ToolbarPageSteps.isVerticalOrientation();
     });
+
+    it('Should execute a query and change the view depends on passed arguments', () => {
+      // When I open a page with ontotext-yasgui-web-component component on it,
+      ToolbarPageSteps.isYasguiModeSelected();
+      // And call query method of the component.
+      ViewModePageSteps.executeQueryAndGoToYasr();
+
+      // Then I expect the view mode be YASR
+      ToolbarPageSteps.isYasrModeSelected();
+
+      // When I call query method of component with param 'mode-yasgui'
+      ViewModePageSteps.switchToModeYasqe();
+
+
+    });
 })

--- a/cypress/steps/view-mode-page-steps.ts
+++ b/cypress/steps/view-mode-page-steps.ts
@@ -38,4 +38,12 @@ export class ViewModePageSteps {
     static showToolbar() {
         this.getShowToolbarButton().click();
     }
+
+    static executeQueryAndGoToYasgui() {
+      cy.get('#executeQueryAndGoToYasqui').click();
+    }
+
+    static executeQueryAndGoToYasr() {
+      cy.get('#executeQueryAndGoToYasr').click();
+    }
 }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -19,6 +19,7 @@ import { Page } from "./models/page";
 import { ExternalYasguiConfiguration, TabQueryModel } from "./models/external-yasgui-configuration";
 import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/saved-query-configuration";
 import { OutputEvent } from "./models/output-events/output-event";
+import { RenderingMode } from "./models/yasgui-configuration";
 import { YasqeButtonType } from "./models/yasqe-button-name";
 import { ShareQueryDialogConfig } from "./components/share-query-dialog/share-query-dialog";
 export namespace Components {
@@ -183,7 +184,7 @@ export namespace Components {
         /**
           * Executes the yasqe query.
          */
-        "query": () => Promise<any>;
+        "query": (renderingMode?: RenderingMode) => Promise<any>;
         /**
           * A configuration model related with all the saved queries actions.
          */

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -92,9 +92,9 @@
         }
 
         // Position the query button at the bottom right corner of the editor.
-        yasgui-tooltip:last-of-type {
-          position: absolute;
-          bottom: 32px;
+        .yasqe_tooltip_queryButton {
+          margin-top: auto;
+          margin-bottom: 32px;
         }
 
         .yasqe_queryButton {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -62,7 +62,7 @@ export class OntotextYasguiWebComponent {
   private readonly yasguiBuilder: YasguiBuilder;
   private readonly ontotextYasguiService: OntotextYasguiService;
   private readonly notificationMessageService: NotificationMessageService;
-  private viewModeAfterQuery = RenderingMode.YASGUI;
+  private defaultViewMode = RenderingMode.YASGUI;
 
   /**
    * The instance of our adapter around the actual yasgui instance.
@@ -237,13 +237,15 @@ export class OntotextYasguiWebComponent {
   }
 
   /**
-   * Executes the yasqe query.
+   * Executes the YASQE query from the currently opened tab and switches to the specified <code>renderingMode</code> when the query is executed.
+   *
+   * @param renderingMode - specifies the new view mode of the component when the query is executed.
    */
   @Method()
   query(renderingMode: RenderingMode = RenderingMode.YASGUI): Promise<any> {
     return this.getOntotextYasgui()
       .then((ontotextYasgui) => {
-        this.viewModeAfterQuery = renderingMode;
+        this.defaultViewMode = renderingMode;
         return ontotextYasgui.query();
       });
   }
@@ -589,8 +591,8 @@ export class OntotextYasguiWebComponent {
 
   @Listen('internalQueryEvent')
   onQuery(event: CustomEvent<InternalQueryEvent>): void {
-    this.changeRenderMode(this.viewModeAfterQuery);
-    this.viewModeAfterQuery = RenderingMode.YASGUI;
+    this.changeRenderMode(this.defaultViewMode);
+    this.defaultViewMode = RenderingMode.YASGUI;
     this.output.emit(toOutputEvent(event));
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -62,6 +62,7 @@ export class OntotextYasguiWebComponent {
   private readonly yasguiBuilder: YasguiBuilder;
   private readonly ontotextYasguiService: OntotextYasguiService;
   private readonly notificationMessageService: NotificationMessageService;
+  private viewModeAfterQuery = RenderingMode.YASGUI;
 
   /**
    * The instance of our adapter around the actual yasgui instance.
@@ -239,10 +240,10 @@ export class OntotextYasguiWebComponent {
    * Executes the yasqe query.
    */
   @Method()
-  query(): Promise<any> {
+  query(renderingMode: RenderingMode = RenderingMode.YASGUI): Promise<any> {
     return this.getOntotextYasgui()
       .then((ontotextYasgui) => {
-        console.log('run query', );
+        this.viewModeAfterQuery = renderingMode;
         return ontotextYasgui.query();
       });
   }
@@ -588,7 +589,8 @@ export class OntotextYasguiWebComponent {
 
   @Listen('internalQueryEvent')
   onQuery(event: CustomEvent<InternalQueryEvent>): void {
-    this.changeRenderMode(RenderingMode.YASGUI);
+    this.changeRenderMode(this.viewModeAfterQuery);
+    this.viewModeAfterQuery = RenderingMode.YASGUI;
     this.output.emit(toOutputEvent(event));
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -170,7 +170,7 @@ Type: `Promise<void>`
 
 
 
-### `query() => Promise<any>`
+### `query(renderingMode?: RenderingMode) => Promise<any>`
 
 Executes the yasqe query.
 

--- a/ontotext-yasgui-web-component/src/pages/view-modes/index.html
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/index.html
@@ -17,6 +17,8 @@
   <button id="renderHorizontal" onclick="renderOrientation('orientation-horizontal')">horizontal</button>
   <button id="hideToolbar" onclick="hideToolbar()">Hide toolbar</button>
   <button id="showToolbar" onclick="showToolbar()">Show toolbar</button>
+  <button id="executeQueryAndGoToYasgui" onclick="executeQueryAndGoToYasgui()">Execute Query And Go To Yasgui</button>
+  <button id="executeQueryAndGoToYasr" onclick="executeQueryAndGoToYasr()">Execute Query And Go To Yasr</button>
   <hr/>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/view-modes/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/main.js
@@ -33,3 +33,11 @@ function showToolbar() {
 function hideToolbar() {
   ontoElement.config = {...ontoElement.config, showToolbar: false};
 }
+
+function executeQueryAndGoToYasgui() {
+  ontoElement.query('mode-yasgui');
+}
+
+function executeQueryAndGoToYasr() {
+  ontoElement.query('mode-yasr');
+}

--- a/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
@@ -26,7 +26,6 @@ export class VisualisationUtils {
           // TODO: this 40px which are contracted by the height are taken from the workbench and
           // probably are related with the workbench footer height.
           newHeight -= 40;
-          console.log('set height', newHeight);
           codemirrorEl.style.setProperty('height', newHeight + 'px');
         }
       });


### PR DESCRIPTION
## What
- When the "Run" button is not visible the last yasqe button is on the bottom of the editor;
- When executing a query, the view mode is changed to "RenderMode.YASGUI" (both YASQE and YASR are visible).

## Why
- With implementation of [GDB-8995](https://ontotext.atlassian.net/browse/GDB-8995) we added a style to displays
the last element of yasqe to be always on the bottom of the yasqe editor with assumption that the last element is the "Run" button, but this is not right, there are scenarios;
- We implemented this functionality with [GDB-8995](https://ontotext.atlassian.net/browse/GDB-8995), because this is expected behaviour. However, there are scenarios where YASGUI needs to be switched to another view, such as the test query of WB similarity view.

## How
- Changed the style of the last YASQE button to be applied only to the "Run" query button;
- Extends the exposed method "query" with a parameter that controls the view after executing the query. The default view is "RenderMode.YASGUI" for backward compatibility.

# Additional work
Fixed:
 - [GDB-9352](https://ontotext.atlassian.net/browse/GDB-9352)