### PR TITLE
Expose a new "showYasqeResizer" configuration.

### DIFF
--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -116,6 +116,7 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
    - READ - the editor is read-only, but the query can be copied;
    - PROTECTED - the editor is read-only and the query can't be copied.
 - **showQueryButton**: if false the "Run" query button will be hidden. Default value is true.
+- **showYasqeResizer**: flag that controls whether the YASQE editor is resizable. The default value is true.
 - **getCellContent**: function that will be called for every one cell. It must return valid html as string.
 - **sparqlResponse**: a response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
 - **infer**: the value of "infer" parameter when a query is executed. Default value is true.

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -53,6 +53,11 @@ export interface ExternalYasguiConfiguration {
   showQueryButton?: boolean;
 
   /**
+   * Flag that controls whether the YASQE editor is resizable. The default value is true.
+   */
+  showYasqeResizer: boolean;
+
+  /**
    * Flag that controls displaying the loader during the run query process.
    */
   showQueryLoader?: boolean;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -130,6 +130,8 @@ export interface YasguiConfiguration {
 
       showQueryButton?: boolean;
 
+      resizeable?: boolean;
+
       prefixes: string[];
 
       /**
@@ -313,6 +315,7 @@ export const defaultYasqeConfig: Record<string, any> = {
   },
   isVirtualRepository: false,
   showQueryButton: true,
+  resizeable: true,
   readOnly: false
 }
 

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -140,6 +140,7 @@ export class YasguiConfigurationBuilder {
     }
 
     config.yasguiConfig.yasqe.showQueryButton = externalConfiguration.showQueryButton !== undefined ? externalConfiguration.showQueryButton : defaultYasqeConfig.showQueryButton;
+    config.yasguiConfig.yasqe.resizeable = externalConfiguration.showYasqeResizer !== undefined ? externalConfiguration.showYasqeResizer : defaultYasqeConfig.resizeable;
 
     config.yasguiConfig.yasqe.yasqeActionButtons =
       externalConfiguration.yasqeActionButtons !== undefined && externalConfiguration.yasqeActionButtons.length ?


### PR DESCRIPTION
## What
Introduce a new configuration option, "showYasqeResizer."

## Why
This provides clients with the ability to toggle the visibility of the yasqe resizer.

## How
The original yasgui has a "resizeable" configuration with a default value of true, controlling when the yasqe resizer is displayed. The newly exposed "showYasqeResizer" configuration allows clients to change this value as needed.