### PR TITLE
GDB-11281: Extend Saved Query Functionality

### DIFF
--- a/cypress/e2e/saved-query/delete-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/delete-saved-query.spec.cy.ts
@@ -48,4 +48,14 @@ describe('Delete saved query action', () => {
         YasqeSteps.getSavedQueries().should('have.length', 12)
             .and('contain.text', 'q2');
     });
+    
+    it('Should not allow deleting a saved query if it is readonly', () => {
+        // When: I have opened the saved queries popup
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        YasqeSteps.getSavedQueries().should('have.length', 12);
+        
+        // Then: The delete button should not exist if the saved query is marked as readonly
+        YasqeSteps.getDeleteQueryButton(0).should('not.exist');
+    });
 });

--- a/cypress/e2e/saved-query/edit-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/edit-saved-query.spec.cy.ts
@@ -33,4 +33,14 @@ describe('Edit saved query action', () => {
         YasqeSteps.getSavedQueriesPopup().should('not.exist');
         ActionsPageSteps.getSaveQueryPayload().should('contain.value', '{"queryName":"q2-new","query":"select *","isPublic":true}');
     });
+    
+    it('Should not allow editing a saved query if it is read-only', () => {
+        // When: I open the saved queries popup
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        YasqeSteps.getSavedQueries().should('have.length', 12);
+        
+        // Then: The edit button should not exist if the saved query is marked as read-only
+        YasqeSteps.getEditQueryButton(0).should('not.exist');
+    });
 });

--- a/cypress/e2e/saved-query/share-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/share-saved-query.spec.cy.ts
@@ -54,4 +54,14 @@ describe('Share saved query action', () => {
         YasguiSteps.getCurrentTab().should('contain', 'Clear graph');
         YasqeSteps.getTabQuery(1).should('equal', 'CLEAR GRAPH <http://example>');
     });
+    
+    it('Should allow sharing of a saved query regardless it is read-only', () => {
+        // When: I open the saved queries popup
+        YasqeSteps.showSavedQueries();
+        YasqeSteps.getSavedQueriesPopup().should('be.visible');
+        YasqeSteps.getSavedQueries().should('have.length', 12);
+        
+        // Then: The share saved query button exist regardless the query is marked as read-only
+        YasqeSteps.getShareSavedQueryButton(0).should('be.visible');
+    });
 });

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -191,17 +191,28 @@ export class YasqeSteps {
       return (el[tabIndex] as any).CodeMirror.setValue(query);
     });
   }
-
+  
+  static getEditQueryButton(index: number) {
+    return this.getSavedQueries().eq(index).realHover().find('.edit-saved-query');
+  }
+  
   static editQuery(index: number) {
-    this.getSavedQueries().eq(index).realHover().find('.edit-saved-query').click();
+    this.getEditQueryButton(index).click();
+  }
+  
+  static getDeleteQueryButton(index: number) {
+    return this.getSavedQueries().eq(index).realHover().find('.delete-saved-query');
   }
 
   static deleteQuery(index: number) {
-    this.getSavedQueries().eq(index).realHover().find('.delete-saved-query').click();
+    this.getDeleteQueryButton(index).click();
   }
 
+  static getShareSavedQueryButton(index: number) {
+    return this.getSavedQueries().eq(index).realHover().find('.share-saved-query');
+  }
   static shareSavedQuery(index: number) {
-    this.getSavedQueries().eq(index).realHover().find('.share-saved-query').click();
+    this.getShareSavedQueryButton(index).click();
   }
 
   static getShareSavedQueryDialog() {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -767,7 +767,8 @@ export class OntotextYasguiWebComponent {
           queryName: savedQuery.queryName,
           query: savedQuery.query,
           isPublic: savedQuery.isPublic,
-          owner: savedQuery.owner
+          owner: savedQuery.owner,
+          readonly: savedQuery.readonly !== undefined ? savedQuery.readonly : false
         }
       });
 

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -124,15 +124,19 @@ export class SavedQueriesPopup {
               <li class="saved-query">
                 <a class="saved-query-link" onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
                 <span class="saved-query-actions">
-                  <button class="saved-query-action edit-saved-query icon-edit"
-                          title={this.translationService.translate('yasqe.actions.saved_query_dialog.edit.button.tooltip')}
-                          onClick={(evt) => this.onEdit(evt, savedQuery)}></button>
-                <button class="saved-query-action delete-saved-query icon-trash"
-                        title={this.translationService.translate('yasqe.actions.saved_query_dialog.delete.button.tooltip')}
-                        onClick={(evt) => this.onDelete(evt, savedQuery)}></button>
-                <button class="saved-query-action share-saved-query icon-link"
-                        title={this.translationService.translate('yasqe.actions.saved_query_dialog.share.button.tooltip')}
-                        onClick={(evt) => this.onShare(evt, savedQuery)}></button>
+                  {!savedQuery.readonly ?
+                    <button class="saved-query-action edit-saved-query icon-edit"
+                            title={this.translationService.translate('yasqe.actions.saved_query_dialog.edit.button.tooltip')}
+                            onClick={(evt) => this.onEdit(evt, savedQuery)}></button>
+                    : ''}
+                  {!savedQuery.readonly ?
+                    <button class="saved-query-action delete-saved-query icon-trash"
+                            title={this.translationService.translate('yasqe.actions.saved_query_dialog.delete.button.tooltip')}
+                            onClick={(evt) => this.onDelete(evt, savedQuery)}></button>
+                    : ''}
+                  <button class="saved-query-action share-saved-query icon-link"
+                          title={this.translationService.translate('yasqe.actions.saved_query_dialog.share.button.tooltip')}
+                          onClick={(evt) => this.onShare(evt, savedQuery)}></button>
                 </span>
               </li>
             ))}

--- a/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
@@ -31,6 +31,7 @@ export interface SavedQueryInput {
   query: string;
   isPublic: boolean;
   owner: string;
+  readonly: boolean
 }
 
 // TODO: rename to be like internal model
@@ -39,6 +40,7 @@ export class SaveQueryData {
               public query: string,
               public isPublic: boolean,
               public isNew?: boolean,
+              public readonly?: boolean,
               public owner?: string,
               public messages?: string[]) {
   }

--- a/ontotext-yasgui-web-component/src/pages/actions/main.js
+++ b/ontotext-yasgui-web-component/src/pages/actions/main.js
@@ -290,13 +290,15 @@ let savedQueries = [
     "queryName": "Add statements",
     "query": "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA\n      {\n      GRAPH <http://example> {\n          <http://example/book1> dc:title \"A new book\" ;\n                                 dc:creator \"A.N.Other\" .\n          }\n      }",
     "isPublic": false,
-    "owner": "admin"
+    "owner": "admin",
+    "readonly": true
   },
   {
     "queryName": "Clear graph",
     "query": "CLEAR GRAPH <http://example>",
     "isPublic": false,
-    "owner": "admin"
+    "owner": "admin",
+    "readonly": false
   },
   {
     "queryName": "new query",


### PR DESCRIPTION
## What
The saved query model has been extended with an additional property, "readonly".

## Why
When the property is set to true, the edit and delete buttons are hidden.

## How
- The SavedQuery model has been extended with a new property, "readonly";
- saved-queries-popup.tsx has been updated to hide the edit and delete buttons if the query is marked as readonly.

![image](https://github.com/user-attachments/assets/5fd351b4-d0ac-4f7b-9d3f-bb9e0f3263e3)

read-only
![image](https://github.com/user-attachments/assets/61174408-4a37-422b-8215-7fdc7d8dbf6d)
