### PR TITLE
Updates the calculation of the YASR position

### DIFF
--- a/ontotext-yasgui-web-component/src/services/utils/time-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/time-utils.ts
@@ -1,0 +1,9 @@
+export class TimeUtils {
+  static createDebouncedFunction(func, timeout = 300) {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => func.apply(this, args), timeout);
+    };
+  }
+}


### PR DESCRIPTION
## What
Refactors the calculation of the YASR position.

## Why
- There was an issue with the "[ResizeObserver loop completed with undelivered notifications](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors)" error, which occurred when YASGUI was initialized with more than one row of YASQE tabs;
- The ResizeObserver is registered when a component is created, which is not optimal because the client may not switch the view to horizontally orientation.

## How
- Added debounce for resize events;
- Registers the Resizer Observer when the horizontal orientation is activated and unregisters it when the orientation is changed to vertical.