### PR TITLE
GDB-9268 make yasgui layout modes consistent with current workbench

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -137,7 +137,7 @@ export namespace Components {
           * Changes rendering mode of component.
           * @param newRenderMode - then new render mode of component.
          */
-        "changeRenderMode": (newRenderMode: any) => Promise<void>;
+        "changeRenderMode": (newRenderMode: RenderingMode) => Promise<void>;
         /**
           * An input object property containing the yasgui configuration.
          */

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -671,6 +671,34 @@
     }
   }
 
+  &.orientation-horizontal.mode-yasqe {
+
+    .yasgui {
+
+      .tabsList {
+        display: none;
+      }
+
+      .tabPanel > div > div:nth-of-type(2) {
+        width: 100%;
+      }
+    }
+  }
+
+  &.orientation-horizontal.mode-yasr {
+
+    .yasgui {
+
+      .tabsList {
+        display: none;
+      }
+
+      .tabPanel > div > div:nth-of-type(3) {
+        width: 100%;
+      }
+    }
+  }
+
   button, button:focus {
     outline: none;
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -1,5 +1,5 @@
 import {Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch} from '@stencil/core';
-import {defaultOntotextYasguiConfig, RenderingMode} from '../../models/yasgui-configuration';
+import {defaultOntotextYasguiConfig, Orientation, RenderingMode} from '../../models/yasgui-configuration';
 import {YASGUI_MIN_SCRIPT} from '../yasgui/yasgui-script';
 import {YasguiBuilder} from '../../services/yasgui/yasgui-builder';
 import {OntotextYasgui} from '../../models/ontotext-yasgui';
@@ -215,10 +215,10 @@ export class OntotextYasguiWebComponent {
    * @param newRenderMode - then new render mode of component.
    */
   @Method()
-  changeRenderMode(newRenderMode): Promise<void> {
+  changeRenderMode(newRenderMode: RenderingMode): Promise<void> {
     return this.getOntotextYasgui()
       .then(() => {
-        VisualisationUtils.changeRenderMode(this.hostElement, newRenderMode, this.getOrientationMode());
+        VisualisationUtils.changeRenderMode(this.hostElement, newRenderMode, this.getOrientationMode() === Orientation.VERTICAL);
       });
   }
 

--- a/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
@@ -39,6 +39,12 @@ export class VisualisationUtils {
     }
   }
 
+  /**
+   * Changes the rendering mode of the yasgui component.
+   * @param hostElement
+   * @param newMode
+   * @param isVerticalOrientation
+   */
   static changeRenderMode(hostElement: HTMLElement, newMode: RenderingMode, isVerticalOrientation: boolean): void {
     VisualisationUtils.unselectAllToolbarButtons(hostElement);
     const button = HtmlElementsUtil.getRenderModeButton(hostElement, newMode);


### PR DESCRIPTION
## What
Make yasgui layout modes consistent with current workbench.

## Why
There was a bug in the change mode method which used to pass wrong parameter type for the orientation to the utility method which is used to properly configure the yasgui for different modes. Also, there weren't proper styles to expand the yasqe or yasr when they were standalone.

## How
* Fixed the parameter resolving passed by the changeMode method to the utility.
* Extended the styles with css rules to expand yasqe and yasr properly when they were standalone.