### PR TITLE
GDB-8247: Update results cells to not cut the long IRIs

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -428,7 +428,7 @@
           display: none;
         }
 
-        &:not(.extendedTableEllipseTable) {
+        &:not(.ellipseTable) {
           .uri-cell {
             word-break: break-word;
             // break-word doesn't work in flex container as expected in our case
@@ -446,7 +446,10 @@
           }
         }
 
-        &.extendedTableEllipseTable {
+        &.ellipseTable {
+          wbr {
+            display: none;
+          }
           div:not(.expanded) {
             // overrides yasr value of word-break property
             word-break: normal;
@@ -456,6 +459,7 @@
           .literal-cell .nonUri {
             overflow: hidden;
             text-overflow: ellipsis;
+            white-space: nowrap;
           }
         }
 


### PR DESCRIPTION
## What
When "Compact view" is enabled, long URIs and literals are split across columns.

## Why
The functionality that adds <wbr> tags after certain characters (e.g., '/', ':') causes URIs to break.

## How
The <wbr> tags are hidden when "Compact view" is enabled. Additionally, for all types of cell content, the white-space property has been set to nowrap, preventing the browser from breaking words.