### PR TITLE
GDB-14496: Add showFullscreenButton configuration for YASR and hide Geo plugin tab when showResultTabs false

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -688,6 +688,7 @@ export class Tab extends EventEmitter {
     yasrConf.isExplainPlan = this.yasgui.config.yasr.isExplainPlan
     yasrConf.tabId = this.getId();
     yasrConf.fullscreen = this.yasgui.config.yasr.fullscreen;
+    yasrConf.showFullscreenButton = this.yasgui.config.yasr.showFullscreenButton;
     if (this.yasgui.config.yasr.selectedPlugin != null) {
         yasrConf.selectedPlugin = this.yasgui.config.yasr.selectedPlugin;
     }

--- a/Yasgui/packages/yasr/src/extended-yasr.ts
+++ b/Yasgui/packages/yasr/src/extended-yasr.ts
@@ -52,7 +52,7 @@ export class ExtendedYasr extends Yasr {
     }
     const pluginSelectorsEl = this.getPluginSelectorsEl();
 
-    if (!this.config.fullscreen) {
+    if (!this.config.fullscreen && this.config.showFullscreenButton) {
       this.fullscreenButton = this.createFullscreenButton();
       pluginSelectorsEl.appendChild(this.fullscreenButton);
 

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -833,6 +833,7 @@ export interface Config {
   showQueryLoader: boolean;
   sparqlResponse?: string;
   fullscreen?: boolean;
+  showFullscreenButton?: boolean;
   selectedPlugin?: string;
   /**
    * Custom renderers for errors.

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -34,6 +34,11 @@ export interface ExternalYasguiConfiguration {
   showResultTabs: boolean;
 
   /**
+   * Flag that controls whether the button for toggling fullscreen mode in YASR should be displayed. By default, it is set to true.
+   */
+  showFullscreenButton?: boolean;
+
+  /**
    * If the result information header of YASR should be rendered or not.
    */
   showResultInfo: boolean;

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -301,6 +301,11 @@ export interface YasrConfiguration {
   showResultInfo?: boolean;
 
   /**
+   * Flag that controls whether the button for toggling fullscreen mode in YASR should be displayed. By default, it is set to true.
+   */
+  showFullscreenButton?: boolean;
+
+  /**
    * Function that checks if the current query is run for explain plan.
    */
   isExplainPlan: (results: []) => boolean;
@@ -403,5 +408,9 @@ export const defaultYasrConfig: Partial<YasrConfiguration> = {
       fillColor: '#3388ff',
       fillOpacity: 0.2
     }
-  }
+  },
+  /**
+   * Flag that controls whether the button for toggling fullscreen mode in YASR should be displayed. By default, it is set to true.
+   */
+  showFullscreenButton: true
 }

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -97,6 +97,7 @@ export class YasguiConfigurationBuilder {
         externalPluginsConfigurations: YasrService.getPluginsConfigurations(externalConfiguration),
         isExplainPlan: ExplainPlanUtil.isExplainResults,
         fullscreen: externalConfiguration.yasrFullscreen ?? defaultYasrConfig.fullscreen,
+        showFullscreenButton: externalConfiguration.showFullscreenButton ?? defaultYasrConfig.showFullscreenButton
       },
       yasrFullscreen: externalConfiguration.yasrFullscreen ?? defaultYasguiConfig.yasrFullscreen
     };

--- a/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/ontotext-yasgui-service.ts
@@ -46,7 +46,7 @@ export class OntotextYasguiService {
 
   private static initResultTabs(hostElement: HTMLElement, config: YasguiConfiguration): void {
     // TODO: this can be improved by getting the registered plugins directly from the yasr instead of hard-coding them here
-    const pluginTabsElementsSelectors = ['.select_extended_table', '.select_extended_response', '.select_charts', '.select_pivot-table-plugin'];
+    const pluginTabsElementsSelectors = ['.select_extended_table', '.select_extended_response', '.select_charts', '.select_pivot-table-plugin', '.select_geo'];
     HtmlElementsUtil.toggleHiddenByCondition(hostElement, pluginTabsElementsSelectors, () => !config.showResultTabs);
   }
 


### PR DESCRIPTION
## What
Introduced a new configuration option `showFullscreenButton` to control the visibility of the fullscreen toggle button in YASR. Fixed hiding geo plugin tab when showResultTabs false

## Why
This enhancement allows users to customize the interface by showing or hiding the fullscreen button, improving user experience based on individual preferences.

## How
- Added `showFullscreenButton` property to `YasguiConfiguration` and `YasrConfiguration`.
- Updated relevant configuration files to include the new property.
- Modified logic in `extended-yasr.ts` to conditionally create the fullscreen button based on the new configuration.