### PR TITLE
GDB-9374: We need a certain number of characters to display the tab name

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -122,7 +122,7 @@ export class OntotextEditableTextField {
    * Saves the value of text field and emits "valueChanged" event with the new value.
    */
   private save(): void {
-    const isValueChanged = this.value === this.editedValue;
+    const isValueChanged = this.value !== this.editedValue;
     this.value = this.editedValue;
     this.edit = false;
     if (isValueChanged) {

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.scss
@@ -12,6 +12,7 @@
 
 .editable-text-field-wrapper {
   display: inline-block;
+  max-width: 200px;
 
   .edit-mode-container {
     display: flex;
@@ -43,5 +44,11 @@
     cursor: pointer;
     transform: scale(1.1);
     font-weight: 800;
+  }
+
+  .preview-value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.scss
@@ -24,6 +24,11 @@
       margin: 0;
 
       .saved-query {
+        .saved-query-link{
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
         position: relative;
         display: flex;
         justify-content: space-between;

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -122,7 +122,7 @@ export class SavedQueriesPopup {
           <ul>
             {this.config.savedQueriesList.map((savedQuery) => (
               <li class="saved-query">
-                <a onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
+                <a class="saved-query-link" onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
                 <span class="saved-query-actions">
                   <button class="saved-query-action edit-saved-query icon-edit"
                           title={this.translationService.translate('yasqe.actions.saved_query_dialog.edit.button.tooltip')}


### PR DESCRIPTION
## What
 - When a tab name is displayed as it is, it may look unattractive if the name is too long;
 - When a saved query name is displayed as it is, it may look unattractive if the name is too long.

## Why
 - There is no implementation to add ellipsis to long tab names;
 - There is no implementation to add ellipsis to long saved query names.

## How
 - Added ellipsis CSS properties to the "ontotext-editable-text-field" component;
 - Added ellipsis CSS properties to the "saved-queries-popup" component.

# Additional work
## Tab name not persisted after rename

### What
When editing the tab name and refreshing the page, the tab name remains the old one instead of the new one.

### Why
Incorrect check for value changes in the "ontotext-editable-text-field" component.

### How
The check has been fixed.