### PR TITLE
GDB-9414 preserve the query loader indicator while query is running

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -61,9 +61,18 @@ export class ExtendedYasr extends Yasr {
   }
 
   draw() {
+    let message = this.translationService.translate("loader.message.query.editor.render.results");
+    // If the query is running, show the loader with proper message.
+    if (this.yasqe.isQueryRunning()) {
+      message = this.yasqe.isUpdateQuery()
+        ? this.translationService.translate("loader.message.query.editor.executing.update")
+        : this.translationService.translate("loader.message.query.editor.evaluating.query");
+        this.showLoader(message, true);
+    } else {
+      this.showLoader(message);
+    }
     // The rendering of YASR is synchronous and can take time, especially when populating numerous results.
     // Setting a timeout resolves the visualization of other components without waiting for YASR to finish drawing.
-    this.showLoader(this.translationService.translate("loader.message.query.editor.render.results"));
     setTimeout(() => {
       this.updatePluginElementVisibility();
       super.draw();

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -356,7 +356,8 @@ export class Yasr extends EventEmitter {
   }
 
   hideLoader() {
-    if (!this.loader) {
+    // don't hide the loader if there is a running query
+    if (!this.loader || this.yasqe.isQueryRunning()) {
       return;
     }
     removeClass(this.headerEl, "hidden");

--- a/cypress/e2e/yasr/query-loader.spec.cy.ts
+++ b/cypress/e2e/yasr/query-loader.spec.cy.ts
@@ -1,0 +1,33 @@
+import DefaultViewPageSteps from '../../steps/default-view-page-steps';
+import {QueryStubs} from '../../stubs/query-stubs';
+import {YasqeSteps} from '../../steps/yasqe-steps';
+import {YasrSteps} from '../../steps/yasr-steps';
+import {YasguiSteps} from "../../steps/yasgui-steps";
+
+describe('Query loader', () => {
+  beforeEach(() => {
+    DefaultViewPageSteps.visit();
+    QueryStubs.stubLongRunningQuery();
+  });
+
+  it('Should show loader while query is running', () => {
+    // Given I have opened a page
+    // And I have opened another tab
+    YasguiSteps.openANewTab();
+    YasguiSteps.getTabs().should('have.length', 2);
+    // When I execute a query
+    YasqeSteps.executeQueryWithoutWaitResult(1);
+    // Then I expect the loader to be visible
+    YasrSteps.getLoader(1).should('be.visible');
+    // When I switch to the previous tab
+    YasguiSteps.openTab(0);
+    // Then I expect the loader to not be visible
+    YasrSteps.getLoader(0).should('not.be.visible');
+    // When I switch back to the tab with the running query
+    YasguiSteps.openTab(1);
+    // Then I expect the loader to be visible
+    YasrSteps.getLoader(1).should('be.visible');
+    // When the query is finished
+    YasrSteps.getTableResults(1).should('have.length', 35);
+  });
+});

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -232,4 +232,8 @@ export class YasrSteps {
   static toggleCompactView() {
     YasrSteps.getHideRowNumbersCheckbox().click();
   }
+
+  static getLoader(index?: number) {
+    return YasrSteps.getYasr(index).find('.ontotext-yasgui-loader');
+  }
 }

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -59,6 +59,10 @@ export class QueryStubs {
     }).as('updaeResponse');
   }
 
+  static stubLongRunningQuery(delay = 3000) {
+    this.stubQueryResponse('/queries/default-query-response.json', 'longRunningQuery', delay);
+  }
+
   static stubChartDataQuery() {
     cy.intercept('/repositories/chart-data', {fixture: '/queries/chart-data-response.json'}).as('chart-data-request');
   }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -579,7 +579,7 @@ declare namespace LocalJSX {
          */
         "onQueryShareLinkCopied"?: (event: OntotextYasguiCustomEvent<any>) => void;
         /**
-          * Event emitted whe a saved query is loaded into a tab.
+          * Event emitted when a saved query is loaded into a tab.
          */
         "onSaveQueryOpened"?: (event: OntotextYasguiCustomEvent<SavedQueryOpened>) => void;
         /**

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/readme.md
@@ -45,7 +45,7 @@ yasgui can be tweaked using the values from the configuration.
 | `loadSavedQueries`     | Event emitted when saved queries is expected to be loaded by the component client and provided back in order to be displayed.                           | `CustomEvent<boolean>`          |
 | `output`               | Event emitter used to send message to the clients of component.                                                                                         | `CustomEvent<OutputEvent>`      |
 | `queryShareLinkCopied` | Event emitted when query share link gets copied in the clipboard.                                                                                       | `CustomEvent<any>`              |
-| `saveQueryOpened`      | Event emitted whe a saved query is loaded into a tab.                                                                                                   | `CustomEvent<SavedQueryOpened>` |
+| `saveQueryOpened`      | Event emitted when a saved query is loaded into a tab.                                                                                                  | `CustomEvent<SavedQueryOpened>` |
 | `shareQuery`           | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<TabQueryModel>`    |
 | `shareSavedQuery`      | Event emitted when saved query share link has to be build by the client.                                                                                | `CustomEvent<SaveQueryData>`    |
 | `updateSavedQuery`     | Event emitted when a query payload is updated and the query name is the same as the one being edited. In result the client must perform a query update. | `CustomEvent<SaveQueryData>`    |
@@ -63,7 +63,7 @@ Type: `Promise<any>`
 
 
 
-### `changeRenderMode(newRenderMode: any) => Promise<void>`
+### `changeRenderMode(newRenderMode: RenderingMode) => Promise<void>`
 
 Changes rendering mode of component.
 

--- a/yasgui-patches/2024-01-22-GDB-9414_dont_hide_loader_when_query_is_running_and_show_proper_message_before_showing_it.patch
+++ b/yasgui-patches/2024-01-22-GDB-9414_dont_hide_loader_when_query_is_running_and_show_proper_message_before_showing_it.patch
@@ -1,0 +1,48 @@
+Subject: [PATCH] * Added check for running query before hiding the loader. * Added a check for running query before rendering the loader and added proper message in the loader.
+---
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision 6608a8e4d557be82c69265e6e2cb7260f3894075)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision c9d5ed5bff1b82304da8c8b9ae3cc483bc95c718)
+@@ -61,9 +61,18 @@
+   }
+ 
+   draw() {
++    let message = this.translationService.translate("loader.message.query.editor.render.results");
++    // If the query is running, show the loader with proper message.
++    if (this.yasqe.isQueryRunning()) {
++      message = this.yasqe.isUpdateQuery()
++        ? this.translationService.translate("loader.message.query.editor.executing.update")
++        : this.translationService.translate("loader.message.query.editor.evaluating.query");
++        this.showLoader(message, true);
++    } else {
++      this.showLoader(message);
++    }
+     // The rendering of YASR is synchronous and can take time, especially when populating numerous results.
+     // Setting a timeout resolves the visualization of other components without waiting for YASR to finish drawing.
+-    this.showLoader(this.translationService.translate("loader.message.query.editor.render.results"));
+     setTimeout(() => {
+       this.updatePluginElementVisibility();
+       super.draw();
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 6608a8e4d557be82c69265e6e2cb7260f3894075)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision c9d5ed5bff1b82304da8c8b9ae3cc483bc95c718)
+@@ -356,7 +356,8 @@
+   }
+ 
+   hideLoader() {
+-    if (!this.loader) {
++    // don't hide the loader if there is a running query
++    if (!this.loader || this.yasqe.isQueryRunning()) {
+       return;
+     }
+     removeClass(this.headerEl, "hidden");


### PR DESCRIPTION
## What
Preserve the query loader indicator while query is running.

## Why
* There was a case where switching the tab while the indicator was visible and then going back to the tab with the running query, then the loader wasn't rendered as expected.
* Also improved the code for showing the loader with a proper message when query was still in progress.

## How
* Added check for running query before hiding the loader.
* Added a check for running query before rendering the loader and added proper message in the loader.