### PR TITLE
GDB-9946: Workbench should allow to copy any long (truncated) value

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -134,7 +134,7 @@ export class ExtendedTable extends Table {
       this.disableTableResizer();
       removeClass(this.tableEl, "extendedTableEllipseTable");
       this.tableEl?.style.removeProperty("width");
-      this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
+      this.tableEl?.style.setProperty("width", this.tableEl?.clientWidth + "px");
       return true; // Indicate it should re-render
     }
   }
@@ -174,7 +174,56 @@ export class ExtendedTable extends Table {
     }
   }
 
+  /**
+   * Checks if the specified <code>element</code> is truncated with ellipses.
+   *
+   * @param element The element to be checked for truncation.
+   * @return <code>true</code> if the element is truncated with ellipses, <code>false</code> otherwise.
+   */
+  private isTextEllipsized(element: HTMLElement) {
+    // If the scroll width is greater than the client width, content is likely truncated with an ellipsis
+    return element.scrollWidth > element.clientWidth;
+  }
+
+  private dataTableClickHandler(event) {
+    if (this.isCompactViewActive()) {
+      let literalElement = event.target.closest('.literal-cell p');
+      if (literalElement && this.isTextEllipsized(literalElement)) {
+        // Adding the "expanded-literal" class will prevent the value from being truncated with ellipses.
+        literalElement.classList.add('expanded-literal');
+        // Removing the "expandable-literal" class will remove the cursor styling when a literal cell is hovered.
+        literalElement.classList.remove('expandable-literal');
+      }
+    }
+  }
+
+  private isCompactViewActive(): boolean {
+    return !!this.persistentConfig.isEllipsed;
+  }
+
+  private tableMouseoverHandler(event): void {
+    if (this.isCompactViewActive()) {
+      let literalElement = event.target.closest('.literal-cell p');
+      if (literalElement && this.isTextEllipsized(literalElement)) {
+        // Adding the 'expandable-literal' class will change cursor to point when literal is hovered.
+        literalElement.classList.add('expandable-literal');
+      }
+    }
+  }
+
+  private tableMouseoutHandler(event): void {
+    if (this.isCompactViewActive() && event.target.matches('.expandable-literal')) {
+      // Remove pointer cursor when mouse leaves the cell
+      event.target.classList.remove('expandable-literal');
+    }
+  }
+
   private afterDraw() {
+    if (this.tableEl) {
+      this.tableEl.addEventListener('click', this.dataTableClickHandler.bind(this));
+      this.tableEl.addEventListener('mouseover', this.tableMouseoverHandler.bind(this));
+      this.tableEl.addEventListener('mouseout', this.tableMouseoutHandler.bind(this));
+    }
     this.setupIndexColumn();
     const explainPlanQueryElement = this.yasr.rootEl.querySelector("#explainPlanQuery") as HTMLElement | null;
     if (!explainPlanQueryElement) {
@@ -302,10 +351,18 @@ export class ExtendedTable extends Table {
   }
 
   private updateTableEllipseClasses() {
+    if (!this.tableEl) {
+      return;
+    }
+    // When 'Compact view' is toggled, remove the 'expanded-literal' class from all elements.
+    // This will reset the literal cells.
+    this.tableEl?.querySelectorAll('.expanded-literal').forEach((element) => {
+      element.classList.remove('expanded-literal');
+    });
     if (this.persistentConfig.isEllipsed === true) {
-      addClass(this.getTableElement(), "extendedTableEllipseTable");
+      addClass(this.tableEl, "extendedTableEllipseTable");
     } else {
-      removeClass(this.getTableElement(), "extendedTableEllipseTable");
+      removeClass(this.tableEl, "extendedTableEllipseTable");
     }
   }
 
@@ -319,7 +376,12 @@ export class ExtendedTable extends Table {
   }
 
   destroy() {
-    super.destroy();
+    if (this.tableEl) {
+      this.tableEl.removeEventListener('click', this.dataTableClickHandler.bind(this));
+      this.tableEl.removeEventListener('mouseover', this.tableMouseoverHandler.bind(this));
+      this.tableEl.removeEventListener('mouseout', this.tableMouseoutHandler.bind(this));
+    }
     this.cancelTableRenderingHandler();
+    super.destroy();
   }
 }

--- a/cypress/e2e/yasr/plugins/table/compact-view.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/compact-view.spec.cy.ts
@@ -1,0 +1,69 @@
+import {QueryStubs} from "../../../../stubs/query-stubs";
+import {YasqeSteps} from "../../../../steps/yasqe-steps";
+import {YasrSteps} from "../../../../steps/yasr-steps";
+import {YasrTablePluginSteps} from "../../../../steps/yasr-table-plugin-steps";
+import {CompactViewPageSteps} from "../../../../steps/pages/compact-view-page-steps";
+
+describe('Compact view', () => {
+  beforeEach(() => {
+    CompactViewPageSteps.visit();
+    QueryStubs.stubManyColumnResult();
+  });
+
+  it('Should expand the literal when it is collapsed and the user clicks on it', () => {
+    // When execute a query that returns literals.
+    YasqeSteps.executeQuery();
+
+    // Then I expect the literals not to be truncated with ellipses.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+
+    // When I switch on "Compact view".
+    YasrTablePluginSteps.getCompactViewCheckbox().click();
+
+    // Then I expect the literals to be truncated with ellipses.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+
+
+    // When I click on first cell with truncated value.
+    YasrSteps.getResultCell(0, 1).click();
+
+    // Then I expect only first cell to be expanded.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+
+    // When I click on fourth cell with truncated value.
+    YasrSteps.getResultCell(0, 4).click();
+
+    // Then I expect both cells to be expanded.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+
+    // When I switch off "Compact view".
+    YasrTablePluginSteps.getCompactViewCheckbox().click();
+
+    // Then I expect all cells to be expanded.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisNotActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisNotActive($element[0]));
+
+    // When I switch on "Compact view" again.
+    YasrTablePluginSteps.getCompactViewCheckbox().click();
+
+    // Then I expect all cells be truncated with ellipsis.
+    YasrSteps.getResultCell(0, 1).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 2).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 3).find('a').then(($element) => cy.assertEllipsisActive($element[0]));
+    YasrSteps.getResultCell(0, 4).find('p').then(($element) => cy.assertEllipsisActive($element[0]));
+  });
+});

