### PR TITLE
GDB-9528: Copy link buttons for an RDF star link are not properly displayed.

### DIFF
--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -47,7 +47,7 @@ export class YasrSteps {
   }
 
   static getTriple(rowNumber: number, tripleNumber: 0 | 1 | 2, yasrIndex = 0) {
-    return this.getResultCell(rowNumber, 1, yasrIndex).find('.triple-list').find('li').eq(tripleNumber);
+    return this.getResultCell(rowNumber, 1, yasrIndex).find('.triple-list').find('.uri-cell').eq(tripleNumber);
   }
 
   static hoverTripleResource(rowNumber: number, tripleNumber: 0 | 1 | 2, yasrIndex = 0) {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -458,20 +458,50 @@
           text-overflow: ellipsis;
       }
 
-      .dataTable tbody td div.triple-cell ul.triple-list {
-        margin-bottom: 0;
-      }
-
       /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
-      .dataTable tbody td div.uri-cell:hover .resource-copy-link,
-      .dataTable tbody td div.triple-cell ul.triple-list li:hover .resource-copy-link,
-      .dataTable td div.triple-cell div.triple-close:hover .resource-copy-link {
+      .dataTable tbody td div.uri-cell:hover .resource-copy-link {
         display: inline;
       }
 
-      .dataTable tbody td div.uri-cell:hover,
-      .dataTable tbody td div.triple-cell ul.triple-list li:hover,
-      .dataTable td div.triple-cell div.triple-close:hover {
+      .dataTable tbody td div.uri-cell:hover {
+        .spacer {
+          display: none;
+        }
+      }
+
+      .dataTable tbody tr td .triple-cell {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+
+        .triple-link {
+          color: #770088;
+          text-decoration: none;
+        }
+
+        .triple-list {
+          display: flex;
+          flex-direction: column;
+
+          .uri-link {
+            padding-left: 20px;
+          }
+        }
+      }
+
+      .dataTable tbody tr td div.triple-cell div.triple-close-link,
+      .dataTable tbody tr td div.triple-cell div.triple-open-link {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+      }
+
+      .dataTable tbody tr td div.triple-cell div.triple-close-link:hover,
+      .dataTable tbody tr td div.triple-cell div.triple-open-link:hover {
+        .resource-copy-link {
+          display: inline;
+        }
+
         .spacer {
           display: none;
         }
@@ -483,25 +513,10 @@
         }
       }
 
-      .dataTable tbody td div.triple-cell ul.triple-list li {
-        list-style-type: none;
-      }
-
-      .dataTable td div.triple-cell .triple-link {
-        color: #770088;
-        text-decoration: none;
-      }
-
-      .dataTable tr td > div {
+      .dataTable tr td > div, .dataTable tbody tr td .uri-cell {
         display: flex;
         justify-items: end;
         align-items: center;
-      }
-
-      .dataTable tr td div.triple-cell {
-        // Override the default we set above for the triple-cell to allow rdf star triples to be displayed properly on separate lines
-        flex-direction: column;
-        align-items: start;
       }
 
       .uri-link:hover {
@@ -515,13 +530,6 @@
         padding: 0;
         margin: 0;
         white-space: pre-wrap;
-      }
-
-      .dataTable td div.triple-cell .triple-close:hover .resource-copy-link {
-        display: inline;
-        padding-left: 4px;
-        padding-right: 10px;
-        position: absolute;
       }
 
       .error-response-plugin {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -423,113 +423,105 @@
     }
 
     .yasr_results {
-      .resource-copy-link {
-        display: none;
-      }
-
-      .dataTable:not(.extendedTableEllipseTable) {
-        .uri-cell {
-          word-break: break-word;
-          // break-word doesn't work in flex container as expected in our case
-          overflow-wrap: anywhere;
-        }
-
-        .literal-cell .nonUri {
-          word-break: normal !important;
-          // break-word doesn't work in flex container as expected in our case
-          overflow-wrap: anywhere;
-          -webkit-hyphens: auto;
-          -moz-hyphens: auto;
-          -ms-hyphens: auto;
-          hyphens: auto;
-        }
-      }
-
-      .dataTable.extendedTableEllipseTable {
-        div:not(.expanded) {
-          // overrides yasr value of word-break property
-          word-break: normal;
-        }
-      }
-
-      .dataTable.extendedTableEllipseTable .uri-cell .uri-link,
-      .dataTable.extendedTableEllipseTable .literal-cell .nonUri {
-          overflow: hidden;
-          text-overflow: ellipsis;
-      }
-
-      /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
-      .dataTable tbody td div.uri-cell:hover .resource-copy-link {
-        display: inline;
-      }
-
-      .dataTable tbody td div.uri-cell:hover {
-        .spacer {
+      .dataTable {
+        .resource-copy-link {
           display: none;
         }
-      }
 
-      .dataTable tbody tr td .triple-cell {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
+        &:not(.extendedTableEllipseTable) {
+          .uri-cell {
+            word-break: break-word;
+            // break-word doesn't work in flex container as expected in our case
+            overflow-wrap: anywhere;
+          }
 
-        .triple-link {
-          color: #770088;
+          .literal-cell .nonUri {
+            word-break: normal !important;
+            // break-word doesn't work in flex container as expected in our case
+            overflow-wrap: anywhere;
+            -webkit-hyphens: auto;
+            -moz-hyphens: auto;
+            -ms-hyphens: auto;
+            hyphens: auto;
+          }
+        }
+
+        &.extendedTableEllipseTable {
+          div:not(.expanded) {
+            // overrides yasr value of word-break property
+            word-break: normal;
+          }
+
+          .uri-cell .uri-link,
+          .literal-cell .nonUri {
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+        }
+
+        .uri-cell .spacer {
+          min-width: 1em;
+        }
+
+        .uri-cell:hover,
+        .triple-close-link:hover,
+        .triple-open-link:hover {
+          .resource-copy-link {
+            /** Shows copy resource link when mouse is over a table row with resources of type uri or triple */
+            display: inline;
+          }
+
+          .spacer {
+            display: none;
+          }
+        }
+
+        .triple-cell {
+          display: flex;
+          flex-direction: column;
+          align-items: stretch;
+
+          .triple-link {
+            color: #770088;
+            text-decoration: none;
+          }
+
+          .triple-list {
+            display: flex;
+            flex-direction: column;
+
+            .uri-link {
+              padding-left: 20px;
+            }
+          }
+
+          .triple-close-link,
+          .triple-open-link {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+          }
+        }
+
+        tr td > div,
+        .uri-cell {
+          display: flex;
+          justify-items: end;
+          align-items: center;
+        }
+
+        .uri-link:hover {
           text-decoration: none;
         }
 
-        .triple-list {
-          display: flex;
-          flex-direction: column;
-
-          .uri-link {
-            padding-left: 20px;
-          }
+        .nonUri {
+          color: #003663;
+          border: none;
+          background-color: transparent;
+          padding: 0;
+          margin: 0;
+          white-space: pre-wrap;
         }
-      }
-
-      .dataTable tbody tr td div.triple-cell div.triple-close-link,
-      .dataTable tbody tr td div.triple-cell div.triple-open-link {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-      }
-
-      .dataTable tbody tr td div.triple-cell div.triple-close-link:hover,
-      .dataTable tbody tr td div.triple-cell div.triple-open-link:hover {
-        .resource-copy-link {
-          display: inline;
-        }
-
-        .spacer {
-          display: none;
-        }
-      }
-
-      .dataTable td div {
-        .spacer {
-          min-width: 1em;
-        }
-      }
-
-      .dataTable tr td > div, .dataTable tbody tr td .uri-cell {
-        display: flex;
-        justify-items: end;
-        align-items: center;
-      }
-
-      .uri-link:hover {
-        text-decoration: none;
-      }
-
-      .nonUri {
-        color: #003663;
-        border: none;
-        background-color: transparent;
-        padding: 0;
-        margin: 0;
-        white-space: pre-wrap;
       }
 
       .error-response-plugin {

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -74,7 +74,7 @@ export class YasrService {
     if (!context.hasElement(uri)) {
       const content = `<div class="uri-cell" lang="${this.getLang(binding, 'xx')}">` +
         `<a title="${uri}" class="uri-link" href="${this.getHref(uri, context)}">${YasrService.addWordBreakToIRIs(context.getShortUri(uri))}</a>` +
-        `<copy-resource-link-button class="resource-copy-link" uri="${uri}"></copy-resource-link-button>` +
+        `<copy-resource-link-button title="${uri}" class="resource-copy-link" uri="${uri}"></copy-resource-link-button>` +
         '<span class="spacer"></span></div>';
       context.setElement(uri, content);
     }
@@ -105,17 +105,23 @@ export class YasrService {
     const tripleLinkHref = `resource?triple=${this.replaceSingleQuote(encodeURIComponent(tripleAsString))}`;
     const tripleLinkTitle = HtmlUtil.escapeHTMLEntities(tripleAsString);
 
-    return '<div class="triple-cell">' +
-      `<a title="${tripleLinkTitle}" class="triple-link" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_LOWER}</a>` +
-      '<ul class="triple-list">' +
-      `<li>${this.toCellContent(binding.value['s'], context)}</li>` +
-      `<li>${this.toCellContent(binding.value['p'], context)}</li>` +
-      `<li>${this.toCellContent(binding.value['o'], context)}</li>` +
-      '</ul><div class="triple-close">' +
-      `<a title="${tripleLinkTitle}" class="triple-link triple-link-end" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_GREATER}</a>` +
-      `<copy-resource-link-button class="resource-copy-link" uri="${HtmlUtil.escapeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
-      '</div></div>'
-
+    return `<div class="triple-cell">` +
+              `<div class="triple-open-link">` +
+                `<a title="${tripleLinkTitle}" class="triple-link" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_LOWER}</a>` +
+                `<copy-resource-link-button title="${tripleLinkTitle}" class="resource-copy-link" uri="${HtmlUtil.escapeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
+                `<span class="spacer"></span>` +
+              `</div>` +
+              `<div class="triple-list">` +
+                `<div>${this.toCellContent(binding.value['s'], context)}</div>` +
+                `<div>${this.toCellContent(binding.value['p'], context)}</div>` +
+                `<div>${this.toCellContent(binding.value['o'], context)}</div>` +
+              `</div>` +
+              `<div class="triple-close-link">` +
+                `<a title="${tripleLinkTitle}" class="triple-link triple-link-end" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_GREATER}</a>` +
+                `<copy-resource-link-button title="${tripleLinkTitle}" class="resource-copy-link" uri="${HtmlUtil.escapeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
+                `<span class="spacer"></span>` +
+              `</div>` +
+            `</div>`;
   }
 
   private static replaceSingleQuote(text: string): string {


### PR DESCRIPTION
## What
When the column containing an RDF star link is too small, the 'Copy link' button is not properly displayed.

## Why
The rdf star link styling is not properly set.

## How
Modified the HTML of RDF star links and applied proper styling.

# Additional work
 - Added a 'Copy Link' button to 'open an RDF star' link when the link is hovered;
 - Added a tooltip (title) with the value of the hovered link to the 'Copy Link' button because when the column is small, the link is broken into many lines or is ellipsised, making it hard to understand which link will be copied.