### PR TITLE
GDB-9414 expand yasqe after query is executed when yasgui is in two column layout

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -615,6 +615,7 @@ export class OntotextYasguiWebComponent {
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {
         ontotextYasgui.leaveFullScreen();
+        VisualisationUtils.setYasqeFullHeight(this.renderingMode, VisualisationUtils.resolveOrientation(this.isVerticalOrientation));
       });
   }
 


### PR DESCRIPTION
## What
Expand yasqe after query is executed when yasgui is in two column layout.

## Why
For consistency with current workbench.

## How
Invoke the utility which calculates and sets  the yasqe height after query was run.