### PR TITLE
GDB-14205: Add text direction support to YASR table results

### DIFF
--- a/Yasgui/packages/yasr/src/parsers/index.ts
+++ b/Yasgui/packages/yasr/src/parsers/index.ts
@@ -23,6 +23,7 @@ namespace Parser {
     type: "uri" | "literal" | "typed-literal" | "bnode";
     datatype?: string;
     "xml:lang"?: string;
+    "its:dir"?: string;
   }
   export interface Binding {
     [varname: string]: BindingValue;

--- a/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/table/plugin-table.spec.cy.ts
@@ -67,7 +67,7 @@ describe('Plugin: Table', () => {
         PaginationPageSteps.visit();
       });
 
-      it('should that there aren\'t results when query returns no results', () => {
+      it('should verify that there aren\'t results when query returns no results', () => {
         // When I visit a page with "ontotext-yasgui" in it,
         // and execute a query which don't return results.
         const queryDescription = new QueryStubDescription()
@@ -286,6 +286,45 @@ describe('Plugin: Table', () => {
       });
     });
     describe('Literal result formatting', () => {
+      it('should apply dir="ltr" and show @lang--ltr when binding has dir ltr', () => {
+        // When I execute a query which returns a literal with dir: "ltr".
+        QueryStubs.stubSingleLiteralWithDirLtrResult();
+        YasqeSteps.executeQuery();
+        // Then I expect the literal cell to have dir="ltr".
+        YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'dir', 'ltr');
+        // And the displayed language tag should include the direction suffix.
+        YasrSteps.getResultLiteralCell(0, 1).contains('@en--ltr');
+      });
+
+      it('should apply dir="rtl" and show @lang--rtl when binding has dir rtl', () => {
+        // When I execute a query which returns a literal with dir: "rtl".
+        QueryStubs.stubSingleLiteralWithDirRtlResult();
+        YasqeSteps.executeQuery();
+        // Then I expect the literal cell to have dir="rtl".
+        YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'dir', 'rtl');
+        // And the displayed language tag should include the direction suffix.
+        YasrSteps.getResultLiteralCell(0, 1).contains('@he--rtl');
+      });
+
+      it('should apply dir="rtl" and show @lang--rtl when direction is embedded in the lang tag', () => {
+        // When I execute a query which returns a literal with direction embedded in xml:lang (e.g. "ar--rtl").
+        QueryStubs.stubSingleLiteralWithEmbeddedDirResult();
+        YasqeSteps.executeQuery();
+        // Then I expect the literal cell to have dir="rtl" extracted from the lang tag.
+        YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'dir', 'rtl');
+        // And the HTML lang attribute should be stripped to just the language code.
+        YasrSteps.getResultLiteralCell(0, 1).should('have.attr', 'lang', 'ar');
+        // And the displayed language tag should include the direction suffix.
+        YasrSteps.getResultLiteralCell(0, 1).contains('@ar--rtl');
+      });
+
+      it('should not add dir attribute to literal cell when binding has no dir field', () => {
+        // When I execute a query which returns a literal without a dir field.
+        QueryStubs.stubSingleLiteralWithoutLangTagResult();
+        YasqeSteps.executeQuery();
+        // Then I expect the literal cell to have no dir attribute.
+        YasrSteps.getResultLiteralCell(0, 1).should('not.have.attr', 'dir');
+      });
     });
   });
 });

--- a/cypress/fixtures/queries/single-literal-with-dir-ltr-response.json
+++ b/cypress/fixtures/queries/single-literal-with-dir-ltr-response.json
@@ -1,0 +1,20 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "xml:lang": "en",
+          "its:dir": "ltr",
+          "type": "literal",
+          "value": "left-to-right text"
+        }
+      }
+    ]
+  }
+}
+

--- a/cypress/fixtures/queries/single-literal-with-dir-rtl-response.json
+++ b/cypress/fixtures/queries/single-literal-with-dir-rtl-response.json
@@ -1,0 +1,20 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "xml:lang": "he",
+          "its:dir": "rtl",
+          "type": "literal",
+          "value": "טקסט מימין לשמאל"
+        }
+      }
+    ]
+  }
+}
+

--- a/cypress/fixtures/queries/single-literal-with-embedded-dir-response.json
+++ b/cypress/fixtures/queries/single-literal-with-embedded-dir-response.json
@@ -1,0 +1,19 @@
+{
+  "head": {
+    "vars": [
+      "x"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x": {
+          "xml:lang": "ar--rtl",
+          "type": "literal",
+          "value": "يهوه"
+        }
+      }
+    ]
+  }
+}
+

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -42,6 +42,18 @@ export class QueryStubs {
     QueryStubs.stubQueryResponse('/queries/single-literal-with-data-type-response.json', repositoryId, 'single-iri-result', withDelay);
   }
 
