### PR TITLE
Gdb 9678 the abort button doesn't get translated when there are multiple running queries

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -175,6 +175,8 @@ export class Tab extends EventEmitter {
       this.emit("close", this);
       this.yasgui.tabElements.get(this.persistentJson.id).delete();
       delete this.yasgui._tabs[this.persistentJson.id];
+      // Calls the yasqe destroy method to unsubscribe all resources.
+      this.yasqe?.destroy();
     };
     if (confirm) {
       new CloseTabConfirmation(

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -575,6 +575,13 @@ export class Yasqe extends CodeMirror {
 
     yasqeFooterButtons.appendChild(abortButtonTooltip);
     this.rootEl.appendChild(yasqeFooterButtons);
+    this.subscriptions.push(
+      this.translationService.subscribeForLanguageChange({
+        name: "AbortButtonLanguageChangeObserver",
+        notify: this.updateAbortQueryLabels,
+      })
+    );
+
     this.updateAbortQueryButton();
   }
 
@@ -596,13 +603,6 @@ export class Yasqe extends CodeMirror {
     } else {
       removeClass(this.abortQueryButton, "disabled");
     }
-
-    this.subscriptions.push(
-      this.translationService.subscribeForLanguageChange({
-        name: "AbortButtonLanguageChangeObserver",
-        notify: this.updateAbortQueryLabels,
-      })
-    );
 
     this.updateAbortQueryLabels();
   }

--- a/yasgui-patches/2024-02-28-fixes_issues_with_resources.patch
+++ b/yasgui-patches/2024-02-28-fixes_issues_with_resources.patch
@@ -1,0 +1,55 @@
+Subject: [PATCH] fixes issues with resources
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision e2f5a5070bc0aee5f9d88a55637eb424f57ab6a1)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision c299f46784ce404e6af93d4e222dbbc0a973c782)
+@@ -175,6 +175,8 @@
+       this.emit("close", this);
+       this.yasgui.tabElements.get(this.persistentJson.id).delete();
+       delete this.yasgui._tabs[this.persistentJson.id];
++      // Calls the yasqe destroy method to unsubscribe all resources.
++      this.yasqe?.destroy();
+     };
+     if (confirm) {
+       new CloseTabConfirmation(
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision e2f5a5070bc0aee5f9d88a55637eb424f57ab6a1)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision c299f46784ce404e6af93d4e222dbbc0a973c782)
+@@ -575,6 +575,13 @@
+ 
+     yasqeFooterButtons.appendChild(abortButtonTooltip);
+     this.rootEl.appendChild(yasqeFooterButtons);
++    this.subscriptions.push(
++      this.translationService.subscribeForLanguageChange({
++        name: "AbortButtonLanguageChangeObserver",
++        notify: this.updateAbortQueryLabels,
++      })
++    );
++
+     this.updateAbortQueryButton();
+   }
+ 
+@@ -597,13 +604,6 @@
+       removeClass(this.abortQueryButton, "disabled");
+     }
+ 
+-    this.subscriptions.push(
+-      this.translationService.subscribeForLanguageChange({
+-        name: "AbortButtonLanguageChangeObserver",
+-        notify: this.updateAbortQueryLabels,
+-      })
+-    );
+-
+     this.updateAbortQueryLabels();
+   }
+ 


### PR DESCRIPTION
GDB-9678: The 'Abort' button doesn't get translated when there are multiple running queries.

## What
If there are more than one "Abort query" button, only the first one is translated when the language is changed.

## Why
TranslationService has subscription functionality, which gives opportunity to attach function that will be called when the language is changed. Every one event observer is registered with event name. Registration is one name to one notification function. The registration of the 'Abort query' button occurs when a Yasqe instance is created, and it is associated with a single name. This is the reason only one button is notified when the event occurs.

## How
Changed subscription functionality to support many callback functions for one name.

# Additional work
## What
 All listeners of YASQE are not released when the tab is closed.

## Why
This issue arises from the original YASGUI implementation.

## How
Added a call to the YASQE destroy method when a tab is closed.