### PR TITLE
GDB-14492 fix yasqe buttons panel placement

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -98,6 +98,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 2px;
+        z-index: auto;
 
         .yasqe_buttons-top,
         .yasqe_buttons-bottom {


### PR DESCRIPTION
## What
Fix yasqe buttons panel placement.

## Why
The buttons panel in the editor covers part of the editor lines on lower resolutions.

## How
Reset the z-index of the buttons panel.