### PR TITLE
GDB-9448 - Freeze row numbers in the YASR results

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -425,7 +425,18 @@
 
     .yasr_results {
       .dataTable {
-
+        &.withRowNumber {
+          tr td:first-child {
+            position: sticky;
+            left: 0;
+          }
+          tr.odd > td:first-child {
+            background-color: #f9f9f9;
+          }
+          tr.even > td:first-child {
+            background-color: $color-onto-white;
+          }
+        }
         & .expandable-literal {
           cursor: pointer;
         }


### PR DESCRIPTION
## What?
When the horizontal scroll appears in the YASR results, the user will be able to scroll and still see the row numbers column.

## Why?
The column with row numbers was not frozen before and it was easy to forget which row you are on, while scrolling.

## How?
I added styling to freeze the column and match the row background color.

## Screenshots?
![image](https://github.com/Ontotext-AD/ontotext-yasgui/assets/158429017/9f595ce2-af25-47f8-be28-7477f40f1ba6)
