### PR TITLE
Fixes translation issue with buttons that change the component modes "Yasqe," "Yasgui," or "Yasr.

### DIFF
--- a/cypress/e2e/languages.spec.cy.ts
+++ b/cypress/e2e/languages.spec.cy.ts
@@ -15,28 +15,31 @@ describe('Languages', () => {
 
     it('Should labels be translated to different languages', () => {
       // I expect to see the button "editor only" to be translated to the default English language.
-      ToolbarPageSteps.getYasqeModeButton().contains('Editor only');
+      ToolbarPageSteps.getYasqeModeButton().contains('Éditeur seulement');
       // When the mouse is over the button orientation.
       ToolbarPageSteps.showLayoutOrientationButtonTooltip();
       // Then I expect to see the tooltip to be translated to the default English language.
-      cy.contains('Switch to horizontal view');
+      cy.contains('Basculer vers horizontal voir');
 
       // When change the language to be French
-      LanguagesSteps.switchToFr();
+      LanguagesSteps.switchToEn();
 
       // Then I expect to see the button "editor only" to be translated to French language.
-      ToolbarPageSteps.getYasqeModeButton().contains('Éditeur seulement');
+      ToolbarPageSteps.getYasqeModeButton().contains('Editor only');
 
       // When the mouse is over the button orientation.
       ToolbarPageSteps.showLayoutOrientationButtonTooltip();
       // Then I expect to see the tooltip to be translated to French language.
-      cy.contains('Basculer vers horizontal voir');
+      cy.contains('Switch to horizontal view');
     });
 
     it('Should translate with translation passed as configuration', () => {
+      ToolbarPageSteps.getYasqeModeButton().contains('Éditeur seulement');
+      LanguagesSteps.switchToEn();
       ToolbarPageSteps.getYasqeModeButton().contains('Editor only');
       // When I add external translations
       LanguagesSteps.addTranslationConfiguration();
+      LanguagesSteps.switchToEn();
       // I expect to see the button "editor only" to be translated trough label passed as external configuration
       ToolbarPageSteps.getYasqeModeButton().contains('Editor only passed from external configuration');
       // When I switch to Bulgarian language passed as external configuration
@@ -59,17 +62,17 @@ describe('Languages', () => {
 
       // Then I expect to see messages in table plugin be translated to English language.
       YasrSteps.getTableResults().should('be.visible');
-      YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filter query results');
+      YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filtrer les résultats des requêtes');
 
       // When change the language to be French
-      LanguagesSteps.switchToFr();
+      LanguagesSteps.switchToEn();
       // Yasgui re-renders all DOM elements to shows the new labels. This includes the plugins of yasr which is time-consuming.
       // We have to wait a bit because cypress is too fast and grabs the old element (with the old label) and the test fails.
       cy.wait(500);
 
       // Then I expect yasr to be translated to French.
       YasrSteps.getResultFilter().should('be.visible');
-      YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filtrer les résultats des requêtes');
+      YasrSteps.getResultFilter().invoke('attr', 'placeholder').should('contain', 'Filter query results');
 
     });
   });

--- a/cypress/steps/languages-steps.ts
+++ b/cypress/steps/languages-steps.ts
@@ -5,7 +5,7 @@ export class LanguagesSteps {
    }
 
    static switchToEn() {
-      cy.get('#locale_en').click();
+      cy.get('#locale_en').click({force: true});
    }
 
    static switchToFr() {

--- a/ontotext-yasgui-web-component/src/pages/languages/main.js
+++ b/ontotext-yasgui-web-component/src/pages/languages/main.js
@@ -2,6 +2,7 @@ const ontoElement = document.querySelector("ontotext-yasgui");
 ontoElement.config = {
   endpoint: "/repositories/test-repo",
   showToolbar: true,
+  language: 'fr',
   prefixes: {
     "gn": "http://www.geonames.org/ontology#",
     "path": "http://www.ontotext.com/path#",
@@ -17,7 +18,10 @@ ontoElement.config = {
 };
 
 function changeLanguage(lang) {
-  ontoElement.language = lang;
+  ontoElement.config = {
+    ...ontoElement.config,
+    language: lang
+  }
 }
 
 function setTranslation() {


### PR DESCRIPTION
## What
When the component is initialized with a language different from the default "en," the change mode buttons still display in English.

## Why
This is an old bug that originated when we introduced the language field to the configuration. Here's how the functionality works:
 - The component is created and translated based on the configuration language.
 - Initially, the component's language property is set to the default "en," resulting in English labels for the buttons during initialization.
 - Later, when the componentDidLoad hook is called, the client configuration updates the language to, for example, French.
 - Although inner components are re-rendered with the new translations, the main component's buttons remain untranslated because its state is not changed, and it's not re-rendered.

## How
Refactored the buttons to use state properties for button labels. Listeners are registered for translation changes when the main component is loaded. When the event occurs, the property values are updated, triggering a change in component state and re-rendering with the correct labels.

# Additional work
Language tests has been changed to cover this scenario.