### PR TITLE
GDB-9964: Clear data for old ran query after new query is executed

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -536,7 +536,15 @@ export class Tab extends EventEmitter {
     //the blur event might not have fired (e.g. when pressing ctrl-enter). So, we'd like to persist the query as well if needed
     if (this.hasPersistenceJsonBeenChanged(yasqe)) {
       this.updatePersistJson(yasqe);
-      this.emit("change", this, this.persistentJson);
+    }
+    // When a new query is run, we can clear the persistence. This will free up some space in the browser's local storage.
+    this.persistentJson.yasr.response = undefined;
+    this.emit("change", this, this.persistentJson);
+    if (this.yasr) {
+      // clean in-memory stored data of previous response.
+      this.yasr.results = undefined;
+      // The refresh will synchronize the DOM with the YASR instance (in case of clearing of result the YASR will be hidden);
+      this.yasr.refresh();
     }
     this.emit("query", this);
     if (this.rootEl) {

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -504,12 +504,8 @@ export class Yasqe extends CodeMirror {
 
       this.queryBtn.onclick = () => {
         if (this.config.queryingDisabled) return; // Don't do anything
-        if (this.req) {
-          this.abortQuery();
-        } else {
           this.pageNumber = 1;
           this.query().catch(() => {}); //catch this to avoid unhandled rejection
-        }
       };
 
       buttons.appendChild(runButtonTooltip);

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -228,7 +228,12 @@ export class Yasr extends EventEmitter {
       addClass(this.headerEl, "hidden");
       addClass(this.resultsEl, "hidden");
       addClass(this.fallbackInfoEl, "hidden");
-      this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
+      if (!this.yasqe.isQueryRunning()) {
+        // This message appears when there are no results and an ongoing query.
+        // It prevents a scenario where the user clicks the run button, switches to another tab, and returns to the previous tab.
+        // In such cases, the message should not be displayed if the query is not finished.
+        this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
+      }
       return;
     }
     removeClass(this.headerEl, "hidden");

--- a/yasgui-patches/2024-03-22-1-GDB-9964_Clear_data_for_old_ran_query_after_new_query_is_executed.patch
+++ b/yasgui-patches/2024-03-22-1-GDB-9964_Clear_data_for_old_ran_query_after_new_query_is_executed.patch
@@ -1,0 +1,70 @@
+Subject: [PATCH] GDB-9964: Clear data for old ran query after new query is executed
+---
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision e30e1a17f9ab8f4ad1ed4a9da8e0d1a32686f3c1)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision 7f15e7da85d9e30b1a2cf74877ac4bcf403b909a)
+@@ -536,7 +536,15 @@
+     //the blur event might not have fired (e.g. when pressing ctrl-enter). So, we'd like to persist the query as well if needed
+     if (this.hasPersistenceJsonBeenChanged(yasqe)) {
+       this.updatePersistJson(yasqe);
+-      this.emit("change", this, this.persistentJson);
++    }
++    // When a new query is run, we can clear the persistence. This will free up some space in the browser's local storage.
++    this.persistentJson.yasr.response = undefined;
++    this.emit("change", this, this.persistentJson);
++    if (this.yasr) {
++      // clean in-memory stored data of previous response.
++      this.yasr.results = undefined;
++      // The refresh will synchronize the DOM with the YASR instance (in case of clearing of result the YASR will be hidden);
++      this.yasr.refresh();
+     }
+     this.emit("query", this);
+     if (this.rootEl) {
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision e30e1a17f9ab8f4ad1ed4a9da8e0d1a32686f3c1)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 7f15e7da85d9e30b1a2cf74877ac4bcf403b909a)
+@@ -504,12 +504,8 @@
+ 
+       this.queryBtn.onclick = () => {
+         if (this.config.queryingDisabled) return; // Don't do anything
+-        if (this.req) {
+-          this.abortQuery();
+-        } else {
+           this.pageNumber = 1;
+           this.query().catch(() => {}); //catch this to avoid unhandled rejection
+-        }
+       };
+ 
+       buttons.appendChild(runButtonTooltip);
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision e30e1a17f9ab8f4ad1ed4a9da8e0d1a32686f3c1)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 7f15e7da85d9e30b1a2cf74877ac4bcf403b909a)
+@@ -228,7 +228,12 @@
+       addClass(this.headerEl, "hidden");
+       addClass(this.resultsEl, "hidden");
+       addClass(this.fallbackInfoEl, "hidden");
+-      this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
++      if (!this.yasqe.isQueryRunning()) {
++        // This message appears when there are no results and an ongoing query.
++        // It prevents a scenario where the user clicks the run button, switches to another tab, and returns to the previous tab.
++        // In such cases, the message should not be displayed if the query is not finished.
++        this.showWarning(this.translationService.translate("yasr.noresults.box.info"), "success", true);
++      }
+       return;
+     }
+     removeClass(this.headerEl, "hidden");


### PR DESCRIPTION
## What
The browser freezes when switching between tabs. To reproduce this scenario:
- Opens at least two tabs;
- Execute a query that returns many results (many columns and rows). For example:
```
 select * where {
      ?s ?p ?o . 
      ?s1 ?p1 ?o1 . 
      ?s1 ?p2 ?o2 . 
      ?s1 ?p3 ?o3 . 
      ?s1 ?p4 ?o4 . 
      ?s1 ?p5 ?o5 . 
      ?s1 ?p6 ?o6 . 
      ?s1 ?p7 ?o7 . 
      ?s1 ?p8 ?o8 . 
      ?s1 ?p9 ?o9 . 
      .... 
}
 ```
- Wait until the results are displayed;
- Execute a long-running query, for instance
```
 select (count(*) as ?count) where {
        ?s ?p ?o.
        ?s1 ?p1 ?o1.
        ?s2 ?p2 ?o2.
        ?s3 ?p3 ?o3.
    }
 ```

At this point, toggling between tabs is slow, especially when switching to the tab that had many results. It should load quickly because a new query is executed and there are no results to be displayed.

## Why
When a new query is run, the results from the older ran query are not cleared. As a result, when a new query is executed, the Yasr (Yet Another SPARQL Result) component is hidden, and a loader, which indicates that the query is executed, takes a long time to apply style changes, causing the browser to become unresponsive for a while.

## How
The results data is cleared before a new query is executed. This includes clearing data from the browser's local store and from the Yasr instance.

# Additional work

The functionality of the run button has been modified. Previously, clicking the "Run" button would execute a query, and if the button was clicked again before the query finished, the query would be aborted. However, the ability to abort the query by clicking the button again has been removed, as there is now an additional button specifically for aborting ongoing queries.