### PR TITLE
Fixes yasr issues

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -81,11 +81,39 @@ export class ExtendedTable extends Table {
       return;
     }
     const table = this.dataTable;
-    table.on( 'draw.dt', function () {
+    table.on("draw.dt", function () {
       const PageInfo = table.page.info();
-      table.column(0, { page: 'current' }).nodes().each( function (cell, i) {
-        cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
-      });
+      table
+        .column(0, { page: "current" })
+        .nodes()
+        .each(function (cell, i) {
+          cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
+        });
     });
   }
+
+  protected handleSetEllipsisToggle = (event: Event) => {
+    // Store in persistentConfig
+    this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
+    // Update the table
+    this.draw(this.persistentConfig);
+    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+  };
+
+  protected handleSetCompactToggle = (event: Event) => {
+    // Store in persistentConfig
+    this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
+    // Update the table
+    this.draw(this.persistentConfig);
+    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+  };
+
+  protected handleTableSizeSelect = (event: Event) => {
+    const pageLength = parseInt((event.target as HTMLSelectElement).value);
+    // Set page length
+    this.dataTable?.page.len(pageLength).draw("page");
+    // Store in persistentConfig
+    this.persistentConfig.pageSize = pageLength;
+    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+  };
 }

--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -2,6 +2,7 @@ import Table, { PersistentConfig } from "./index";
 import Parser from "../../parsers";
 import Yasr from "@triply/yasr";
 import Yasqe from "@triply/yasqe";
+import { addClass, removeClass } from "@triply/yasgui-utils";
 
 export class ExtendedTable extends Table {
   public label = "Extended_Table";
@@ -46,7 +47,6 @@ export class ExtendedTable extends Table {
         searchable: false,
         width: `${this.getSizeFirstColumn()}px`,
         orderable: false,
-        visible: this.persistentConfig.compact !== true,
         render: (data: number, type: any) =>
           type === "filter" || type === "sort" || !type ? data : `<div class="rowNumber">${data}</div>`,
       }, //prepend with row numbers column
@@ -92,6 +92,11 @@ export class ExtendedTable extends Table {
     });
   }
 
+  drawControls() {
+    super.drawControls();
+    this.updateTableRowNumberClasses();
+  }
+
   protected handleSetEllipsisToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
@@ -103,8 +108,7 @@ export class ExtendedTable extends Table {
   protected handleSetCompactToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
-    // Update the table
-    this.draw(this.persistentConfig);
+    this.updateTableRowNumberClasses();
     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
   };
 
@@ -116,4 +120,13 @@ export class ExtendedTable extends Table {
     this.persistentConfig.pageSize = pageLength;
     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
   };
+
+  private updateTableRowNumberClasses() {
+    const tableElement = this.getTableElement();
+    if (this.persistentConfig.compact) {
+      removeClass(tableElement, "withRowNumber");
+    } else {
+      addClass(tableElement, "withRowNumber");
+    }
+  }
 }

