### PR TITLE
GDB-9479: Different French label on button Abort query

### DIFF
--- a/Yasgui/packages/utils/src/index.ts
+++ b/Yasgui/packages/utils/src/index.ts
@@ -59,6 +59,10 @@ export function getAsValue<E, A>(valueOrFn: E | ((arg: A) => E), arg: A): E {
 }
 
 type TranslationCallback = (translation: string) => void;
+type LanguageChangeObserver = {
+  name: string;
+  notify: (language: string) => void;
+};
 
 export class TranslationService {
   private static _INSTANCE: TranslationService;
@@ -81,6 +85,10 @@ export class TranslationService {
   ) {
     translationCallback(messageLabelKey);
     return () => {};
+  }
+
+  subscribeForLanguageChange(_observer: LanguageChangeObserver): () => void {
+    return () => undefined;
   }
 }
 

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -590,24 +590,40 @@ export class Yasqe extends CodeMirror {
     }
 
     removeClass(this.abortQueryButton, "hidden");
-
-    let buttonLabel;
-
-    let buttonTooltip;
     if (this.isQueryAborted) {
-      buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.label");
-      buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.title");
       addClass(this.abortQueryButton, "disabled");
     } else {
       removeClass(this.abortQueryButton, "disabled");
+    }
+
+    this.subscriptions.push(
+      this.translationService.subscribeForLanguageChange({
+        name: "AbortButtonLanguageChangeObserver",
+        notify: this.updateAbortQueryLabels,
+      })
+    );
+
+    this.updateAbortQueryLabels();
+  }
+
+  private updateAbortQueryLabels(): void {
+    let buttonLabel, buttonTooltip;
+    if (this.isQueryAborted) {
+      buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.label");
+      buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.title");
+    } else {
       buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query.button.label");
       buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query.button.title");
     }
 
-    this.abortQueryButton.innerText = buttonLabel;
+    if (this.abortQueryButton) {
+      this.abortQueryButton.innerText = buttonLabel;
+    }
 
-    const abortQueryButtonTooltip: any = this.abortQueryButton.closest("yasgui-tooltip");
-    abortQueryButtonTooltip.dataTooltip = buttonTooltip;
+    if (this.abortQueryButton) {
+      const abortQueryButtonTooltip: any = this.abortQueryButton.closest("yasgui-tooltip");
+      abortQueryButtonTooltip.dataTooltip = buttonTooltip;
+    }
   }
 
   private initDrag() {

--- a/yasgui-patches/2024-02-12-GDB-9479_Different_French_label_on_button_Abort_query.patch
+++ b/yasgui-patches/2024-02-12-GDB-9479_Different_French_label_on_button_Abort_query.patch
@@ -6,8 +6,8 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/Yasgui/packages/utils/src/index.ts b/Yasgui/packages/utils/src/index.ts
---- a/Yasgui/packages/utils/src/index.ts	(revision 9b3f7990335f0e9434ebe477849cc168599432af)
-+++ b/Yasgui/packages/utils/src/index.ts	(revision 8625db9d495acba5d0d8408ede4b83f9b3505198)
+--- a/Yasgui/packages/utils/src/index.ts	(revision 6623469111e11ec954bc88ff6172163c2b398067)
++++ b/Yasgui/packages/utils/src/index.ts	(revision d0ed79a9d0f4a5c260e2ddd7e5a98ea2321e3365)
 @@ -59,6 +59,10 @@
  }
  
@@ -36,8 +36,8 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
---- a/Yasgui/packages/yasqe/src/index.ts	(revision 9b3f7990335f0e9434ebe477849cc168599432af)
-+++ b/Yasgui/packages/yasqe/src/index.ts	(revision 8625db9d495acba5d0d8408ede4b83f9b3505198)
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 6623469111e11ec954bc88ff6172163c2b398067)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision d0ed79a9d0f4a5c260e2ddd7e5a98ea2321e3365)
 @@ -590,24 +590,40 @@
      }
  

--- a/yasgui-patches/2024-02-12-GDB-9479_Different_French_label_on_button_Abort_query.patch
+++ b/yasgui-patches/2024-02-12-GDB-9479_Different_French_label_on_button_Abort_query.patch
@@ -1,0 +1,90 @@
+Subject: [PATCH] GDB-9479: Different French label on button Abort query
+---
+Index: Yasgui/packages/utils/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/utils/src/index.ts b/Yasgui/packages/utils/src/index.ts
+--- a/Yasgui/packages/utils/src/index.ts	(revision 9b3f7990335f0e9434ebe477849cc168599432af)
++++ b/Yasgui/packages/utils/src/index.ts	(revision 8625db9d495acba5d0d8408ede4b83f9b3505198)
+@@ -59,6 +59,10 @@
+ }
+ 
+ type TranslationCallback = (translation: string) => void;
++type LanguageChangeObserver = {
++  name: string;
++  notify: (language: string) => void;
++};
+ 
+ export class TranslationService {
+   private static _INSTANCE: TranslationService;
+@@ -82,6 +86,10 @@
+     translationCallback(messageLabelKey);
+     return () => {};
+   }
++
++  subscribeForLanguageChange(_observer: LanguageChangeObserver): () => void {
++    return () => undefined;
++  }
+ }
+ 
+ export class TimeFormattingService {
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 9b3f7990335f0e9434ebe477849cc168599432af)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 8625db9d495acba5d0d8408ede4b83f9b3505198)
+@@ -590,24 +590,40 @@
+     }
+ 
+     removeClass(this.abortQueryButton, "hidden");
+-
+-    let buttonLabel;
+-
+-    let buttonTooltip;
+     if (this.isQueryAborted) {
+-      buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.label");
+-      buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.title");
+       addClass(this.abortQueryButton, "disabled");
+     } else {
+       removeClass(this.abortQueryButton, "disabled");
++    }
++
++    this.subscriptions.push(
++      this.translationService.subscribeForLanguageChange({
++        name: "AbortButtonLanguageChangeObserver",
++        notify: this.updateAbortQueryLabels,
++      })
++    );
++
++    this.updateAbortQueryLabels();
++  }
++
++  private updateAbortQueryLabels(): void {
++    let buttonLabel, buttonTooltip;
++    if (this.isQueryAborted) {
++      buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.label");
++      buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query_requested.button.title");
++    } else {
+       buttonLabel = this.translationService.translate("yasqe.footer_buttons.abort_query.button.label");
+       buttonTooltip = this.translationService.translate("yasqe.footer_buttons.abort_query.button.title");
+     }
+ 
+-    this.abortQueryButton.innerText = buttonLabel;
++    if (this.abortQueryButton) {
++      this.abortQueryButton.innerText = buttonLabel;
++    }
+ 
+-    const abortQueryButtonTooltip: any = this.abortQueryButton.closest("yasgui-tooltip");
+-    abortQueryButtonTooltip.dataTooltip = buttonTooltip;
++    if (this.abortQueryButton) {
++      const abortQueryButtonTooltip: any = this.abortQueryButton.closest("yasgui-tooltip");
++      abortQueryButtonTooltip.dataTooltip = buttonTooltip;
++    }
+   }
+ 
+   private initDrag() {


### PR DESCRIPTION
## What
- The "Abort query" label and tooltip are not translated when the language is changed.

## Why
The labels are translated during button initialization and when the button is clicked. However, the update of labels when the language is changed was not implemented.

## How
The translation service has a new functionality that notifies registered observers when the language changes. An observer registration for the language change event has been added, and labels are updated when the event occurs.