### PR TITLE
GDB-12134 - Add an original name property to the Query Data

### DIFF
--- a/cypress/e2e/editor-actions/save-query.spec.cy.ts
+++ b/cypress/e2e/editor-actions/save-query.spec.cy.ts
@@ -162,7 +162,7 @@ describe('Save query action', () => {
         // Then the dialog is closed
         YasqeSteps.getSaveQueryDialog().should('not.exist');
         // And query is saved
-        ActionsPageSteps.getSaveQueryPayload().should('contain.value', '{"queryName":"new query","query":"select *","isPublic":true}');
+        ActionsPageSteps.getSaveQueryPayload().should('contain.value', '{"queryName":"new query","query":"select *","isPublic":true,"originalQueryName":"Query"}');
     });
 
     it('Should show error message in dialog when save fails', () => {

--- a/cypress/e2e/saved-query/edit-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/edit-saved-query.spec.cy.ts
@@ -31,15 +31,15 @@ describe('Edit saved query action', () => {
         // Then I expect that the query is saved
         YasqeSteps.getSaveQueryDialog().should('not.exist');
         YasqeSteps.getSavedQueriesPopup().should('not.exist');
-        ActionsPageSteps.getSaveQueryPayload().should('contain.value', '{"queryName":"q2-new","query":"select *","isPublic":true}');
+        ActionsPageSteps.getSaveQueryPayload().should('contain.value', '{"queryName":"q2-new","query":"select *","isPublic":true,"originalQueryName":"q2"}');
     });
-    
+
     it('Should not allow editing a saved query if it is read-only', () => {
         // When: I open the saved queries popup
         YasqeSteps.showSavedQueries();
         YasqeSteps.getSavedQueriesPopup().should('be.visible');
         YasqeSteps.getSavedQueries().should('have.length', 12);
-        
+
         // Then: The edit button should not exist if the saved query is marked as read-only
         YasqeSteps.getEditQueryButton(0).should('not.exist');
     });

--- a/cypress/stubs/constants.ts
+++ b/cypress/stubs/constants.ts
@@ -2,8 +2,8 @@ export const DEFAULT_SPARQL_QUERY = 'select * where {\n    ?s ?p ?o .\n} limit 1
 
 export const DEFAULT_SPARQL_QUERY_FROM_LOG = '\n"select * where {\\n    ?s ?p ?o .\\n} limit 100"';
 
-export const SAVED_QUERY_PAYLOAD = '{"queryName":"Query","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false}';
-export const SAVED_QUERY2_PAYLOAD = '{"queryName":"Query two","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false}';
+export const SAVED_QUERY_PAYLOAD = '{"queryName":"Query","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false,"originalQueryName":"Query"}';
+export const SAVED_QUERY2_PAYLOAD = '{"queryName":"Query two","query":"select * where {\\n    ?s ?p ?o .\\n} limit 100","isPublic":false,"originalQueryName":"Query"}';
 
 export const SHARE_QUERY_LINK = 'http://localhost:3333/pages/actions?name=Query&query=select%20*%20where%20%7B%0A%20%20%20%20%3Fs%20%3Fp%20%3Fo%20.%0A%7D%20limit%20100&infer=true&sameAs=true';
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -494,6 +494,7 @@ export class OntotextYasguiWebComponent {
    */
   @Listen('internalSaveQueryEvent')
   createSavedQueryHandler(event: CustomEvent<SaveQueryData>) {
+    this.savedQueryData = undefined;
     this.createSavedQuery.emit(event.detail);
   }
 
@@ -502,6 +503,7 @@ export class OntotextYasguiWebComponent {
    */
   @Listen('internalUpdateQueryEvent')
   updateSavedQueryHandler(event: CustomEvent<UpdateQueryData>) {
+    this.savedQueryData = undefined;
     this.updateSavedQuery.emit(event.detail);
   }
 
@@ -511,6 +513,8 @@ export class OntotextYasguiWebComponent {
   @Listen('internalSaveQueryDialogClosedEvent')
   closeSaveDialogHandler() {
     this.showSaveQueryDialog = false;
+    this.savedQueryData = undefined;
+    this.saveQueryData = undefined;
   }
 
   /**
@@ -765,6 +769,7 @@ export class OntotextYasguiWebComponent {
       data.savedQueriesList = this.savedQueryConfig.savedQueries.map((savedQuery) => {
         return {
           queryName: savedQuery.queryName,
+          originalQueryName: savedQuery.queryName,
           query: savedQuery.query,
           isPublic: savedQuery.isPublic,
           owner: savedQuery.owner,

--- a/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
+++ b/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.tsx
@@ -35,6 +35,10 @@ export class SaveQueryDialog {
   @Prop() data: SaveQueryData;
 
   @State() queryName = '';
+  /**
+   * Represents the name of the original query, before any modifications, transformations, or updates are applied.
+   */
+  @State() originalQueryName = '';
 
   @State() query = '';
 
@@ -80,6 +84,7 @@ export class SaveQueryDialog {
     this.translationService = this.serviceFactory.get(TranslationService);
     if (this.data) {
       this.queryName = this.data.queryName || this.queryName;
+      this.originalQueryName = this.data.queryName || this.queryName;
       this.query = this.data.query || this.query;
       this.isPublic = this.data.isPublic !== undefined ? this.data.isPublic : this.isPublic;
       this.isNew = this.data.isNew !== undefined ? this.data.isNew : this.isNew;
@@ -116,9 +121,9 @@ export class SaveQueryDialog {
     const isPublic = this.isPublic;
 
     if (this.isNew) {
-      this.internalSaveQueryEvent.emit(new SaveQueryData(queryName, query, isPublic));
+      this.internalSaveQueryEvent.emit(new SaveQueryData(queryName, query, isPublic, this.originalQueryName));
     } else {
-      this.internalUpdateQueryEvent.emit(new UpdateQueryData(queryName, query, isPublic));
+      this.internalUpdateQueryEvent.emit(new UpdateQueryData(queryName, query, isPublic, this.originalQueryName));
     }
   }
 
@@ -181,7 +186,7 @@ export class SaveQueryDialog {
           <div class="dialog">
             <div class="dialog-header">
               <h3
-                class="dialog-title">{this.translationService.translate('yasqe.actions.save_query.dialog.title')}</h3>
+                class="dialog-title">{this.translationService.translate(this.isNew ? 'yasqe.actions.save_query.dialog.title' : 'yasqe.actions.edit_query.dialog.title')}</h3>
               <button class="close-button icon-close" onClick={(evt) => this.onClose(evt)}></button>
             </div>
             <div class="dialog-body">
@@ -222,7 +227,7 @@ export class SaveQueryDialog {
                       onClick={(evt) => this.onClose(evt)}
                       ref={(el) => (this.cancelButton = el)}>{this.translationService.translate('yasqe.actions.save_query.dialog.cancel.button')}</button>
               <button class="ok-button" disabled={!this.isSaveAllowed}
-                      onClick={(evt) => this.onCreate(evt)}>{this.translationService.translate('yasqe.actions.save_query.dialog.create.button')}</button>
+                      onClick={(evt) => this.onCreate(evt)}>{this.translationService.translate(this.isNew ? 'yasqe.actions.save_query.dialog.create.button' : 'yasqe.actions.save_query.dialog.save.button')}</button>
             </div>
           </div>
         </div>

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -83,7 +83,7 @@ export class SavedQueriesPopup {
 
   onEdit(evt: MouseEvent, selectedQuery: SaveQueryData): void {
     evt.stopPropagation();
-    this.internalEditSavedQueryEvent.emit(new UpdateQueryData(selectedQuery.queryName, selectedQuery.query, selectedQuery.isPublic, false));
+    this.internalEditSavedQueryEvent.emit(new UpdateQueryData(selectedQuery.queryName, selectedQuery.query, selectedQuery.isPublic, selectedQuery.originalQueryName, false));
   }
 
   onDelete(evt: MouseEvent, selectedQuery: SaveQueryData): void {

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -249,6 +249,8 @@
   "yasqe.actions.save_query.dialog.cancel.button": "Cancel",
   "yasqe.actions.show_saved_queries.button.tooltip": "Show saved queries",
   "yasqe.actions.edit_saved_query.button.tooltip": "Edit",
+  "yasqe.actions.edit_query.dialog.title": "Edit Saved Query",
+  "yasqe.actions.save_query.dialog.save.button": "Save",
   "yasqe.actions.delete_saved_query.button.tooltip": "Delete",
   "yasqe.actions.delete_saved_query.confirm.dialog.label": "Confirm",
   "yasqe.actions.delete_saved_query.confirm.dialog.message": "Are you sure you want to delete the saved query '{{query}}'?",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -249,6 +249,8 @@
   "yasqe.actions.save_query.dialog.cancel.button": "Annuler",
   "yasqe.actions.show_saved_queries.button.tooltip": "Afficher les requêtes enregistrées",
   "yasqe.actions.edit_saved_query.button.tooltip": "Modifier",
+  "yasqe.actions.edit_query.dialog.title": "Modifier la requête enregistrée",
+  "yasqe.actions.save_query.dialog.save.button": "Enregistrer",
   "yasqe.actions.delete_saved_query.button.tooltip": "Supprimer",
   "yasqe.actions.delete_saved_query.confirm.dialog.label": "Confirmer",
   "yasqe.actions.delete_saved_query.confirm.dialog.message": "Êtes-vous sûr de vouloir supprimer la requête enregistrée '{{query}}' ?",

--- a/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/saved-query-configuration.ts
@@ -30,6 +30,7 @@ export interface SavedQueryInput {
   queryName: string;
   query: string;
   isPublic: boolean;
+  originalQueryName: string;
   owner: string;
   readonly: boolean
 }
@@ -39,6 +40,7 @@ export class SaveQueryData {
   constructor(public queryName: string,
               public query: string,
               public isPublic: boolean,
+              public originalQueryName?: string,
               public isNew?: boolean,
               public readonly?: boolean,
               public owner?: string,


### PR DESCRIPTION
## What?
The original name of the query will be added to the event data on saved query edit.

## Why?
The original name is required by GDB to allow editing the name of a saved query.

## How?
I added the new field to the query objects.