### PR TITLE
GDB-9360_GDB-9431 fixes css issues

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -272,6 +272,8 @@
 
     /* Make the datatable horizontally scrollable when there is not enough space to fit the columns */
     .dataTables_wrapper {
+      overflow-x: auto;
+      overflow-y: hidden;
       table.dataTable {
         table-layout: fixed;
       }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -279,7 +279,7 @@
       }
 
       table.dataTable.fixedColumns {
-        tr td:not(:first-child), tr th:not(:first-child) {
+        tr td:not(.rowNumber) {
           width: 100px;
         }
       }


### PR DESCRIPTION
## What
 - When expanding some columns in the result table, the table overflows its parent container;
 - The width of the first column is not set properly when columns are not resizable and the number column is hidden.

## Why
 - The overflow properties were not set;
 - When the result table becomes unresizable, we set a fixed width for columns by CSS, excluding the first column for row numbers. However, the selector skips the first column even when the numbers column is hidden, causing the issue.

## How
 - Added the necessary overflow properties;
 - Changed the selector to now include all `<td>` elements that do not have the class "rowNumber" (this class is applied to row number `<td>` elements).