### PR TITLE
Cherry pick form 1.2 GDB-9318: Scrollbar in Sparql editor (Yasqe)

### DIFF
--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -524,7 +524,8 @@ export class Yasqe extends CodeMirror {
     addClass(chip, "resizeChip");
     this.resizeWrapper.appendChild(chip);
     this.resizeWrapper.addEventListener("mousedown", this.initDrag, false);
-    this.resizeWrapper.addEventListener("dblclick", this.expandEditor);
+    // We don't want this behavior, when the component is used with other components in a view, this behavior can make the view look strange.
+    // this.resizeWrapper.addEventListener("dblclick", this.expandEditor);
     this.rootEl.appendChild(this.resizeWrapper);
   }
   private drawKeyboardShortcutsButton() {
@@ -1251,7 +1252,7 @@ export class Yasqe extends CodeMirror {
     this.abortQuery();
     this.unregisterEventListeners();
     this.resizeWrapper?.removeEventListener("mousedown", this.initDrag, false);
-    this.resizeWrapper?.removeEventListener("dblclick", this.expandEditor);
+    // this.resizeWrapper?.removeEventListener("dblclick", this.expandEditor);
     for (const autocompleter in this.autocompleters) {
       this.disableCompleter(autocompleter);
     }

--- a/yasgui-patches/2024-02-26-GDB-9318__Scrollbar_in_Sparql_editor.patch
+++ b/yasgui-patches/2024-02-26-GDB-9318__Scrollbar_in_Sparql_editor.patch
@@ -1,0 +1,29 @@
+Subject: [PATCH] GDB-9318: Scrollbar in Sparql editor (Yasqe)
+---
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 7172dd35c69e34954e840dedc97fbc51c373e940)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 98d562e877dea075fa618a06e66057d08b8829bc)
+@@ -524,7 +524,8 @@
+     addClass(chip, "resizeChip");
+     this.resizeWrapper.appendChild(chip);
+     this.resizeWrapper.addEventListener("mousedown", this.initDrag, false);
+-    this.resizeWrapper.addEventListener("dblclick", this.expandEditor);
++    // We don't want this behavior, when the component is used with other components in a view, this behavior can make the view look strange.
++    // this.resizeWrapper.addEventListener("dblclick", this.expandEditor);
+     this.rootEl.appendChild(this.resizeWrapper);
+   }
+   private drawKeyboardShortcutsButton() {
+@@ -1251,7 +1252,7 @@
+     this.abortQuery();
+     this.unregisterEventListeners();
+     this.resizeWrapper?.removeEventListener("mousedown", this.initDrag, false);
+-    this.resizeWrapper?.removeEventListener("dblclick", this.expandEditor);
++    // this.resizeWrapper?.removeEventListener("dblclick", this.expandEditor);
+     for (const autocompleter in this.autocompleters) {
+       this.disableCompleter(autocompleter);
+     }


### PR DESCRIPTION
## What
Turn off double click of YASQE resizer.

## Why
We don't want this behavior, when the component is used with other components in a view, this behavior can make the view look strange.

## How
The functionality has been removed.