### PR TITLE
Remove the restriction of opening a new tab when a query is run

### DIFF
--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -418,11 +418,6 @@ export class Yasgui extends EventEmitter {
     partialTabConfig?: Partial<PersistedTabJson>,
     opts: { atIndex?: number; avoidDuplicateTabs?: boolean } = {}
   ): Tab | undefined {
-    if (this.isQueryRunning()) {
-      const message = this.translationService.translate("yasqe.tab_list.new_tab.query_running.warning.message");
-      this.notificationMessageService.info("query_is_running", message);
-      return;
-    }
     const tabConfig = merge({}, Tab.getDefaults(this), partialTabConfig);
     if (tabConfig.id && this.getTab(tabConfig.id)) {
       throw new Error("Duplicate tab ID");

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -32,7 +32,6 @@
   "yasgui.tab_list.menu.new_tab.btn.label": "New Tab",
   "yasgui.tab_list.menu.rename_tab.btn.label": "Rename Tab",
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Undo close Tab",
-  "yasqe.tab_list.new_tab.query_running.warning.message": "New tabs may not be opened while query or update is running.",
   "yasqe.tab_list.new_tab.query_invalid.warning.message": "Query contains a syntax error. See the relevant line for more information.",
   "yasqe.tab_list.tab_rename.save.btn.label": "Submit",
   "yasqe.tab_list.tab_rename.cancel.btn.label": "Cancel",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -32,7 +32,6 @@
   "yasgui.tab_list.menu.new_tab.btn.label": "Nouvel onglet",
   "yasgui.tab_list.menu.rename_tab.btn.label": "Renommer l'onglet",
   "yasgui.tab_list.menu.undo_close_tab.btn.label": "Annuler la fermeture de l'onglet",
-  "yasqe.tab_list.new_tab.query_running.warning.message": "Il est impossible d'ouvrir de nouveaux onglets pendant l'exécution d'une requête ou d'une mise à jour.",
   "yasqe.tab_list.new_tab.query_invalid.warning.message": "La requête contient une erreur de syntaxe. Consultez la ligne concernée pour plus d'informations.",
   "yasqe.tab_list.tab_rename.save.btn.label": "Soumettre",
   "yasqe.tab_list.tab_rename.cancel.btn.label": "Annuler",

--- a/yasgui-patches/2024-01-24-Remove_the_restriction_of_opening_a_new_tab_when_a_query_is_run.patch
+++ b/yasgui-patches/2024-01-24-Remove_the_restriction_of_opening_a_new_tab_when_a_query_is_run.patch
@@ -1,0 +1,22 @@
+Subject: [PATCH] Remove the restriction of opening a new tab when a query is run
+---
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision 881478c9f5f7f7f118617f301286c9452f207458)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision dacd1feeee80eb3f46212c9fd9cd591ef9503268)
+@@ -418,11 +418,6 @@
+     partialTabConfig?: Partial<PersistedTabJson>,
+     opts: { atIndex?: number; avoidDuplicateTabs?: boolean } = {}
+   ): Tab | undefined {
+-    if (this.isQueryRunning()) {
+-      const message = this.translationService.translate("yasqe.tab_list.new_tab.query_running.warning.message");
+-      this.notificationMessageService.info("query_is_running", message);
+-      return;
+-    }
+     const tabConfig = merge({}, Tab.getDefaults(this), partialTabConfig);
+     if (tabConfig.id && this.getTab(tabConfig.id)) {
+       throw new Error("Duplicate tab ID");


### PR DESCRIPTION
## What
Removed the restriction that controlled the opening of a new tab when a query is run.

## Why
The new YASGUI has a separate instance for each tab with YASQE and YASR, allowing us to safely run concurrent queries on different tabs.

## How
The functionality that prevented the opening of a tab when a query is run has been removed.