### PR TITLE
GDB-14351: Updated the Leaflet Attribution Link.

### DIFF
--- a/ontotext-yasgui-web-component/src/plugins/yasr/geo/geo-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/geo/geo-plugin.ts
@@ -140,6 +140,7 @@ export class GeoPlugin implements YasrPlugin {
       center: [50 + 38 / 60 + 28 / 3600, 4 + 40 / 60 + 5 / 3600],
       zoom: 5,
     });
+    this.map.attributionControl.setPrefix('<a href="https://leafletjs.com" target="_blank" rel="noopener noreferrer">Leaflet</a>');
   }
 
   /**


### PR DESCRIPTION
## What
Updated the Leaflet attribution link.

## Why
The link was opening in the current tab, causing users to navigate away from the workbench.

## How
Changed the link to open in a new tab.

## Screenshots
<img width="271" height="201" alt="image" src="https://github.com/user-attachments/assets/8b8f1424-f346-45a4-b95d-b5ed599ad8d6" />
