### PR TITLE
GDB-9968 - Prevent CodeMirror auto-scroll on paste

### DIFF
--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -54,13 +54,17 @@ export class OntotextYasgui {
   }
 
   /**
-   * Sets a query value in the editor by preserving the cursor position.
+   * Sets a query value in the editor by preserving the cursor position and calculating the new scroll location.
    * @param query The query value to be set.
    */
   setQuery(query: string): void {
-    const cursor = this.yasgui.getTab().getYasqe().getDoc().getCursor();
-    this.yasgui.getTab().getYasqe().setValue(query);
-    this.yasgui.getTab().getYasqe().getDoc().setCursor(cursor);
+    const yasqe = this.yasgui.getTab().getYasqe();
+    const scrollInfo = yasqe.getScrollInfo();
+    const lastVisibleLine = yasqe.lineAtHeight(scrollInfo.top + scrollInfo.clientHeight, 'window');
+    const cursor = yasqe.getDoc().getCursor();
+    yasqe.setValue(query);
+    yasqe.getDoc().setCursor(cursor);
+    yasqe.scrollIntoView({line: lastVisibleLine - 1, ch: 0});
   }
 
   query(): Promise<any> {

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -54,17 +54,16 @@ export class OntotextYasgui {
   }
 
   /**
-   * Sets a query value in the editor by preserving the cursor position and calculating the new scroll location.
+   * Sets a query value in the editor by preserving the cursor position.
    * @param query The query value to be set.
    */
   setQuery(query: string): void {
     const yasqe = this.yasgui.getTab().getYasqe();
-    const scrollInfo = yasqe.getScrollInfo();
-    const lastVisibleLine = yasqe.lineAtHeight(scrollInfo.top + scrollInfo.clientHeight, 'window');
     const cursor = yasqe.getDoc().getCursor();
-    yasqe.setValue(query);
+    const lastLine = yasqe.getDoc().lastLine();
+    const lastLineLength = yasqe.getDoc().getLine(lastLine).length;
+    yasqe.getDoc().replaceRange(query, {line: 0, ch: 0}, {line: lastLine, ch: lastLineLength});
     yasqe.getDoc().setCursor(cursor);
-    yasqe.scrollIntoView({line: lastVisibleLine - 1, ch: 0});
   }
 
   query(): Promise<any> {

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
@@ -62,6 +62,12 @@ export interface Yasqe {
   getCursor: () => Cursor;
 
   setCursor: (cursor: Cursor) => void;
+
+  getScrollInfo(): {left:  number, top: number, width: number, height: number, clientWidth: number, clientHeight: number};
+
+  scrollIntoView(what: {line: number, ch: number}|{left: number, top: number, right: number, bottom: number}|{from: number, to: number}|null, margin?: number): void;
+
+  lineAtHeight(number: number, window: string): number;
 }
 
 export class Doc {

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
@@ -62,12 +62,6 @@ export interface Yasqe {
   getCursor: () => Cursor;
 
   setCursor: (cursor: Cursor) => void;
-
-  getScrollInfo(): {left:  number, top: number, width: number, height: number, clientWidth: number, clientHeight: number};
-
-  scrollIntoView(what: {line: number, ch: number}|{left: number, top: number, right: number, bottom: number}|{from: number, to: number}|null, margin?: number): void;
-
-  lineAtHeight(number: number, window: string): number;
 }
 
 export class Doc {
@@ -78,6 +72,7 @@ export class Doc {
   replaceRange: (replacement: string | string[], from: Cursor, to?: Cursor, origin?: string) => void;
   getLine: (line: number) => string;
   isClean: () => boolean;
+  lastLine: () => number;
 }
 
 export class Cursor {


### PR DESCRIPTION
## What?
When pasting a value in the editor, the editor will not scroll the cursor to the bottom.

## Why?
Previously, the editor would scroll the cursor line to the bottom of the CodeMirror input, regardless how many lines were pasted.
**The cause**: when we set the prefixes for a query in the Workbench and pass it along to the YASGUI, the method which sets the value in the editor, triggers the CodeMirror to scroll its content to the cursor position. 

## How?
Alternative function for setting the query is used, instead of the one causing the scroll issue. The cursor position is preserved.