### PR TITLE
GDB-14288: Add autocompleter for GeoSPARQL variables

### DIFF
--- a/Yasgui/packages/yasqe/src/autocompleters/variables.ts
+++ b/Yasgui/packages/yasqe/src/autocompleters/variables.ts
@@ -1,5 +1,21 @@
 import * as autocompleter from "./";
 
+/**
+ * Returns geo-variable suggestions for tokens that start with '?geo_'.
+ * E.g. for token "?geo_f" it returns ["?geo_fillColor", "?geo_fillOpacity"].
+ *
+ * @param variableIndicator - the leading character of the token ('?' or '$')
+ * @param variableName - the token string without the leading indicator
+ * @param geoProperties - the list of known geo property names
+ */
+function getGeoVariableSuggestions(variableIndicator: string, variableName: string, geoProperties: string[]): string[] {
+  return geoProperties
+    .filter((s) => s !== variableName && s.startsWith(variableName))
+    .map((s) => `${variableIndicator}${s}`)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+
 var conf: autocompleter.CompleterConfig = {
   name: "variables",
   isValidCompletionPosition: function (yasqe) {
@@ -44,7 +60,25 @@ var conf: autocompleter.CompleterConfig = {
         vars.push(variable);
       }
     }
-    return vars.sort();
+
+    vars.sort();
+
+    // If the token starts with '?geo_', also suggest geo-variable values from GeoSparqlVariable.
+    const geoProperties = yasqe.config.geoProperties;
+    const geoPropertiesPrefix = yasqe.config.geoPropertiesPrefix;
+    const variableName = token.string.slice(1);
+
+    if (variableName.startsWith(geoPropertiesPrefix)) {
+      const geoSuggestions = getGeoVariableSuggestions(token.string[0], variableName, geoProperties);
+      for (const suggestion of geoSuggestions) {
+        if (!distinctVars[suggestion]) {
+          distinctVars[suggestion] = true;
+          vars.push(suggestion);
+        }
+      }
+    }
+
+    return vars;
   },
   bulk: false,
   autoShow: true,

--- a/Yasgui/packages/yasqe/src/defaults.ts
+++ b/Yasgui/packages/yasqe/src/defaults.ts
@@ -103,6 +103,8 @@ SELECT * WHERE {
         yasqe.getInputField().blur();
       },
     },
