### PR TITLE
Fixed the position of the 'Copy Link' button when a cell is collapsed.

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -450,9 +450,20 @@
       .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
       .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link {
         display: inline;
-        padding-left: 4px;
-        padding-right: 10px;
-        position: absolute;
+      }
+
+      .dataTable tbody td div.uri-cell:hover,
+      .dataTable tbody td div.triple-cell ul.triple-list li:hover,
+      .dataTable td div.triple-cell div.triple-close:hover {
+        .spacer {
+          display: none;
+        }
+      }
+
+      .dataTable td div {
+        .spacer {
+          min-width: 1em;
+        }
       }
 
       .dataTable tbody td div.triple-cell ul.triple-list li {
@@ -462,6 +473,20 @@
       .dataTable td div.triple-cell .triple-link {
         color: #770088;
         text-decoration: none;
+      }
+
+      .dataTable tr td div {
+        display: flex;
+        justify-items: end;
+        align-items: center;
+      }
+
+      .dataTable.ellipseTable tr td div:not(.expanded) {
+        width: 100%;
+        .uri-link {
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
       }
 
       .uri-link:hover {

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -74,7 +74,8 @@ export class YasrService {
     if (!context.hasElement(uri)) {
       const content = `<div class="uri-cell" lang="${this.getLang(binding, 'xx')}">` +
         `<a title="${uri}" class="uri-link" href="${this.getHref(uri, context)}">${YasrService.addWordBreakToIRIs(context.getShortUri(uri))}</a>` +
-        `<copy-resource-link-button class="resource-copy-link" uri="${uri}"></copy-resource-link-button></div>`;
+        `<copy-resource-link-button class="resource-copy-link" uri="${uri}"></copy-resource-link-button>` +
+        '<span class="spacer"></span></div>';
       context.setElement(uri, content);
     }
     return context.getElement(uri);


### PR DESCRIPTION
What
When hovering the mouse over a result cell with small width, the 'Copy Link' button was being displayed outside the cell.

Why
The button was hidden, when the table was displayed, its width was not considered in the cell width calculation.

How
A flex style is applied to the parent of the table cell elements to properly center the positioning of elements. Additionally, a span element is added after the 'Copy Link' button. The span is set with a min-width corresponding to the width of the 'Copy Link' button. When the mouse hovers over the cell, the 'Copy Link' button becomes visible, and the span invisible.