### PR TITLE
GDB-10876 - Add escape HTML entity "&"

### DIFF
--- a/ontotext-yasgui-web-component/src/services/utils/html-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-util.ts
@@ -10,7 +10,6 @@ export class HtmlUtil {
     if (text) {
       escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
-    console.log(escapedText);
     return escapedText;
   }
 

--- a/ontotext-yasgui-web-component/src/services/utils/html-util.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/html-util.ts
@@ -8,8 +8,9 @@ export class HtmlUtil {
     // The result should be "&lt;&lt;&lt;urn:test&gt; &lt;http://www.w3.org/2000/01/rdf-schema#label&gt; &quot;test&quot;&gt;&gt;&gt;".
     let escapedText = text;
     if (text) {
-      escapedText = text.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      escapedText = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
+    console.log(escapedText);
     return escapedText;
   }
 


### PR DESCRIPTION
## What?
HTML entity "&" in literals will not be encoded when shown in the results.

## Why?
The "&" will be escaped as "&amp;" to prevent XSS vulnerabilities.

## How?
I extended the encoding method.

## Screenshots?
For example, if the data is entered as "Real power in watts (J/s). Electrical power may have real and reactive components. The real portion of electrical power (I&#178;R or VIcos(phi)), is expressed in Watts. See also apparent power and reactive power.", the fetched result will be the one in the second row in the screenshot.
![image](https://github.com/user-attachments/assets/661b5930-c4d2-44b8-8e50-b0c20271ac04)
