### PR TITLE
GDB-9004 reposition autocomplete hint to prevent overlapping with the current line in editor

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -777,11 +777,11 @@ export class OntotextYasguiWebComponent {
 
     this.ontotextYasgui.getInstance().on('autocompletionShown', (_instance, _tab, _widget) => {
       hint.parentNode && hint.parentNode.removeChild(hint);
-      let codemirrorHints: any = document.querySelector('.CodeMirror-hints');
+      const codemirrorHints: any = document.querySelector('.CodeMirror-hints');
       const elRect = codemirrorHints.getBoundingClientRect();
       codemirrorHints.style.top = elRect.top + 14 + 'px';
       codemirrorHints.before(hint);
-      const topPosition = elRect.top;
+      const topPosition = elRect.top - 6;
       let leftPosition = elRect.right - hint.offsetWidth;
       leftPosition = leftPosition < elRect.left ? elRect.left : leftPosition - 12
       hint.style.top = `${topPosition}px`;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -779,8 +779,11 @@ export class OntotextYasguiWebComponent {
       hint.parentNode && hint.parentNode.removeChild(hint);
       const codemirrorHints: any = document.querySelector('.CodeMirror-hints');
       const elRect = codemirrorHints.getBoundingClientRect();
-      codemirrorHints.style.top = elRect.top + 14 + 'px';
-      codemirrorHints.before(hint);
+      // We don't use boundingClientRect because it is not accurate in case yasgui is two column layout and dropdown
+      // appears to have incorrect position.
+      const hintsTop = codemirrorHints.style.top.substring(0, codemirrorHints.style.top.length - 2) * 1;
+      codemirrorHints.style.top = hintsTop + 14 + 'px';
+      document.body.appendChild(hint);
       const topPosition = elRect.top - 6;
       let leftPosition = elRect.right - hint.offsetWidth;
       leftPosition = leftPosition < elRect.left ? elRect.left : leftPosition - 12

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -777,12 +777,13 @@ export class OntotextYasguiWebComponent {
 
     this.ontotextYasgui.getInstance().on('autocompletionShown', (_instance, _tab, _widget) => {
       hint.parentNode && hint.parentNode.removeChild(hint);
-      const elRect = document.querySelector('.CodeMirror-hints').getBoundingClientRect();
-      document.body.appendChild(hint);
-      const topPosition = elRect.top - 20;
+      let codemirrorHints: any = document.querySelector('.CodeMirror-hints');
+      const elRect = codemirrorHints.getBoundingClientRect();
+      codemirrorHints.style.top = elRect.top + 14 + 'px';
+      codemirrorHints.before(hint);
+      const topPosition = elRect.top;
       let leftPosition = elRect.right - hint.offsetWidth;
-      // move it additionally 40px on the right to prevent overlapping with the current cursor position
-      leftPosition = leftPosition < elRect.left ? elRect.left + 40 : leftPosition - 12
+      leftPosition = leftPosition < elRect.left ? elRect.left : leftPosition - 12
       hint.style.top = `${topPosition}px`;
       hint.style.left = `${leftPosition}px`;
     });

--- a/ontotext-yasgui-web-component/src/pages/view-modes/index.html
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/index.html
@@ -7,6 +7,7 @@
 
     <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
     <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
     <script src="./view-modes/main.js" defer></script>
   </head>
   <body>

--- a/ontotext-yasgui-web-component/src/pages/view-modes/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-modes/main.js
@@ -15,7 +15,8 @@ ontoElement.config = {
     "xml": "http://www.w3.org/XML/1998/namespace",
     "voc": "https://swapi.co/vocabulary/",
     "psys": "http://proton.semanticweb.org/protonsys#transitiveOver"
-  }
+  },
+  yasqeAutocomplete: getYasqeAutocompleter()
 };
 
 function renderMode(mode) {

--- a/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-elements-util.ts
@@ -59,7 +59,7 @@ export class HtmlElementsUtil {
     hint.style.backgroundColor = 'white';
     hint.style.position = 'absolute';
     hint.style.zIndex = '3';
-    hint.style.paddingLeft = 12 + 'px';
+    hint.style.paddingLeft = 6 + 'px';
     return hint;
   }
 }


### PR DESCRIPTION
## What
Reposition autocomplete hint to prevent overlapping with the current line in editor.

## Why
When the hint appears, in some cases it might overlap with the current line where the user types in the editor.

## How
Reposition the autocomplete dropdown and the hint element a bit below the current line.