### PR TITLE
GDB-10933 - add more descriptive label to "Download as" button

### DIFF
--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -185,7 +185,7 @@
   "yasr.plugin_control.response_chip.message.result_info.total_results": " of {{totalResults}}",
   "yasr.plugin_control.response_chip.message.result_info.at_least_results": " of at least {{atLeastResults}}",
   "yasr.plugin_control.response_chip.message.seconds": "{{seconds}}s",
-  "yasr.plugin_control.download_as.extended_table.dropdown.label": "Download as",
+  "yasr.plugin_control.download_as.extended_table.dropdown.label": "Download as SPARQL Results JSON",
   "yasr.plugin_control.download_as.pivot_table.dropdown.label": "Download result",
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Download as",
   "yasr.plugin_control.download_as.charts.dropdown.label": "Download result",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -185,7 +185,7 @@
   "yasr.plugin_control.response_chip.message.result_info.total_results": " pour un total de {{totalResults}}",
   "yasr.plugin_control.response_chip.message.result_info.at_least_results": " d'au moins {{atLeastResults}}",
   "yasr.plugin_control.response_chip.message.seconds": "{{seconds}}s",
-  "yasr.plugin_control.download_as.extended_table.dropdown.label": "Téléchargement",
+  "yasr.plugin_control.download_as.extended_table.dropdown.label": "Télécharger les résultats SPARQL au format JSON",
   "yasr.plugin_control.download_as.raw_response.dropdown.label": "Téléchargement",
   "yasr.plugin_control.download_as.pivot_table.dropdown.label": "Télécharger le résultat",
   "yasr.plugin_control.download_as.charts.dropdown.label": "Télécharger le résultat",


### PR DESCRIPTION
## What
The "Download as" button label in the **Table** tab has been changed to "Download as SPARQL Results JSON".

## Why
The file format for JSON option was `.srj`, which confused some users. This new label was approved as more descriptive.

## How
I edited the text.

## Screenshots
![Screenshot from 2025-03-19 13-23-19](https://github.com/user-attachments/assets/fb2176eb-8e6c-4772-a0b9-1eae97d8eedc)
![Screenshot from 2025-03-19 15-14-46](https://github.com/user-attachments/assets/9b696385-be8b-4e6e-9605-c777a1efe669)
