### PR TITLE
GDB-9338: When opening a saved query, there should be a very brief highlighting of the tab name in red

### DIFF
--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -18,6 +18,7 @@ import { InternalDropdownValueSelectedEvent } from "./models/internal-events/int
 import { Page } from "./models/page";
 import { ExternalYasguiConfiguration, TabQueryModel } from "./models/external-yasgui-configuration";
 import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/saved-query-configuration";
+import { Tab } from "./models/yasgui/tab";
 import { OutputEvent } from "./models/output-events/output-event";
 import { RenderingMode } from "./models/yasgui-configuration";
 import { YasqeButtonType } from "./models/yasqe-button-name";
@@ -185,7 +186,7 @@ export namespace Components {
           * Allows the client to init the editor using a query model. When the query and query name are found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and initialized using the provided query model.
           * @param queryModel The query model.
          */
-        "openTab": (queryModel: TabQueryModel) => Promise<void>;
+        "openTab": (queryModel: TabQueryModel) => Promise<Tab>;
         /**
           * Executes the YASQE query from the currently opened tab and switches to the specified <code>renderingMode</code> when the query is executed.
           * @param renderingMode - specifies the new view mode of the component when the query is executed.
@@ -576,6 +577,10 @@ declare namespace LocalJSX {
           * Event emitted when query share link gets copied in the clipboard.
          */
         "onQueryShareLinkCopied"?: (event: OntotextYasguiCustomEvent<any>) => void;
+        /**
+          * Event emitted whe a saved query is loaded into a tab.
+         */
+        "onSaveQueryOpened"?: (event: OntotextYasguiCustomEvent<Tab>) => void;
         /**
           * Event emitted when saved query share link has to be build by the client.
          */

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -18,9 +18,10 @@ import { InternalDropdownValueSelectedEvent } from "./models/internal-events/int
 import { Page } from "./models/page";
 import { ExternalYasguiConfiguration, TabQueryModel } from "./models/external-yasgui-configuration";
 import { SavedQueriesData, SavedQueryConfig, SaveQueryData, UpdateQueryData } from "./models/saved-query-configuration";
-import { Tab } from "./models/yasgui/tab";
+import { SavedQueryOpened } from "./models/output-events/saved-query-opened";
 import { OutputEvent } from "./models/output-events/output-event";
 import { RenderingMode } from "./models/yasgui-configuration";
+import { Tab } from "./models/yasgui/tab";
 import { YasqeButtonType } from "./models/yasqe-button-name";
 import { ShareQueryDialogConfig } from "./components/share-query-dialog/share-query-dialog";
 export namespace Components {
@@ -580,7 +581,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted whe a saved query is loaded into a tab.
          */
-        "onSaveQueryOpened"?: (event: OntotextYasguiCustomEvent<Tab>) => void;
+        "onSaveQueryOpened"?: (event: OntotextYasguiCustomEvent<SavedQueryOpened>) => void;
         /**
           * Event emitted when saved query share link has to be build by the client.
          */

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -29,6 +29,7 @@ import {YasrService} from '../../services/yasr/yasr-service';
 import {PivotTablePlugin} from '../../plugins/yasr/pivot-table/pivot-table-plugin';
 import {ChartsPlugin} from "../../plugins/yasr/charts/charts-plugin";
 import {Tab} from '../../models/yasgui/tab';
+import {SavedQueryOpened} from '../../models/output-events/saved-query-opened';
 
 /**
  * This is the custom web component which is adapter for the yasgui library. It allows as to
@@ -130,9 +131,9 @@ export class OntotextYasguiWebComponent {
   @Event() updateSavedQuery: EventEmitter<SaveQueryData>;
 
   /**
-   * Event emitted whe a saved query is loaded into a tab.
+   * Event emitted when a saved query is loaded into a tab.
    */
-  @Event() saveQueryOpened: EventEmitter<Tab>;
+  @Event() saveQueryOpened: EventEmitter<SavedQueryOpened>;
 
   /**
    * Event emitted when a saved query should be deleted. In result the client must perform a query
@@ -476,7 +477,7 @@ export class OntotextYasguiWebComponent {
       query: queryData.query,
       owner: undefined
     })
-      .then((tab: Tab) => this.saveQueryOpened.emit(tab));
+      .then((tab: Tab) => this.saveQueryOpened.emit(new SavedQueryOpened(tab)));
   }
 
   /**

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -45,6 +45,7 @@ yasgui can be tweaked using the values from the configuration.
 | `loadSavedQueries`     | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`       |
 | `output`               | Event emitter used to send message to the clients of component.                                                                                         | `CustomEvent<OutputEvent>`   |
 | `queryShareLinkCopied` | Event emitted when query share link gets copied in the clipboard.                                                                                       | `CustomEvent<any>`           |
+| `saveQueryOpened`      | Event emitted whe a saved query is loaded into a tab.                                                                                                   | `CustomEvent<Tab>`           |
 | `shareQuery`           | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<TabQueryModel>` |
 | `shareSavedQuery`      | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<SaveQueryData>` |
 | `updateSavedQuery`     | Event emitted when a query payload is updated and the query name is the same as the one being edited. In result the client must perform a query update. | `CustomEvent<SaveQueryData>` |
@@ -158,7 +159,7 @@ Type: `Promise<boolean>`
 
 
 
-### `openTab(queryModel: TabQueryModel) => Promise<void>`
+### `openTab(queryModel: TabQueryModel) => Promise<Tab>`
 
 Allows the client to init the editor using a query model. When the query and query name are
 found in any existing opened tab, then it'd be focused. Otherwise a new tab will be created and
@@ -166,7 +167,7 @@ initialized using the provided query model.
 
 #### Returns
 
-Type: `Promise<void>`
+Type: `Promise<Tab>`
 
 
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -38,17 +38,17 @@ yasgui can be tweaked using the values from the configuration.
 
 ## Events
 
-| Event                  | Description                                                                                                                                             | Type                         |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `createSavedQuery`     | Event emitted when saved query payload is collected and the query should be saved by the component client.                                              | `CustomEvent<SaveQueryData>` |
-| `deleteSavedQuery`     | Event emitted when a saved query should be deleted. In result the client must perform a query delete.                                                   | `CustomEvent<SaveQueryData>` |
-| `loadSavedQueries`     | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`       |
-| `output`               | Event emitter used to send message to the clients of component.                                                                                         | `CustomEvent<OutputEvent>`   |
-| `queryShareLinkCopied` | Event emitted when query share link gets copied in the clipboard.                                                                                       | `CustomEvent<any>`           |
-| `saveQueryOpened`      | Event emitted whe a saved query is loaded into a tab.                                                                                                   | `CustomEvent<Tab>`           |
-| `shareQuery`           | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<TabQueryModel>` |
-| `shareSavedQuery`      | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<SaveQueryData>` |
-| `updateSavedQuery`     | Event emitted when a query payload is updated and the query name is the same as the one being edited. In result the client must perform a query update. | `CustomEvent<SaveQueryData>` |
+| Event                  | Description                                                                                                                                             | Type                            |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `createSavedQuery`     | Event emitted when saved query payload is collected and the query should be saved by the component client.                                              | `CustomEvent<SaveQueryData>`    |
+| `deleteSavedQuery`     | Event emitted when a saved query should be deleted. In result the client must perform a query delete.                                                   | `CustomEvent<SaveQueryData>`    |
+| `loadSavedQueries`     | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`          |
+| `output`               | Event emitter used to send message to the clients of component.                                                                                         | `CustomEvent<OutputEvent>`      |
+| `queryShareLinkCopied` | Event emitted when query share link gets copied in the clipboard.                                                                                       | `CustomEvent<any>`              |
+| `saveQueryOpened`      | Event emitted whe a saved query is loaded into a tab.                                                                                                   | `CustomEvent<SavedQueryOpened>` |
+| `shareQuery`           | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<TabQueryModel>`    |
+| `shareSavedQuery`      | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<SaveQueryData>`    |
+| `updateSavedQuery`     | Event emitted when a query payload is updated and the query name is the same as the one being edited. In result the client must perform a query update. | `CustomEvent<SaveQueryData>`    |
 
 
 ## Methods

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -2,6 +2,7 @@ import {Yasqe} from './yasgui/yasqe';
 import {YasguiConfiguration} from './yasgui-configuration';
 import {TabQueryModel} from "./external-yasgui-configuration";
 import {Yasgui} from './yasgui/yasgui';
+import {Tab} from './yasgui/tab';
 
 /**
  * An adapter around the actual yasgui instance.
@@ -150,22 +151,24 @@ export class OntotextYasgui {
     return this.getInstance().getTab().getQuery();
   }
 
-  openTab(queryModel: TabQueryModel): void {
+  openTab(queryModel: TabQueryModel): Tab {
     const existingTab = this.getInstance().getTabByNameAndQuery(queryModel?.queryName, queryModel?.query);
     if (existingTab) {
       this.getInstance().selectTabId(existingTab.getId());
+      return existingTab;
     } else {
-      this.createNewTab(queryModel?.queryName, queryModel?.query);
+      return this.createNewTab(queryModel?.queryName, queryModel?.query);
     }
   }
 
-  createNewTab(queryName: string, query: string): void {
+  createNewTab(queryName: string, query: string): Tab {
     const tabInstance = this.getInstance().addTab(true, {
       name: queryName
     });
     if (query) {
       tabInstance.setQuery(query);
     }
+    return tabInstance;
   }
 
   destroy() {

--- a/ontotext-yasgui-web-component/src/models/output-events/output-event-types.ts
+++ b/ontotext-yasgui-web-component/src/models/output-events/output-event-types.ts
@@ -5,6 +5,7 @@ export enum OutputEventType {
   OUTPUT_DOWNLOAD_AS_EVENT = 'downloadAs',
   OUTPUT_NOTIFICATION_MESSAGE_EVENT = 'notificationMessage',
   OUTPUT_QUERY_EXECUTED = 'queryExecuted',
+  OUTPUT_SAVED_QUERY_OPENED = 'saveQueryOpened'
 }
 
 export type OutputEventTypes = `${OutputEventType}`;

--- a/ontotext-yasgui-web-component/src/models/output-events/saved-query-opened.ts
+++ b/ontotext-yasgui-web-component/src/models/output-events/saved-query-opened.ts
@@ -1,0 +1,9 @@
+import {Tab} from '../yasgui/tab';
+import {OutputEvent} from './output-event';
+import {OutputEventType} from './output-event-types';
+
+export class SavedQueryOpened extends OutputEvent {
+  constructor(tab: Tab) {
+    super(OutputEventType.OUTPUT_SAVED_QUERY_OPENED, {tab});
+  }
+}


### PR DESCRIPTION
## What
- Exposed a new event "saveQueryOpened" that returns the instance of the opened tab;
- Extended the method "openTab" to return the instance of the opened tab.

## Why
To provide clients with the opportunity to interact with the opened instance. For instance, Workbench has functionality that highlights the tab name in red when a tab is opened from saved queries.

## How
The code is modified to return the instance of the opened tab.