### PR TITLE
GDB-9409 add alert class to error plugin element

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
+++ b/Yasgui/packages/yasr/src/plugins/error/extended-error.ts
@@ -15,7 +15,7 @@ export default class ExtendedError extends Error {
 
   private createErrorElement(error: Parser.ErrorSummary): HTMLDivElement {
     const errorResponseElement = document.createElement("div");
-    errorResponseElement.classList.add("error-response-plugin");
+    errorResponseElement.classList.add("error-response-plugin", "alert");
     errorResponseElement.appendChild(this.getErrorStatusElement(error));
     this.errorMessageElement = this.createErrorMessageElement();
     const isErrorMessageBig = error?.text?.length > COUNT_OF_ERROR_CHARACTERS_TO_BE_SHOWN;


### PR DESCRIPTION
## What
Add alert class to error plugin element.

## Why
Basically this element needs to be styled as an alert component with error type color and it has the color but when the dark theme gets applied, then alert element color is inverted using css filter and as far as this element currently doesn't have the `alert` class it remains unaffected by the filter.

## How
Just added the alert class to the root element.