### PR TITLE
GDB-9433: When trying to delete a saved query with a long name, the name goes off the confirmation screen

### DIFF
--- a/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/confirmation-dialog/confirmation-dialog.scss
@@ -59,6 +59,7 @@
   }
 
   .dialog-body {
+    overflow-x: auto;
     padding: 15px;
   }
 


### PR DESCRIPTION
## What
When attempting to delete a saved query with a long name, the name goes off the confirmation screen

## Why
The issue occurs when the saved query name is too long and cannot be broken into a new line.

## How
Set the property `overflow-x: auto` on the dialog body.