### PR TITLE
Cherry-pick GDB-14616: Fix popover width and improve popup styling 

### DIFF
--- a/ontotext-yasgui-web-component/src/css/geo-plugin.scss
+++ b/ontotext-yasgui-web-component/src/css/geo-plugin.scss
@@ -2,4 +2,8 @@
   height: 100%;
   min-height: 500px;
   width: 100%;
+
+  .geo-popup {
+    overflow-wrap: break-word
+  }
 }

--- a/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
@@ -213,7 +213,7 @@ export class LeafletOptionsBuilder {
   private onEachFeatureFunction(feature: Feature, layer: Layer) {
     const popupContent = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_POPUP_CONTENT, feature) ?? this.getDefaultPopupContent(feature);
 
-    layer.bindPopup(popupContent);
+    layer.bindPopup(popupContent, {maxWidth: 500, className: 'geo-popup'});
 
     const tooltip = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_TOOLTIP, feature);
     if (tooltip) {


### PR DESCRIPTION
## What
- Set a maximum width for popups in the leaflet options builder.
- Added a CSS class for geo popups to enable word breaking.

## Why
This change ensures that popups do not exceed a specified width, improving the user experience by preventing overflow. The new styling allows for better text handling within popups.

## How
- Updated `bindPopup` method to include a `maxWidth` option.
- Added a `.geo-popup` class in the SCSS file to apply `overflow-wrap: break-word;`.


(cherry picked from commit 76b73eb8e35de89e8a16d029831f5ff30a670b6e)