--- a/Yasgui/packages/yasr/src/plugins/table/index.scss
+++ b/Yasgui/packages/yasr/src/plugins/table/index.scss
@@ -64,6 +64,13 @@ Delimiters used by datatables
       padding-right: 5px !important;
     }
     .dataTable {
+      &:not(.withRowNumber) {
+        tr td:first-child,
+        tr th:first-child {
+          display: none;
+        }
+      }
+
       min-width: 100%;
       box-sizing: border-box;
       // Override border-bottom datatables styling

--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -186,6 +186,10 @@ export default class Table implements Plugin<PluginConfig> {
     return numResults.toString().length * 8;
   }
 
+  getTableElement() {
+    return this.tableEl;
+  }
+
   public draw(persistentConfig: PersistentConfig) {
     this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
     this.tableEl = document.createElement("table");
@@ -320,7 +324,7 @@ export default class Table implements Plugin<PluginConfig> {
   private handleTableSearch = (event: KeyboardEvent) => {
     this.dataTable?.search((event.target as HTMLInputElement).value).draw("page");
   };
-  private handleTableSizeSelect = (event: Event) => {
+  protected handleTableSizeSelect = (event: Event) => {
     const pageLength = parseInt((event.target as HTMLSelectElement).value);
     // Set page length
     this.dataTable?.page.len(pageLength).draw("page");
@@ -328,14 +332,14 @@ export default class Table implements Plugin<PluginConfig> {
     this.persistentConfig.pageSize = pageLength;
     this.yasr.storePluginConfig("table", this.persistentConfig);
   };
-  private handleSetCompactToggle = (event: Event) => {
+  protected handleSetCompactToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
     // Update the table
     this.draw(this.persistentConfig);
     this.yasr.storePluginConfig("table", this.persistentConfig);
   };
-  private handleSetEllipsisToggle = (event: Event) => {
+  protected handleSetEllipsisToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
     // Update the table

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -278,8 +278,14 @@
         table-layout: fixed;
       }
 
-      table.dataTable.fixedColumns {
-        tr td:not(.rowNumber) {
+      table.dataTable.fixedColumns:not(.withRowNumber) {
+        tr td, tr th {
+          width: 100px;
+        }
+      }
+
+      table.dataTable.fixedColumns.withRowNumber {
+        tr td:not(:first-child), tr th:not(:first-child) {
           width: 100px;
         }
       }

--- a/yasgui-patches/2024-01-26-рefactoring_the_hide_row_number_functionality_GDB-9449_sparql_results_checkboxes_do_not_persisted.patch
+++ b/yasgui-patches/2024-01-26-рefactoring_the_hide_row_number_functionality_GDB-9449_sparql_results_checkboxes_do_not_persisted.patch
@@ -1,0 +1,151 @@
+Subject: [PATCH] Refactoring the hide row number functionality.
+GDB-9449: Sparql results checkboxes do not persist on browser refresh
+---
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision bd13a0fd832876f392d2ae9666e5d4bc1e36376b)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision a65d3afa85271e5fe96b7c9d88c4c05e05df7b91)
+@@ -2,6 +2,7 @@
+ import Parser from "../../parsers";
+ import Yasr from "@triply/yasr";
+ import Yasqe from "@triply/yasqe";
++import { addClass, removeClass } from "@triply/yasgui-utils";
+ 
+ export class ExtendedTable extends Table {
+   public label = "Extended_Table";
+@@ -46,7 +47,6 @@
+         searchable: false,
+         width: `${this.getSizeFirstColumn()}px`,
+         orderable: false,
+-        visible: this.persistentConfig.compact !== true,
+         render: (data: number, type: any) =>
+           type === "filter" || type === "sort" || !type ? data : `<div class="rowNumber">${data}</div>`,
+       }, //prepend with row numbers column
+@@ -81,11 +81,52 @@
+       return;
+     }
+     const table = this.dataTable;
+-    table.on( 'draw.dt', function () {
++    table.on("draw.dt", function () {
+       const PageInfo = table.page.info();
+-      table.column(0, { page: 'current' }).nodes().each( function (cell, i) {
+-        cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
+-      });
++      table
++        .column(0, { page: "current" })
++        .nodes()
++        .each(function (cell, i) {
++          cell.innerHTML = `<span>${i + 1 + PageInfo.start}</span>`;
++        });
+     });
+   }
++
++  drawControls() {
++    super.drawControls();
++    this.updateTableRowNumberClasses();
++  }
++
++  protected handleSetEllipsisToggle = (event: Event) => {
++    // Store in persistentConfig
++    this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
++    // Update the table
++    this.draw(this.persistentConfig);
++    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
++  };
++
++  protected handleSetCompactToggle = (event: Event) => {
++    // Store in persistentConfig
++    this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
++    this.updateTableRowNumberClasses();
++    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
++  };
++
++  protected handleTableSizeSelect = (event: Event) => {
++    const pageLength = parseInt((event.target as HTMLSelectElement).value);
++    // Set page length
++    this.dataTable?.page.len(pageLength).draw("page");
++    // Store in persistentConfig
++    this.persistentConfig.pageSize = pageLength;
++    this.yasr.storePluginConfig("extended_table", this.persistentConfig);
++  };
++
++  private updateTableRowNumberClasses() {
++    const tableElement = this.getTableElement();
++    if (this.persistentConfig.compact) {
++      removeClass(tableElement, "withRowNumber");
++    } else {
++      addClass(tableElement, "withRowNumber");
++    }
++  }
+ }
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision bd13a0fd832876f392d2ae9666e5d4bc1e36376b)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 431b89eccc45a7bff653c176ae1851ea8cb7992c)
+@@ -186,6 +186,10 @@
+     return numResults.toString().length * 8;
+   }
+ 
++  getTableElement() {
++    return this.tableEl;
++  }
++
+   public draw(persistentConfig: PersistentConfig) {
+     this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
+     this.tableEl = document.createElement("table");
+@@ -320,7 +324,7 @@
+   private handleTableSearch = (event: KeyboardEvent) => {
+     this.dataTable?.search((event.target as HTMLInputElement).value).draw("page");
+   };
+-  private handleTableSizeSelect = (event: Event) => {
++  protected handleTableSizeSelect = (event: Event) => {
+     const pageLength = parseInt((event.target as HTMLSelectElement).value);
+     // Set page length
+     this.dataTable?.page.len(pageLength).draw("page");
+@@ -328,14 +332,14 @@
+     this.persistentConfig.pageSize = pageLength;
+     this.yasr.storePluginConfig("table", this.persistentConfig);
+   };
+-  private handleSetCompactToggle = (event: Event) => {
++  protected handleSetCompactToggle = (event: Event) => {
+     // Store in persistentConfig
+     this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
+     // Update the table
+     this.draw(this.persistentConfig);
+     this.yasr.storePluginConfig("table", this.persistentConfig);
+   };
+-  private handleSetEllipsisToggle = (event: Event) => {
++  protected handleSetEllipsisToggle = (event: Event) => {
+     // Store in persistentConfig
+     this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
+     // Update the table
+Index: Yasgui/packages/yasr/src/plugins/table/index.scss
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.scss b/Yasgui/packages/yasr/src/plugins/table/index.scss
+--- a/Yasgui/packages/yasr/src/plugins/table/index.scss	(revision 431b89eccc45a7bff653c176ae1851ea8cb7992c)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.scss	(revision a65d3afa85271e5fe96b7c9d88c4c05e05df7b91)
+@@ -64,6 +64,13 @@
+       padding-right: 5px !important;
+     }
+     .dataTable {
++      &:not(.withRowNumber) {
++        tr td:first-child,
++        tr th:first-child {
++          display: none;
++        }
++      }
++
+       min-width: 100%;
+       box-sizing: border-box;
+       // Override border-bottom datatables styling


### PR DESCRIPTION
# GDB-9449: Sparql results checkboxes do not persist on browser refresh

## What
When refreshing the SPARQL view ,the checkboxes for "Hide row numbers" and "Compact view" are reset to their default values, disregarding user changes.

## Why
The plugin configurations are persisted with a key using their plugin name. We use "extended_table" instead of "table" (the original YASGUI plugin) as it extends the table plugin. The plugin stores the configuration in "handleSetEllipsisToggle", "handleSetCompactToggle", and "handleTableSizeSelect" functions, but these are implemented in the table plugin. The issue arises as the incorrect name of the plugin "table" is passed as the first argument.

## How
Overrode the function and corrected the name argument to be the correct one, "extended_table".

# Refactoring the hide row number functionality.

## What
When selecting/deselecting the checkbox "Hide row numbers", the yasr result table is updated too slowly.

## Why
Changing the checkbox value triggers a re-render of the entire table.

## How
Modified the behavior of the checkbox value change handler. When the checkbox is unselected (indicating that row numbers should not be hidden), a class "withRowNumber" is added. When selected, the class is removed. Based on the presence of this class, we set the `display: none` property on the first column when the "withRowNumber" class is missing.