### PR TITLE
GDB-14492 change yasgui buttons panel background to not overlap with the editor lines selection background

### DIFF
--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -98,7 +98,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 2px;
-        z-index: auto;
+        background-color: transparent;
 
         .yasqe_buttons-top,
         .yasqe_buttons-bottom {


### PR DESCRIPTION
## What
Change yasgui buttons panel background.

## Why
When a user selects some lines in the editor, the selection background color appears to interfere with the buttons panel background.

## How
Made the buttons panel transparent.
Removed the previous fix that used to apply some z-index that appeared to be an inappropriate solution.