### PR TITLE
GDB-3107 extend datatable to allow sorting individual columns based on the values type

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -38,7 +38,8 @@ export class ExtendedTable extends Table {
     this.tableEl = document.createElement("table");
     const rows = this.getRows();
     const columns = this.getColumns();
-
+    const types = this.resolveTypes();
+    const columnDefinitions = this.getColumnDefinitions(types);
     if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
       this.yasr.pluginControls;
       addClass(this.yasr.rootEl, "isSinglePage");
@@ -59,6 +60,7 @@ export class ExtendedTable extends Table {
       pageLength: -1,
       data: rows,
       columns: columns,
+      columnDefs: columnDefinitions,
       // DataTables will only render the rows that are initially visible on the page.
       deferRender: true,
       // // Switch off the pagination.
@@ -77,6 +79,7 @@ export class ExtendedTable extends Table {
         },
       },
     };
+
     this.dataTable = $(this.tableEl).DataTable(dtConfig);
     this.tableEl.style.removeProperty("width");
     this.tableEl.style.width = this.tableEl.clientWidth + "px";
@@ -110,6 +113,108 @@ export class ExtendedTable extends Table {
     if (!rows || rows.length < 1) {
       this.updateEmptyTable(this.persistentConfig);
     }
+  }
+
+  /**
+   * Resolves the type of binding in the sparql result using its datatype if present. If the datatype is not present,
+   * null is returned. The types which this function can resolve are 'num', 'date' and 'str' and they are used to
+   * bind the DataTables column type with the custom ordering functions where the name of the functions are based on
+   * the type suffixed with '-pre'. For example
+   * <code>$.fn.dataTable.ext.type.order['num-pre'] = function(d) {...}</code> is the custom ordering function for the
+   * 'num' type.
+   * @param binding The binding to resolve the type for.
+   * @return The type of the binding or null if the binding is null.
+   */
+  private resolveValueType(binding: any){
+      if (!binding) {
+          return null;
+      }
+      if (binding.type != null && (binding.type === 'typed-literal' || binding.type === 'literal')) {
+          const xsdType = binding.datatype;
+          switch (xsdType) {
+              case "http://www.w3.org/2001/XMLSchema#float":
+              case "http://www.w3.org/2001/XMLSchema#double":
+              case "http://www.w3.org/2001/XMLSchema#byte":
+              case "http://www.w3.org/2001/XMLSchema#short":
+              case "http://www.w3.org/2001/XMLSchema#int":
+              case "http://www.w3.org/2001/XMLSchema#integer":
+              case "http://www.w3.org/2001/XMLSchema#long":
+              case "http://www.w3.org/2001/XMLSchema#decimal":
+              case "http://www.w3.org/2001/XMLSchema#unsignedByte":
+              case "http://www.w3.org/2001/XMLSchema#unsignedInt":
+              case "http://www.w3.org/2001/XMLSchema#unsignedLong":
+              case "http://www.w3.org/2001/XMLSchema#unsignedShort":
+              case "http://www.w3.org/2001/XMLSchema#negativeInteger":
+              case "http://www.w3.org/2001/XMLSchema#nonNegativeInteger":
+              case "http://www.w3.org/2001/XMLSchema#positiveInteger":
+              case "http://www.w3.org/2001/XMLSchema#nonPositiveInteger":
+              case "http://www.w3.org/2001/XMLSchema#gDay":
+              case "http://www.w3.org/2001/XMLSchema#gMonth":
+              case "http://www.w3.org/2001/XMLSchema#gMonthDay":
+              case "http://www.w3.org/2001/XMLSchema#gYear":
+              case "http://www.w3.org/2001/XMLSchema#gYearMonth":
+                  return "num";
+              case "http://www.w3.org/2001/XMLSchema#date":
+              case "http://www.w3.org/2001/XMLSchema#dateTime":
+              case "http://www.w3.org/2001/XMLSchema#time":
+                  return "date";
+              default:
+                  return "str";
+          }
+      }
+  }
+
+  /**
+   * Resolves the types of the bindings in the sparql result.
+   * For each variable in the result, this function counts the number of different types of the bindings for that
+   * variable. If the type can be resolved unambiguously, the type is returned. If no type is found, 'str' is returned.
+   * If multiple types are found, then an error is registered and logged because this renderer cannot allow sorting by
+   * multiple types in a single column.
+   * @return A record with the variable names as keys and the types as values.
+   */
+  private resolveTypes() {
+    if (!this.yasr.results) return {};
+    const variables = this.yasr.results?.getVariables();
+    const bindings = this.yasr.results?.getBindings();
+    const bindingTypes: Record<string, string> = {};
+    variables.forEach((variable) => {
+      const types: Record<string, number> = {};
+      let typeCount = 0;
+      bindings?.forEach((binding) => {
+        const valueType = this.resolveValueType(binding[variable]);
+        if (valueType != null) {
+          if (!(valueType in types)) {
+            types[valueType] = 0;
+            typeCount++;
+          }
+          types[valueType]++;
+        }
+      });
+      if (typeCount == 0) {
+        bindingTypes[variable] = 'str';
+      } else if (typeCount == 1) {
+        bindingTypes[variable] = Object.keys(types)[0];
+      } else {
+        console.log('Mapping bindings to types failed. Multiple types for a variable found', types, variable);
+      }
+    });
+    return bindingTypes;
+  }
+
+  /**
+   * Builds a list with column definitions for the DataTables plugin. This is needed in order to allow sorting of the
+   * columns based on their type.
+   * @param types The types of the bindings in the sparql result.
+   * @return A list with column definitions.
+   */
+  private getColumnDefinitions(types: Record<string, string>): DataTables.ColumnDefsSettings[] {
+    const columnDefinitions = Object.keys(types).map((variable, index) => {
+      return {targets: index + 1, type: types[variable]};
+    });
+    if (this.persistentConfig.compact) {
+      columnDefinitions.unshift({targets: 0, type: 'num'});
+    }
+    return columnDefinitions;
   }
 
   private registerDataTableEventHandlers(dataTable: DataTables.Api) {
@@ -235,7 +340,6 @@ export class ExtendedTable extends Table {
   protected getColumns(): DataTables.ColumnSettings[] {
     if (!this.yasr.results) return [];
     const prefixes = this.yasr.getPrefixes();
-
     return [
       {
         searchable: false,
@@ -256,11 +360,29 @@ export class ExtendedTable extends Table {
             if (!type) {
               return data.value;
             }
+            // The render function is called with different type property based on the operation currently performed,
+            // e.g. filter, display, sort. We need to hook to sort operation to convert the value to the correct type
+            // in order to allow DataTables to sort the column correctly.
+            if (type === "sort") {
+                const valueType = this.resolveValueType(data) || 'str'
+                return this.convertValue(data, valueType);
+            }
             return this.getCellContent(data, prefixes);
           },
         };
       }),
     ];
+  }
+
+  private convertValue(data: any, valueType: string) {
+    switch (valueType) {
+        case "num":
+            return parseFloat(data.value);
+        case "date":
+            return new Date(data.value);
+        default:
+            return data.value;
+    }
   }
 
   /**

--- a/cypress/e2e/yasr/plugins/table/sort-results.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/sort-results.spec.cy.ts
@@ -1,41 +1,56 @@
-import DefaultViewPageSteps from '../../../../steps/default-view-page-steps';
 import {YasqeSteps} from '../../../../steps/yasqe-steps';
 import {YasrSteps} from '../../../../steps/yasr-steps';
+import {YasrTableSortingPageSteps} from "../../../../steps/pages/yasr-table-sorting-page.steps";
 
 describe('Sort table plugin functionality', () => {
 
   beforeEach(() => {
-    DefaultViewPageSteps.visit();
+    YasrTableSortingPageSteps.visit();
   });
 
-  it('should sort results', () => {
-    // When I visit a page with "ontotext-yasgui-web-component" in it,
-    // and execute a query that returns results.
+  it('should sort results by columns with different types', () => {
+    // Given I have opened the YASGUI
+    // And I have executed a query that returns results
     YasqeSteps.executeQuery();
+    // Then I expect to have 5 columns in the results table
+    YasrSteps.getResultsTableColumns().should('have.length', 5);
+    // And I expect the columns to be named as follows (the first column is for the index and doesn't have a name)
+    YasrSteps.verifyColumnHeaders(['', 'string', 'integer', 'date', 'literal']);
+    // Given Initial order of the results in the third column is
+    YasrSteps.verifyTableColumnOrder(0, ['1', '2', '3', '4', '5']);
+    YasrSteps.verifyTableColumnOrder(1, ['"a"', '"d"', '"b"', '"w"']);
+    YasrSteps.verifyTableColumnOrder(2, ['"10"^^xsd:integer', '"2"^^xsd:integer', '"100"^^xsd:integer', '"11"^^xsd:integer']);
+    YasrSteps.verifyTableColumnOrder(3, ['"1981-05-07"^^xsd:date', '"1999-05-10"^^xsd:date', '"2011-01-07"^^xsd:date', '"2000-11-01"^^xsd:date']);
+    YasrSteps.verifyTableColumnOrder(4, ['"10"', '"2"', '"100"', '"11"']);
 
-    // Then I expect the first column shows the result row number,
-    YasrSteps.getResultCell(0, 0).should('have.text', '1');
-    YasrSteps.getResultCell(1, 0).should('have.text', '2');
-    // and results are displayed without sorting,
-    YasrSteps.getResultCell(73, 1).should('have.text', 'owl:differentFrom');
-    YasrSteps.getResultCell(74, 1).should('have.text', 'http://example/book1');
+    // Index column is not sortable
+    // When I click on the first column
+    YasrSteps.clickOnColumnHeader(0);
+    // Then I expect the order to be preserved because the first column is the index
+    YasrSteps.verifyTableColumnOrder(0, ['1', '2', '3', '4', '5']);
 
-    // When I click on a table column.
+    // Sort by string
+    // When I click on the second column to sort the results by string
     YasrSteps.clickOnColumnHeader(1);
-    // Then I expect the first column shows the result row number,
-    YasrSteps.getResultCell(0, 0).should('have.text', '1');
-    YasrSteps.getResultCell(1, 0).should('have.text', '2');
-    // and results are sorted ascending,
-    YasrSteps.getResultCell(0, 1).should('have.text', 'http://example/book1');
-    YasrSteps.getResultCell(1, 1).should('have.text', 'http://purl.org/dc/elements/1.1/creator');
+    // Then I expect results to be ordered alphabetically by the string column
+    YasrSteps.verifyTableColumnOrder(1, ['"a"', '"b"', '"d"', '"w"']);
 
-    // When I click on a table column.
-    YasrSteps.clickOnColumnHeader(1);
-    // Then I expect the first column shows the result row number,
-    YasrSteps.getResultCell(0, 0).should('have.text', '1');
-    YasrSteps.getResultCell(1, 0).should('have.text', '2');
-    // and results are sorted descending,
-    YasrSteps.getResultCell(2, 1).should('have.text', 'xsd:string');
-    YasrSteps.getResultCell(3, 1).should('have.text', 'xsd:nonNegativeInteger');
+    // Sort by integer
+    // When I click on the third column to sort the results by integer
+    YasrSteps.clickOnColumnHeader(2);
+    // Then I expect results to be ordered numerically by the integer column
+    YasrSteps.verifyTableColumnOrder(2, ['"2"^^xsd:integer', '"10"^^xsd:integer', '"11"^^xsd:integer', '"100"^^xsd:integer']);
+
+    // Sort by date
+    // When I click on the fourth column to sort the results by date
+    YasrSteps.clickOnColumnHeader(3);
+    // Then I expect results to be ordered chronologically by the date column
+    YasrSteps.verifyTableColumnOrder(3, ['"1981-05-07"^^xsd:date', '"1999-05-10"^^xsd:date', '"2000-11-01"^^xsd:date', '"2011-01-07"^^xsd:date']);
+
+    // Sort by literal
+    // When I click on the fifth column to sort the results by literal
+    YasrSteps.clickOnColumnHeader(4);
+    // Then I expect results to be ordered alphabetically by the literal column
+    YasrSteps.verifyTableColumnOrder(4, ['"10"', '"100"', '"11"', '"2"']);
   });
 });

--- a/cypress/steps/pages/yasr-table-sorting-page.steps.ts
+++ b/cypress/steps/pages/yasr-table-sorting-page.steps.ts
@@ -1,0 +1,6 @@
+export class YasrTableSortingPageSteps {
+
+  static visit() {
+    cy.visit('/pages/yasr-table-sorting');
+  }
+}

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -18,8 +18,25 @@ export class YasrSteps {
   static getResultsTable(yasrIndex = 0) {
     return YasrSteps.getYasr(yasrIndex).find('.yasr_results tbody');
   }
+
   static getResultsTableHeaders(yasrIndex = 0) {
     return YasrSteps.getYasr(yasrIndex).find('.yasr_results thead');
+  }
+
+  static getResultsTableColumns(yasrIndex = 0) {
+    return YasrSteps.getResultsTableHeaders(yasrIndex).find('th');
+  }
+
+  static verifyColumnHeaders(columnHeaders: string[]) {
+    columnHeaders.forEach((header, index) => {
+      YasrSteps.getResultsTableColumns().eq(index).should('have.text', header);
+    });
+  }
+
+  static verifyTableColumnOrder(columnIndex: number, expectedOrder: string[]) {
+    YasrSteps.getResultsTable().find('tr').each((row, index) => {
+      cy.wrap(row).find('td').eq(columnIndex).should('have.text', expectedOrder[index]);
+    });
   }
 
   static getHeaderCell(columnNumber = 0, yasrIndex = 0) {

--- a/ontotext-yasgui-web-component/src/pages/fake-server.js
+++ b/ontotext-yasgui-web-component/src/pages/fake-server.js
@@ -5,16 +5,17 @@ module.exports = function (req, res, next) {
     // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(queryResponse));
-  } else if (req.url === '/repositories/multicolumn-results-repo') {
+  } else if (req.url === '/repositories/multiple-types') {
     // custom response overriding the dev server
+    res.writeHead(200, {"Content-Type": "application/json"});
+    res.end(JSON.stringify(multipleTypesResult));
+  } else if (req.url === '/repositories/multicolumn-results-repo') {
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(multicolumnResults));
   } else if (req.url === '/repositories/rdf-star') {
-    // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(rdfStarResponse));
   } else if (req.url === '/repositories/chart-data') {
-    // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(chartDataResponse));
   } else if (req.url === '/repositories/chart-data-small-set') {
@@ -30,12 +31,107 @@ module.exports = function (req, res, next) {
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(localNamesResponse));
   } else if (req.url === '/repositories/compact-view') {
-    // custom response overriding the dev server
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify(compactViewResponse));
   } else {
     // pass request on to the default dev server
     next();
+  }
+};
+
+const multipleTypesResult = {
+  "head" : {
+    "vars" : [
+      "string",
+      "integer",
+      "date",
+      "literal"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "string" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#string",
+          "type" : "literal",
+          "value" : "a"
+        },
+        "integer" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "10"
+        },
+        "date" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#date",
+          "type" : "literal",
+          "value" : "1981-05-07"
+        },
+        "literal" : {
+          "type" : "literal",
+          "value" : "10"
+        },
+      }, {
+        "string" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#string",
+          "type" : "literal",
+          "value" : "d"
+        },
+        "integer" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "2"
+        },
+        "date" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#date",
+          "type" : "literal",
+          "value" : "1999-05-10"
+        },
+        "literal" : {
+          "type" : "literal",
+          "value" : "2"
+        },
+      }, {
+        "string" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#string",
+          "type" : "literal",
+          "value" : "b"
+        },
+        "integer" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "100"
+        },
+        "date" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#date",
+          "type" : "literal",
+          "value" : "2011-01-07"
+        },
+        "literal" : {
+          "type" : "literal",
+          "value" : "100"
+        },
+      }, {
+        "string" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#string",
+          "type" : "literal",
+          "value" : "w"
+        },
+        "integer" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+          "type" : "literal",
+          "value" : "11"
+        },
+        "date" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#date",
+          "type" : "literal",
+          "value" : "2000-11-01"
+        },
+        "literal" : {
+          "type" : "literal",
+          "value" : "11"
+        },
+      }
+    ]
   }
 };
 

--- a/ontotext-yasgui-web-component/src/pages/yasr-table-sorting/index.html
+++ b/ontotext-yasgui-web-component/src/pages/yasr-table-sorting/index.html
@@ -7,7 +7,8 @@
 
     <script type="module" src="/build/ontotext-yasgui-web-component.esm.js"></script>
     <script nomodule src="/build/ontotext-yasgui-web-component.js"></script>
-    <script src="js/main.js" defer></script>
+    <script src="../js/ontotext-yasgui-tests-util.js"></script>
+    <script src="./yasr-table-sorting/main.js" defer></script>
   </head>
   <body>|
   <a href="/pages/default-view">default-view</a> |
@@ -21,7 +22,6 @@
   <a href="/pages/view-modes">view-modes</a> |
   <a href="/pages/yasr-plugins">yasr-plugins</a> |
   <a href="/pages/yasr-chart-plugin">yasr-chart-plugin</a> |
-  <a href="/pages/yasr-table-sorting">yasr table sorting</a> |
   <a href="/pages/autocomplete">autocomplete</a> |
   <a href="/pages/keyboard-shortcuts">keyboard-shortcuts</a> |
   <a href="/pages/pagination">pagination</a> |

--- a/ontotext-yasgui-web-component/src/pages/yasr-table-sorting/main.js
+++ b/ontotext-yasgui-web-component/src/pages/yasr-table-sorting/main.js
@@ -1,0 +1,1 @@
+let ontoElement = getOntotextYasgui('yasgui-component', "/repositories/multiple-types");

--- a/yasgui-patches/2024-05-16-GDB-3107-allow-sorting-of-results-table-by-column-type.patch
+++ b/yasgui-patches/2024-05-16-GDB-3107-allow-sorting-of-results-table-by-column-type.patch
@@ -1,0 +1,183 @@
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 9d26f38c0eec25d3398d5b6606793e79637df601)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 3536dfe5667e581c2bbcced5b8cd2189dba0e6d5)
+@@ -38,7 +38,8 @@
+     this.tableEl = document.createElement("table");
+     const rows = this.getRows();
+     const columns = this.getColumns();
+-
++    const types = this.resolveTypes();
++    const columnDefinitions = this.getColumnDefinitions(types);
+     if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+       this.yasr.pluginControls;
+       addClass(this.yasr.rootEl, "isSinglePage");
+@@ -59,6 +60,7 @@
+       pageLength: -1,
+       data: rows,
+       columns: columns,
++      columnDefs: columnDefinitions,
+       // DataTables will only render the rows that are initially visible on the page.
+       deferRender: true,
+       // // Switch off the pagination.
+@@ -77,6 +79,7 @@
+         },
+       },
+     };
++
+     this.dataTable = $(this.tableEl).DataTable(dtConfig);
+     this.tableEl.style.removeProperty("width");
+     this.tableEl.style.width = this.tableEl.clientWidth + "px";
+@@ -112,6 +115,108 @@
+     }
+   }
+ 
++  /**
++   * Resolves the type of binding in the sparql result using its datatype if present. If the datatype is not present,
++   * null is returned. The types which this function can resolve are 'num', 'date' and 'str' and they are used to
++   * bind the DataTables column type with the custom ordering functions where the name of the functions are based on
++   * the type suffixed with '-pre'. For example
++   * <code>$.fn.dataTable.ext.type.order['num-pre'] = function(d) {...}</code> is the custom ordering function for the
++   * 'num' type.
++   * @param binding The binding to resolve the type for.
++   * @return The type of the binding or null if the binding is null.
++   */
++  private resolveValueType(binding: any){
++      if (!binding) {
++          return null;
++      }
++      if (binding.type != null && (binding.type === 'typed-literal' || binding.type === 'literal')) {
++          const xsdType = binding.datatype;
++          switch (xsdType) {
++              case "http://www.w3.org/2001/XMLSchema#float":
++              case "http://www.w3.org/2001/XMLSchema#double":
++              case "http://www.w3.org/2001/XMLSchema#byte":
++              case "http://www.w3.org/2001/XMLSchema#short":
++              case "http://www.w3.org/2001/XMLSchema#int":
++              case "http://www.w3.org/2001/XMLSchema#integer":
++              case "http://www.w3.org/2001/XMLSchema#long":
++              case "http://www.w3.org/2001/XMLSchema#decimal":
++              case "http://www.w3.org/2001/XMLSchema#unsignedByte":
++              case "http://www.w3.org/2001/XMLSchema#unsignedInt":
++              case "http://www.w3.org/2001/XMLSchema#unsignedLong":
++              case "http://www.w3.org/2001/XMLSchema#unsignedShort":
++              case "http://www.w3.org/2001/XMLSchema#negativeInteger":
++              case "http://www.w3.org/2001/XMLSchema#nonNegativeInteger":
++              case "http://www.w3.org/2001/XMLSchema#positiveInteger":
++              case "http://www.w3.org/2001/XMLSchema#nonPositiveInteger":
++              case "http://www.w3.org/2001/XMLSchema#gDay":
++              case "http://www.w3.org/2001/XMLSchema#gMonth":
++              case "http://www.w3.org/2001/XMLSchema#gMonthDay":
++              case "http://www.w3.org/2001/XMLSchema#gYear":
++              case "http://www.w3.org/2001/XMLSchema#gYearMonth":
++                  return "num";
++              case "http://www.w3.org/2001/XMLSchema#date":
++              case "http://www.w3.org/2001/XMLSchema#dateTime":
++              case "http://www.w3.org/2001/XMLSchema#time":
++                  return "date";
++              default:
++                  return "str";
++          }
++      }
++  }
++
++  /**
++   * Resolves the types of the bindings in the sparql result.
++   * For each variable in the result, this function counts the number of different types of the bindings for that
++   * variable. If the type can be resolved unambiguously, the type is returned. If no type is found, 'str' is returned.
++   * If multiple types are found, then an error is registered and logged because this renderer cannot allow sorting by
++   * multiple types in a single column.
++   * @return A record with the variable names as keys and the types as values.
++   */
++  private resolveTypes() {
++    if (!this.yasr.results) return {};
++    const variables = this.yasr.results?.getVariables();
++    const bindings = this.yasr.results?.getBindings();
++    const bindingTypes: Record<string, string> = {};
++    variables.forEach((variable) => {
++      const types: Record<string, number> = {};
++      let typeCount = 0;
++      bindings?.forEach((binding) => {
++        const valueType = this.resolveValueType(binding[variable]);
++        if (valueType != null) {
++          if (!(valueType in types)) {
++            types[valueType] = 0;
++            typeCount++;
++          }
++          types[valueType]++;
++        }
++      });
++      if (typeCount == 0) {
++        bindingTypes[variable] = 'str';
++      } else if (typeCount == 1) {
++        bindingTypes[variable] = Object.keys(types)[0];
++      } else {
++        console.log('Mapping bindings to types failed. Multiple types for a variable found', types, variable);
++      }
++    });
++    return bindingTypes;
++  }
++
++  /**
++   * Builds a list with column definitions for the DataTables plugin. This is needed in order to allow sorting of the
++   * columns based on their type.
++   * @param types The types of the bindings in the sparql result.
++   * @return A list with column definitions.
++   */
++  private getColumnDefinitions(types: Record<string, string>): DataTables.ColumnDefsSettings[] {
++    const columnDefinitions = Object.keys(types).map((variable, index) => {
++      return {targets: index + 1, type: types[variable]};
++    });
++    if (this.persistentConfig.compact) {
++      columnDefinitions.unshift({targets: 0, type: 'num'});
++    }
++    return columnDefinitions;
++  }
++
+   private registerDataTableEventHandlers(dataTable: DataTables.Api) {
+     // Both handlers are called only on sort column.
+     dataTable.on("preDraw", this.preDrawTableHandler.bind(this));
+@@ -235,7 +340,6 @@
+   protected getColumns(): DataTables.ColumnSettings[] {
+     if (!this.yasr.results) return [];
+     const prefixes = this.yasr.getPrefixes();
+-
+     return [
+       {
+         searchable: false,
+@@ -256,6 +360,13 @@
+             if (!type) {
+               return data.value;
+             }
++            // The render function is called with different type property based on the operation currently performed,
++            // e.g. filter, display, sort. We need to hook to sort operation to convert the value to the correct type
++            // in order to allow DataTables to sort the column correctly.
++            if (type === "sort") {
++                const valueType = this.resolveValueType(data) || 'str'
++                return this.convertValue(data, valueType);
++            }
+             return this.getCellContent(data, prefixes);
+           },
+         };
+@@ -263,6 +374,17 @@
+     ];
+   }
+ 
++  private convertValue(data: any, valueType: string) {
++    switch (valueType) {
++        case "num":
++            return parseFloat(data.value);
++        case "date":
++            return new Date(data.value);
++        default:
++            return data.value;
++    }
++  }
++
+   /**
+    * Set-ups first column to be index column.
+    * 1. Listen for the event 'draw.dt'


### PR DESCRIPTION
## What
Extend datatable to allow sorting individual columns based on the values type.

## Why
Currently the table allows sorting only by string, but sparql results can come with different datatypes for each binding. It'd be convenient to properly sort the table based on the type of the data in the respective column being sorted on.

## How
Implemented custom ordering functions for numbers, dates and strings which also remains the default if no datatype is found. The table settings is augmented with additional columnDef property providing the types for each column so that ordering functions to be able to properly order results. Also the column render function was extended with logic which converts the cell value to proper type based on the datatype from the results binding.