--- a/cypress/fixtures/queries/many-column-response.json
+++ b/cypress/fixtures/queries/many-column-response.json
@@ -1,0 +1,85 @@
+{
+  "head": {
+    "vars": [
+      "s",
+      "p",
+      "o",
+      "s1",
+      "p1",
+      "o1",
+      "s2",
+      "p2",
+      "o2",
+      "s3",
+      "p3",
+      "o3"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "s": {
+          "type": "literal",
+          "value": "s column literal"
+        },
+        "p": {
+          "type" : "literal",
+          "value" : "p column literal"
+        },
+        "o": {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#uri-with-long-value"
+        },
+        "s1": {
+          "type": "literal",
+          "value": "http://url-in-literal/1999/02/22-rdf-syntax-ns#url-in-literal"
+        },
+        "p1": {
+          "type": "literal",
+          "value": "p1 column literal"
+        },
+        "o1": {
+          "type": "literal",
+          "value": "o1 column literal"
+        },
+        "s2": {
+          "type": "literal",
+          "value": "s2 column literal"
+        },
+        "p2": {
+          "type": "literal",
+          "value": "p2 column literal"
+        },
+        "o2": {
+          "type": "literal",
+          "value": "o2 column literal"
+        },
+        "s3": {
+          "type": "literal",
+          "value": "s3 column literal"
+        },
+        "p3": {
+          "type": "literal",
+          "value": "p3 column literal"
+        },
+        "o3": {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "o" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/cypress/steps/pages/compact-view-page-steps.ts
+++ b/cypress/steps/pages/compact-view-page-steps.ts
@@ -1,0 +1,5 @@
+export class CompactViewPageSteps {
+  static visit() {
+    cy.visit('/compact-view');
+  }
+}

--- a/cypress/steps/yasr-table-plugin-steps.ts
+++ b/cypress/steps/yasr-table-plugin-steps.ts
@@ -11,4 +11,8 @@ export class YasrTablePluginSteps {
    static getResults() {
       return cy.get('.dataTable tbody tr');
    }
+
+   static getCompactViewCheckbox() {
+     return cy.get('.tableControls .switch').contains('Compact view');
+   }
 }

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -42,6 +42,10 @@ export class QueryStubs {
     QueryStubs.stubQueryResponse('/queries/single-literal-with-data-type-response.json', 'single-iri-result', withDelay);
   }
 
+  static stubManyColumnResult(withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/many-column-response.json', 'many-column-result', withDelay);
+  }
+
   static stubQueryResponse(fixture: string, alias: string, withDelay: number = 0) {
     cy.intercept('/repositories/test-repo', {fixture, delay: withDelay}).as(alias);
   }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,3 +40,15 @@ Cypress.Commands.add('assertClipboardValue', value => {
         })
     })
 })
