### PR TITLE
GDB-14165 fix SPARQL editor not showing results

### DIFF
--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -26,9 +26,6 @@ export class ExtendedYasr extends Yasr {
   //       Overridden functions.
   //=================================
   drawPluginSelectors() {
-    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery()) {
-      return;
-    }
     super.drawPluginSelectors();
 
     if (!this.yasrToolbarManagers && this.config.yasrToolbarPlugins) {

--- a/yasgui-patches/2026-03-30-GDB-14165_fix_SPARQL_editor_not_showing_results.patch
+++ b/yasgui-patches/2026-03-30-GDB-14165_fix_SPARQL_editor_not_showing_results.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] GDB-14165 fix SPARQL editor not showing results
+---
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision c20133ed13d966ead726d069ed7ea9c80bc91991)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision a990b43132d6ff09deeb1705810d3341f9c3b2ec)
+@@ -26,9 +26,6 @@
+   //       Overridden functions.
+   //=================================
+   drawPluginSelectors() {
+-    if (this.yasqe.isUpdateQuery() || this.yasqe.isAskQuery()) {
+-      return;
+-    }
+     super.drawPluginSelectors();
+ 
+     if (!this.yasrToolbarManagers && this.config.yasrToolbarPlugins) {


### PR DESCRIPTION
## What
Fix SPARQL editor not showing results header.

## Why
The buttons for selecting a plugin in the results header was not showing under certain conditions if we use ask or update queries

## How
Removed the conditional check for `this.yasqe.isUpdateQuery()` and `this.yasqe.isAskQuery()` in the `drawPluginSelectors` method to allow the rendering of results regardless of the query type. The problem was that it was ran only once upon the constructor initialization and if the query is update or ask, we don't add the header at all. Upon opening a new tab, the query check returns `SELECT` always regardless of what tab we are coming from and what query we are opening, hence we display the header. Showing/hiding is handled when a query is run inside `updatePluginElementVisibility` so we need to always render the header

## Testing
n/a