### PR TITLE
GDB-10292: Doubled hover on menus in SPARQL section.

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.scss
@@ -8,3 +8,13 @@
 .tippy-arrow {
   color: $color-onto-blue;
 }
+
+
+.jfk-tooltip {
+  z-index: 12;
+  background-color: #003663 !important;
+}
+
+.jfk-tooltip-arrowdown .jfk-tooltip-arrowimplafter, .jfk-tooltip-arrowup .jfk-tooltip-arrowimplafter {
+  border-color: #003663 transparent !important;
+}

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.scss
@@ -8,13 +8,3 @@
 .tippy-arrow {
   color: $color-onto-blue;
 }
-
-
-.jfk-tooltip {
-  z-index: 12;
-  background-color: #003663 !important;
-}
-
-.jfk-tooltip-arrowdown .jfk-tooltip-arrowimplafter, .jfk-tooltip-arrowup .jfk-tooltip-arrowimplafter {
-  border-color: #003663 transparent !important;
-}

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
@@ -57,7 +57,18 @@ export class OntotextTooltipWebComponent {
       placement: this.placement as Placement,
       allowHTML: true,
       triggerTarget: this.el,
+      /**
+       * The tippy library has some conflict with the Google Chart Editor. The editor adds a div element with the "jfk-tooltip" class.
+       * When the mouse hovers over a chart editor element, this div is positioned accordingly.
+       * When the mouse leaves the element, a "jfk-tooltip-hidden" class is added, and the div tag is hidden.
+       * For some reason, when a 'ontotext-tooltip-web-component' is open, the "jfk-tooltip-hidden" class is removed, and the Google Chart tooltip is displayed along with
+       * 'ontotext-tooltip-web-component' (maybe Google uses an old version of tippy or popover and there is a conflict in implementations).
+       * When 'ontotext-tooltip-web-component' is open, we add the class 'hidden' to the Google Chart tooltip to hide it.
+       */
       onShow: () => document.querySelectorAll('.jfk-tooltip').forEach(popper => popper.classList.add('hidden')),
+      /**
+       * When 'ontotext-tooltip-web-component' is closed, we remove the 'hidden' class to allow the Google Chart tooltip to work properly.
+       */
       onHide: () => document.querySelectorAll('.jfk-tooltip').forEach(popper => popper.classList.remove('hidden'))
     };
     this.tooltip = tippy(this.el, options);

--- a/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-tooltip-web-component/ontotext-tooltip-web-component.tsx
@@ -56,6 +56,9 @@ export class OntotextTooltipWebComponent {
       trigger: 'manual',
       placement: this.placement as Placement,
       allowHTML: true,
+      triggerTarget: this.el,
+      onShow: () => document.querySelectorAll('.jfk-tooltip').forEach(popper => popper.classList.add('hidden')),
+      onHide: () => document.querySelectorAll('.jfk-tooltip').forEach(popper => popper.classList.remove('hidden'))
     };
     this.tooltip = tippy(this.el, options);
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -735,3 +735,14 @@
     white-space: pre-wrap;
   }
 }
+
+// Styling for the Google Chart Editor tooltip.
+.jfk-tooltip {
+  // For some reason, the tooltip was under the chart editor dialog and was not visible; adding a z-index will set it on top.
+  z-index: 12;
+  background-color: #003663 !important;
+}
+
+.jfk-tooltip-arrowdown .jfk-tooltip-arrowimplafter, .jfk-tooltip-arrowup .jfk-tooltip-arrowimplafter {
+  border-color: #003663 transparent !important;
+}


### PR DESCRIPTION
## What
 - The tooltips in Google editor are not visible.
 - There are double tooltips when hovering over a SPARQL editor button. How to reproduce:
    - Open SPARQL view;
    - Execute a query (the query type doesn't matter); -Switch to “Pivot Table” and choose a Google renderer (e.g., Bar chart) or simply switch to the “Google Chart” plugin; - Click on the “Chart config” button; - When the “Chart editor” dialog opens, hover the mouse over some recommended charts (at this point, a div with the class “jfk-tooltip” is appended to the DOM; this is the reason for the issue); - Hover the mouse over some SPARQL editor buttons.

## Why
 - The tooltip is under the chart editor dialog;
 - The chart editor tooltip is implemented as a div element with the "jfk-tooltip" class. When the mouse hovers over a chart editor element, this div is positioned accordingly. When the mouse leaves the element, a "jfk-tooltip-hidden" class is added, and the div tag is hidden. When the mouse is over a SPARQL editor button for some reason (I did not find it; maybe Google uses an old version of tippy or popover libraries, and there is interference between them), the "jfk-tooltip-hidden" class is removed, and the tooltip is shown.

## How
 - Increase the z-index of the chart editor tooltip and change its color;
 - Added two functions "onShow" and "onHide" to tippy configuration. When a SPARQL tooltip is shown, a hidden class is added to the chart editor tooltip, and when it is hidden, the class is removed to allow the chart tooltip to work correctly.