+  static stubSingleLiteralWithDirLtrResult(repositoryId = 'test-repo', withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-with-dir-ltr-response.json', repositoryId, 'single-literal-with-dir-ltr', withDelay);
+  }
+
+  static stubSingleLiteralWithDirRtlResult(repositoryId = 'test-repo', withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-with-dir-rtl-response.json', repositoryId, 'single-literal-with-dir-rtl', withDelay);
+  }
+
+  static stubSingleLiteralWithEmbeddedDirResult(repositoryId = 'test-repo', withDelay = 0) {
+    QueryStubs.stubQueryResponse('/queries/single-literal-with-embedded-dir-response.json', repositoryId, 'single-literal-with-embedded-dir', withDelay);
+  }
+
   static stubManyColumnResult(repositoryId =  'test-repo', withDelay = 0) {
     QueryStubs.stubQueryResponse('/queries/many-column-response.json', repositoryId, 'many-column-result', withDelay);
   }

--- a/ontotext-yasgui-web-component/src/models/yasgui/parser.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/parser.ts
@@ -3,6 +3,7 @@ export interface BindingValue {
   type: 'uri' | 'literal' | 'typed-literal' | 'bnode';
   datatype?: string;
   'xml:lang'?: string;
+  'its:dir'?: string;
 }
 
 export type Binding = Record<string, BindingValue>;

--- a/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasr/yasr-service.ts
@@ -117,7 +117,11 @@ export class YasrService {
 
   // @ts-ignore
   private static getLiteralCellContent(binding: Parser.BindingValue): string {
-    return `<div lang="${YasrService.getLang(binding, 'xx')}" class="literal-cell"><p class="nonUri">${this.getLiteralAsString(binding, true)}</p></div>`;
+    const lang = HtmlUtil.escapeHTMLEntities(YasrService.getLang(binding, 'xx'));
+    const dir = YasrService.getDir(binding);
+    const dirAttr = dir ? ` dir="${dir}"` : '';
+
+    return `<div lang="${lang}"${dirAttr} class="literal-cell"><p class="nonUri">${this.getLiteralAsString(binding, true)}</p></div>`;
   }
 
   //@ts-ignore
@@ -128,12 +132,12 @@ export class YasrService {
 
     const stringRepresentation = HtmlUtil.escapeHTMLEntities(binding.value);
 
-    if (binding["xml:lang"]) {
-      return YasrService.addWordBreakToLiterals(`"${stringRepresentation}"${forHtml ? '<sup>' : ''}@${binding["xml:lang"]}${forHtml ? '</sup>' : ''}`);
-    }
+    const lang = HtmlUtil.escapeHTMLEntities(YasrService.getLang(binding, undefined));
 
-    if (binding["lang"]) {
-      return YasrService.addWordBreakToLiterals(`"${stringRepresentation}"${forHtml ? '<sup>' : ''}@${binding["lang"]}${forHtml ? '</sup>' : ''}`);
+    if (lang) {
+      const dir = YasrService.getDir(binding);
+      const langTag = dir ? `${lang}--${dir}` : lang;
+      return YasrService.addWordBreakToLiterals(`"${stringRepresentation}"${forHtml ? '<sup>' : ''}@${langTag}${forHtml ? '</sup>' : ''}`);
     }
 
     if (binding.datatype && YasrService.XML_SCHEMA_NS_STRING !== binding.datatype) {
@@ -170,13 +174,36 @@ export class YasrService {
   }
 
   private static getLang(literalBinding, defaultLang) {
-    if (literalBinding["xml:lang"]) {
-      return literalBinding["xml:lang"];
-    }
-    if (literalBinding["lang"]) {
-      return literalBinding["lang"];
+    const lang = literalBinding["xml:lang"] || literalBinding["lang"];
+    if (lang) {
+      // Strip the direction suffix (e.g. "ar--rtl" → "ar") so the HTML lang
+      // attribute only contains a valid BCP 47 language subtag.
+      return lang.replace(/--(?:ltr|rtl)$/i, '');
     }
     return defaultLang;
+  }
+
+  private static getDir(literalBinding): 'ltr' | 'rtl' | undefined {
+    // its:dir field with values like "--ltr" or "--rtl" (ITS 2.0 / some SPARQL implementations).
+    const itsDir = literalBinding["its:dir"];
+    if (itsDir) {
+      const itsDirNormalized = itsDir.replace(/^-+/, '').toLowerCase();
+      if (itsDirNormalized === 'ltr' || itsDirNormalized === 'rtl') {
+        return itsDirNormalized as 'ltr' | 'rtl';
+      }
+    }
+    // Fallback: direction embedded in the lang tag (e.g. "ar--rtl").
+    const lang = literalBinding["xml:lang"] || literalBinding["lang"];
+    if (lang) {
+      const match = lang.match(/--([a-zA-Z]+)$/);
+      if (match) {
+        const dir = match[1].toLowerCase();
+        if (dir === 'ltr' || dir === 'rtl') {
+          return dir as 'ltr' | 'rtl';
+        }
+      }
+    }
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## What
Enhance the YASR table to support text direction attributes for literals. This includes adding the ability to specify 'dir' attributes based on language direction.

## Why
This change improves the accessibility and readability of text in the YASR table by ensuring that the correct text direction is applied based on the language of the content.

## How
- Modified `getLiteralCellContent` to include a `dir` attribute based on the language direction.
- Implemented `getDir` method to extract direction information from the binding.
- Updated language handling to append direction suffixes in language tags.
- Added new test cases to verify the correct application of direction attributes in the rendered output.

<img width="1246" height="508" alt="image" src="https://github.com/user-attachments/assets/8dc454cf-c77c-48f5-a088-b984e37f7a82" />
