### PR TITLE
GDB-10304: Blinking hovers on Google Pie charts

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -746,3 +746,6 @@
 .jfk-tooltip-arrowdown .jfk-tooltip-arrowimplafter, .jfk-tooltip-arrowup .jfk-tooltip-arrowimplafter {
   border-color: #003663 transparent !important;
 }
+
+// Fixes Google visualization tooltip flickering. More info can be found at https://github.com/google/google-visualization-issues/issues/2162.
+svg > g > g.google-visualization-tooltip { pointer-events: none }


### PR DESCRIPTION
What
The Google tooltip blinks when the mouse is over Google Pie charts.

Why
 - Mousing over the chart activates the popup;
 - The popup is superimposed on top of the chart and under the pointer. This situation activates the flicker;
 - The pointer is no longer over the chart (because it's over the popup), and therefore the popup is removed;
 - This creates a loop (Go to 1).

The reason is described at https://github.com/google/google-visualization-issues/issues/2162.

How
Removes pointer events from Google tooltips as suggested in https://github.com/google/google-visualization-issues/issues/2162".