### PR TITLE
GDB-9578 fix triple escaping when copying link

### DIFF
--- a/cypress/e2e-flaky/yasr/plugins/table/copy-link-dialog.spec.cy.ts
+++ b/cypress/e2e-flaky/yasr/plugins/table/copy-link-dialog.spec.cy.ts
@@ -19,12 +19,11 @@ describe('Plugin: Table', () => {
       YasqeSteps.executeQuery();
       // And click on a copy link.
       YasrSteps.clickOnCopyResourceLink(1, 2);
-
       // Then I expect copy link dialog to be opened.
       YasrSteps.getCopyResourceLinkDialog().should('be.visible');
     });
 
-    it('Should close copy link dialog when click on close button', {
+    it('Should close copy link dialog on close button click', {
       retries: {
         runMode: 1,
         openMode: 0
@@ -36,15 +35,13 @@ describe('Plugin: Table', () => {
       YasqeSteps.executeQuery();
       // And copy resource dialog is open.
       openCopyResourceLinkDialog(1);
-
       // When I click on close button
       YasrSteps.clickCopyLinkDialogCloseButton();
-
       // Then I expect copy link dialog to be closed.
       YasrSteps.getCopyResourceLinkDialog().should('not.exist');
     });
 
-    it('Should close copy link dialog when click on cancel button', {
+    it('Should close copy link dialog on cancel button click', {
       retries: {
         runMode: 1,
         openMode: 0,
@@ -56,15 +53,13 @@ describe('Plugin: Table', () => {
       YasqeSteps.executeQuery();
       // And copy resource link dialog is open
       openCopyResourceLinkDialog(1);
-
       // And click on cancel button
       YasrSteps.clickCopyLinkDialogCancelButton();
-
       // Then I expect copy link dialog to be closed.
       YasrSteps.getCopyResourceLinkDialog().should('not.exist');
     });
 
-    it('Should close copy link dialog when click on copy link button', {
+    it('Should close copy link dialog on copy link button click', {
       retries: {
         runMode: 1,
         openMode: 0
@@ -76,52 +71,56 @@ describe('Plugin: Table', () => {
       YasqeSteps.executeQuery();
       // And copy resource link dialog is open
       openCopyResourceLinkDialog(2);
-
       // And click on copy button
       YasrSteps.clickCopyLinkDialogCopyButton();
-
       // Then I expect copy link dialog to be closed.
       YasrSteps.getCopyResourceLinkDialog().should('not.exist');
     });
 
-    it('Should close copy link dialog when click outside dialog', () => {
+    it('Should close copy link dialog on click outside of the dialog', () => {
       // When I execute a query which returns results of type is uri.
       const queryDescription = new QueryStubDescription().setPageSize(10).setTotalElements(2);
       QueryStubs.stubQueryResults(queryDescription);
       YasqeSteps.executeQuery();
       // And copy resource link dialog is open
       openCopyResourceLinkDialog(1);
-
       // And click on copy button
       YasrSteps.clickOutsideCopyLinkDialog();
-
       // Then I expect copy link dialog to be closed.
       YasrSteps.getCopyResourceLinkDialog().should('not.exist');
     });
 
-    it('Should input of copy link dialog be filled when dialog is open', () => {
+    it('Should see the copied uri link in the copy link dialog', () => {
       // When I execute a query which returns results of type is uri.
       const queryDescription = new QueryStubDescription().setPageSize(10).setTotalElements(2);
       QueryStubs.stubQueryResults(queryDescription);
       YasqeSteps.executeQuery();
       // And copy resource link dialog is open
       openCopyResourceLinkDialog(1);
-
       // Then I expect the input of dialog to have value.
       YasrSteps.getCopyResourceLinkInput().should('have.value', 'http://ontotext-yasgui/generated-yri#page_1-row_2-column_2');
     });
 
-    it('Should copy value of copy link dialog input into clipboard when click on copy link dialog', () => {
+    it('Should see the copied triple link in the copy link dialog', () => {
+      // When I execute a query which returns results of type is uri.
+      const queryDescription = new QueryStubDescription().setPageSize(10).setTotalElements(2);
+      QueryStubs.stubQueryResults(queryDescription);
+      YasqeSteps.executeQuery();
+      // And copy resource link dialog is open
+      openCopyResourceLinkDialog(1);
+      // Then I expect the input of dialog to have value.
+      YasrSteps.getCopyResourceLinkInput().should('have.value', 'http://ontotext-yasgui/generated-yri#page_1-row_2-column_2');
+    });
+
+    it('Should put the link in the clipboard on copy link button click', () => {
       // When I execute a query which returns results of type is uri.
       const queryDescription = new QueryStubDescription().setPageSize(10).setTotalElements(3);
       QueryStubs.stubQueryResults(queryDescription);
       YasqeSteps.executeQuery();
       // And copy resource link dialog is open
       openCopyResourceLinkDialog(1);
-
       // When click on button copy to clipboard
       YasrSteps.clickCopyLinkDialogCopyButton();
-
       // Then I expect the value from input to be copied into clipboard.
       cy.assertClipboardValue('http://ontotext-yasgui/generated-yri#page_1-row_2-column_2');
     });
@@ -142,14 +141,13 @@ describe('Plugin: Table', () => {
       openCopyResourceLinkDialog(2);
       // And click on button copy to clipboard
       YasrSteps.clickCopyLinkDialogCopyButton();
-
       // Then I expect the value from input to be copied into clipboard.
       YasrSteps.getMessage().contains('{"TYPE":"notificationMessage","payload":{"code":"resource_link_copied_successfully","messageType":"success","message":"URL copied successfully to clipboard."}}');
     });
   });
-
-  function openCopyResourceLinkDialog(rowNumber = 10, cellNumber = 2) {
-    YasrSteps.clickOnCopyResourceLink(rowNumber, cellNumber);
-    YasrSteps.getCopyResourceLinkDialog().should('be.visible');
-  }
 });
+
+function openCopyResourceLinkDialog(rowNumber = 10, cellNumber = 2) {
+  YasrSteps.clickOnCopyResourceLink(rowNumber, cellNumber);
+  YasrSteps.getCopyResourceLinkDialog().should('be.visible');
+}

--- a/cypress/e2e/rdf-star.spec.cy.ts
+++ b/cypress/e2e/rdf-star.spec.cy.ts
@@ -1,0 +1,25 @@
+import {YasqeSteps} from "../steps/yasqe-steps";
+import {YasrSteps} from "../steps/yasr-steps";
+import {RdfStarPageSteps} from "../steps/pages/rdf-star-page-steps";
+
+describe('RDF Star support', () => {
+
+  beforeEach(() => {
+    // Given I visit a page with "ontotex-yasgui-web-component" in it.
+    RdfStarPageSteps.visit();
+  });
+
+  it('Should copy the triple', () => {
+    // When I execute a query which returns an RDF* triple.
+    YasqeSteps.executeQuery();
+    // And copy resource link dialog is open
+    openCopyResourceLinkDialog(0);
+    // Then I expect the input of dialog to have value.
+    YasrSteps.getCopyResourceLinkInput().should('have.value', '<<<urn:test> <http://www.w3.org/2000/01/rdf-schema#label> "test">>');
+  });
+});
+
+function openCopyResourceLinkDialog(rowNumber = 10, cellNumber = 1) {
+  YasrSteps.clickOnCopyTripleLink(rowNumber, cellNumber);
+  YasrSteps.getCopyResourceLinkDialog().should('be.visible');
+}

--- a/cypress/steps/pages/rdf-star-page-steps.ts
+++ b/cypress/steps/pages/rdf-star-page-steps.ts
@@ -1,0 +1,6 @@
+export class RdfStarPageSteps {
+
+  static visit() {
+    cy.visit('/pages/rdf-star');
+  }
+}

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -75,6 +75,13 @@ export class YasrSteps {
       .find('.resource-copy-link a');
   }
 
+  static clickOnCopyTripleLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
+    return this.getResultCell(rowNumber, cellNumber, yasrIndex)
+      .find('.triple-open-link').eq(0)
+      .realHover()
+      .find('.resource-copy-link a').realClick();
+  }
+
   static clickOnCopyResourceLink(rowNumber: number, cellNumber: number, yasrIndex = 0) {
     this.showSharedResourceLink(rowNumber, cellNumber, yasrIndex).realClick();
   }

--- a/ontotext-yasgui-web-component/src/pages/fake-server.js
+++ b/ontotext-yasgui-web-component/src/pages/fake-server.js
@@ -9,6 +9,10 @@ module.exports = function (req, res, next) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(multicolumnResults));
+  } else if (req.url === '/repositories/rdf-star') {
+    // custom response overriding the dev server
+    res.writeHead(200, {"Content-Type": "application/json"});
+    res.end(JSON.stringify(rdfStarResponse));
   } else if (req.url === '/repositories/chart-data') {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
@@ -4353,6 +4357,37 @@ const multicolumnResults = {
     ]
   }
 }
+
+const rdfStarResponse = {
+  "head" : {
+    "vars" : [
+      "a"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "a" : {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "urn:test"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/2000/01/rdf-schema#label"
+            },
+            "o" : {
+              "type" : "literal",
+              "value" : "test"
+            }
+          }
+        }
+      }
+    ]
+  }
+};
 
 const queryResponse = {
   "head": {

--- a/ontotext-yasgui-web-component/src/pages/rdf-star/index.html
+++ b/ontotext-yasgui-web-component/src/pages/rdf-star/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
+
+    <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
+    <script src="./rdf-star/main.js" defer></script>
+  </head>
+  <body>
+  <hr/>
+  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  </body>
+</html>

--- a/ontotext-yasgui-web-component/src/pages/rdf-star/main.js
+++ b/ontotext-yasgui-web-component/src/pages/rdf-star/main.js
@@ -1,0 +1,7 @@
+let ontoElement = getOntotextYasgui('yasgui-component', "/repositories/rdf-star");
+
+setOutputEventListener(ontoElement);
+
+let textAreaElement = document.createElement('textarea');
+textAreaElement.id = 'output';
+document.body.appendChild(textAreaElement);

--- a/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
+++ b/ontotext-yasgui-web-component/src/pages/yasr-plugins/main.js
@@ -2,6 +2,10 @@ const ontoElement = getOntotextYasgui('yasr-plugins');
 
 setOutputEventListener(ontoElement);
 
+let textAreaElement = document.createElement('textarea');
+textAreaElement.id = 'output';
+document.body.appendChild(textAreaElement);
+
 function attachMessageHandler() {
   ontoElement.addEventListener('output', (event) => {
     if ('notificationMessage' === event.detail.TYPE) {

--- a/ontotext-yasgui-web-component/src/services/utils/html-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-util.ts
@@ -3,8 +3,14 @@ const INTERACTIVE_ELEMENTS_SELECTOR = 'button, [href], input:not([type="hidden"]
 export class HtmlUtil {
 
   static escapeHTMLEntities(text: string): string {
-    //taken from http://stackoverflow.com/questions/5499078/fastest-method-to-escape-html-tags-as-html-entities
-    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    // Escape the text parameter to prevent XSS attacks.
+    // The text parameter can be like "<<<urn:test> <http://www.w3.org/2000/01/rdf-schema#label> "test">>".
+    // The result should be "&lt;&lt;&lt;urn:test&gt; &lt;http://www.w3.org/2000/01/rdf-schema#label&gt; &quot;test&quot;&gt;&gt;&gt;".
+    let escapedText = text;
+    if (text) {
+      escapedText = text.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+    return escapedText;
   }
 
   static decodeHTMLEntities(text: string): string {

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -100,15 +100,14 @@ export class YasrService {
 
   // @ts-ignore
   private static getTripleCellContent(binding: Parser.BindingValue, context: CellContentContext): string {
-
     const tripleAsString = this.getValueAsString(binding, false);
     const tripleLinkHref = `resource?triple=${this.replaceSingleQuote(encodeURIComponent(tripleAsString))}`;
-    const tripleLinkTitle = HtmlUtil.escapeHTMLEntities(tripleAsString);
+    const escapedTriple = HtmlUtil.escapeHTMLEntities(tripleAsString);
 
     return `<div class="triple-cell">` +
               `<div class="triple-open-link">` +
-                `<a title="${tripleLinkTitle}" class="triple-link" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_LOWER}</a>` +
-                `<copy-resource-link-button title="${tripleLinkTitle}" class="resource-copy-link" uri="${HtmlUtil.escapeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
+                `<a title="${escapedTriple}" class="triple-link" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_LOWER}</a>` +
+                `<copy-resource-link-button title="${escapedTriple}" class="resource-copy-link" uri="${escapedTriple}"></copy-resource-link-button>` +
                 `<span class="spacer"></span>` +
               `</div>` +
               `<div class="triple-list">` +
@@ -117,8 +116,8 @@ export class YasrService {
                 `<div>${this.toCellContent(binding.value['o'], context)}</div>` +
               `</div>` +
               `<div class="triple-close-link">` +
-                `<a title="${tripleLinkTitle}" class="triple-link triple-link-end" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_GREATER}</a>` +
-                `<copy-resource-link-button title="${tripleLinkTitle}" class="resource-copy-link" uri="${HtmlUtil.escapeHTMLEntities(tripleAsString)}"></copy-resource-link-button>` +
+                `<a title="${escapedTriple}" class="triple-link triple-link-end" href="${tripleLinkHref}">${YasrService.ESCAPED_HTML_DOUBLE_GREATER}</a>` +
+                `<copy-resource-link-button title="${escapedTriple}" class="resource-copy-link" uri="${escapedTriple}"></copy-resource-link-button>` +
                 `<span class="spacer"></span>` +
               `</div>` +
             `</div>`;


### PR DESCRIPTION
## What
Fix escaping triples when copy link dialog is triggered.

## Why
In the utility function which was used to escape the uri was missed the possibility to have a literal in the triple which used to cut literals during the escaping.

## How
Fixed the escape function to properly escape the double quotes around string literals. Also added test.

(cherry picked from commit 27a63815adfdd46ea88d198415fe12abffafbda0)