### PR TITLE
GDB-14616: Fix popover width and improve popup styling

### DIFF
--- a/ontotext-yasgui-web-component/src/css/geo-plugin.scss
+++ b/ontotext-yasgui-web-component/src/css/geo-plugin.scss
@@ -2,4 +2,8 @@
   height: 100%;
   min-height: 500px;
   width: 100%;
+
+  .geo-popup {
+    overflow-wrap: break-word
+  }
 }

--- a/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
@@ -213,7 +213,7 @@ export class LeafletOptionsBuilder {
   private onEachFeatureFunction(feature: Feature, layer: Layer) {
     const popupContent = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_POPUP_CONTENT, feature) ?? this.getDefaultPopupContent(feature);
 
-    layer.bindPopup(popupContent);
+    layer.bindPopup(popupContent, {maxWidth: 500, className: 'geo-popup'});
 
     const tooltip = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_TOOLTIP, feature);
     if (tooltip) {


### PR DESCRIPTION
## What
- Set a maximum width for popups in the leaflet options builder.
- Added a CSS class for geo popups to enable word breaking.

## Why
This change ensures that popups do not exceed a specified width, improving the user experience by preventing overflow. The new styling allows for better text handling within popups.

## How
- Updated `bindPopup` method to include a `maxWidth` option.
- Added a `.geo-popup` class in the SCSS file to apply `word-break: break-word;`.

<img width="1074" height="505" alt="image" src="https://github.com/user-attachments/assets/d650fb84-9374-45f6-a542-5ec7acde65f1" />

<img width="1074" height="505" alt="image" src="https://github.com/user-attachments/assets/cc60b658-1449-4dfe-83f0-4e31109e9f2b" />
