### PR TITLE
GDB-14608: Fix map not loading with unsupported features

### DIFF
--- a/cypress/e2e/yasr/plugins/geo/geo-plugin-parsers.spec.cy.ts
+++ b/cypress/e2e/yasr/plugins/geo/geo-plugin-parsers.spec.cy.ts
@@ -165,6 +165,42 @@ describe('Geo Plugin Parsers', () => {
     // THEN: Only the valid WKT point should be rendered; the malformed one is silently skipped.
     GeoPluginSteps.getAllGeoFeatures().should('have.length', 0);
     GeoPluginSteps.getAllMarkers().should('have.length', 1);
+    // AND: A warning should be displayed indicating that some geometries could not be rendered.
+    GeoPluginSteps.getWarningMessage().should('contain', 'Some geometries could not be rendered due to invalid format.');
+  });
+
+  it('should display a warning and render no features when all WKT geometries are invalid', () => {
+    // GIVEN: I visit the geo plugin page.
+    YasrGeoPluginPageSteps.visit();
+    // AND: The query returns only invalid wktLiteral entries.
+    QueryStubs.stubGeoAllInvalidWktResponse();
+
+    // WHEN: I execute a query and open the geo tab (no wait – all results will be invalid).
+    YasqeSteps.executeQueryWithoutWaitResult();
+    YasrSteps.openGeoPluginTab();
+
+    // THEN: No features should be rendered on the map.
+    GeoPluginSteps.getAllGeoFeatures().should('have.length', 0);
+    GeoPluginSteps.getAllMarkers().should('have.length', 0);
+    // AND: A warning should be displayed indicating that no valid geometries were found.
+    GeoPluginSteps.getWarningMessage().should('contain', 'No valid geometries found in the results.');
+  });
+
+  it('should render only the valid feature when some binding rows are missing the geo column', () => {
+    // GIVEN: I visit the geo plugin page.
+    YasrGeoPluginPageSteps.visit();
+    // AND: The query returns three rows but only one has a location binding (the other two have no geo value).
+    QueryStubs.stubGeoSparseBindingResponse();
+
+    // WHEN: I execute a query and open the geo tab.
+    YasqeSteps.executeQuery();
+    YasrSteps.openGeoPluginTab();
+
+    // THEN: Only the one row with a valid binding should be rendered on the map.
+    GeoPluginSteps.getAllGeoFeatures().should('have.length', 0);
+    GeoPluginSteps.getAllMarkers().should('have.length', 1);
+    // AND: A warning should not be shown even though two out of three rows had no geometry value.
+    GeoPluginSteps.getWarningMessage().should('not.exist');
   });
 
   it('should render a geo feature from a full KML document (input already contains <kml> root)', () => {

--- a/cypress/fixtures/queries/geo-all-invalid-wkt-response.json
+++ b/cypress/fixtures/queries/geo-all-invalid-wkt-response.json
@@ -1,0 +1,26 @@
+{
+  "head": {
+    "vars": ["featureType", "location"]
+  },
+  "results": {
+    "bindings": [
+      {
+        "featureType": {"type": "uri", "value": "http://www.opengis.net/ont/sf#Point"},
+        "location": {
+          "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
+          "type": "literal",
+          "value": "NOT VALID WKT !!!"
+        }
+      },
+      {
+        "featureType": {"type": "uri", "value": "http://www.opengis.net/ont/sf#Point"},
+        "location": {
+          "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
+          "type": "literal",
+          "value": "ALSO INVALID WKT !!!"
+        }
+      }
+    ]
+  }
+}
+

--- a/cypress/fixtures/queries/geo-sparse-binding-response.json
+++ b/cypress/fixtures/queries/geo-sparse-binding-response.json
@@ -1,0 +1,24 @@
+{
+  "head": {
+    "vars": ["featureType", "location"]
+  },
+  "results": {
+    "bindings": [
+      {
+        "featureType": {"type": "uri", "value": "http://www.opengis.net/ont/sf#Point"}
+      },
+      {
+        "featureType": {"type": "uri", "value": "http://www.opengis.net/ont/sf#LineString"},
+        "location": {
+          "datatype": "http://www.opengis.net/ont/geosparql#wktLiteral",
+          "type": "literal",
+          "value": "POINT(25.9657 43.8356)"
+        }
+      },
+      {
+        "featureType": {"type": "uri", "value": "http://www.opengis.net/ont/sf#Point"}
+      }
+    ]
+  }
+}
+

--- a/cypress/steps/geo-plugin-steps.ts
+++ b/cypress/steps/geo-plugin-steps.ts
@@ -81,4 +81,12 @@ export class GeoPluginSteps {
   static getLeafletPopupContent() {
     return cy.get('.leaflet-popup-content');
   }
+
+  /**
+   * Returns the alert-box warning element rendered inside the YASR root element
+   * by the geo plugin when geometries are invalid or missing.
+   */
+  static getWarningMessage() {
+    return cy.get('alert-box .message');
+  }
 }

--- a/cypress/stubs/query-stubs.ts
+++ b/cypress/stubs/query-stubs.ts
@@ -147,6 +147,14 @@ export class QueryStubs {
     QueryStubs.stubGeoQueryResponse('/queries/geo-invalid-geojson-response.json', repositoryId);
   }
 
+  static stubGeoAllInvalidWktResponse(repositoryId = 'yasr-geo-plugin') {
+    QueryStubs.stubGeoQueryResponse('/queries/geo-all-invalid-wkt-response.json', repositoryId);
+  }
+
+  static stubGeoSparseBindingResponse(repositoryId = 'yasr-geo-plugin') {
+    QueryStubs.stubGeoQueryResponse('/queries/geo-sparse-binding-response.json', repositoryId);
+  }
+
   static stubChartDataQuery() {
     cy.intercept('/repositories/chart-data', {fixture: '/queries/chart-data-response.json'}).as('chart-data-request');
   }

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -260,6 +260,8 @@
   "yasr.plugin.geo-plugin.tile-layer.cartodb-voyager.name": "CartoDB Voyager",
   "yasr.plugin.geo-plugin.tile-layer.cartodb-voyager-dark.name": "Dark CartoDB Positron",
   "yasr.plugin.geo-plugin.tile-layer.results": "Results",
+  "yasr.plugin.geo-plugin.tile-layer.no_valid_geometries": "No valid geometries found in the results. Please ensure that the geometry column contains valid GeoSPARQL literals (e.g., WKT or GeoJSON) and that the correct datatype is specified.",
+  "yasr.plugin.geo-plugin.tile-layer.some_invalid_geometries": "Some geometries could not be rendered due to invalid format. Please ensure that the geometry column contains valid GeoSPARQL literals (e.g., WKT or GeoJSON) and that the correct datatype is specified.",
   "yasr.explain_plan.copy_button.label": "Copy to clipboard",
   "yasr.explain_plan.copied_success": "Copied to clipboard",
   "yasqe.actions.saved_query_dialog.edit.button.tooltip": "Edit query",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -262,6 +262,8 @@
   "yasr.plugin.geo-plugin.tile-layer.cartodb-voyager.name": "CartoDB Voyager",
   "yasr.plugin.geo-plugin.tile-layer.cartodb-voyager-dark.name": "CartoDB Positron Sombre",
   "yasr.plugin.geo-plugin.tile-layer.results": "Résultats",
+  "yasr.plugin.geo-plugin.tile-layer.no_valid_geometries": "Aucune géométrie valide n'a été trouvée dans les résultats. Veuillez vous assurer que la colonne « géométrie » contient des littéraux GeoSPARQL valides (par exemple, WKT ou GeoJSON) et que le type de données approprié est spécifié.",
+  "yasr.plugin.geo-plugin.tile-layer.some_invalid_geometries": "Certaines géométries invalides ont été trouvées dans les résultats et ont été ignorées. Veuillez vous assurer que la colonne « géométrie » contient des littéraux GeoSPARQL valides (par exemple, WKT ou GeoJSON) et que le type de données approprié est spécifié.",
   "yasqe.actions.saved_query_dialog.edit.button.tooltip": "Modifier la requête",
   "yasqe.actions.saved_query_dialog.delete.button.tooltip": "Supprimer une requête",
   "yasqe.actions.saved_query_dialog.share.button.tooltip": "Obtenir l'URL de la requête",

--- a/ontotext-yasgui-web-component/src/plugins/yasr/geo/geo-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/geo/geo-plugin.ts
@@ -176,27 +176,50 @@ export class GeoPlugin implements YasrPlugin {
       return;
     }
     const bindings = this.getBindings();
-    Object.entries(this.getGeometryColumns() ?? {})
-      .forEach(([colName, _datatype]) => {
-        this.resultsLayer.addLayer(this.createGeoLayer(bindings, colName));
+    const geometryColumns = this.getGeometryColumns() ?? {};
+
+    let totalGeometries = 0;
+    let validGeometries = 0;
+
+    const featuresPerColumn = Object.keys(geometryColumns)
+      .map((colName) => {
+        totalGeometries += bindings.filter((item) => item[colName]).length;
+        const features = this.createGeoJson(bindings, colName);
+        validGeometries += features.length;
+        return features;
       });
+
+    const hasValidFeatures = featuresPerColumn.some((features) => Boolean(features.length));
+
+    if (hasValidFeatures) {
+      featuresPerColumn.forEach((features) => {
+        const geoLayer = this.createGeoLayer(features);
+        this.resultsLayer.addLayer(geoLayer);
+      });
+
+      if (validGeometries < totalGeometries) {
+        this.yasr.showWarning(this.translationService.translate('yasr.plugin.geo-plugin.tile-layer.some_invalid_geometries'));
+      }
+    } else {
+      this.yasr.showWarning(this.translationService.translate('yasr.plugin.geo-plugin.tile-layer.no_valid_geometries'));
+      this.map.setView([0, 0], 0);
+    }
+
     this.fitResultsLayerBounds();
   }
 
   /**
    * Creates a Leaflet FeatureGroup from query bindings for a specific geometry column.
    *
-   * @param bindings SPARQL query bindings
-   * @param colName The geometry column name
+   * @param features An array of GeoJSON features to be added to the map layer.
    */
-  private createGeoLayer(bindings: Binding[], colName: string): FeatureGroup {
-    const geojson = this.createGeoJson(bindings, colName);
+  private createGeoLayer(features: Feature[]): FeatureGroup {
     const leafletOptions = new LeafletOptionsBuilder(this.pluginGonfiguration, this.subscriptions)
       .withPointMarker()
       .withFeatureClick()
       .withStyle()
       .build();
-    return geoJson(geojson, leafletOptions);
+    return geoJson(features, leafletOptions);
   }
 
   /**
@@ -269,12 +292,9 @@ export class GeoPlugin implements YasrPlugin {
    */
   private createGeoJson(bindings: Binding[], columnName: string): Feature[] {
     return bindings
+      .filter((item) => item[columnName])
       .map<Feature | undefined>((item) => {
         const binding = item[columnName];
-        if (!binding) {
-          return undefined;
-        }
-
         const geometry = GeoSPARQLService.parse(binding.datatype, binding.value);
         if (!geometry) {
           return undefined;


### PR DESCRIPTION
## What
Added a warning message for cases where no valid or some invalid geometries are found in the results, and adjusted the logic for adding layers to the map.

## Why
This change ensures that users are informed when their query results do not contain valid geometries, preventing confusion and improving user experience.

## How
- Introduced a new translation key for the warning message in both English and French.
- Updated the logic to check for valid features before adding layers to the map.
- Displayed a warning message if no valid geometries are found, and reset the map view.
- Displayed a warning message if some geometries are invalid to notify the user

<img width="801" height="811" alt="image" src="https://github.com/user-attachments/assets/3eb7ce89-d7aa-49bf-94ce-6b78869666ca" />

<img width="801" height="811" alt="image" src="https://github.com/user-attachments/assets/78b4bdfd-a0f2-4b89-8510-f007cc9c2540" />
