### PR TITLE
Cherry pick form 1.2.8 skip aborting the query if the on query aborted function is passed to the configuration

### DIFF
--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -562,9 +562,12 @@ export class Yasqe extends CodeMirror {
       }
       this.isQueryAborted = true;
       const req = this.req;
-      this.abortQuery();
+
       if (this.config.onQueryAborted instanceof Function) {
+        this.queryStateChanged(true, true);
         this.config.onQueryAborted(req).finally(() => this.queryStateChanged(false, false));
+      } else {
+        this.abortQuery();
       }
     };
 

--- a/yasgui-patches/2024-03-05-1-Skip_aborting_the_query_if_the__onQueryAborted__function_is_passed_to_the_configuration.patch
+++ b/yasgui-patches/2024-03-05-1-Skip_aborting_the_query_if_the__onQueryAborted__function_is_passed_to_the_configuration.patch
@@ -1,0 +1,24 @@
+Subject: [PATCH] Skip aborting the query if the "onQueryAborted" function is passed to the configuration
+---
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 55b586a4262ce217b9bb37bf56360e021ddead6e)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 1e9f064aa484ea6b9873561af73580063ab68fa8)
+@@ -562,9 +562,12 @@
+       }
+       this.isQueryAborted = true;
+       const req = this.req;
+-      this.abortQuery();
++
+       if (this.config.onQueryAborted instanceof Function) {
++        this.queryStateChanged(true, true);
+         this.config.onQueryAborted(req).finally(() => this.queryStateChanged(false, false));
++      } else {
++        this.abortQuery();
+       }
+     };
+ 


### PR DESCRIPTION
## What
Skip aborting the query if the "onQueryAborted" function is passed to the configuration.

## Why
If client want to control aborting of ongoing query, it can pass function "onQueryAborted".

## How
Added check if function is passed then the ongoing query is not aborted, this will be responsibility of the client.

cherry-pick from [commit 412cde7...](https://github.com/Ontotext-AD/ontotext-yasgui/commit/412cde77f8531ae42ffebc4e383328de3b15ff1b)