### PR TITLE
Gdb 8984 fixes styling of tabs

### DIFF
--- a/Yasgui/packages/yasgui/src/extended-TabElements.ts
+++ b/Yasgui/packages/yasgui/src/extended-TabElements.ts
@@ -1,9 +1,10 @@
 import TabList, { TabListEl } from "./TabElements";
-import { addClass, removeClass } from "@triply/yasgui-utils";
+import { addClass, removeClass, TranslationService } from "@triply/yasgui-utils";
 
 class EditableTextField extends HTMLElement {
   edit? = false;
   value?: string;
+  translationService?: TranslationService;
 }
 
 const TAB_ID_PREFIX = "tab-";
@@ -37,6 +38,7 @@ export class ExtendedTabListEl extends TabListEl {
     renameElement.setAttribute("role", "tab");
     // use the id for the tabpanel which is tabId to set the actual tab id
     renameElement.id = TAB_ID_PREFIX + this.tabId;
+    renameElement.translationService = this.translationService;
     renameElement.setAttribute("aria-controls", this.tabId); // respective tabPanel id
     renameElement.addEventListener("valueChanged", this.renameElementValueChangedHandler.bind(this));
     renameElement.addEventListener("componentModeChanged", this.renameElementComponentModeChangedHandler.bind(this));

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -99,6 +99,7 @@ export namespace Components {
           * Controls the view mode of component. If true the component will be in Edit mode.
          */
         "edit": boolean;
+        "translationService": TranslationService;
         /**
           * The value of the text field.
          */
@@ -516,6 +517,7 @@ declare namespace LocalJSX {
           * The "valueChanged" event is fired when the text field value changes.
          */
         "onValueChanged"?: (event: OntotextEditableTextFieldCustomEvent<string>) => void;
+        "translationService"?: TranslationService;
         /**
           * The value of the text field.
          */

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -1,4 +1,5 @@
 import {Component, Host, h, Prop, Event, EventEmitter, Listen, Element, Watch} from '@stencil/core';
+import {TranslationService} from '../../services/translation.service';
 
 @Component({
   tag: 'ontotext-editable-text-field',
@@ -32,6 +33,8 @@ export class OntotextEditableTextField {
    * Controls the view mode of component. If true the component will be in Edit mode.
    */
   @Prop({mutable: true}) edit = false;
+
+  @Prop() translationService: TranslationService;
 
   /**
    * Handler for changing view mode of component. When this happened a componentModeChanged even will be fired.
@@ -150,8 +153,14 @@ export class OntotextEditableTextField {
               value={this.editedValue}
               onInput={(event) => this.handleValueChanged(event)}
               ref={(el) => (this.inputElement = el)}></input>
-            <button onClick={() => this.save()} class='save-btn'><span class='save-btn-label icon-tick'></span></button>
-            <button onClick={() => this.cancel()} class='cancel-btn'><span class='cancel-btn-label icon-close'></span></button>
+            <button onClick={() => this.save()} class='save-btn'
+                    title={(this.translationService ? this.translationService.translate('yasqe.tab_list.tab_rename.save.btn.label') : '')}>
+              <span class='save-btn-label icon-tick'></span>
+            </button>
+            <button onClick={() => this.cancel()} class='cancel-btn'
+                    title={(this.translationService ? this.translationService.translate('yasqe.tab_list.tab_rename.cancel.btn.label') : '')}>
+              <span class='cancel-btn-label icon-close'></span>
+            </button>
           </div>
         )}
       </Host>

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.scss
@@ -11,8 +11,8 @@
 }
 
 .editable-text-field-wrapper {
-  display: inline-block;
-  max-width: 200px;
+  display: flex;
+  align-items: center;
 
   .edit-mode-container {
     display: flex;
@@ -22,6 +22,7 @@
   .editable-text-field {
     outline-color: $color-onto-grey;
     border: 1px solid $color-onto-grey;
+    padding: 0;
   }
 
   .save-btn, .cancel-btn {
@@ -39,14 +40,20 @@
     background-color: $color-ontotext-orange-dark;
   }
 
-
-  .cancel-btn:hover .cancel-btn-label, .save-btn:hover .save-btn-label {
+  .cancel-btn:hover, .save-btn:hover {
     cursor: pointer;
-    transform: scale(1.1);
-    font-weight: 800;
   }
 
+
+  .cancel-btn:hover .cancel-btn-label, .save-btn:hover .save-btn-label {
+    transform: scale(1.2);
+    transition: transform .15s ease-out;
+  }
+
+
   .preview-value {
+    padding-top: 1px;
+    max-width: 200px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                      | Type      | Default     |
-| -------- | --------- | -------------------------------------------------------------------------------- | --------- | ----------- |
-| `edit`   | `edit`    | Controls the view mode of component. If true the component will be in Edit mode. | `boolean` | `false`     |
-| `value`  | `value`   | The value of the text field.                                                     | `string`  | `undefined` |
+| Property             | Attribute | Description                                                                      | Type                 | Default     |
+| -------------------- | --------- | -------------------------------------------------------------------------------- | -------------------- | ----------- |
+| `edit`               | `edit`    | Controls the view mode of component. If true the component will be in Edit mode. | `boolean`            | `false`     |
+| `translationService` | --        |                                                                                  | `TranslationService` | `undefined` |
+| `value`              | `value`   | The value of the text field.                                                     | `string`             | `undefined` |
 
 
 ## Events

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -184,6 +184,10 @@
         margin-top: 0.2em;
         padding: 8px;
 
+        &:hover:not(.active) {
+          border-bottom: 1px solid #dddddd;
+        }
+
         .closeTab {
           margin-left: 10px;
           display: inline-block;
@@ -193,17 +197,14 @@
           cursor: pointer;
           color: $color-ontotext-orange-dark;
 
-          .icon-close {
-            transform: scale(1.1);
+          i::before {
+            transform: scale(1.2);
+            transition: transform .15s ease-out;
           }
         }
 
         .closeTab i::before {
           display: inline-block;
-        }
-
-        .closeTab:hover i::before {
-          transform: scale(1.1);
         }
 
         .editable-text-field-wrapper:focus {
@@ -235,7 +236,8 @@
           color: $color-ontotext-orange-dark;
 
           i {
-            transform: scale(1.1);
+            transform: scale(1.2);
+            transition: transform .15s ease-out;
           }
         }
       }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -34,6 +34,8 @@
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Undo close Tab",
   "yasqe.tab_list.new_tab.query_running.warning.message": "New tabs may not be opened while query or update is running.",
   "yasqe.tab_list.new_tab.query_invalid.warning.message": "Query contains a syntax error. See the relevant line for more information.",
+  "yasqe.tab_list.tab_rename.save.btn.label": "Submit",
+  "yasqe.tab_list.tab_rename.cancel.btn.label": "Cancel",
   "yasgui.toolbar.mode_yasgui.btn.label": "Editor and results",
   "yasgui.toolbar.mode_yasqe.btn.label": "Editor only",
   "yasgui.toolbar.mode_yasr.btn.label": "Results only",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -34,6 +34,8 @@
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Annuler la fermeture de l'onglet",
   "yasqe.tab_list.new_tab.query_running.warning.message": "Il est impossible d'ouvrir de nouveaux onglets pendant l'exécution d'une requête ou d'une mise à jour.",
   "yasqe.tab_list.new_tab.query_invalid.warning.message": "La requête contient une erreur de syntaxe. Consultez la ligne concernée pour plus d'informations.",
+  "yasqe.tab_list.tab_rename.save.btn.label": "Soumettre",
+  "yasqe.tab_list.tab_rename.cancel.btn.label": "Annuler",
   "yasgui.toolbar.mode_yasgui.btn.label": "Éditeur et résultats",
   "yasgui.toolbar.mode_yasqe.btn.label": "Éditeur seulement",
   "yasgui.toolbar.mode_yasr.btn.label": "Résultats seulement",

--- a/yasgui-patches/2024-01-18-GDB-8984_added_tooltips_to_save_cancel_rename_tag_buttons.patch
+++ b/yasgui-patches/2024-01-18-GDB-8984_added_tooltips_to_save_cancel_rename_tag_buttons.patch
@@ -1,0 +1,30 @@
+Subject: [PATCH] GDB-8984: Added tooltips to save/cancel rename tag buttons.
+---
+Index: Yasgui/packages/yasgui/src/extended-TabElements.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/extended-TabElements.ts b/Yasgui/packages/yasgui/src/extended-TabElements.ts
+--- a/Yasgui/packages/yasgui/src/extended-TabElements.ts	(revision 021d9ef65ae138511856417e344b276c36248fd6)
++++ b/Yasgui/packages/yasgui/src/extended-TabElements.ts	(revision 5ebdf29dacd8f43f70eb39f99ee977e18783957e)
+@@ -1,9 +1,10 @@
+ import TabList, { TabListEl } from "./TabElements";
+-import { addClass, removeClass } from "@triply/yasgui-utils";
++import { addClass, removeClass, TranslationService } from "@triply/yasgui-utils";
+ 
+ class EditableTextField extends HTMLElement {
+   edit? = false;
+   value?: string;
++  translationService?: TranslationService;
+ }
+ 
+ const TAB_ID_PREFIX = "tab-";
+@@ -37,6 +38,7 @@
+     renameElement.setAttribute("role", "tab");
+     // use the id for the tabpanel which is tabId to set the actual tab id
+     renameElement.id = TAB_ID_PREFIX + this.tabId;
++    renameElement.translationService = this.translationService;
+     renameElement.setAttribute("aria-controls", this.tabId); // respective tabPanel id
+     renameElement.addEventListener("valueChanged", this.renameElementValueChangedHandler.bind(this));
+     renameElement.addEventListener("componentModeChanged", this.renameElementComponentModeChangedHandler.bind(this));


### PR DESCRIPTION
## What
 - When opening "ontotext-editable-text-field" in edit mode, the buttons are positioned outside its container;
 - When opening "ontotext-editable-text-field" in preview mode, the tab name and close button are not properly aligned;
 - When hovering over the "Close tab" and "Add tab" icons, they do not resemble the appearance of the old version in Workbench;
 - The cancel icon X on edit is different from the old version;
 - When opening the "ontotext-edit-text-field," everything below is pushed down;
 - Added a bottom border to inactive tabs when hovered.

## Why
 - With the fix for GDB-9374, we added max-width to the component to trigger ellipsis of the component value. However, this somehow disrupts the calculation of input width within the flex container;
 - There was improper styling;
 - The size and transition properties are not properly set compared to the old implementation;
 - Not properly set styles;
 - This is due to padding on the input element;
 - Enhances the user experience.

## How
 - Moved the max-width property to be applied only in edit mode;
 - Made the container display flex to control the alignments of its children.
 - Changed the transformation value and added transition properties to the icons;
 - Removed the font-weight. Added transform and transition to buttons on hover;
 - Removed the padding from the element;
 - Added the necessary styling for mouse hover on an inactive tab.

# Additional work
## What
Added tooltips to the save/cancel "rename tag" buttons.

## Why
Enhances the user experience.

## How
Extended the "ontotext-editable-text-field" component to support tooltips for the save/cancel buttons by adding localized titles to these buttons.
