### PR TITLE
GDB-8247 improve styling of yasr results containing long strings

### DIFF
--- a/cypress/e2e/yasr/sparql-result-formatting.spec.cy.ts
+++ b/cypress/e2e/yasr/sparql-result-formatting.spec.cy.ts
@@ -18,8 +18,6 @@ describe('Formatting of SPARQL result bindings.', () => {
     YasrSteps.getResultCellLink(0, 1).then(function($el) {
       expect($el.html()).to.eq('http://<wbr>example.com/<wbr>foobarbaz/<wbr>meow/<wbr>123');
     });
-    // and break-word is applied,
-    YasrSteps.getResultCellLink(0, 1).should('have.css', 'word-wrap', 'break-word');
     YasrSteps.getResultUriCell(0, 1).should('have.attr', 'lang', 'xx');
   });
 
@@ -28,11 +26,8 @@ describe('Formatting of SPARQL result bindings.', () => {
     QueryStubs.stubSingleLiteralWithLangTagResult();
     YasqeSteps.executeQuery();
 
-    // Then I expect break-word is applied,
-    YasrSteps.getResultNoUriCell(0, 1).should('have.css', 'word-wrap', 'break-word');
-    // language attribute is applied.
+    // Then I expect language attribute is applied.
     YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'en-GB');
-    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
   });
 
   it('should format properly result cell if result binding is literal and has not language tag', () => {
@@ -40,11 +35,8 @@ describe('Formatting of SPARQL result bindings.', () => {
     QueryStubs.stubSingleLiteralWithoutLangTagResult();
     YasqeSteps.executeQuery();
 
-    // Then I expect break-word is applied,
-    YasrSteps.getResultNoUriCell(0, 1).should('have.css', 'word-wrap', 'break-word');
-    // language attribute is applied.
+    // Then I expect language attribute is applied.
     YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'xx');
-    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
   });
 
   it('should format result cell properly if result binding is literal and contains data type value', () => {
@@ -57,10 +49,7 @@ describe('Formatting of SPARQL result bindings.', () => {
       expect($el.html()).to.eq("\"some text with data type 2.0<wbr>^^xsd:<wbr>floatsup\"");
     });
 
-    // and I expect break-word is applied,
-    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'word-wrap', 'break-word');
-    // and language attribute is applied.
+    // and I expect language attribute is applied.
     YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'xx');
-    YasrSteps.getResultLiteralCell(0, 1).should('have.css', 'hyphens', 'auto');
   });
 });

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -431,12 +431,14 @@
         // overrides yasr value of word-break property
         // import is needed because yasr selector has bigger weight ".dataTable:not(.ellipseTable) div:not(.expanded)"
         word-break: break-word !important;
-        overflow-wrap: break-word;
+        // break-word doesn't work in flex container as expected in our case
+        overflow-wrap: anywhere;
       }
 
       .literal-cell {
         word-break: normal !important;
-        overflow-wrap: break-word;
+        // break-word doesn't work in flex container as expected in our case
+        overflow-wrap: anywhere;
         -webkit-hyphens: auto;
         -moz-hyphens: auto;
         hyphens: auto;
@@ -447,6 +449,10 @@
       .dataTable tbody td div.triple-cell,
       .dataTable td div.triple-cell {
         padding-right: 10px;
+      }
+
+      .dataTable tbody td div.triple-cell ul.triple-list {
+        margin-bottom: 0;
       }
 
       /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
@@ -483,6 +489,12 @@
         display: flex;
         justify-items: end;
         align-items: center;
+      }
+
+      .dataTable tr td div.triple-cell {
+        // Override the default we set above for the triple-cell to allow rdf star triples to be displayed properly on separate lines
+        flex-direction: column;
+        align-items: start;
       }
 
       .dataTable.ellipseTable tr td div:not(.expanded) {


### PR DESCRIPTION
## What
Improve styling of yasr results containing long strings.

## Why
Appears we broke styling of results in the table cells when we applied the flexbox in order to properly show the copy uri button. This made the `overflow-wrap:break-word` ineffective because our cells had fixed width in the table and in result any long string which didn't fit overflowed the cell.

## How
* Replaced the `overflow-wrap: break-word` with `overflow-wrap: anywhere`. See a good explanation why here https://dev.to/somshekhar/overflow-wrap-in-a-flex-container-35
* Also improved styling of the rdf star triples which were also broken by the flex container.