### PR TITLE
GDB-13768 fix editor cursor not moved past pasted URI

### DIFF
--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -83,11 +83,12 @@ export class OntotextYasgui {
    */
   setQuery(query: string): void {
     const yasqe = this.yasgui.getTab().getYasqe();
-    const cursor = yasqe.getDoc().getCursor();
+    // clone the original, as replaceRange will overwrite it
+    const originalCursor = {...yasqe.getDoc().getCursor()};
     const lastLine = yasqe.getDoc().lastLine();
     const lastLineLength = yasqe.getDoc().getLine(lastLine).length;
     yasqe.getDoc().replaceRange(query, {line: 0, ch: 0}, {line: lastLine, ch: lastLineLength});
-    yasqe.getDoc().setCursor(cursor);
+    yasqe.getDoc().setCursor(originalCursor);
   }
 
   query(config?: any, explainType?: EXPLAIN_PLAN_TYPE | undefined): Promise<any> {


### PR DESCRIPTION
## What
Fix editor cursor not moved past pasted URI.

## Why
The cursor ended up before the pasted text. `replaceRange` updated the original cursor object, which meant `setCursor(cursor)` did nothing

## How
Saved the original cursor position using `structuredClone` before replacing the content in the editor. The cursor is now set back to its original position after the content is replaced.

## Testing
n/a