### PR TITLE
GDB-9277: Implement treemap render for pivottable plugin

### DIFF
--- a/ontotext-yasgui-web-component/.eslintrc.json
+++ b/ontotext-yasgui-web-component/.eslintrc.json
@@ -19,6 +19,7 @@
   ],
   "ignorePatterns": [
     "yasgui-script.js",
+    "d3_7_8_5_renders.js",
     "**/*.scss",
     "**/*.html",
     "**/*.md",

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/d3_7_8_5_renders.js
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/d3_7_8_5_renders.js
@@ -84,10 +84,11 @@ export const D3_7_8_5_RENDER = (function () {
   const register = (renderName = 'Treemap') => {
     const render = {};
     render[renderName] = treemapFunction;
-    return $.pivotUtilities.d3_7_8_3_renderers = render;
+    return $.pivotUtilities[D3_7_8_5_RENDER.RENDER_NAME] = render;
   };
 
   return {
     register,
+    RENDER_NAME: 'd3_7_8_5_renderers'
   };
 })();

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/d3_7_8_5_renders.js
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/d3_7_8_5_renders.js
@@ -1,0 +1,93 @@
+export const D3_7_8_5_RENDER = (function () {
+
+  const DEFAULTS = {
+    localeStrings: {},
+    d3: {
+      width: () => $(window).width() / 1.4,
+      height: () => $(window).height() / 1.4,
+    },
+  };
+
+  const createRenderElement = () => {
+    return $("<div>").css({
+      width: "100%",
+      height: "100%",
+    })[0];
+  }
+
+  const createTree = () => {
+    return {
+      name: "All",
+      children: [],
+    };
+  }
+
+  const addToTree = (tree, path, value) => {
+    if (path.length === 0) {
+      tree.value = value;
+      return;
+    }
+
+    if (tree.children == null) {
+      tree.children = [];
+    }
+
+    const x = path.shift();
+    const existingChild = tree.children.find((child) => child.name === x);
+
+    if (existingChild) {
+      addToTree(existingChild, path, value);
+    } else {
+      const newChild = {
+        name: x,
+      };
+      addToTree(newChild, path, value);
+      tree.children.push(newChild);
+    }
+  };
+
+  const treemapFunction = (pivotData, opts) => {
+    const tree = createTree();
+    const rowKeys = pivotData.getRowKeys();
+    rowKeys.forEach((rowKey) => {
+      const value = pivotData.getAggregator(rowKey, []).value();
+      if (value != null) {
+        addToTree(tree, rowKey, value);
+      }
+    });
+
+    opts = $.extend(true, {}, DEFAULTS, opts);
+    const treemap = d3.treemap().size([opts.d3.width(), opts.d3.height()]).padding([15, 0, 0, 0]).round(true);
+    const root = d3.hierarchy(tree).sum((d) => d.value);
+    const nodes = treemap(root).descendants();
+    const renderElement = createRenderElement();
+
+    const color = d3.scaleOrdinal(d3.schemeCategory10);
+    d3.select(renderElement)
+      .selectAll(".node")
+      .data(nodes)
+      .enter()
+      .append("div")
+      .attr("class", "node")
+      .style("background", (d) => d.children ? "lightgrey" : color(d.data.name))
+      .text((d) => d.data.name)
+      .call((n) => {
+      n.style("left", (d) => `${d.x0}px`)
+        .style("top", (d) => `${d.y0}px`)
+        .style("width", (d) => `${Math.max(0, d.x1 - d.x0 - 1)}px`)
+        .style("height", (d) => `${Math.max(0, d.y1 - d.y0 - 1)}px`);
+    });
+
+    return renderElement;
+  };
+
+  const register = (renderName = 'Treemap') => {
+    const render = {};
+    render[renderName] = treemapFunction;
+    return $.pivotUtilities.d3_7_8_3_renderers = render;
+  };
+
+  return {
+    register,
+  };
+})();

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -136,7 +136,7 @@ export class PivotTablePlugin implements YasrPlugin {
 
   private getRenders(): any {
     // @ts-ignore
-    return $.extend(true, $.pivotUtilities.renderers, $.pivotUtilities.d3_7_8_3_renderers, $.pivotUtilities.gchart_renderers, $.pivotUtilities.export_renderers);
+    return $.extend(true, $.pivotUtilities.renderers, $.pivotUtilities[D3_7_8_5_RENDER.RENDER_NAME], $.pivotUtilities.gchart_renderers, $.pivotUtilities.export_renderers);
   }
 
   private showPlugin(config: PivotTableConfig) {

--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -6,6 +6,7 @@ import {HtmlUtil} from '../../../services/utils/html-util';
 import {PivotTableDownloadUtil} from './pivot-table-download-util';
 import {PivotTableConfig, PivotTablePersistentConfig} from '../../../models/plugins/pivot-table/pivot-table-persistent-config';
 import {PivotTableRendererName} from '../../../models/plugins/pivot-table/pivot-table-renderer-name';
+import {D3_7_8_5_RENDER} from './d3_7_8_5_renders';
 
 export class PivotTablePlugin implements YasrPlugin {
 
@@ -40,9 +41,11 @@ export class PivotTablePlugin implements YasrPlugin {
       HtmlUtil.loadJavaScript('https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js');
       HtmlUtil.loadJavaScript('https://www.gstatic.com/charts/loader.js');
       HtmlUtil.loadJavaScript('https://pivottable.js.org/dist/pivot.js');
-      HtmlUtil.loadJavaScript('https://pivottable.js.org/dist/d3_renderers.js');
       HtmlUtil.loadJavaScript('https://pivottable.js.org/dist/export_renderers.js');
-      HtmlUtil.loadJavaScript('https://pivottable.js.org/dist/gchart_renderers.js', resolve);
+      HtmlUtil.loadJavaScript('https://pivottable.js.org/dist/gchart_renderers.js', () => {
+        D3_7_8_5_RENDER.register();
+        resolve();
+      });
     });
   }
 
@@ -133,7 +136,7 @@ export class PivotTablePlugin implements YasrPlugin {
 
   private getRenders(): any {
     // @ts-ignore
-    return $.extend(true, $.pivotUtilities.renderers, $.pivotUtilities.d3_renderers, $.pivotUtilities.gchart_renderers, $.pivotUtilities.export_renderers);
+    return $.extend(true, $.pivotUtilities.renderers, $.pivotUtilities.d3_7_8_3_renderers, $.pivotUtilities.gchart_renderers, $.pivotUtilities.export_renderers);
   }
 
   private showPlugin(config: PivotTableConfig) {


### PR DESCRIPTION
## What
The Treemap render for the pivot-table plugin is not working.

## Why
The implementation of the Treemap render relies on the d3 functionality. The d3 library was updated to version 7.8.5, but the render is implemented for an older version of d3, and there is no new implementation. That's why there is an error and render not working.

## How
Implemented a render that works with the new version of the d3 library.