### PR TITLE
Increase default spaces in sparql editor

### DIFF
--- a/Yasgui/packages/yasqe/src/defaults.ts
+++ b/Yasgui/packages/yasqe/src/defaults.ts
@@ -32,6 +32,7 @@ SELECT * WHERE {
     tabMode: "indent",
     lineNumbers: true,
     lineWrapping: true,
+    indentUnit: 4,
     foldGutter: {
       rangeFinder: new (<any>CodeMirror).fold.combine((<any>CodeMirror).fold.brace, (<any>CodeMirror).fold.prefix),
     },

--- a/cypress/e2e/keyboard-shortcuts.spec.cy.ts
+++ b/cypress/e2e/keyboard-shortcuts.spec.cy.ts
@@ -145,7 +145,7 @@ describe('Keyboard Shortcuts', () => {
       KeyboardShortcutSteps.clickOnAutoformatLinesShortcut();
 
       // Then I expect the query to be formatted.
-      YasqeSteps.getQuery().should('eq', 'select * where {\n  ?s ?p ?o.\n} limit 100');
+      YasqeSteps.getQuery().should('eq', 'select * where {\n    ?s ?p ?o.\n} limit 100');
     });
 
     it('should trigger "INDENT_CURRENT_LINE_MORE" action', () => {
@@ -158,7 +158,7 @@ describe('Keyboard Shortcuts', () => {
       KeyboardShortcutSteps.clickOnIndentCurrentLineMoreShortcut();
 
       // Then I expect third line to have got more indent.
-      YasqeSteps.getQuery().should('eq', 'select * where { \n?s ?p ?o. \n  } limit 100');
+      YasqeSteps.getQuery().should('eq', 'select * where { \n?s ?p ?o. \n    } limit 100');
     });
 
     it('should trigger "INDENT_CURRENT_LINE_LESS" action', () => {

--- a/cypress/stubs/constants.ts
+++ b/cypress/stubs/constants.ts
@@ -1,11 +1,11 @@
-export const DEFAULT_SPARQL_QUERY = 'select * where {\n\t?s ?p ?o .\n} limit 100';
+export const DEFAULT_SPARQL_QUERY = 'select * where {\n    ?s ?p ?o .\n} limit 100';
 
-export const DEFAULT_SPARQL_QUERY_FROM_LOG = '\n"select * where {\\n\\t?s ?p ?o .\\n} limit 100"';
+export const DEFAULT_SPARQL_QUERY_FROM_LOG = '\n"select * where {\\n    ?s ?p ?o .\\n} limit 100"';
 
-export const SAVED_QUERY_PAYLOAD = '{"queryName":"Query","query":"select * where {\\n\\t?s ?p ?o .\\n} limit 100","isPublic":false}';
-export const SAVED_QUERY2_PAYLOAD = '{"queryName":"Query two","query":"select * where {\\n\\t?s ?p ?o .\\n} limit 100","isPublic":false}';
+export const SAVED_QUERY_PAYLOAD = '{"queryName":"Query","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false}';
+export const SAVED_QUERY2_PAYLOAD = '{"queryName":"Query two","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false}';
 
-export const SHARE_QUERY_LINK = 'http://localhost:3333/pages/actions?name=Query&query=select%20*%20where%20%7B%0A%09%3Fs%20%3Fp%20%3Fo%20.%0A%7D%20limit%20100&infer=true&sameAs=true';
+export const SHARE_QUERY_LINK = 'http://localhost:3333/pages/actions?name=Query&query=select%20*%20where%20%7B%0A%20%20%20%20%3Fs%20%3Fp%20%3Fo%20.%0A%7D%20limit%20100&infer=true&sameAs=true';
 
-export const DOWNLOAD_AS_CSV_QUERY = '{"TYPE":"downloadAs","payload":{"value":"text/csv","pluginName":"extended_table","query":"select * where {\\n\\t?s ?p ?o .\\n} limit 100","infer":true,"sameAs":true}}';
-export const DOWNLOAD_AS_JSON_QUERY = '{"TYPE":"downloadAs","payload":{"value":"application/sparql-results+json","pluginName":"extended_response","query":"select * where {\\n\\t?s ?p ?o .\\n} limit 100","infer":true,"sameAs":true}}';
+export const DOWNLOAD_AS_CSV_QUERY = '{"TYPE":"downloadAs","payload":{"value":"text/csv","pluginName":"extended_table","query":"select * where {\\n ?s ?p ?o .\\n} limit 100","infer":true,"sameAs":true}}';
+export const DOWNLOAD_AS_JSON_QUERY = '{"TYPE":"downloadAs","payload":{"value":"application/sparql-results+json","pluginName":"extended_response","query":"select * where {\\n ?s ?p ?o .\\n} limit 100","infer":true,"sameAs":true}}';

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -299,7 +299,7 @@ export const defaultYasguiConfig: Record<string, any> = {
 }
 
 export const defaultYasqeConfig: Record<string, any> = {
-  query: 'select * where {\n\t?s ?p ?o .\n} limit 100',
+  query: 'select * where {\n    ?s ?p ?o .\n} limit 100',
   initialQuery: '',
   createShareableLink: null,
   yasqeActionButtons: [

--- a/yasgui-patches/2024-01-18-Increased_the_indent_spaces_in_SPARQL_editor.patch
+++ b/yasgui-patches/2024-01-18-Increased_the_indent_spaces_in_SPARQL_editor.patch
@@ -1,0 +1,18 @@
+Subject: [PATCH] Increased the indent spaces in SPARQL editor
+---
+Index: Yasgui/packages/yasqe/src/defaults.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/defaults.ts b/Yasgui/packages/yasqe/src/defaults.ts
+--- a/Yasgui/packages/yasqe/src/defaults.ts	(revision 81d0f9685ce7ba8717f9677e656db118a253557c)
++++ b/Yasgui/packages/yasqe/src/defaults.ts	(revision 68c0fb87117bfac3e94b9cfec8c41b04d8591d7e)
+@@ -32,6 +32,7 @@
+     tabMode: "indent",
+     lineNumbers: true,
+     lineWrapping: true,
++    indentUnit: 4,
+     foldGutter: {
+       rangeFinder: new (<any>CodeMirror).fold.combine((<any>CodeMirror).fold.brace, (<any>CodeMirror).fold.prefix),
+     },


### PR DESCRIPTION
Increased the indent spaces in SPARQL editor

## What
Increased the number of indent spaces.

## Why
The codeMirror instance is created without configuration for indent spaces, and the default value is 2 spaces.

## How
Added the configuration "indentUnit" with a value of 4.