### PR TITLE
Cherry-pick GDB-14485: Display markdown in the geo popups

### DIFF
--- a/ontotext-yasgui-web-component/package-lock.json
+++ b/ontotext-yasgui-web-component/package-lock.json
@@ -17,6 +17,7 @@
         "dompurify": "^3.4.1",
         "h3-js": "^4.4.0",
         "leaflet": "^1.9.4",
+        "markdown-it": "^14.1.1",
         "open-location-code-typescript": "^1.5.0",
         "proj4": "^2.20.3",
         "remixicon": "^4.7.0"
@@ -2302,6 +2303,17 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4244,6 +4256,14 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4303,6 +4323,32 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4767,6 +4813,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "engines": {
         "node": ">=6"
       }
@@ -5474,6 +5528,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/unbzip2-stream": {
       "version": "1.3.3",
@@ -7508,6 +7567,11 @@
         "once": "^1.4.0"
       }
     },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -8959,6 +9023,14 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -9006,6 +9078,31 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        }
+      }
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -9364,6 +9461,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
     "puppeteer": {
       "version": "10.4.0",
@@ -9857,6 +9959,11 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "peer": true
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "unbzip2-stream": {
       "version": "1.3.3",

--- a/ontotext-yasgui-web-component/package.json
+++ b/ontotext-yasgui-web-component/package.json
@@ -33,9 +33,10 @@
     "@tmcw/togeojson": "^7.1.2",
     "betterknown": "^1.2.0",
     "codemirror": "^5.51.0",
-    "h3-js": "^4.4.0",
     "dompurify": "^3.4.1",
+    "h3-js": "^4.4.0",
     "leaflet": "^1.9.4",
+    "markdown-it": "^14.1.1",
     "open-location-code-typescript": "^1.5.0",
     "proj4": "^2.20.3",
     "remixicon": "^4.7.0"

--- a/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/geo/services/leaflet-options-builder.ts
@@ -8,6 +8,7 @@ import {GeoStyleOptionKeys, GeoStyleOptions} from '../models/geo-style-options';
 import {FeatureClickPayload} from '../models/feature-click-payload';
 import {LeafletService} from './leaflet-service';
 import {GeoPropertySanitizer} from '../utils/geo-property-sanitizer';
+import markdownit from "markdown-it";
 
 /**
  * Parsers for converting raw feature property values into typed GeoStyleOptions.
@@ -52,6 +53,8 @@ export class LeafletOptionsBuilder {
    */
   private subscriptions: Array<() => void>;
 
+  private markdown: markdownit.MarkdownIt;
+
   /**
    * Creates a new instance of the Geo plugin configuration wrapper.
    *
@@ -66,6 +69,7 @@ export class LeafletOptionsBuilder {
   constructor(configuration: GeoPluginConfiguration, subscriptions: Array<() => void>) {
     this.configuration = configuration;
     this.subscriptions = subscriptions;
+    this.markdown = markdownit({html: true});
   }
 
   /**
@@ -211,9 +215,20 @@ export class LeafletOptionsBuilder {
    * @param layer - The Leaflet Layer representing the feature.
    */
   private onEachFeatureFunction(feature: Feature, layer: Layer) {
-    const popupContent = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_POPUP_CONTENT, feature) ?? this.getDefaultPopupContent(feature);
+    // Cache the rendered popup content to avoid re-rendering on each open.
+    let renderedPopupContent: string | HTMLElement | undefined;
+    // Lazily render popup content only when the popup is first opened. This avoids unnecessary processing for features
+    // that are never clicked.
+    layer.bindPopup(() => {
+      if (renderedPopupContent !== null && renderedPopupContent !== undefined) {
+        return renderedPopupContent;
+      }
 
-    layer.bindPopup(popupContent, {maxWidth: 500, className: 'geo-popup'});
+      const popupContent = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_POPUP_CONTENT, feature);
+      // Caches the result for future opens
+      renderedPopupContent = popupContent !== null && popupContent !== undefined ? this.markdown.render(popupContent) : this.getDefaultPopupContent(feature);
+      return renderedPopupContent;
+    }, {maxWidth: 500, className: 'geo-popup'});
 
     const tooltip = this.getFeaturePropertyValue(GeoSparqlVariable.FIGURE_TOOLTIP, feature);
     if (tooltip) {


### PR DESCRIPTION
## What
Added Markdown support for popup content.

## Why
Provide richer and more flexible popup content rendering.

## How
Integrated markdown-it into the popup rendering flow.

### Additional work
- Changed popup content setup to use a function-based approach instead of pre-processing content. This enables lazy rendering, so popup content is processed only when a user clicks on a feature, rather than eagerly processing content for every feature regardless of whether the user ever views the popup.
- Added caching for rendered popup content to avoid re-rendering it every time the popup is opened.

(cherry picked from commit a523cdae448525dbda243a37b0efd722237b048a)