+    geoProperties: [],
+    geoPropertiesPrefix: '',
 
     createShareableLink: function (yasqe: Yasqe) {
       return (

--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -1468,6 +1468,15 @@ export interface Config extends Partial<CodeMirror.EditorConfiguration> {
   tabId: string;
   getRepositoryStatementsCount: () => Promise<number>;
   onQueryAborted?: (req: superagent.SuperAgentRequest | undefined) => Promise<void>;
+  /**
+   * Available GeoSPARQL properties
+   */
+  geoProperties: string[];
+
+  /**
+   * GeoSPARQL properties prefix
+   */
+  geoPropertiesPrefix: string;
 }
 
 export interface CustomResultMessage {

--- a/cypress/e2e/autocomplete/geo-sparql-autocomplete.spec.cy.ts
+++ b/cypress/e2e/autocomplete/geo-sparql-autocomplete.spec.cy.ts
@@ -1,0 +1,80 @@
+import AutocompletePageSteps from "../../steps/pages/autocomplete-page-steps";
+import { YasqeSteps } from "../../steps/yasqe-steps";
+
+describe("Geo SPARQL variables autocomplete", () => {
+
+  beforeEach(() => {
+    AutocompletePageSteps.visit();
+  });
+
+  it("Should show all geo variable suggestions when typing a variable with underscore", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_");
+    cy.get(".CodeMirror-hints").should("be.visible");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").should("have.length", 7);
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(0).should("contain", "?geo_color");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(1).should("contain", "?geo_fillColor");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(2).should("contain", "?geo_fillOpacity");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(3).should("contain", "?geo_opacity");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(4).should("contain", "?geo_popup");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(5).should("contain", "?geo_tooltip");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(6).should("contain", "?geo_weight");
+  });
+
+  it("Should filter suggestions based on partial suffix", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_pop");
+    cy.get(".CodeMirror-hints").should("be.visible");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").should("have.length", 1);
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(0).should("contain", "?geo_popup");
+  });
+
+  it("Should not show suggestions for variables with multiple underscores", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_node_");
+    cy.get(".CodeMirror-hints").should("not.exist");
+  });
+
+  it("Should not show suggestions for variables with multiple underscores and partial suffix", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_layer_pop");
+    cy.get(".CodeMirror-hints").should("not.exist");
+  });
+
+  it("Should apply selected geo variable suggestion", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_pop");
+    cy.get(".CodeMirror-hints").should("be.visible");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(0).click();
+    YasqeSteps.getQuery().should("contain", "?geo_popup");
+  });
+
+  it("Should show all geo variable suggestions when typing a variable with $ prefix and underscore", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} $geo_");
+    cy.get(".CodeMirror-hints").should("be.visible");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").should("have.length", 7);
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(0).should("contain", "$geo_color");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(1).should("contain", "$geo_fillColor");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(2).should("contain", "$geo_fillOpacity");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(3).should("contain", "$geo_opacity");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(4).should("contain", "$geo_popup");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(5).should("contain", "$geo_tooltip");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(6).should("contain", "$geo_weight");
+  });
+
+  it("Should filter suggestions matching fill prefix", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo_fill");
+    cy.get(".CodeMirror-hints").should("be.visible");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").should("have.length", 2);
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(0).should("contain", "?geo_fillColor");
+    cy.get(".CodeMirror-hints .CodeMirror-hint").eq(1).should("contain", "?geo_fillOpacity");
+  });
+
+  it("Should not show autocomplete for variables without underscore", () => {
+    YasqeSteps.clearEditor();
+    YasqeSteps.writeInEditor("select * where {{} ?geo");
+    cy.get(".CodeMirror-hints").should("not.exist");
+  });
+});

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -137,6 +137,16 @@ export interface YasguiConfiguration {
       prefixes: string[];
 
       /**
+       * Available GeoSPARQL properties
+       */
+      geoProperties: string[];
+
+      /**
+       * GeoSPARQL properties prefix
+       */
+      geoPropertiesPrefix: string;
+
+      /**
        * Object contains pair keyboard shortcut and function to be executed when user press the keyboard shortcut.
        * Example:
        * <pre>

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -22,6 +22,7 @@ import {PivotTableDownloadPlugin} from '../../yasr/toolbar/pivot-table-download-
 import {ChartDownloadPlugin} from "../../yasr/toolbar/chart-download-plugin";
 import { ExplainPlanUtil } from '../../utils/explain-plan-util';
 import {DEFAULT_THEME} from "../../../configurations/constants";
+import {GEO_PROPERTIES_PREFIX, GeoSparqlVariable} from '../../../plugins/yasr/geo/models/geo-sparql-variable';
 
 /**
  * Builder for yasgui configuration.
@@ -77,6 +78,8 @@ export class YasguiConfigurationBuilder {
       paginationOn: externalConfiguration.paginationOn !== undefined ? externalConfiguration.paginationOn : defaultYasguiConfig.paginationOn,
       pageSize: externalConfiguration.pageSize !== undefined ? externalConfiguration.pageSize : defaultYasguiConfig.pageSize,
       yasqe: {
+        geoProperties: Object.values(GeoSparqlVariable),
+        geoPropertiesPrefix: GEO_PROPERTIES_PREFIX,
         prefixes: [],
         extraKeys: {},
         keyboardShortcutDescriptions: [],

--- a/yasgui-patches/2026-04-21-GDB-14288__added_geo_sparql_autocompleter.patch
+++ b/yasgui-patches/2026-04-21-GDB-14288__added_geo_sparql_autocompleter.patch
@@ -1,0 +1,98 @@
+Index: Yasgui/packages/yasqe/src/autocompleters/variables.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/autocompleters/variables.ts b/Yasgui/packages/yasqe/src/autocompleters/variables.ts
+--- a/Yasgui/packages/yasqe/src/autocompleters/variables.ts	(revision d3ded20ade8e93e6829fe16bce235d26c4a13ee4)
++++ b/Yasgui/packages/yasqe/src/autocompleters/variables.ts	(revision c3549e073d4453d9bf50d15ae1ce2a389d629484)
+@@ -1,5 +1,21 @@
+ import * as autocompleter from "./";
+
++/**
++ * Returns geo-variable suggestions for tokens that start with '?geo_'.
++ * E.g. for token "?geo_f" it returns ["?geo_fillColor", "?geo_fillOpacity"].
++ *
++ * @param variableIndicator - the leading character of the token ('?' or '$')
++ * @param variableName - the token string without the leading indicator
++ * @param geoProperties - the list of known geo property names
++ */
++function getGeoVariableSuggestions(variableIndicator: string, variableName: string, geoProperties: string[]): string[] {
++  return geoProperties
++    .filter((s) => s !== variableName && s.startsWith(variableName))
++    .map((s) => `${variableIndicator}${s}`)
++    .sort((a, b) => a.localeCompare(b));
++}
++
++
+ var conf: autocompleter.CompleterConfig = {
+   name: "variables",
+   isValidCompletionPosition: function (yasqe) {
+@@ -44,7 +60,25 @@
+         vars.push(variable);
+       }
+     }
+-    return vars.sort();
++
++    vars.sort();
++
++    // If the token starts with '?geo_', also suggest geo-variable values from GeoSparqlVariable.
++    const geoProperties = yasqe.config.geoProperties;
++    const geoPropertiesPrefix = yasqe.config.geoPropertiesPrefix;
++    const variableName = token.string.slice(1);
++
++    if (variableName.startsWith(geoPropertiesPrefix)) {
++      const geoSuggestions = getGeoVariableSuggestions(token.string[0], variableName, geoProperties);
++      for (const suggestion of geoSuggestions) {
++        if (!distinctVars[suggestion]) {
++          distinctVars[suggestion] = true;
++          vars.push(suggestion);
++        }
++      }
++    }
++
++    return vars;
+   },
+   bulk: false,
+   autoShow: true,
+Index: Yasgui/packages/yasqe/src/defaults.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/defaults.ts b/Yasgui/packages/yasqe/src/defaults.ts
+--- a/Yasgui/packages/yasqe/src/defaults.ts	(revision d3ded20ade8e93e6829fe16bce235d26c4a13ee4)
++++ b/Yasgui/packages/yasqe/src/defaults.ts	(revision c3549e073d4453d9bf50d15ae1ce2a389d629484)
+@@ -103,6 +103,8 @@
+         yasqe.getInputField().blur();
+       },
+     },
++    geoProperties: [],
++    geoPropertiesPrefix: '',
+
+     createShareableLink: function (yasqe: Yasqe) {
+       return (
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision d3ded20ade8e93e6829fe16bce235d26c4a13ee4)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision c3549e073d4453d9bf50d15ae1ce2a389d629484)
+@@ -1468,6 +1468,15 @@
+   tabId: string;
+   getRepositoryStatementsCount: () => Promise<number>;
+   onQueryAborted?: (req: superagent.SuperAgentRequest | undefined) => Promise<void>;
++  /**
++   * Available GeoSPARQL properties
++   */
++  geoProperties: string[];
++
++  /**
++   * GeoSPARQL properties prefix
++   */
++  geoPropertiesPrefix: string;
+ }
+
+ export interface CustomResultMessage {


### PR DESCRIPTION
## What
Implemented an autocompleter for GeoSPARQL variables that suggests suffixes based on user input. Added corresponding tests to verify functionality.

## Why
This feature enhances the user experience by providing relevant suggestions when typing GeoSPARQL variables, improving efficiency and accuracy in query writing.

## How
- Introduced a function `getGeoVariableSuggestions` to generate suffix suggestions for tokens containing underscores.
- Updated the autocompleter configuration to include geo-variable suggestions.
- Created a new test suite to validate the autocomplete functionality for various scenarios.