### PR TITLE
GDB-9483 fix query explain plan styling when displayed in multiple yasgui tabs

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -31,7 +31,7 @@ export class ExtendedTable extends Table {
   public draw(persistentConfig: PersistentConfig) {
     super.draw(persistentConfig);
     this.setupIndexColumn();
-    const explainPlanQueryElement = document.getElementById("explainPlanQuery");
+    const explainPlanQueryElement = this.yasr.rootEl.querySelector("#explainPlanQuery") as HTMLElement | null;
     if (!explainPlanQueryElement) {
       return;
     }

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -214,7 +214,7 @@
   "yasqe.actions.expand_results_same_as.true.button.tooltip": "Développer les résultats sur owl:sameAs: AU",
   "yasqe.actions.expand_results_same_as.false.button.tooltip": "Développer les résultats sur owl:sameAs: DÉSACTIVÉ",
   "yasqe.actions.expand_results_same_as.disable.button.tooltip": "Nécessite 'Inclure les données inférées' !",
-  "yasqe.footer_buttons.abort_query.button.label": "Annuler la requête",
+  "yasqe.footer_buttons.abort_query.button.label": "Abandon de la requête",
   "yasqe.footer_buttons.abort_query.button.title": "Cliquez pour annuler la requête",
   "yasqe.footer_buttons.abort_query_requested.button.label": "L'arrêt a été demandé",
   "yasqe.footer_buttons.abort_query_requested.button.title": "Il a été demandé d'interrompre la requête et celle-ci sera interrompue lors de la première opération d'E/S.",


### PR DESCRIPTION
## What
Fix query explain plan styling when displayed in multiple yasgui tabs.

## Why
There was a wrong selector from the document for the explain plan html element on which the styling should be applied which in this case was always the first yasgui tab where there is one. In result the rest tabs with displayed explain plan remained unstyled.

## How
* Fixed selector for the explain plan element to be relative to current yasr.
* Also fixed a label for the abort query button.