### PR TITLE
GDB-9480: when open rename form the tab name should be selected

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-editable-text-field/ontotext-editable-text-field.component.tsx
@@ -102,6 +102,7 @@ export class OntotextEditableTextField {
   componentDidUpdate() {
     if (this.edit && this.inputElement) {
       this.inputElement.focus();
+      this.inputElement.select();
     }
   }
 


### PR DESCRIPTION
## What
When open a tab for renaming the input field is on focus but not selected.

## Why
Whe the name is selected the user can start typing the new name instead to delete the old name.

## How
Made the input selected when rename form is opened.