### PR TITLE
GDB-9315: Warning Message in the Console After Clicking on Google Tab

### DIFF
--- a/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/pivot-table/pivot-table-plugin.ts
@@ -60,7 +60,7 @@ export class PivotTablePlugin implements YasrPlugin {
       this.drawPivotTable(persistentConfig);
     } else {
       // @ts-ignore
-      google.load("visualization", "1", {packages: ["corechart", "charteditor"]});
+      google.charts.load('current', {packages: ['corechart', 'charteditor']});
       // If the render is a Google chart we have to wait the module to be loaded.
       if (persistentConfig && this.isGoogleChartRender(persistentConfig.rendererName)) {
         // @ts-ignore


### PR DESCRIPTION
## What
There is a warning message when opening the "Google Chart" plugin. Scenario to Be Reproduced:
 - Refresh the page (any page will do, just not the SPARQL view with the "Google plugin" open).
 - Open the SPARQL view and execute a query if one is not already running.
 - Click on the "Pivot Table" plugin.
 - Click on the "Google Chart" plugin. The warning message "Attempting to load version 'current' of Google Charts, but the previously loaded version '1' will be used instead" should appear.

## Why
Changes have been made to how the [Google Chart library](https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code) is loaded. Both plugins use different methods for loading, leading to the appearance of the warning message.

## How
Changed the "Table Plugin" to use the new loading method.