### PR TITLE
GDB-13149: Copy URL is White on White Background

### DIFF
--- a/ontotext-yasgui-web-component/README.md
+++ b/ontotext-yasgui-web-component/README.md
@@ -147,6 +147,16 @@ The "config" value of "ngce-prop-config" or "[config]" is an object with followi
   - full_screen
   - esc
 
+### ontotext version and GraphDB Version Compatibility
+| ontotext-yasgui-web-component | Workbench | GraphDB Version |
+|-------------------------------|-----------|-----------------|
+| 1.2+                          | 2.6+      | 10+             |
+| 1.3.18                        | 2.7+      | 10.7+           |
+| 1.3.23                        | 2.8+      | 10.8+           |
+| 1.3.23                        | 3.0+      | 11.0+           |
+| 1.3+                          | 3.1+      | 11.1+           |
+| 1.4+                          | 3.2+      | 11.2+           |
+
 
 ## Developers guide
 

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -211,6 +211,8 @@
         .editable-text-field {
           display: inline-block;
           border: 1px solid $color-onto-grey;
+          color: #55595c;
+          background-color: #fff;
         }
       }
 

--- a/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.scss
+++ b/ontotext-yasgui-web-component/src/components/save-query-dialog/save-query-dialog.scss
@@ -78,6 +78,7 @@
         border: 1px solid rgba(0, 0, 0, .15);
         font-size: 1rem;
         color: #55595c;
+        background-color: #fff;
 
         &:focus {
           border-color: rgba(0, 54, 99, .5);

--- a/ontotext-yasgui-web-component/src/css/_common.scss
+++ b/ontotext-yasgui-web-component/src/css/_common.scss
@@ -55,6 +55,7 @@
       border: 1px solid rgba(0, 0, 0, .15);
       font-size: 1rem;
       color: #55595c;
+      background-color: #fff;
 
       &:focus {
         border-color: rgba(0, 54, 99, .5);


### PR DESCRIPTION
## What
In dark mode, the background color of text inputs and textareas appears white, causing readability issues.

## Why
The background colors for text inputs and textareas were not explicitly defined, leaving them to depend on the browser’s default styling, which may conflict with dark themes.

## How
Explicitly set the background color for text inputs and textareas to ensure consistent visibility across all themes, including dark mode.

## Additional work
Also fixes background issues in rename and create saved query dialog inputs and textareas.

(cherry picked from commit 10302328d5651f6df10199ca2cf8a00f54145562)