### PR TITLE
GDB-9476: Some queries with empty results squish the cells

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/index.scss
+++ b/Yasgui/packages/yasr/src/plugins/table/index.scss
@@ -65,7 +65,7 @@ Delimiters used by datatables
     }
     .dataTable {
       &:not(.withRowNumber) {
-        tr td:first-child,
+        tr td:first-child:not(.dataTables_empty),
         tr th:first-child {
           display: none;
         }

--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -224,6 +224,7 @@ export default class Table implements Plugin<PluginConfig> {
       // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
       autoWidth: false,
       language: {
+        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
         info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
         paginate: {
           first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
@@ -297,7 +298,30 @@ export default class Table implements Plugin<PluginConfig> {
       addClass(this.tableEl, "ellipseTable");
       this.setEllipsisHandlers();
     }
+
+    if (!rows || rows.length < 1) {
+      this.updateEmptyTable(this.persistentConfig);
+    }
+
     // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
+  }
+
+  protected updateEmptyTable(persistentConfig: PersistentConfig): void {
+    const element: HTMLTableCellElement | null | undefined = this.tableEl?.querySelector("td.dataTables_empty");
+    if (element) {
+      const columns = this.dataTable?.columns().count();
+      const columnCount = columns || 0;
+      element.colSpan = persistentConfig.compact ? columnCount - 1 : columnCount;
+    }
+    if (this.tableFilterField) {
+      this.tableFilterField.disabled = true;
+    }
+    if (this.tableCompactSwitch) {
+      this.tableCompactSwitch.disabled = true;
+    }
+    if (this.tableEllipseSwitch) {
+      this.tableEllipseSwitch.disabled = true;
+    }
   }
 
   private setEllipsisHandlers = () => {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -406,6 +406,10 @@
         background-image: none;
         border: 1px solid rgba(0, 0, 0, .15);
         border-radius: 0;
+
+        &.tableFilter:disabled {
+          cursor: not-allowed;
+        }
       }
 
       .tableFilter::placeholder {

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -124,6 +124,7 @@
   "yasr.plugin_control.plugin.name.charts": "Google Chart",
   "yasr.plugin_control.plugin.charts.config.button": "Chart Config",
   "yasr.plugin_control.shows_view.btn.aria_label": "Shows {{name}} view",
+  "yasr.plugin_control.table.empty_result.label": "No data available in table",
   "yasr.plugin_control.response_chip.timestamp.minutes_ago": "minutes ago",
   "yasr.plugin_control.response_chip.timestamp.moments_ago": "moments ago",
   "yasr.plugin_control.response_chip.timestamp.on_at": "on {{year}}-{{month}}-{{date}} at {{hours}}:{{minutes}}",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -124,6 +124,7 @@
   "yasr.plugin_control.plugin.name.charts": "Graphique Google",
   "yasr.plugin_control.plugin.charts.config.button": "Configuration du graphique",
   "yasr.plugin_control.shows_view.btn.aria_label": "Affiche la vue {{name}}",
+  "yasr.plugin_control.table.empty_result.label": "Aucune donnée disponible dans le tableau",
   "yasr.plugin_control.response_chip.timestamp.minutes_ago": "minutes",
   "yasr.plugin_control.response_chip.timestamp.moments_ago": "il y a quelques instants",
   "yasr.plugin_control.response_chip.timestamp.on_at": "au {{year}}-{{month}}-{{date}} à {{hours}}:{{minutes}}",

--- a/yasgui-patches/2024-02-02-GDB-9476__Some_queries_with_empty_results_squish_the_cells.patch
+++ b/yasgui-patches/2024-02-02-GDB-9476__Some_queries_with_empty_results_squish_the_cells.patch
@@ -1,0 +1,68 @@
+Subject: [PATCH] GDB-9476: Some queries with empty results squish the cells
+---
+Index: Yasgui/packages/yasr/src/plugins/table/index.scss
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.scss b/Yasgui/packages/yasr/src/plugins/table/index.scss
+--- a/Yasgui/packages/yasr/src/plugins/table/index.scss	(revision f0e81973a5f963020820ae86868951cedcd1933d)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.scss	(revision 038d71ee85d3888ca51661e3d99f1f46f4f603f1)
+@@ -65,7 +65,7 @@
+     }
+     .dataTable {
+       &:not(.withRowNumber) {
+-        tr td:first-child,
++        tr td:first-child:not(.dataTables_empty),
+         tr th:first-child {
+           display: none;
+         }
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision f0e81973a5f963020820ae86868951cedcd1933d)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 038d71ee85d3888ca51661e3d99f1f46f4f603f1)
+@@ -224,6 +224,7 @@
+       // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+       autoWidth: false,
+       language: {
++        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
+         info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
+         paginate: {
+           first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
+@@ -297,9 +298,32 @@
+       addClass(this.tableEl, "ellipseTable");
+       this.setEllipsisHandlers();
+     }
++
++    if (!rows || rows.length < 1) {
++      this.updateEmptyTable(this.persistentConfig);
++    }
++
+     // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
+   }
+ 
++  protected updateEmptyTable(persistentConfig: PersistentConfig): void {
++    const element: HTMLTableCellElement | null | undefined = this.tableEl?.querySelector("td.dataTables_empty");
++    if (element) {
++      const columns = this.dataTable?.columns().count();
++      const columnCount = columns || 0;
++      element.colSpan = persistentConfig.compact ? columnCount - 1 : columnCount;
++    }
++    if (this.tableFilterField) {
++      this.tableFilterField.disabled = true;
++    }
++    if (this.tableCompactSwitch) {
++      this.tableCompactSwitch.disabled = true;
++    }
++    if (this.tableEllipseSwitch) {
++      this.tableEllipseSwitch.disabled = true;
++    }
++  }
++
+   private setEllipsisHandlers = () => {
+     this.dataTable?.cells({ page: "current" }).every((rowIdx, colIdx) => {
+       const cell = this.dataTable?.cell(rowIdx, colIdx);


### PR DESCRIPTION
## What
This issue arises when there are no triples matching the query, leading to improper display empty row message.

## Why
The empty result message is displayed as row of datatable (jquery datatable behaviour). But the first column (row number) can be hidden and this causes the issues.

## How
Added properly colSpan property of td tab where the message is displayed.

# Additional work
Added translation of empty result label.
The "Filter search results" input and both "Compact view" and "Hide row numbers" checkboxes are disabled when there are no results.