### PR TITLE
GDB-9500 fix explain plan styling

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -485,7 +485,7 @@
         text-decoration: none;
       }
 
-      .dataTable tr td div {
+      .dataTable tr td > div {
         display: flex;
         justify-items: end;
         align-items: center;


### PR DESCRIPTION
## What
Fix explain plan styling

## Why
It was affected by incorrect css selector which used to apply flexbox on each div inside the results table cells.

## How
Fixed by narrowing the selector to match only the immediate div child inside the table cells and not the entire possible div tag hierarchy in the cell.