### PR TITLE
GDB-12633: SPARQL Editor copied query templates URLs not working

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -986,6 +986,10 @@ export class OntotextYasguiWebComponent {
     // loaded. More info https://github.com/TriplyDB/Yasgui/issues/143
     this.init(this.config);
   }
+  
+  connectedCallback(): void {
+       this.init(this.config);
+  }
 
   disconnectedCallback(): void {
     if (this.subscriptions) {


### PR DESCRIPTION
## What
Fix component not reinitializing if unmounted and then mounted again

## Why
The component was initialized in `componentDidLoad` which runs only once. If the component was later unmounded, the `disconnectedCallback` would destroy the YASGUI instance, but upon mounting the initialization would not run again.

## How
- Added initialization routine in `connectedCallback`