### PR TITLE
Cherry pick from main GDB-9514 prevent closing last yasgui tab

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -150,6 +150,13 @@ export class Tab extends EventEmitter {
     this.yasgui.selectTabId(this.persistentJson.id);
   }
   public close(confirm = true) {
+    if (this.yasgui.persistentConfig.getTabs().length === 1) {
+      this.yasgui.config.notificationMessageService.error(
+        "close_last_tab_warning",
+        this.yasgui.config.translationService.translate("yasgui.tab_list.close_last_tab.warning.message")
+      );
+      return;
+    }
     const closeTab = () => {
       if (this.yasqe) this.yasqe.abortQuery();
       if (this.yasgui.getTab() === this) {

--- a/cypress/e2e/yasgui-tabs.spec.cy.ts
+++ b/cypress/e2e/yasgui-tabs.spec.cy.ts
@@ -123,6 +123,16 @@ describe('Yasgui tabs', () => {
     YasguiSteps.getTabs().should('have.length', 1);
     YasguiSteps.getCurrentTabTitle().should('have.text', 'Unnamed 2');
   });
+
+  it('Should prevent closing the last yasgui tab', () => {
+    // Given I have opened yasgui with a single opened tab
+    YasguiSteps.getTabs().should('have.length', 1);
+    // When I try closing the tab
+    YasguiSteps.closeTab(0);
+    // Then I expect the tab to remain opened
+    YasguiSteps.getTabs().should('have.length', 1);
+    DefaultViewPageSteps.getOutputField().should('have.value', 'Last tab must remain open.');
+  });
 });
 
 function openNewTab(tabIndex: number, expectedTabsCount: number) {

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -25,6 +25,7 @@
   "yasgui.tab_list.close_tab.confirmation.title": "Confirm",
   "yasgui.tab_list.close_tab.confirmation.message": "Are you sure you want to close this query tab?",
   "yasgui.tab_list.close_other_tabs.confirmation.message": "Are you sure you want to close all other query tabs?",
+  "yasgui.tab_list.close_last_tab.warning.message": "Last tab must remain open.",
   "yasgui.tab_list.tab.default.name": "Unnamed",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Close other tabs",
   "yasgui.tab_list.menu.close_tab.btn.label": "Close Tab",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -25,6 +25,7 @@
   "yasgui.tab_list.close_tab.confirmation.title": "Confirmer",
   "yasgui.tab_list.close_tab.confirmation.message": "Êtes-vous sûr de vouloir fermer cet onglet de requête?",
   "yasgui.tab_list.close_other_tabs.confirmation.message": "Are you sure you want to close all other query tabs?",
+  "yasgui.tab_list.close_last_tab.warning.message": "Le dernier onglet doit rester ouvert.",
   "yasgui.tab_list.tab.default.name": "Anonyme",
   "yasgui.tab_list.menu.close_other_tabs.btn.label": "Fermer les autres onglets",
   "yasgui.tab_list.menu.close_tab.btn.label": "Fermer l'onglet",

--- a/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
+++ b/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
@@ -35,7 +35,7 @@ function getPrefixes() {
   }
 }
 
-function setQueryListener(ontoElement) {
+function setOutputEventListener(ontoElement) {
   ontoElement.addEventListener('output', (event) => {
     if ('countQuery' === event.detail.TYPE) {
       const request = event.detail.payload.request;
@@ -47,6 +47,8 @@ function setQueryListener(ontoElement) {
       event.detail.payload.response.body.totalElements = getCount(event.detail.payload.response);
     } else if ('query' === event.detail.TYPE) {
       onQuery(event);
+    } else if ('notificationMessage' === event.detail.TYPE) {
+      document.querySelector('#output').value = event.detail.payload.message;
     }
   });
 

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -22,7 +22,7 @@ function changeLanguage(lang) {
   ontoElement.language = lang;
 }
 
-setQueryListener(ontoElement);
+setOutputEventListener(ontoElement);
 
 let textAreaElement = document.createElement('textarea');
 textAreaElement.id = 'saveQueryPayload';

--- a/ontotext-yasgui-web-component/src/pages/default-view/main.js
+++ b/ontotext-yasgui-web-component/src/pages/default-view/main.js
@@ -1,5 +1,5 @@
 let ontoElement = getOntotextYasgui();
-setQueryListener(ontoElement);
+setOutputEventListener(ontoElement);
 
 let textAreaElement = document.createElement('textarea');
 textAreaElement.id = 'output';

--- a/ontotext-yasgui-web-component/src/pages/multicolumn-results/main.js
+++ b/ontotext-yasgui-web-component/src/pages/multicolumn-results/main.js
@@ -1,5 +1,5 @@
 let ontoElement = getOntotextYasgui();
-setQueryListener(ontoElement);
+setOutputEventListener(ontoElement);
 
 ontoElement.config = {
   endpoint: () => "/repositories/multicolumn-results-repo",

--- a/ontotext-yasgui-web-component/src/pages/pagination/main.js
+++ b/ontotext-yasgui-web-component/src/pages/pagination/main.js
@@ -1,6 +1,6 @@
 let ontoElement = getOntotextYasgui();
 
-setQueryListener(ontoElement);
+setOutputEventListener(ontoElement);
 
 function changeComponentId(componentId) {
   ontoElement.config =  {...ontoElement.config, componentId};

--- a/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
+++ b/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
@@ -1,6 +1,6 @@
 const ontoElement = getOntotextYasgui('yasr-plugins');
 
-setQueryListener(ontoElement);
+setOutputEventListener(ontoElement);
 
 function attachMessageHandler() {
   ontoElement.addEventListener('output', (event) => {

--- a/yasgui-patches/2024-02-12-GDB-9514_prevent_closing_last_yasgui_tab.patch
+++ b/yasgui-patches/2024-02-12-GDB-9514_prevent_closing_last_yasgui_tab.patch
@@ -1,0 +1,24 @@
+Subject: [PATCH] GDB-9514 prevent closing last yasgui tab
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision 8ddad4d335a39853e75be30aab262e6425858e68)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 7ab9ef6809989f169de2eb60e95b9fca3602e776)
+@@ -150,6 +150,13 @@
+     this.yasgui.selectTabId(this.persistentJson.id);
+   }
+   public close(confirm = true) {
++    if (this.yasgui.persistentConfig.getTabs().length === 1) {
++      this.yasgui.config.notificationMessageService.error(
++        "close_last_tab_warning",
++        this.yasgui.config.translationService.translate("yasgui.tab_list.close_last_tab.warning.message")
++      );
++      return;
++    }
+     const closeTab = () => {
+       if (this.yasqe) this.yasqe.abortQuery();
+       if (this.yasgui.getTab() === this) {


### PR DESCRIPTION
## What
Prevent closing last yasgui tab and show notification message.

## Why
For consistency with the old yasgui.

## How
Check for existing tabs count and trigger a notification via the generic output emitter.