### PR TITLE
Cherry-pick from master GDB-9242: Refactoring the compact view functionality.

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -1,8 +1,12 @@
-import Table, { PersistentConfig } from "./index";
+import Table, { DEFAULT_PAGE_SIZE, PersistentConfig } from "./index";
 import Parser from "../../parsers";
 import Yasr from "@triply/yasr";
 import Yasqe from "@triply/yasqe";
 import { addClass, removeClass } from "@triply/yasgui-utils";
+import { cloneDeep } from "lodash-es";
+import $ from "jquery";
+
+const ColumnResizer = require("column-resizer");
 
 export class ExtendedTable extends Table {
   public label = "Extended_Table";
@@ -29,7 +33,147 @@ export class ExtendedTable extends Table {
   }
 
   public draw(persistentConfig: PersistentConfig) {
-    super.draw(persistentConfig);
+    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
+    this.tableEl = document.createElement("table");
+    const rows = this.getRows();
+    const columns = this.getColumns();
+
+    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+      this.yasr.pluginControls;
+      addClass(this.yasr.rootEl, "isSinglePage");
+    } else {
+      removeClass(this.yasr.rootEl, "isSinglePage");
+    }
+
+    if (this.dataTable) {
+      this.destroyResizer();
+      this.removeDataTableEventHandlers(this.dataTable);
+      this.dataTable.destroy(true);
+      this.dataTable = undefined;
+    }
+    this.yasr.resultsEl.appendChild(this.tableEl);
+    // reset some default config properties as they couldn't be initialized beforehand
+    const dtConfig: DataTables.Settings = {
+      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
+      pageLength: -1,
+      data: rows,
+      columns: columns,
+      // DataTables will only render the rows that are initially visible on the page.
+      deferRender: true,
+      // // Switch off the pagination.
+      paging: false,
+      // Switched off for optimization purposes.
+      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+      autoWidth: false,
+      language: {
+        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
+        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
+        paginate: {
+          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
+          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
+          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
+          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
+        },
+      },
+    };
+    this.dataTable = $(this.tableEl).DataTable(dtConfig);
+    this.tableEl.style.removeProperty("width");
+    this.tableEl.style.width = this.tableEl.clientWidth + "px";
+
+    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+    const maxResizableResultsColumns = this.persistentConfig.compact
+      ? this.config.maxResizableResultsColumns - 1
+      : this.config.maxResizableResultsColumns;
+
+    if (columns.length <= maxResizableResultsColumns) {
+      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+      setTimeout(() => {
+        this.tableResizer = new ColumnResizer.default(this.tableEl, {
+          partialRefresh: true,
+          headerOnly: false,
+          disabledColumns: this.persistentConfig.compact ? [] : [0],
+        });
+      }, 0);
+    } else {
+      addClass(this.tableEl, "fixedColumns");
+    }
+
+    this.registerDataTableEventHandlers(this.dataTable);
+
+    this.drawControls();
+    this.updateTableEllipseClasses();
+    this.afterDraw();
+
+    if (!rows || rows.length < 1) {
+      this.updateEmptyTable(this.persistentConfig);
+    }
+  }
+
+  private registerDataTableEventHandlers(dataTable: DataTables.Api) {
+    // Both handlers are called only on sort column.
+    dataTable.on("preDraw", this.preDrawTableHandler.bind(this));
+    dataTable.on("draw", this.drawTableHandler.bind(this));
+  }
+
+  private removeDataTableEventHandlers(dataTable: DataTables.Api) {
+    // Both handlers are called only on sort column.
+    dataTable.off("preDraw", this.preDrawTableHandler.bind(this));
+    dataTable.off("draw", this.drawTableHandler.bind(this));
+  }
+
+  /**
+   * DataTables uses the rendered style to decide the widths of columns.
+   * Before a draw remove the extendedTableEllipseTable styling and disable the table resizer.
+   * @private
+   */
+  private preDrawTableHandler() {
+    if (this.persistentConfig.isEllipsed !== false) {
+      this.disableTableResizer();
+      removeClass(this.tableEl, "extendedTableEllipseTable");
+      this.tableEl?.style.removeProperty("width");
+      this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
+      return true; // Indicate it should re-render
+    }
+  }
+
+  private disableTableResizer() {
+    this.tableResizer?.reset({ disable: true });
+  }
+
+  private enableTableResizer() {
+    // Enable the re-sizer
+    this.tableResizer?.reset({
+      disable: false,
+      partialRefresh: true,
+      headerOnly: false,
+      disabledColumns: this.persistentConfig.compact ? [] : [0],
+    });
+  }
+
+  /**
+   * Recalculate the width of columns and enables the table resizer.
+   *
+   * @private
+   */
+  private drawTableHandler() {
+    if (!this.tableEl) return;
+    if (this.persistentConfig.isEllipsed !== false) {
+      // Width of table after render, removing width will make it fall back to 100%
+      let targetSize = this.tableEl.clientWidth;
+      this.tableEl.style.removeProperty("width");
+      // Let's make sure the new size is not bigger
+      if (targetSize > this.tableEl.clientWidth) {
+        targetSize = this.tableEl.clientWidth;
+      }
+      this.tableEl?.style.setProperty("width", `${targetSize}px`);
+      this.enableTableResizer();
+      this.updateTableEllipseClasses();
+    }
+  }
+
+  private afterDraw() {
     this.setupIndexColumn();
     const explainPlanQueryElement = this.yasr.rootEl.querySelector("#explainPlanQuery") as HTMLElement | null;
     if (!explainPlanQueryElement) {
@@ -100,15 +244,23 @@ export class ExtendedTable extends Table {
   protected handleSetEllipsisToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
-    // Update the table
-    this.draw(this.persistentConfig);
+    // Set in a timeout because if there are many columns to be displayed, the checkbox is updated after the table is refreshed.
+    // This looks like nothing happened from the user's point of view.
+    setTimeout(() => this.updateTableEllipseClasses());
     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
   };
 
   protected handleSetCompactToggle = (event: Event) => {
     // Store in persistentConfig
     this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
-    this.updateTableRowNumberClasses();
+    // Set in a timeout because if there are many columns to be displayed, the checkbox is updated after the table is refreshed.
+    // This looks like nothing happened from the user's point of view.
+    setTimeout(() => {
+      // the resizer is refreshed because it has to recalculate the position fo the column resizer elements.
+      this.disableTableResizer();
+      this.updateTableRowNumberClasses();
+      this.enableTableResizer();
+    });
     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
   };
 
@@ -120,6 +272,14 @@ export class ExtendedTable extends Table {
     this.persistentConfig.pageSize = pageLength;
     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
   };
+
+  private updateTableEllipseClasses() {
+    if (this.persistentConfig.isEllipsed === true) {
+      addClass(this.getTableElement(), "extendedTableEllipseTable");
+    } else {
+      removeClass(this.getTableElement(), "extendedTableEllipseTable");
+    }
+  }
 
   private updateTableRowNumberClasses() {
     const tableElement = this.getTableElement();

--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -18,7 +18,7 @@ import { DeepReadonly } from "ts-essentials";
 import { cloneDeep } from "lodash-es";
 
 const ColumnResizer = require("column-resizer");
-const DEFAULT_PAGE_SIZE = 50;
+export const DEFAULT_PAGE_SIZE = 50;
 
 export interface PluginConfig {
   openIriInNewWindow: boolean;
@@ -40,17 +40,17 @@ function expand(this: HTMLDivElement, event: MouseEvent) {
 }
 
 export default class Table implements Plugin<PluginConfig> {
-  private config: DeepReadonly<PluginConfig>;
+  protected config: DeepReadonly<PluginConfig>;
   protected persistentConfig: PersistentConfig = {};
   protected yasr: Yasr;
   private tableControls: Element | undefined;
-  private tableEl: HTMLTableElement | undefined;
+  protected tableEl: HTMLTableElement | undefined;
   protected dataTable: DataTables.Api | undefined;
   private tableFilterField: HTMLInputElement | undefined;
   private tableSizeField: HTMLSelectElement | undefined;
   private tableCompactSwitch: HTMLInputElement | undefined;
   private tableEllipseSwitch: HTMLInputElement | undefined;
-  private tableResizer:
+  protected tableResizer:
     | {
         reset: (options: {
           disable: boolean;
@@ -65,7 +65,7 @@ export default class Table implements Plugin<PluginConfig> {
   public helpReference = "https://triply.cc/docs/yasgui#table";
   public label = "Table";
   public priority = 10;
-  private readonly translationService: TranslationService;
+  protected readonly translationService: TranslationService;
   public getIcon() {
     return drawSvgStringAsElement(drawFontAwesomeIconAsSvg(faTableIcon));
   }
@@ -97,7 +97,7 @@ export default class Table implements Plugin<PluginConfig> {
       },
     },
   };
-  private getRows(): DataRow[] {
+  protected getRows(): DataRow[] {
     if (!this.yasr.results) return [];
     const bindings = this.yasr.results.getBindings();
     if (!bindings) return [];
@@ -479,7 +479,7 @@ export default class Table implements Plugin<PluginConfig> {
     while (this.tableControls?.firstChild) this.tableControls.firstChild.remove();
     this.tableControls?.remove();
   }
-  private destroyResizer() {
+  protected destroyResizer() {
     if (this.tableResizer) {
       this.tableResizer.reset({ disable: true });
       window.removeEventListener("resize", this.tableResizer.onResize);

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -428,7 +428,7 @@
           display: none;
         }
 
-        &:not(.ellipseTable) {
+        &:not(.extendedTableEllipseTable) {
           .uri-cell {
             word-break: break-word;
             // break-word doesn't work in flex container as expected in our case
@@ -446,7 +446,7 @@
           }
         }
 
-        &.ellipseTable {
+        &.extendedTableEllipseTable {
           wbr {
             display: none;
           }

--- a/yasgui-patches/2024-02-20-GDB-9242__Refactoring_the_compact_view_functionality.patch
+++ b/yasgui-patches/2024-02-20-GDB-9242__Refactoring_the_compact_view_functionality.patch
@@ -1,0 +1,280 @@
+Subject: [PATCH] GDB-9242: Refactoring the compact view functionality.
+---
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 33e3998375010e375d4d9e62dd052a146539a647)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 4922a795a0933fd741ae0cbb634704f37857e803)
+@@ -1,8 +1,12 @@
+-import Table, { PersistentConfig } from "./index";
++import Table, { DEFAULT_PAGE_SIZE, PersistentConfig } from "./index";
+ import Parser from "../../parsers";
+ import Yasr from "@triply/yasr";
+ import Yasqe from "@triply/yasqe";
+ import { addClass, removeClass } from "@triply/yasgui-utils";
++import { cloneDeep } from "lodash-es";
++import $ from "jquery";
++
++const ColumnResizer = require("column-resizer");
+ 
+ export class ExtendedTable extends Table {
+   public label = "Extended_Table";
+@@ -29,7 +33,147 @@
+   }
+ 
+   public draw(persistentConfig: PersistentConfig) {
+-    super.draw(persistentConfig);
++    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
++    this.tableEl = document.createElement("table");
++    const rows = this.getRows();
++    const columns = this.getColumns();
++
++    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
++      this.yasr.pluginControls;
++      addClass(this.yasr.rootEl, "isSinglePage");
++    } else {
++      removeClass(this.yasr.rootEl, "isSinglePage");
++    }
++
++    if (this.dataTable) {
++      this.destroyResizer();
++      this.removeDataTableEventHandlers(this.dataTable);
++      this.dataTable.destroy(true);
++      this.dataTable = undefined;
++    }
++    this.yasr.resultsEl.appendChild(this.tableEl);
++    // reset some default config properties as they couldn't be initialized beforehand
++    const dtConfig: DataTables.Settings = {
++      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
++      pageLength: -1,
++      data: rows,
++      columns: columns,
++      // DataTables will only render the rows that are initially visible on the page.
++      deferRender: true,
++      // // Switch off the pagination.
++      paging: false,
++      // Switched off for optimization purposes.
++      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
++      autoWidth: false,
++      language: {
++        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
++        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
++        paginate: {
++          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
++          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
++          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
++          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
++        },
++      },
++    };
++    this.dataTable = $(this.tableEl).DataTable(dtConfig);
++    this.tableEl.style.removeProperty("width");
++    this.tableEl.style.width = this.tableEl.clientWidth + "px";
++
++    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
++    const maxResizableResultsColumns = this.persistentConfig.compact
++      ? this.config.maxResizableResultsColumns - 1
++      : this.config.maxResizableResultsColumns;
++
++    if (columns.length <= maxResizableResultsColumns) {
++      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
++      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
++      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
++      setTimeout(() => {
++        this.tableResizer = new ColumnResizer.default(this.tableEl, {
++          partialRefresh: true,
++          headerOnly: false,
++          disabledColumns: this.persistentConfig.compact ? [] : [0],
++        });
++      }, 0);
++    } else {
++      addClass(this.tableEl, "fixedColumns");
++    }
++
++    this.registerDataTableEventHandlers(this.dataTable);
++
++    this.drawControls();
++    this.updateTableEllipseClasses();
++    this.afterDraw();
++
++    if (!rows || rows.length < 1) {
++      this.updateEmptyTable(this.persistentConfig);
++    }
++  }
++
++  private registerDataTableEventHandlers(dataTable: DataTables.Api) {
++    // Both handlers are called only on sort column.
++    dataTable.on("preDraw", this.preDrawTableHandler.bind(this));
++    dataTable.on("draw", this.drawTableHandler.bind(this));
++  }
++
++  private removeDataTableEventHandlers(dataTable: DataTables.Api) {
++    // Both handlers are called only on sort column.
++    dataTable.off("preDraw", this.preDrawTableHandler.bind(this));
++    dataTable.off("draw", this.drawTableHandler.bind(this));
++  }
++
++  /**
++   * DataTables uses the rendered style to decide the widths of columns.
++   * Before a draw remove the extendedTableEllipseTable styling and disable the table resizer.
++   * @private
++   */
++  private preDrawTableHandler() {
++    if (this.persistentConfig.isEllipsed !== false) {
++      this.disableTableResizer();
++      removeClass(this.tableEl, "extendedTableEllipseTable");
++      this.tableEl?.style.removeProperty("width");
++      this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
++      return true; // Indicate it should re-render
++    }
++  }
++
++  private disableTableResizer() {
++    this.tableResizer?.reset({ disable: true });
++  }
++
++  private enableTableResizer() {
++    // Enable the re-sizer
++    this.tableResizer?.reset({
++      disable: false,
++      partialRefresh: true,
++      headerOnly: false,
++      disabledColumns: this.persistentConfig.compact ? [] : [0],
++    });
++  }
++
++  /**
++   * Recalculate the width of columns and enables the table resizer.
++   *
++   * @private
++   */
++  private drawTableHandler() {
++    if (!this.tableEl) return;
++    if (this.persistentConfig.isEllipsed !== false) {
++      // Width of table after render, removing width will make it fall back to 100%
++      let targetSize = this.tableEl.clientWidth;
++      this.tableEl.style.removeProperty("width");
++      // Let's make sure the new size is not bigger
++      if (targetSize > this.tableEl.clientWidth) {
++        targetSize = this.tableEl.clientWidth;
++      }
++      this.tableEl?.style.setProperty("width", `${targetSize}px`);
++      this.enableTableResizer();
++      this.updateTableEllipseClasses();
++    }
++  }
++
++  private afterDraw() {
+     this.setupIndexColumn();
+     const explainPlanQueryElement = this.yasr.rootEl.querySelector("#explainPlanQuery") as HTMLElement | null;
+     if (!explainPlanQueryElement) {
+@@ -100,15 +244,23 @@
+   protected handleSetEllipsisToggle = (event: Event) => {
+     // Store in persistentConfig
+     this.persistentConfig.isEllipsed = (event.target as HTMLInputElement).checked;
+-    // Update the table
+-    this.draw(this.persistentConfig);
++    // Set in a timeout because if there are many columns to be displayed, the checkbox is updated after the table is refreshed.
++    // This looks like nothing happened from the user's point of view.
++    setTimeout(() => this.updateTableEllipseClasses());
+     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+   };
+ 
+   protected handleSetCompactToggle = (event: Event) => {
+     // Store in persistentConfig
+     this.persistentConfig.compact = (event.target as HTMLInputElement).checked;
+-    this.updateTableRowNumberClasses();
++    // Set in a timeout because if there are many columns to be displayed, the checkbox is updated after the table is refreshed.
++    // This looks like nothing happened from the user's point of view.
++    setTimeout(() => {
++      // the resizer is refreshed because it has to recalculate the position fo the column resizer elements.
++      this.disableTableResizer();
++      this.updateTableRowNumberClasses();
++      this.enableTableResizer();
++    });
+     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+   };
+ 
+@@ -121,6 +273,14 @@
+     this.yasr.storePluginConfig("extended_table", this.persistentConfig);
+   };
+ 
++  private updateTableEllipseClasses() {
++    if (this.persistentConfig.isEllipsed === true) {
++      addClass(this.getTableElement(), "extendedTableEllipseTable");
++    } else {
++      removeClass(this.getTableElement(), "extendedTableEllipseTable");
++    }
++  }
++
+   private updateTableRowNumberClasses() {
+     const tableElement = this.getTableElement();
+     if (this.persistentConfig.compact) {
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 33e3998375010e375d4d9e62dd052a146539a647)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 4922a795a0933fd741ae0cbb634704f37857e803)
+@@ -18,7 +18,7 @@
+ import { cloneDeep } from "lodash-es";
+ 
+ const ColumnResizer = require("column-resizer");
+-const DEFAULT_PAGE_SIZE = 50;
++export const DEFAULT_PAGE_SIZE = 50;
+ 
+ export interface PluginConfig {
+   openIriInNewWindow: boolean;
+@@ -40,17 +40,17 @@
+ }
+ 
+ export default class Table implements Plugin<PluginConfig> {
+-  private config: DeepReadonly<PluginConfig>;
++  protected config: DeepReadonly<PluginConfig>;
+   protected persistentConfig: PersistentConfig = {};
+   protected yasr: Yasr;
+   private tableControls: Element | undefined;
+-  private tableEl: HTMLTableElement | undefined;
++  protected tableEl: HTMLTableElement | undefined;
+   protected dataTable: DataTables.Api | undefined;
+   private tableFilterField: HTMLInputElement | undefined;
+   private tableSizeField: HTMLSelectElement | undefined;
+   private tableCompactSwitch: HTMLInputElement | undefined;
+   private tableEllipseSwitch: HTMLInputElement | undefined;
+-  private tableResizer:
++  protected tableResizer:
+     | {
+         reset: (options: {
+           disable: boolean;
+@@ -65,7 +65,7 @@
+   public helpReference = "https://triply.cc/docs/yasgui#table";
+   public label = "Table";
+   public priority = 10;
+-  private readonly translationService: TranslationService;
++  protected readonly translationService: TranslationService;
+   public getIcon() {
+     return drawSvgStringAsElement(drawFontAwesomeIconAsSvg(faTableIcon));
+   }
+@@ -97,7 +97,7 @@
+       },
+     },
+   };
+-  private getRows(): DataRow[] {
++  protected getRows(): DataRow[] {
+     if (!this.yasr.results) return [];
+     const bindings = this.yasr.results.getBindings();
+     if (!bindings) return [];
+@@ -479,7 +479,7 @@
+     while (this.tableControls?.firstChild) this.tableControls.firstChild.remove();
+     this.tableControls?.remove();
+   }
+-  private destroyResizer() {
++  protected destroyResizer() {
+     if (this.tableResizer) {
+       this.tableResizer.reset({ disable: true });
+       window.removeEventListener("resize", this.tableResizer.onResize);


### PR DESCRIPTION
## What
When selecting/deselecting the checkbox "Compact view", the yasr result table is updated too slowly.

## Why
The ellipse functionality is created during the table initialization. The table behaves differently depending on the value of the checkbox, causing the entire table to be re-rendered when the checkbox value is changed.
- When the "Compact view" is switched on: Two major changes occur; a class "ellipseTable" is added to the table element. The cells' contents are ellipsed, and when a user clicks on an ellipsed cell, the ellipsis is turned off for that cell, allowing the user to see the full content of the cell. If the content is a link, clicking on it twice will open the link. The table creation involves calculating the width for each cell to determine if the content will overflow, and if it does, click listeners are added to the cell. All these calculations and rendering of the table take a considerable amount of time.

- When the "Compact view" is switched off: In this state, there is nothing special; the cell content is broken depending on the cell width.

## How
- The functionality when "Compact view" is switched on has been removed because it is not needed. We have a tooltip with the full cell content when hovering over a link. The functionality has been refactored to add/remove the 'ellipseTable' class when clicking on the checkboxes, applying/unapplying ellipses to the entire table.