+
+Cypress.Commands.add('assertEllipsisActive', (element) => {
+  const offsetWidth = element.offsetWidth;
+  const scrollWidth = element.scrollWidth;
+  expect(offsetWidth, 'Expected element to be truncated with ellipses').to.be.lessThan(scrollWidth);
+});
+
+Cypress.Commands.add('assertEllipsisNotActive', (element) => {
+  const offsetWidth = element.offsetWidth;
+  const scrollWidth = element.scrollWidth;
+  expect(offsetWidth, 'Expected element to not be truncated').to.be.at.least(scrollWidth);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -21,5 +21,19 @@ declare namespace Cypress {
        * @param value - to be checked.
        */
       assertClipboardValue(value);
+
+     /**
+      * Checks if the <code>element</code> is truncated with ellipsis.
+      *
+      * @param element - the HTML element to be checked for truncation with ellipses.
+      */
+     assertEllipsisActive(element: HTMLElement);
+
+     /**
+      * Checks if the <code>element</code> is not truncated with ellipsis.
+      *
+      * @param element - the HTML element to be checked for the absence of truncation with ellipses.
+      */
+     assertEllipsisNotActive(element: HTMLElement);
    }
 }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -425,6 +425,10 @@
 
     .yasr_results {
       .dataTable {
+
+        & .expandable-literal {
+          cursor: pointer;
+        }
         .resource-copy-link {
           display: none;
         }
@@ -457,7 +461,7 @@
           }
 
           .uri-cell .uri-link,
-          .literal-cell .nonUri {
+          .literal-cell .nonUri:not(.expanded-literal) {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -466,6 +466,10 @@
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+
+          .literal-cell .nonUri.expanded-literal {
+            word-break: break-word;
+          }
         }
 
         .uri-cell .spacer {

--- a/ontotext-yasgui-web-component/src/index.html
+++ b/ontotext-yasgui-web-component/src/index.html
@@ -25,6 +25,7 @@
   <a href="/pages/keyboard-shortcuts">keyboard-shortcuts</a> |
   <a href="/pages/pagination">pagination</a> |
   <a href="/pages/multicolumn-results">multicolumns result</a> |
+  <a href="/pages/compact-view">compact view</a> |
   <hr/>
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>

--- a/ontotext-yasgui-web-component/src/pages/compact-view/index.html
+++ b/ontotext-yasgui-web-component/src/pages/compact-view/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
+
+    <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
+    <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
+    <script src="./compact-view/main.js" defer></script>
+  </head>
+  <body>
+  <hr/>
+  <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
+  </body>
+</html>

--- a/ontotext-yasgui-web-component/src/pages/compact-view/main.js
+++ b/ontotext-yasgui-web-component/src/pages/compact-view/main.js
@@ -1,0 +1,1 @@
+let ontoElement = getOntotextYasgui('compact-view', '/repositories/compact-view');

--- a/ontotext-yasgui-web-component/src/pages/fake-server.js
+++ b/ontotext-yasgui-web-component/src/pages/fake-server.js
@@ -29,6 +29,10 @@ module.exports = function (req, res, next) {
   } else if (req.url === 'https://lov.linkeddata.es/dataset/lov/api/v2/autocomplete/terms?q=rdf&page_size=50&type=property') {
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(localNamesResponse));
+  } else if (req.url === '/repositories/compact-view') {
+    // custom response overriding the dev server
+    res.writeHead(200, {"Content-Type": "application/json"});
+    res.end(JSON.stringify(compactViewResponse));
   } else {
     // pass request on to the default dev server
     next();
@@ -5466,3 +5470,91 @@ const queryResponse = {
     ]
   }
 };
+
+
+const compactViewResponse = {
+  "head": {
+    "vars": [
+      "s",
+      "p",
+      "o",
+      "s1",
+      "p1",
+      "o1",
+      "s2",
+      "p2",
+      "o2",
+      "s3",
+      "p3",
+      "o3"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "s": {
+          "type": "literal",
+          "value": "s column literal"
+        },
+        "p": {
+          "type" : "literal",
+          "value" : "p column literal"
+        },
+        "o": {
+          "type" : "uri",
+          "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#uri-with-long-value"
+        },
+        "s1": {
+          "type": "literal",
+          "value": "http://url-in-literal/1999/02/22-rdf-syntax-ns#url-in-literal"
+        },
+        "p1": {
+          "type": "literal",
+          "value": "p1 column literal"
+        },
+        "o1": {
+          "type": "literal",
+          "value": "o1 column literal"
+        },
+        "s2": {
+          "type": "literal",
+          "value": "s2 column literal"
+        },
+        "p2": {
+          "type": "literal",
+          "value": "p2 column literal"
+        },
+        "o2": {
+          "type": "literal",
+          "value": "o2 column literal"
+        },
+        "s3": {
+          "type": "literal",
+          "value": "s3 column literal"
+        },
+        "p3": {
+          "type": "literal",
+          "value": "p3 column literal"
+        },
+        "o3": {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            },
+            "o" : {
+              "type" : "uri",
+              "value" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+

--- a/yasgui-patches/2024-03-15-GDB-9946_Workbench_should_allow_to_copy_any_long_truncated_value.patch
+++ b/yasgui-patches/2024-03-15-GDB-9946_Workbench_should_allow_to_copy_any_long_truncated_value.patch
@@ -1,0 +1,111 @@
+Subject: [PATCH] GDB-9946: Workbench should allow to copy any long (truncated) value
+---
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 529c91c5a9183e981b7a0eed0796f34c482cc42a)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 8a12817ee0f6fa2850b0f26ba7133b4ba4e4d968)
+@@ -134,7 +134,7 @@
+       this.disableTableResizer();
+       removeClass(this.tableEl, "extendedTableEllipseTable");
+       this.tableEl?.style.removeProperty("width");
+-      this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
++      this.tableEl?.style.setProperty("width", this.tableEl?.clientWidth + "px");
+       return true; // Indicate it should re-render
+     }
+   }
+@@ -174,7 +174,56 @@
+     }
+   }
+ 
++  /**
++   * Checks if the specified <code>element</code> is truncated with ellipses.
++   *
++   * @param element The element to be checked for truncation.
++   * @return <code>true</code> if the element is truncated with ellipses, <code>false</code> otherwise.
++   */
++  private isTextEllipsized(element: HTMLElement) {
++    // If the scroll width is greater than the client width, content is likely truncated with an ellipsis
++    return element.scrollWidth > element.clientWidth;
++  }
++
++  private dataTableClickHandler(event) {
++    if (this.isCompactViewActive()) {
++      let literalElement = event.target.closest('.literal-cell p');
++      if (literalElement && this.isTextEllipsized(literalElement)) {
++        // Adding the "expanded-literal" class will prevent the value from being truncated with ellipses.
++        literalElement.classList.add('expanded-literal');
++        // Removing the "expandable-literal" class will remove the cursor styling when a literal cell is hovered.
++        literalElement.classList.remove('expandable-literal');
++      }
++    }
++  }
++
++  private isCompactViewActive(): boolean {
++    return !!this.persistentConfig.isEllipsed;
++  }
++
++  private tableMouseoverHandler(event): void {
++    if (this.isCompactViewActive()) {
++      let literalElement = event.target.closest('.literal-cell p');
++      if (literalElement && this.isTextEllipsized(literalElement)) {
++        // Adding the 'expandable-literal' class will change cursor to point when literal is hovered.
++        literalElement.classList.add('expandable-literal');
++      }
++    }
++  }
++
++  private tableMouseoutHandler(event): void {
++    if (this.isCompactViewActive() && event.target.matches('.expandable-literal')) {
++      // Remove pointer cursor when mouse leaves the cell
++      event.target.classList.remove('expandable-literal');
++    }
++  }
++
+   private afterDraw() {
++    if (this.tableEl) {
++      this.tableEl.addEventListener('click', this.dataTableClickHandler.bind(this));
++      this.tableEl.addEventListener('mouseover', this.tableMouseoverHandler.bind(this));
++      this.tableEl.addEventListener('mouseout', this.tableMouseoutHandler.bind(this));
++    }
+     this.setupIndexColumn();
+     const explainPlanQueryElement = this.yasr.rootEl.querySelector("#explainPlanQuery") as HTMLElement | null;
+     if (!explainPlanQueryElement) {
+@@ -302,10 +351,18 @@
+   }
+ 
+   private updateTableEllipseClasses() {
++    if (!this.tableEl) {
++      return;
++    }
++    // When 'Compact view' is toggled, remove the 'expanded-literal' class from all elements.
++    // This will reset the literal cells.
++    this.tableEl?.querySelectorAll('.expanded-literal').forEach((element) => {
++      element.classList.remove('expanded-literal');
++    });
+     if (this.persistentConfig.isEllipsed === true) {
+-      addClass(this.getTableElement(), "extendedTableEllipseTable");
++      addClass(this.tableEl, "extendedTableEllipseTable");
+     } else {
+-      removeClass(this.getTableElement(), "extendedTableEllipseTable");
++      removeClass(this.tableEl, "extendedTableEllipseTable");
+     }
+   }
+ 
+@@ -319,7 +376,12 @@
+   }
+ 
+   destroy() {
++    if (this.tableEl) {
++      this.tableEl.removeEventListener('click', this.dataTableClickHandler.bind(this));
++      this.tableEl.removeEventListener('mouseover', this.tableMouseoverHandler.bind(this));
++      this.tableEl.removeEventListener('mouseout', this.tableMouseoutHandler.bind(this));
++    }
++    this.cancelTableRenderingHandler();
+     super.destroy();
+-    this.cancelTableRenderingHandler();
+   }
+ }


### PR DESCRIPTION
## What
When the result table is truncated with ellipses, the literal values of the cells cannot be selected and copied by the user.

## Why
This issue arises particularly when the result table is in 'Compact view,' where all cell values are truncated with ellipses and cannot be selected for copying.

## How
Implemented functionality that gives the opportunity to the client to view the full content of a truncated cell with ellipsis when they click on it.
Added three listeners:
- "mouseover" - the handler add "expandable-literal" class if string literal is truncated with ellipses. Adding the "expandable-literal" class will change cursor to point when literal is hovered;
- "mouseout" - the handler will remove the "expandable-literal";
- "click" - the handler add "expanded-literal" class. Adding the "expanded-literal" class will prevent the value from being truncated with ellipses.