### PR TITLE
GDB-12548: add test for auto-adding empty prefix

### DIFF
--- a/cypress/e2e/autocomplete/sesame-autocomplete.spec.cy.ts
+++ b/cypress/e2e/autocomplete/sesame-autocomplete.spec.cy.ts
@@ -18,7 +18,7 @@ describe('Sesame autocomplete', () => {
     YasqeSteps.writeInEditor('{enter} ?o {}} limit 1');
     YasqeSteps.getQuery().should('eq', 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nselect * where { ?s rdf:li ?o } limit 1');
   });
-  
+
   it('Should set apply a prefix if a suggestion start with a namespace', () => {
     AutocompleteStubs.stubSesamePrefixesResponse();
     YasqeSteps.getQuery().should('eq', DEFAULT_SPARQL_QUERY);
@@ -26,5 +26,13 @@ describe('Sesame autocomplete', () => {
     YasqeSteps.writeInEditor('PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nselect * where {{} ?s r');
     YasqeSteps.getEditor().find('textarea').type('{alt}{enter}');
     cy.get('.CodeMirror-hints').should('be.visible');
+  });
+
+  it('Should auto add empty prefix when typed', () => {
+    AutocompleteStubs.stubSesamePrefixesResponse();
+    YasqeSteps.getQuery().should('eq', DEFAULT_SPARQL_QUERY);
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor('select * where {{} ?s :}');
+    YasqeSteps.getQuery().should('eq', 'PREFIX : <http://data.europe.eu>\nselect * where { ?s :}');
   });
 })

--- a/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
+++ b/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
@@ -23,6 +23,7 @@ function getYasqeAutocompleter() {
 
 function getPrefixes() {
   return {
+    "": "http://data.europe.eu",
     "gn": "http://www.geonames.org/ontology#",
     "path": "http://www.ontotext.com/path#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",


### PR DESCRIPTION
## What
Added a test to verify that an empty prefix is automatically added when a specific pattern is typed in the editor.

## Why
This change ensures that the autocomplete functionality behaves as expected when users type an empty prefix, improving user experience and reducing potential errors in query formulation.

## How
- Created a new test case in `sesame-autocomplete.spec.cy.ts` to check for the empty prefix behavior.
- Updated the `getPrefixes` function in `ontotext-yasgui-tests-util.js` to include the empty prefix mapping.