### PR TITLE
GDB-14271: Simplify fullscreen configuration for YASR

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -111,11 +111,14 @@ export class Tab extends EventEmitter {
     //controlbar
     this.controlBarEl = document.createElement("div");
     this.controlBarEl.className = "controlbar";
-    wrapper.appendChild(this.controlBarEl);
-
+    if (!this.yasgui.config.yasrFullscreen) {
+      wrapper.appendChild(this.controlBarEl);
+    }
     //yasqe
     this.yasqeWrapperEl = document.createElement("div");
-    wrapper.appendChild(this.yasqeWrapperEl);
+    if (!this.yasgui.config.yasrFullscreen) {
+      wrapper.appendChild(this.yasqeWrapperEl);
+    }
 
     //yasr
     this.yasrWrapperEl = document.createElement("div");
@@ -684,7 +687,7 @@ export class Tab extends EventEmitter {
     yasrConf.clearState = this.yasgui.config.clearState;
     yasrConf.isExplainPlan = this.yasgui.config.yasr.isExplainPlan
     yasrConf.tabId = this.getId();
-    yasrConf.yasrFullscreen = this.yasgui.config.yasr.yasrFullscreen;
+    yasrConf.fullscreen = this.yasgui.config.yasr.fullscreen;
     if (this.yasgui.config.yasr.selectedPlugin != null) {
         yasrConf.selectedPlugin = this.yasgui.config.yasr.selectedPlugin;
     }

--- a/Yasgui/packages/yasgui/src/index.ts
+++ b/Yasgui/packages/yasgui/src/index.ts
@@ -64,6 +64,7 @@ export interface Config<EndpointObject extends CatalogueItem = CatalogueItem> {
   paginationOn?: boolean;
   pageSize?: number;
   pageNumber: number;
+  yasrFullscreen?: boolean;
 }
 export type PartialConfig = {
   [P in keyof Config]?: Config[P] extends object ? Partial<Config[P]> : Config[P];
@@ -136,7 +137,9 @@ export class Yasgui extends EventEmitter {
     this.tabElements = new ExtendedTabElements(this);
     this.tabPanelsEl = document.createElement("div");
 
-    this.rootEl.appendChild(this.tabElements.drawTabsList());
+    if (!config.yasrFullscreen) {
+      this.rootEl.appendChild(this.tabElements.drawTabsList());
+    }
     this.rootEl.appendChild(this.tabPanelsEl);
     let executeIdAfterInit: string | undefined;
     let optionsFromUrl: PersistedTabJson | undefined;

--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -27,7 +27,7 @@ export class ExtendedYasr extends Yasr {
     this.yasqe.on("countAffectedRepositoryStatementsPersisted", this.updateResponseInfo.bind(this));
 
     // Toggle only if the default fullscreen value is true and YASR is not in fullscreen mode.
-    if (this.config.yasrFullscreen?.defaultFullscreen && !this.isFullscreen) {
+    if (this.config.fullscreen && !this.isFullscreen) {
         this.toggleFullscreen();
     }
   }
@@ -51,15 +51,16 @@ export class ExtendedYasr extends Yasr {
       return;
     }
     const pluginSelectorsEl = this.getPluginSelectorsEl();
-    this.fullscreenButton = this.createFullscreenButton();
-    pluginSelectorsEl.appendChild(this.fullscreenButton);
 
-    if (this.config.yasrFullscreen?.allowEscape) {
-        this.boundEscapeHandler = this.onEscapeHandler.bind(this);
-        document.addEventListener('keydown', this.boundEscapeHandler);
+    if (!this.config.fullscreen) {
+      this.fullscreenButton = this.createFullscreenButton();
+      pluginSelectorsEl.appendChild(this.fullscreenButton);
+
+      this.boundEscapeHandler = this.onEscapeHandler.bind(this);
+      document.addEventListener('keydown', this.boundEscapeHandler);
     }
 
-    const spacerElement = document.createElement("li");
+    const spacerElement = document.createElement('li');
     spacerElement.classList.add("spacer");
     pluginSelectorsEl.appendChild(spacerElement);
 
@@ -371,7 +372,7 @@ export class ExtendedYasr extends Yasr {
 
       this.emit('fullscreen-changed', this.isFullscreen);
 
-      if (this.isFullscreen && this.config.yasrFullscreen?.allowEscape) {
+      if (this.isFullscreen && !this.config.fullscreen) {
         const message = this.translationService.translate('yasr.btn.fullscreen.escape.message');
         this.notificationMessageService.info('yasr_exit_fullscreen', message);
       }

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -77,7 +77,7 @@ export class Yasr extends EventEmitter {
     this.storage = new YStorage(Yasr.storageNamespace);
     this.getConfigFromStorage();
     this.headerEl = document.createElement("div");
-    this.headerEl.className = "yasr_header";
+    this.headerEl.className = 'yasr_header';
     this.rootEl.appendChild(this.headerEl);
     this.fallbackInfoEl = document.createElement("div");
     this.fallbackInfoEl.className = "yasr_fallback_info";
@@ -432,6 +432,12 @@ export class Yasr extends EventEmitter {
   drawPluginSelectors() {
     this.pluginSelectorsEl = document.createElement("ul");
     this.pluginSelectorsEl.className = "yasr_btnGroup";
+
+    if (this.config.fullscreen) {
+      this.headerEl.appendChild(this.pluginSelectorsEl);
+      return;
+    }
+
     const pluginOrder = this.config.pluginOrder;
     Object.keys(this.config.plugins)
       .sort()
@@ -471,6 +477,7 @@ export class Yasr extends EventEmitter {
       button.appendChild(nameEl);
       button.addEventListener("click", () => this.selectPlugin(pluginName));
       const li = document.createElement("li");
+      addClass(li, "plugin_selector");
       const buttonPluginTooltip: any = document.createElement("yasgui-tooltip");
       buttonPluginTooltip.yasguiDataTooltip = window.innerWidth < 768 ? name : "";
       buttonPluginTooltip.placement = "top";
@@ -825,10 +832,7 @@ export interface Config {
   showResultInfo: boolean;
   showQueryLoader: boolean;
   sparqlResponse?: string;
-  yasrFullscreen?: {
-      defaultFullscreen: boolean,
-      allowEscape: boolean,
-  };
+  fullscreen?: boolean;
   selectedPlugin?: string;
   /**
    * Custom renderers for errors.

--- a/cypress/e2e/yasr/yasr-fullscreen.spec.cy.ts
+++ b/cypress/e2e/yasr/yasr-fullscreen.spec.cy.ts
@@ -2,10 +2,11 @@ import {YasrSteps} from '../../steps/yasr-steps';
 import {YasguiSteps} from '../../steps/yasgui-steps';
 import ViewConfigurationsPageSteps from '../../steps/view-configurations-page-steps';
 import {YasqeSteps} from '../../steps/yasqe-steps';
+import {ToolbarPageSteps} from '../../steps/toolbar-page-steps';
 
 describe('YASR fullscreen', () => {
 
-  it('should open YASR in non-fullscreen mode with escape enabled by default', () => {
+  it('should open YASR in non-fullscreen mode by default with escape enabled', () => {
     // WHEN: I open a page that contains "ontotext-yasgui-web-component" without a yasrFullscreen configuration.
     ViewConfigurationsPageSteps.visit();
     YasqeSteps.executeQuery();
@@ -15,7 +16,7 @@ describe('YASR fullscreen', () => {
     // WHEN: I toggle to fullscreen mode.
     YasrSteps.toggleFullscreen();
     // THEN: I should see YASR results in fullscreen mode.
-    verifyYasrFullscreen();
+    verifyYasrExpandFullscreen();
     // AND: I should see the notification that describes how to exit fullscreen mode.
     ViewConfigurationsPageSteps.getOutputMessage().should('contain.text', '{"TYPE":"notificationMessage","payload":{"code":"yasr_exit_fullscreen","messageType":"info","message":"Press Esc to exit full screen"}}');
 
@@ -25,59 +26,43 @@ describe('YASR fullscreen', () => {
     verifyYasrNonFullscreen();
   });
 
-  it('should open YASR in fullscreen mode with escape enabled via configuration', () => {
-    // WHEN: I open a page that contains "ontotext-yasgui-web-component" with YASR in fullscreen and escape allowed.
+  it('should open YASR in fullscreen via configuration with escape disabled', () => {
+    // WHEN: I open a page that contains "ontotext-yasgui-web-component" with YASR in fullscreen set via configuration.
     ViewConfigurationsPageSteps.visit();
     YasqeSteps.executeQuery();
-    ViewConfigurationsPageSteps.configureYasrFullscreenOnAllowEscapeOn();
+    verifyYasrNonFullscreen();
+    ViewConfigurationsPageSteps.configureYasrFullscreenOn();
     // THEN: I should see YASR results in fullscreen mode, because it is configured to start in fullscreen.
     verifyYasrFullscreen();
-    // AND: I should see the notification that describes how to exit fullscreen mode.
-    ViewConfigurationsPageSteps.getOutputMessage().should('contain.text', '{"TYPE":"notificationMessage","payload":{"code":"yasr_exit_fullscreen","messageType":"info","message":"Press Esc to exit full screen"}}');
-
-
+    // AND: I should not see the notification that describes how to exit fullscreen mode.
+    ViewConfigurationsPageSteps.getOutputMessage().should('not.exist');
     // WHEN: I press the ESC key.
     YasguiSteps.pressEscape();
-    // THEN: I should see YASR results in non-fullscreen mode, because escape is enabled.
-    verifyYasrNonFullscreen();
+    // THEN: I should see YASR remains in fullscreen.
+    verifyYasrFullscreen();
+    // AND: I should not see the notification that describes how to exit fullscreen mode.
+    ViewConfigurationsPageSteps.getOutputMessage().should('not.exist');
   });
 
-  it('should open YASR in non-fullscreen mode with escape enabled via configuration', () => {
+  it('should open YASR in non-fullscreen mode via configuration and escape enabled', () => {
     // WHEN: I open a page that contains "ontotext-yasgui-web-component" with YASR in non-fullscreen and escape allowed.
     ViewConfigurationsPageSteps.visit();
     YasqeSteps.executeQuery();
-    ViewConfigurationsPageSteps.configureYasrFullscreenOffAllowEscapeOn();
+    verifyYasrNonFullscreen();
+    ViewConfigurationsPageSteps.configureYasrFullscreenOff();
     // THEN: I should see YASR results in non-fullscreen mode, because it is configured not to start in fullscreen.
     verifyYasrNonFullscreen();
-    YasrSteps.getResultHeader().should('be.visible');
-
-    // WHEN: I toggle fullscreen mode.
+    // WHEN: I toggle to fullscreen mode.
     YasrSteps.toggleFullscreen();
     // THEN: I should see YASR results in fullscreen mode.
-    verifyYasrFullscreen();
+    verifyYasrExpandFullscreen();
     // AND: I should see the notification that describes how to exit fullscreen mode.
     ViewConfigurationsPageSteps.getOutputMessage().should('contain.text', '{"TYPE":"notificationMessage","payload":{"code":"yasr_exit_fullscreen","messageType":"info","message":"Press Esc to exit full screen"}}');
 
     // WHEN: I press the ESC key.
     YasguiSteps.pressEscape();
-    // THEN: I should see YASR results in non-fullscreen mode, because escape is enabled.
+    // THEN: I should see YASR results in non-fullscreen mode, because escape is enabled by default.
     verifyYasrNonFullscreen();
-  });
-
-  it('should open YASR in fullscreen mode with escape disabled via configuration', () => {
-    // WHEN: I open a page that contains "ontotext-yasgui-web-component" with YASR in fullscreen and escape disabled.
-    ViewConfigurationsPageSteps.visit();
-    YasqeSteps.executeQuery();
-    ViewConfigurationsPageSteps.configureYasrFullscreenOnAllowEscapeOff();
-    // THEN: I should see YASR results in fullscreen mode, because it is configured to start in fullscreen.
-    verifyYasrFullscreen();
-    // AND: I should not see the notification that describes how to exit fullscreen mode, because escape is disabled.
-    ViewConfigurationsPageSteps.getOutputMessage().should('not.exist');
-
-    // WHEN: I press the ESC key.
-    YasguiSteps.pressEscape();
-    // THEN: I should still see YASR in fullscreen mode, because escape is disabled.
-    YasrSteps.getYasr().should('have.class', 'yasr-fullscreen');
   });
 });
 
@@ -86,12 +71,45 @@ const verifyYasrFullscreen = () => {
   YasrSteps.getResultsTable().should('exist');
   // I should see YASR results in fullscreen.
   YasrSteps.getYasr().should('have.class', 'yasr-fullscreen');
-  // I should see the result header.
+  // I should not see the plugins header
   YasrSteps.getResultHeader().should('be.visible');
-  YasrSteps.getFullscreenButton().should('attr', 'aria-label', 'Exit full screen');
+  YasrSteps.getPluginSelectors().should('not.exist');
+  YasrSteps.getFullscreenButton().should('not.exist')
+  // I should not see YASQE
+  YasqeSteps.getYasqe().should('not.exist');
+  // I should not see control bar
+  YasguiSteps.getControlBar().should('not.exist');
+  // I should not see tabs
+  YasqeSteps.getQueryTabs().should('not.exist');
+  YasrSteps.getPagination().should('be.visible');
+  // I should not see yasgui-toolbar because it has class hidden
+  ToolbarPageSteps.getToolbar().should('have.class', 'hidden').and('not.be.visible');
 }
 
 const verifyYasrNonFullscreen = () => {
   YasrSteps.getYasr().should('not.have.class', 'yasr-fullscreen');
+  YasrSteps.getResultHeader().should('be.visible');
+  YasrSteps.getPluginSelectors().should('be.visible');
+  YasrSteps.getFullscreenButton().should('be.visible')
+  YasqeSteps.getYasqe().should('be.visible');
+  YasguiSteps.getControlBar().should('exist');
+  YasqeSteps.getQueryTabs().should('be.visible');
+  YasrSteps.getPagination().should('be.visible');
+  ToolbarPageSteps.getToolbar().should('not.have.class', 'hidden').and('be.visible');
+
   YasrSteps.getFullscreenButton().should('attr', 'aria-label', 'Enter full screen');
+}
+
+const verifyYasrExpandFullscreen = () => {
+  YasrSteps.getYasr().should('have.class', 'yasr-fullscreen');
+  YasrSteps.getResultHeader().should('be.visible');
+  YasrSteps.getPluginSelectors().should('be.visible');
+  YasrSteps.getFullscreenButton().should('be.visible')
+  YasqeSteps.getYasqe().should('be.visible');
+  YasguiSteps.getControlBar().should('exist');
+  YasqeSteps.getQueryTabs().should('be.visible');
+  YasrSteps.getPagination().should('be.visible');
+  ToolbarPageSteps.getToolbar().should('not.have.class', 'hidden').and('be.visible');
+
+  YasrSteps.getFullscreenButton().should('attr', 'aria-label', 'Exit full screen');
 }

--- a/cypress/steps/view-configurations-page-steps.ts
+++ b/cypress/steps/view-configurations-page-steps.ts
@@ -41,16 +41,12 @@ export default class ViewConfigurationsPageSteps {
         return cy.get('#queryRan');
     }
 
-    static configureYasrFullscreenOnAllowEscapeOff() {
-      cy.get('#configureYasrFullscreenOnAllowEscapeOff').click();
+    static configureYasrFullscreenOff() {
+      cy.get('#configureYasrFullscreenOff').click();
     }
 
-    static configureYasrFullscreenOffAllowEscapeOn() {
-      cy.get('#configureYasrFullscreenOffAllowEscapeOn').click();
-    }
-
-    static configureYasrFullscreenOnAllowEscapeOn() {
-      cy.get('#configureYasrFullscreenOnAllowEscapeOn').click();
+    static configureYasrFullscreenOn() {
+      cy.get('#configureYasrFullscreenOn').click();
     }
 
     static configureSelectedPluginToResponsePlugin() {

--- a/cypress/steps/yasgui-steps.ts
+++ b/cypress/steps/yasgui-steps.ts
@@ -67,6 +67,10 @@ export class YasguiSteps {
   static pressEscape() {
     cy.get('body').type('{esc}');
   }
+
+  static getControlBar() {
+    return cy.get('.controlbar');
+  }
 }
 
 export class EditableTabElement {

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -19,6 +19,10 @@ export class YasrSteps {
     return cy.get('.yasr_btnGroup');
   }
 
+  static getPluginSelectors() {
+    return YasrSteps.getPluginsButtons().find('.plugin_selector');
+  }
+
   static getResultsTable(yasrIndex = 0) {
     return YasrSteps.getYasr(yasrIndex).find('.yasr_results tbody');
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -313,6 +313,7 @@
       background-color: white;
       display: flex;
       flex-direction: column;
+      margin-top: 0;
 
       .yasr_results {
         height: 100%;

--- a/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
+++ b/ontotext-yasgui-web-component/src/js/ontotext-yasgui-tests-util.js
@@ -1,4 +1,4 @@
-function getOntotextYasgui(componentId, endpoint = "/repositories/test-repo") {
+function getOntotextYasgui(componentId, endpoint = "/repositories/test-repo", options = {}) {
   let ontoElement = document.querySelector("ontotext-yasgui");
   ontoElement.config = {
     infer: true,
@@ -7,7 +7,8 @@ function getOntotextYasgui(componentId, endpoint = "/repositories/test-repo") {
       return endpoint;
     },
     prefixes: getPrefixes(),
-    componentId
+    componentId,
+    ...options
   };
   return ontoElement;
 }

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -348,28 +348,12 @@ export interface ExternalYasguiConfiguration {
    * Configuration that controls which keyboard shortcuts are enabled.
    *
    */
-  keyboardShortcutConfiguration: Record<KeyboardShortcutName, boolean>[];
+  keyboardShortcutConfiguration: Partial<Record<KeyboardShortcutName, boolean>>;
 
   /**
-   * Configuration options for controlling YASR fullscreen behavior.
+   * Determines whether YASR should be rendered in fullscreen mode by default when the component is initialized.
    */
-  yasrFullscreen: {
-    /**
-     * Determines whether YASR should be rendered in fullscreen mode by default when the component is initialized.
-     *
-     * - `true` → YASR starts in fullscreen mode
-     * - `false` → YASR starts in normal (embedded) mode
-     */
-    defaultFullscreen: boolean,
-
-    /**
-     * Controls whether the Escape (ESC) key can be used to exit fullscreen mode.
-     *
-     * - `true` → Pressing ESC will exit fullscreen
-     * - `false` → ESC key is ignored while in fullscreen
-     */
-    allowEscape: boolean
-  }
+  yasrFullscreen?: boolean;
 }
 
 export type AutocompleteLoader = () => any;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -7,6 +7,7 @@ import {EventService} from '../services/event-service';
 import {TimeFormattingService} from '../services/utils/time-formatting-service';
 import {KeyboardShortcutName} from './keyboard-shortcut-description';
 import {PluginConfigurations} from './plugin-configurations';
+import {GeoPluginConfiguration} from '../plugins/yasr/geo/models/geo-plugin-configuration';
 
 export interface YasguiConfiguration {
   // ***********************************************************
@@ -74,7 +75,7 @@ export interface YasguiConfiguration {
    * Configuration that controls which keyboard shortcuts are enabled.
    *
    */
-  keyboardShortcutConfiguration?: Record<KeyboardShortcutName, boolean>[];
+  keyboardShortcutConfiguration?: Partial<Record<KeyboardShortcutName, boolean>>;
 
   // ***********************************************************
   //
@@ -107,202 +108,12 @@ export interface YasguiConfiguration {
     clearState: boolean;
     paginationOn: true,
     pageSize: 10,
-    yasqe?: {
-      /**
-       * Setup yasqe editor. There are three options:
-       * 1. true - the query can be edited;
-       * 2. false - the editor is read-only, but the query can be copied;
-       * 3.'nocursor' - the editor is read-only and hte query can't be copied.
-       */
-      readOnly?: boolean | 'nocursor';
-      /**
-       * Default query when a tab is opened.
-       */
-      value?: string;
-      /**
-       * Button implementations for the yasqe actions. This is passed down to yasqe.
-       */
-      pluginButtons?: (() => HTMLElement[] | HTMLElement) | undefined;
-      /**
-       * Used to track the changes in external or internal config for this property.
-       */
-      yasqeActionButtons?: YasqeActionButtonDefinition[];
-
-      createShareableLink?: (yasqe: any) => string | null;
-
-      showQueryButton?: boolean;
-
-      resizeable?: boolean;
-
-      prefixes: string[];
-
-      /**
-       * Available GeoSPARQL properties
-       */
-      geoProperties: string[];
-
-      /**
-       * GeoSPARQL properties prefix
-       */
-      geoPropertiesPrefix: string;
-
-      /**
-       * Object contains pair keyboard shortcut and function to be executed when user press the keyboard shortcut.
-       * Example:
-       * <pre>
-       *   {
-       *     "Ctrl-Space": function (_yasqe: any) {
-       *         const yasqe: Yasqe = _yasqe;
-       *         yasqe.autocomplete();
-       *       },
-       *       "Alt-Enter": function (_yasqe: any) {
-       *         const yasqe: Yasqe = _yasqe;
-       *         yasqe.autocomplete();
-       *       },
-       *   }
-       *   </pre>
-       */
-      //@ts-ignore
-      extraKeys: {[keyboardShortcut:string]: (yasqe: Yasqe) => void}
-
-      /**
-       * Array with keyboard shortcut names {@link KeyboardShortcutName}.
-       */
-      keyboardShortcutDescriptions: Array<{name: string; section: string}>;
-
-      /**
-       * Flag that controls update operations. If this flag is set to true, then all update operations will be disabled.
-       * For virtual repositories only select queries are allowed.
-       */
-      isVirtualRepository: boolean;
-
-      // This function will be called before the update query be executed. The client can abort execution of query for some reason and can
-      // provide a message or label key for the reason of aborting.
-      beforeUpdateQuery: (query: string, tabId: string) => Promise<BeforeUpdateQueryResult>;
-
-      // This function will be called before and after execution of an update query. Depends on results a corresponding result message info will be generated.
-      getRepositoryStatementsCount: () => Promise<number>;
-
-      /**
-       * If this function is present, then an "Abort query" button wil be displayed when a query is running. If the  button is clicked then
-       * this function will be invoked after the abort operation was triggered. The button will be visible until "ontotext-yasgui-web-component" client resolve returned promise.
-       * @param req - the running request.
-       */
-      onQueryAborted?: (req) => Promise<void>;
-
-      /**
-       * Name of the CodeMirror 5 theme to apply in YASQE.
-       *
-       * Usage:
-       * - This must match a theme name recognized by CodeMirror (e.g. "dracula", "monokai").
-       *
-       * Theme CSS requirement:
-       * - CodeMirror themes are entirely CSS-based. The corresponding theme CSS must be
-       *   loaded (via <link>, import, or injected <style>) before the theme can take effect.
-       *
-       * Custom themes:
-       * - You may define your own theme without a separate CSS file by adding styles for:
-       *       .cm-s-{themeName}.CodeMirror { ... }
-       *       .cm-s-{themeName} .cm-keyword { ... }
-       *       etc.
-       *   Example:
-       *       <style>
-       *         .cm-s-mytheme.CodeMirror { background: #222; color: #eee; }
-       *       </style>
-       *   Then set: themeName = "mytheme".
-       *
-       * If the <code>themeName</code> is not passed or the required CSS rules are not present,
-       * the editor will fall back to the default theme.
-       */
-      themeName?: string;
-    }
-    yasr: {
-      /**
-       * Object with uris and their corresponding prefixes.
-       * For example:
-       * <pre>
-       *   {
-       *     "gn": "http://www.geonames.org/ontology#",
-       *     "path": "http://www.ontotext.com/path#",
-       *     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-       *     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-       *     "xsd": "http://www.w3.org/2001/XMLSchema#",
-       *   }
-       * </pre>
-       */
-      prefixes: NamespaceMapping,
-
-      /**
-       * The name of plugin which have to be active when yasr is created.
-       */
-      defaultPlugin: string,
-
-      /**
-       * The plugin name to be selected for the active YASR instance. If not set, the persisted selection or the default plugin will be used.
-       */
-      selectedPlugin?: string;
-
-      /**
-       * Describes the order of how YASR plugins will be displayed.
-       * For example: ["extended_table", "response"]
-       */
-      pluginOrder: string[],
-
-      /**
-       * Map with configuration of given plugin. The key of map is the name of a plugin. The value is any object which fields are supported by
-       * the plugin configuration.
-       */
-      externalPluginsConfigurations: Map<string, PluginConfigurations>;
-
-      /**
-       * Maximum length of response which will be persisted. If response is bigger it will not be persisted in browser local store.
-       * Default value is 100000.
-       */
-      maxPersistentResponseSize?: number;
-
-      yasrToolbarPlugins?: YasrToolbarPlugin[],
-
-      /**
-       * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
-       */
-      sparqlResponse: string | undefined,
-
-      /**
-       * Flag that controls displaying the loader during the run query process.
-       */
-      showQueryLoader?: boolean;
-
-      /**
-       * If the result information header of YASR should be rendered or not.
-       */
-      showResultInfo?: boolean;
-
-      /**
-       * Function that checks if the current query is run for explain plan.
-       */
-      isExplainPlan: (results: []) => boolean;
-
-      /**
-       * Configuration options for controlling YASR fullscreen behavior.
-       */
-      yasrFullscreen: {
-        /**
-         * Determines whether YASR should be rendered in fullscreen mode by default when the component is initialized.
-         *
-         * - `true` → YASR starts in fullscreen mode
-         * - `false` → YASR starts in normal (embedded) mode
-         */
-        defaultFullscreen: boolean,
-
-        /**
-         * Controls whether the Escape (ESC) key can be used to exit fullscreen mode.
-         *
-         * - `true` → Pressing ESC will exit fullscreen
-         * - `false` → ESC key is ignored while in fullscreen
-         */
-        allowEscape: boolean
-        }
-    }
+    /**
+     * Determines whether YASR should be rendered in fullscreen mode by default when the component is initialized
+     */
+    yasrFullscreen: boolean;
+    yasqe?: YasqeConfiguration;
+    yasr: YasrConfiguration;
   };
 
   yasqeConfig?: {
@@ -311,6 +122,198 @@ export interface YasguiConfiguration {
      */
     initialQuery?: string;
   }
+}
+
+export interface YasqeConfiguration {
+  /**
+   * Setup yasqe editor. There are three options:
+   * 1. true - the query can be edited;
+   * 2. false - the editor is read-only, but the query can be copied;
+   * 3.'nocursor' - the editor is read-only and hte query can't be copied.
+   */
+  readOnly?: boolean | 'nocursor';
+  /**
+   * Default query when a tab is opened.
+   */
+  value?: string;
+  /**
+   * Button implementations for the yasqe actions. This is passed down to yasqe.
+   */
+  pluginButtons?: (() => HTMLElement[] | HTMLElement) | undefined;
+  /**
+   * Used to track the changes in external or internal config for this property.
+   */
+  yasqeActionButtons?: YasqeActionButtonDefinition[];
+
+  createShareableLink?: (yasqe: any) => string | null;
+
+  showQueryButton?: boolean;
+
+  resizeable?: boolean;
+
+  prefixes: string[];
+
+  /**
+   * Available GeoSPARQL properties
+   */
+  geoProperties: string[];
+
+  /**
+   * GeoSPARQL properties prefix
+   */
+  geoPropertiesPrefix: string;
+
+  /**
+   * Object contains pair keyboard shortcut and function to be executed when user press the keyboard shortcut.
+   * Example:
+   * <pre>
+   *   {
+   *     "Ctrl-Space": function (_yasqe: any) {
+   *         const yasqe: Yasqe = _yasqe;
+   *         yasqe.autocomplete();
+   *       },
+   *       "Alt-Enter": function (_yasqe: any) {
+   *         const yasqe: Yasqe = _yasqe;
+   *         yasqe.autocomplete();
+   *       },
+   *   }
+   *   </pre>
+   */
+  //@ts-ignore
+  extraKeys: {[keyboardShortcut:string]: (yasqe: Yasqe) => void}
+
+  /**
+   * Array with keyboard shortcut names {@link KeyboardShortcutName}.
+   */
+  keyboardShortcutDescriptions: Array<{name: string; section: string}>;
+
+  /**
+   * Flag that controls update operations. If this flag is set to true, then all update operations will be disabled.
+   * For virtual repositories only select queries are allowed.
+   */
+  isVirtualRepository: boolean;
+
+  // This function will be called before the update query be executed. The client can abort execution of query for some reason and can
+  // provide a message or label key for the reason of aborting.
+  beforeUpdateQuery: (query: string, tabId: string) => Promise<BeforeUpdateQueryResult>;
+
+  // This function will be called before and after execution of an update query. Depends on results a corresponding result message info will be generated.
+  getRepositoryStatementsCount: () => Promise<number>;
+
+  /**
+   * If this function is present, then an "Abort query" button wil be displayed when a query is running. If the  button is clicked then
+   * this function will be invoked after the abort operation was triggered. The button will be visible until "ontotext-yasgui-web-component" client resolve returned promise.
+   * @param req - the running request.
+   */
+  onQueryAborted?: (req) => Promise<void>;
+
+  /**
+   * Name of the CodeMirror 5 theme to apply in YASQE.
+   *
+   * Usage:
+   * - This must match a theme name recognized by CodeMirror (e.g. "dracula", "monokai").
+   *
+   * Theme CSS requirement:
+   * - CodeMirror themes are entirely CSS-based. The corresponding theme CSS must be
+   *   loaded (via <link>, import, or injected <style>) before the theme can take effect.
+   *
+   * Custom themes:
+   * - You may define your own theme without a separate CSS file by adding styles for:
+   *       .cm-s-{themeName}.CodeMirror { ... }
+   *       .cm-s-{themeName} .cm-keyword { ... }
+   *       etc.
+   *   Example:
+   *       <style>
+   *         .cm-s-mytheme.CodeMirror { background: #222; color: #eee; }
+   *       </style>
+   *   Then set: themeName = "mytheme".
+   *
+   * If the <code>themeName</code> is not passed or the required CSS rules are not present,
+   * the editor will fall back to the default theme.
+   */
+  themeName?: string;
+}
+
+export interface YasqeDefaultConfiguration extends YasqeConfiguration {
+  query: string;
+  initialQuery: string;
+}
+
+export interface YasrConfiguration {
+  /**
+   * Object with uris and their corresponding prefixes.
+   * For example:
+   * <pre>
+   *   {
+   *     "gn": "http://www.geonames.org/ontology#",
+   *     "path": "http://www.ontotext.com/path#",
+   *     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+   *     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+   *     "xsd": "http://www.w3.org/2001/XMLSchema#",
+   *   }
+   * </pre>
+   */
+  prefixes: NamespaceMapping,
+
+  /**
+   * The name of plugin which have to be active when yasr is created.
+   */
+  defaultPlugin: string,
+
+  /**
+   * The plugin name to be selected for the active YASR instance. If not set, the persisted selection or the default plugin will be used.
+   */
+  selectedPlugin?: string;
+
+  /**
+   * Describes the order of how YASR plugins will be displayed.
+   * For example: ["extended_table", "response"]
+   */
+  pluginOrder: string[],
+
+  /**
+   * Map with configuration of given plugin. The key of map is the name of a plugin. The value is any object which fields are supported by
+   * the plugin configuration.
+   */
+  externalPluginsConfigurations: Map<string, PluginConfigurations>;
+
+  /**
+   * Maximum length of response which will be persisted. If response is bigger it will not be persisted in browser local store.
+   * Default value is 100000.
+   */
+  maxPersistentResponseSize?: number;
+
+  yasrToolbarPlugins?: YasrToolbarPlugin[],
+
+  /**
+   * A response of a sparql query as string. If the parameter is provided, the result will be visualized in YASR.
+   */
+  sparqlResponse: string | undefined,
+
+  /**
+   * Flag that controls displaying the loader during the run query process.
+   */
+  showQueryLoader?: boolean;
+
+  /**
+   * If the result information header of YASR should be rendered or not.
+   */
+  showResultInfo?: boolean;
+
+  /**
+   * Function that checks if the current query is run for explain plan.
+   */
+  isExplainPlan: (results: []) => boolean;
+
+  /**
+   * Determines whether YASR should be rendered in fullscreen mode by default when the component is initialized
+   */
+  fullscreen: boolean;
+
+  /**
+   * Default configuration for Geo Plugin
+   */
+  defaultGeoPluginConfiguration?: GeoPluginConfiguration;
 }
 
 // namespaces mapped to their prefixes as keys
@@ -366,10 +369,11 @@ export const defaultYasguiConfig: Record<string, any> = {
       'Accept': 'application/sparql-results+json',
       'X-GraphDB-Local-Consistency': 'updating'
     };
-  }
+  },
+  yasrFullscreen: false,
 }
 
-export const defaultYasqeConfig: Record<string, any> = {
+export const defaultYasqeConfig: Partial<YasqeDefaultConfiguration> = {
   query: 'select * where {\n    ?s ?p ?o .\n} limit 100',
   initialQuery: '',
   createShareableLink: null,
@@ -379,23 +383,18 @@ export const defaultYasqeConfig: Record<string, any> = {
     {name: 'shareQuery', visible: true},
     {name: 'includeInferredStatements', visible: true}
   ],
-  prefixes: {
-
-  },
+  prefixes: [],
   isVirtualRepository: false,
   showQueryButton: true,
   resizeable: true,
   readOnly: false
 }
 
-export const defaultYasrConfig: Record<string, any> = {
+export const defaultYasrConfig: Partial<YasrConfiguration> = {
   defaultPlugin: 'extended_table',
   pluginOrder: ['extended_table', 'extended_response', 'pivot-table-plugin', 'charts'],
   showQueryLoader: true,
-  yasrFullscreen: {
-    defaultFullscreen: false,
-    allowEscape: true,
-  },
+  fullscreen: false,
   defaultGeoPluginConfiguration: {
     defaultGeoStyleOptions: {
       weight: 3,

--- a/ontotext-yasgui-web-component/src/pages/view-configurations/index.html
+++ b/ontotext-yasgui-web-component/src/pages/view-configurations/index.html
@@ -25,9 +25,8 @@
   <button id="showControlBar" onclick="setShowControlBar(true)">Show control bar</button>
   <button id="hideControlBar" onclick="setShowControlBar(false)">Hide control bar</button>
 
-  <button id="configureYasrFullscreenOnAllowEscapeOff" onclick="configureYasrFullscreenOnAllowEscapeOff()">Configure YASR Fullscreen On Allow Escape Off</button>
-  <button id="configureYasrFullscreenOffAllowEscapeOn" onclick="configureYasrFullscreenOffAllowEscapeOn()">Configure YASR Fullscreen Off Allow Escape On</button>
-  <button id="configureYasrFullscreenOnAllowEscapeOn" onclick="configureYasrFullscreenOnAllowEscapeOn()">Configure YASR Fullscreen On Allow Escape On</button>
+  <button id="configureYasrFullscreenOn" onclick="configureYasrFullscreenOn()">Configure YASR Fullscreen On</button>
+  <button id="configureYasrFullscreenOff" onclick="configureYasrFullscreenOff()">Configure YASR Fullscreen Off</button>
 
   <button id="configureSelectedPluginToResponsePlugin" onclick="configureSelectedPluginToResponsePlugin()">Configure selectedPlugin To Response Plugin</button>
 

--- a/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
@@ -1,4 +1,4 @@
-let ontoElement = getOntotextYasgui();
+let ontoElement = getOntotextYasgui(undefined, undefined, {showToolbar: true});
 
 ontoElement.addEventListener("output", (event) => {
   if ('query' === event.detail.TYPE) {
@@ -28,33 +28,17 @@ function setShowControlBar(showControlBar) {
   ontoElement.config = {...ontoElement.config, showControlBar: showControlBar}
 }
 
-function configureYasrFullscreenOnAllowEscapeOff() {
+function configureYasrFullscreenOn() {
   ontoElement.config = {
     ...ontoElement.config,
-    yasrFullscreen: {
-      defaultFullscreen: true,
-      allowEscape: false
-    }
+    yasrFullscreen: true
   }
 }
 
-function configureYasrFullscreenOffAllowEscapeOn() {
+function configureYasrFullscreenOff() {
   ontoElement.config = {
     ...ontoElement.config,
-    yasrFullscreen: {
-      defaultFullscreen: false,
-      allowEscape: true
-    }
-  }
-}
-
-function configureYasrFullscreenOnAllowEscapeOn() {
-  ontoElement.config = {
-    ...ontoElement.config,
-    yasrFullscreen: {
-      defaultFullscreen: true,
-      allowEscape: true
-    }
+    yasrFullscreen: false
   }
 }
 

--- a/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
+++ b/ontotext-yasgui-web-component/src/services/keyboard-shortcut-service.ts
@@ -17,7 +17,7 @@ export class KeyboardShortcutService {
 
   static initKeyboardShortcutMapping = (config: YasguiConfiguration): KeyboardShortcutDescription[] => {
     const keyboardShortcutDescriptions = [];
-    const insertAll = !config.keyboardShortcutConfiguration || config.keyboardShortcutConfiguration.length < 1;
+    const insertAll = !config.keyboardShortcutConfiguration || Object.keys(config.keyboardShortcutConfiguration).length < 1;
     KeyboardShortcutService.keyboardShortcutNameToFactoryFunction
       .forEach((factoryFunction: CreateKeyboardShortcutFunction, keyboardShortcutName: KeyboardShortcutName) => {
         if (insertAll || config.keyboardShortcutConfiguration[keyboardShortcutName] === undefined || config.keyboardShortcutConfiguration[keyboardShortcutName]) {

--- a/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
+++ b/ontotext-yasgui-web-component/src/services/utils/visualisation-utils.ts
@@ -65,6 +65,9 @@ export class VisualisationUtils {
 
   static toggleLayoutOrientationButton(hostElement: HTMLElement, newOrientation: Orientation): void {
     const buttonOrientation = HtmlElementsUtil.getOrientationButton(hostElement);
+    if (!buttonOrientation) {
+      return;
+    }
     if (Orientation.HORIZONTAL === newOrientation) {
       buttonOrientation.classList.add('icon-rotate-quarter');
     } else {
@@ -83,6 +86,18 @@ export class VisualisationUtils {
 
   static resolveOrientation(isVerticalOrientation: boolean): Orientation {
     return isVerticalOrientation ? Orientation.VERTICAL : Orientation.HORIZONTAL;
+  }
+
+  static toggleToolbarVisibility(hostElement: HTMLElement, showToolbar: boolean): void {
+    const toolbarElement = HtmlElementsUtil.getToolbar(hostElement);
+    if (!toolbarElement) {
+      return;
+    }
+    if (showToolbar) {
+      toolbarElement.classList.remove('hidden');
+    } else {
+      toolbarElement.classList.add('hidden');
+    }
   }
 
   /**

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -70,9 +70,9 @@ export class YasguiConfigurationBuilder {
       eventService: this.serviceFactory.getEventService(),
       timeFormattingService: this.serviceFactory.get(TimeFormattingService),
       infer: externalConfiguration.infer !== undefined ? externalConfiguration.infer : defaultYasguiConfig.infer,
-      immutableInfer: externalConfiguration.immutableInfer !== undefined ? externalConfiguration.immutableInfer : defaultYasqeConfig.immutableInfer,
+      immutableInfer: externalConfiguration.immutableInfer !== undefined ? externalConfiguration.immutableInfer : defaultYasguiConfig.immutableInfer,
       sameAs: externalConfiguration.sameAs !== undefined ? externalConfiguration.sameAs : defaultYasguiConfig.sameAs,
-      immutableSameAs: externalConfiguration.immutableSameAs !== undefined ? externalConfiguration.immutableSameAs : defaultYasqeConfig.immutableSameAs,
+      immutableSameAs: externalConfiguration.immutableSameAs !== undefined ? externalConfiguration.immutableSameAs : defaultYasguiConfig.immutableSameAs,
       clearState: externalConfiguration.clearState !== undefined ? externalConfiguration.clearState : false,
       requestConfig: {},
       paginationOn: externalConfiguration.paginationOn !== undefined ? externalConfiguration.paginationOn : defaultYasguiConfig.paginationOn,
@@ -96,8 +96,9 @@ export class YasguiConfigurationBuilder {
         pluginOrder: [],
         externalPluginsConfigurations: YasrService.getPluginsConfigurations(externalConfiguration),
         isExplainPlan: ExplainPlanUtil.isExplainResults,
-        yasrFullscreen: {...defaultYasrConfig.yasrFullscreen, ...(externalConfiguration.yasrFullscreen ?? {})},
-      }
+        fullscreen: externalConfiguration.yasrFullscreen ?? defaultYasrConfig.fullscreen,
+      },
+      yasrFullscreen: externalConfiguration.yasrFullscreen ?? defaultYasguiConfig.yasrFullscreen
     };
     config.yasguiConfig.requestConfig.endpoint = externalConfiguration.endpoint || defaultYasguiConfig.endpoint;
     config.yasguiConfig.requestConfig.method = externalConfiguration.method || defaultYasguiConfig.method;

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -62,10 +62,6 @@ export class OntotextYasguiService {
     // Initialize orientation button styling.
     const orientation = config.orientation;
     VisualisationUtils.toggleLayoutOrientationButton(hostElement, orientation);
-    if (config.showToolbar) {
-      HtmlElementsUtil.getToolbar(hostElement).classList.remove('hidden');
-    } else {
-      HtmlElementsUtil.getToolbar(hostElement).classList.add('hidden');
-    }
+    VisualisationUtils.toggleToolbarVisibility(hostElement, !config.yasguiConfig.yasrFullscreen && config.showToolbar);
   }
 }

--- a/yasgui-patches/2026-04-30-GDB-14271-refactor-yasr-fullscreen-configuration.patch
+++ b/yasgui-patches/2026-04-30-GDB-14271-refactor-yasr-fullscreen-configuration.patch
@@ -1,0 +1,161 @@
+Index: Yasgui/packages/yasgui/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/index.ts b/Yasgui/packages/yasgui/src/index.ts
+--- a/Yasgui/packages/yasgui/src/index.ts	(revision f33d8dddfd418e9c53475f37529d716a3ef8cbd4)
++++ b/Yasgui/packages/yasgui/src/index.ts	(revision b14f0fa70ca6875ed2c9b811825ad3af45f9bc43)
+@@ -64,6 +64,7 @@
+   paginationOn?: boolean;
+   pageSize?: number;
+   pageNumber: number;
++  yasrFullscreen?: boolean;
+ }
+ export type PartialConfig = {
+   [P in keyof Config]?: Config[P] extends object ? Partial<Config[P]> : Config[P];
+@@ -136,7 +137,9 @@
+     this.tabElements = new ExtendedTabElements(this);
+     this.tabPanelsEl = document.createElement("div");
+ 
+-    this.rootEl.appendChild(this.tabElements.drawTabsList());
++    if (!config.yasrFullscreen) {
++      this.rootEl.appendChild(this.tabElements.drawTabsList());
++    }
+     this.rootEl.appendChild(this.tabPanelsEl);
+     let executeIdAfterInit: string | undefined;
+     let optionsFromUrl: PersistedTabJson | undefined;
+Index: Yasgui/packages/yasgui/src/Tab.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasgui/src/Tab.ts b/Yasgui/packages/yasgui/src/Tab.ts
+--- a/Yasgui/packages/yasgui/src/Tab.ts	(revision f33d8dddfd418e9c53475f37529d716a3ef8cbd4)
++++ b/Yasgui/packages/yasgui/src/Tab.ts	(revision b14f0fa70ca6875ed2c9b811825ad3af45f9bc43)
+@@ -111,11 +111,14 @@
+     //controlbar
+     this.controlBarEl = document.createElement("div");
+     this.controlBarEl.className = "controlbar";
+-    wrapper.appendChild(this.controlBarEl);
+-
++    if (!this.yasgui.config.yasrFullscreen) {
++      wrapper.appendChild(this.controlBarEl);
++    }
+     //yasqe
+     this.yasqeWrapperEl = document.createElement("div");
+-    wrapper.appendChild(this.yasqeWrapperEl);
++    if (!this.yasgui.config.yasrFullscreen) {
++      wrapper.appendChild(this.yasqeWrapperEl);
++    }
+ 
+     //yasr
+     this.yasrWrapperEl = document.createElement("div");
+@@ -684,7 +687,7 @@
+     yasrConf.clearState = this.yasgui.config.clearState;
+     yasrConf.isExplainPlan = this.yasgui.config.yasr.isExplainPlan
+     yasrConf.tabId = this.getId();
+-    yasrConf.yasrFullscreen = this.yasgui.config.yasr.yasrFullscreen;
++    yasrConf.fullscreen = this.yasgui.config.yasr.fullscreen;
+     if (this.yasgui.config.yasr.selectedPlugin != null) {
+         yasrConf.selectedPlugin = this.yasgui.config.yasr.selectedPlugin;
+     }
+Index: Yasgui/packages/yasr/src/extended-yasr.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/extended-yasr.ts b/Yasgui/packages/yasr/src/extended-yasr.ts
+--- a/Yasgui/packages/yasr/src/extended-yasr.ts	(revision f33d8dddfd418e9c53475f37529d716a3ef8cbd4)
++++ b/Yasgui/packages/yasr/src/extended-yasr.ts	(revision b14f0fa70ca6875ed2c9b811825ad3af45f9bc43)
+@@ -27,7 +27,7 @@
+     this.yasqe.on("countAffectedRepositoryStatementsPersisted", this.updateResponseInfo.bind(this));
+ 
+     // Toggle only if the default fullscreen value is true and YASR is not in fullscreen mode.
+-    if (this.config.yasrFullscreen?.defaultFullscreen && !this.isFullscreen) {
++    if (this.config.fullscreen && !this.isFullscreen) {
+         this.toggleFullscreen();
+     }
+   }
+@@ -51,15 +51,16 @@
+       return;
+     }
+     const pluginSelectorsEl = this.getPluginSelectorsEl();
+-    this.fullscreenButton = this.createFullscreenButton();
+-    pluginSelectorsEl.appendChild(this.fullscreenButton);
++
++    if (!this.config.fullscreen) {
++      this.fullscreenButton = this.createFullscreenButton();
++      pluginSelectorsEl.appendChild(this.fullscreenButton);
+ 
+-    if (this.config.yasrFullscreen?.allowEscape) {
+-        this.boundEscapeHandler = this.onEscapeHandler.bind(this);
+-        document.addEventListener('keydown', this.boundEscapeHandler);
++      this.boundEscapeHandler = this.onEscapeHandler.bind(this);
++      document.addEventListener('keydown', this.boundEscapeHandler);
+     }
+ 
+-    const spacerElement = document.createElement("li");
++    const spacerElement = document.createElement('li');
+     spacerElement.classList.add("spacer");
+     pluginSelectorsEl.appendChild(spacerElement);
+ 
+@@ -371,7 +372,7 @@
+ 
+       this.emit('fullscreen-changed', this.isFullscreen);
+ 
+-      if (this.isFullscreen && this.config.yasrFullscreen?.allowEscape) {
++      if (this.isFullscreen && !this.config.fullscreen) {
+         const message = this.translationService.translate('yasr.btn.fullscreen.escape.message');
+         this.notificationMessageService.info('yasr_exit_fullscreen', message);
+       }
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision f33d8dddfd418e9c53475f37529d716a3ef8cbd4)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision b14f0fa70ca6875ed2c9b811825ad3af45f9bc43)
+@@ -77,7 +77,7 @@
+     this.storage = new YStorage(Yasr.storageNamespace);
+     this.getConfigFromStorage();
+     this.headerEl = document.createElement("div");
+-    this.headerEl.className = "yasr_header";
++    this.headerEl.className = 'yasr_header';
+     this.rootEl.appendChild(this.headerEl);
+     this.fallbackInfoEl = document.createElement("div");
+     this.fallbackInfoEl.className = "yasr_fallback_info";
+@@ -432,6 +432,12 @@
+   drawPluginSelectors() {
+     this.pluginSelectorsEl = document.createElement("ul");
+     this.pluginSelectorsEl.className = "yasr_btnGroup";
++
++    if (this.config.fullscreen) {
++      this.headerEl.appendChild(this.pluginSelectorsEl);
++      return;
++    }
++
+     const pluginOrder = this.config.pluginOrder;
+     Object.keys(this.config.plugins)
+       .sort()
+@@ -471,6 +477,7 @@
+       button.appendChild(nameEl);
+       button.addEventListener("click", () => this.selectPlugin(pluginName));
+       const li = document.createElement("li");
++      addClass(li, "plugin_selector");
+       const buttonPluginTooltip: any = document.createElement("yasgui-tooltip");
+       buttonPluginTooltip.yasguiDataTooltip = window.innerWidth < 768 ? name : "";
+       buttonPluginTooltip.placement = "top";
+@@ -825,10 +832,7 @@
+   showResultInfo: boolean;
+   showQueryLoader: boolean;
+   sparqlResponse?: string;
+-  yasrFullscreen?: {
+-      defaultFullscreen: boolean,
+-      allowEscape: boolean,
+-  };
++  fullscreen?: boolean;
+   selectedPlugin?: string;
+   /**
+    * Custom renderers for errors.


### PR DESCRIPTION
## What
Refactored the fullscreen configuration for YASR to hide all other irrelevant elements from the YASGUI and show only the YASR

## Why
When the YASR is embedded, only the resulsts need to be shown nad user should not have access to any other elements from the YASGUI interface

## How
- Removed the nested `yasrFullscreen` object and replaced it with a single `fullscreen` boolean property.
- Updated all references in the codebase to use the new `fullscreen` property.
- Adjusted the logic in various components to ensure proper rendering based on the fullscreen state.
- Modified tests to reflect the new configuration structure.