### PR TITLE
GDB-9628 properly switch yasgui modes when tabs are switched or opened

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -727,10 +727,6 @@
 
     .yasgui {
 
-      .tabsList {
-        display: none;
-      }
-
       .tabPanel > div > div:nth-of-type(2) {
         width: 100%;
       }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -812,6 +812,13 @@ export class OntotextYasguiWebComponent {
   registerEventHandlers():void {
     const hint =  HtmlElementsUtil.createAutocompleteHintElement(this.translationService.translate('yasqe.autocomplete.hint'));
 
+    this.ontotextYasgui.getInstance().on('tabAdd', (_yasgui, _tab) => {
+      VisualisationUtils.changeRenderMode(this.hostElement, this.renderingMode, this.isVerticalOrientation);
+    });
+    this.ontotextYasgui.getInstance().on('tabSelect', (_yasgui, _tab) => {
+      VisualisationUtils.changeRenderMode(this.hostElement, this.renderingMode, this.isVerticalOrientation);
+    });
+
     this.ontotextYasgui.getInstance().on('autocompletionShown', (_instance, _tab, _widget) => {
       hint.parentNode && hint.parentNode.removeChild(hint);
       const codemirrorHints: any = document.querySelector('.CodeMirror-hints');

--- a/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
@@ -17,12 +17,13 @@ export class VisualisationUtils {
    * @param orientation
    */
   static setYasqeFullHeight(mode: RenderingMode, orientation: Orientation): void {
+    const selectActiveEditor = () => document.querySelector('.yasgui .tabPanel.active .CodeMirror');
     if (mode === RenderingMode.YASQE || orientation === Orientation.HORIZONTAL) {
       setTimeout(() => {
-        const codemirrorEl = document.querySelector('.CodeMirror') as HTMLElement;
+        const codemirrorEl = selectActiveEditor() as HTMLElement;
         if (codemirrorEl) {
           const visibleWindowHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || 0;
-          let newHeight = visibleWindowHeight - (document.querySelector('.CodeMirror').getBoundingClientRect().top);
+          let newHeight = visibleWindowHeight - (selectActiveEditor().getBoundingClientRect().top);
           // TODO: this 40px which are contracted by the height are taken from the workbench and
           // probably are related with the workbench footer height.
           newHeight -= 40;
@@ -31,7 +32,7 @@ export class VisualisationUtils {
       });
     } else {
       setTimeout(() => {
-        const codemirrorEl = document.querySelector('.CodeMirror') as HTMLElement;
+        const codemirrorEl = selectActiveEditor() as HTMLElement;
         if (codemirrorEl) {
           codemirrorEl.style.removeProperty('height');
         }


### PR DESCRIPTION
## What
Properly switch yasgui modes when tabs are switched or opened.

## Why
* When switching to editor only mode, then changing to another tab or opening a new tab won't preserve the selected mode.
* When switching to horizontal layout (2-columns), then yasqe spans the entire available page height, but when opening new tab or switching to another opened one, then yasqe shrinks to its default height.

## How
* Added handlers for the tabAdd and tabSelect events where the mode is reapplied.
* Fixed the setYasqeFullHeight function to select properly the currently opened editor. Previous implementation used to select the first editor available in the DOM whereas its possible to have multiple tabs and editors respectively in the DOM.
* Also fixed a bug where switching to horizontal layout and then switching to editor only used to hide the yasgui tabs.