### PR TITLE
GDB-13833: Support fullscreen mode for the yasgui sparql editor

### DIFF
--- a/Yasgui/packages/yasqe/src/index.ts
+++ b/Yasgui/packages/yasqe/src/index.ts
@@ -516,8 +516,8 @@ export class Yasqe extends CodeMirror {
 
       this.queryBtn.onclick = () => {
         if (this.config.queryingDisabled) return; // Don't do anything
-          this.pageNumber = 1;
-          this.query().catch(() => {}); //catch this to avoid unhandled rejection
+        this.pageNumber = 1;
+        this.query().catch(() => {}); //catch this to avoid unhandled rejection
       };
 
       const querySplitButtonEl = document.createElement("query-split-button");
@@ -1285,6 +1285,17 @@ export class Yasqe extends CodeMirror {
 
   public expandEditor() {
     this.setSize(null, "100%");
+  }
+
+  /**
+   * Registers a callback to be executed on destroy.
+   *
+   * @param destroyCallback Callback invoked when the instance is destroyed.
+   */
+  public addDestroyCallback(destroyCallback: () => void) {
+    if (typeof destroyCallback === "function") {
+      this.subscriptions.push(destroyCallback);
+    }
   }
 
   public destroy() {

--- a/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
+++ b/cypress/e2e/editor-actions/configure-actions.spec.cy.ts
@@ -12,7 +12,7 @@ describe('Configure editor actions', () => {
     });
 
     it('Should see all custom actions by default in particular order', () => {
-        YasqeSteps.getActionButtons().should('have.length', 5);
+        YasqeSteps.getActionButtons().should('have.length', 6);
         YasqeSteps.getActionButtonTooltip(0).should('have.attr', 'yasgui-data-tooltip', 'Create saved query');
         YasqeSteps.getActionButtonTooltip(1).should('have.attr', 'yasgui-data-tooltip', 'Show saved queries');
         YasqeSteps.getActionButtonTooltip(2).should('have.attr', 'yasgui-data-tooltip', 'Get URL to current query');
@@ -44,11 +44,11 @@ describe('Configure editor actions', () => {
     });
 
     it('Should show editor actions on each editor tab', () => {
-        YasqeSteps.getActionButtons().should('have.length', 5);
+        YasqeSteps.getActionButtons().should('have.length', 6);
         YasguiSteps.openANewTab();
-        YasqeSteps.getActionButtons().should('have.length', 5);
+        YasqeSteps.getActionButtons().should('have.length', 6);
         YasguiSteps.openTab(0);
-        YasqeSteps.getActionButtons().should('have.length', 5);
+        YasqeSteps.getActionButtons().should('have.length', 6);
     });
 
     it('should toggle query button', () => {

--- a/cypress/e2e/editor-actions/fullscreen.spec.cy.ts
+++ b/cypress/e2e/editor-actions/fullscreen.spec.cy.ts
@@ -1,0 +1,48 @@
+import {AbortQueryPageSteps} from '../../steps/pages/abort-query-page-steps';
+import {YasqeSteps} from '../../steps/yasqe-steps';
+
+describe('YASQE fullscreen', () => {
+
+  beforeEach(() => {
+    AbortQueryPageSteps.visit();
+  });
+
+  it('should toggle the SPARQL editor fullscreen mode.', () => {
+    // WHEN: I open a page with YASQE
+    // THEN: I should see the fullscreen button in the editor
+    YasqeSteps.getFullscreenButton().should('have.class', 'ri-fullscreen-line');
+    // AND: YASQE should not be in fullscreen mode
+    YasqeSteps.getYasqe().should('not.have.class', 'yasqe-fullscreen');
+
+    // WHEN: I click the fullscreen button
+    YasqeSteps.toggleFullscreen();
+    // THEN: I should see the exit fullscreen button in the editor
+    YasqeSteps.getFullscreenButton().should('have.class', 'ri-fullscreen-exit-line');
+    // AND: YASQE should be in fullscreen mode
+    YasqeSteps.getYasqe().should('have.class', 'yasqe-fullscreen');
+
+    // WHEN: I click the exit fullscreen button
+    YasqeSteps.toggleFullscreen();
+    // THEN: I should see the fullscreen button in the editor
+    YasqeSteps.getFullscreenButton().should('have.class', 'ri-fullscreen-line');
+    // AND: YASQE should not be in fullscreen mode
+    YasqeSteps.getYasqe().should('not.have.class', 'yasqe-fullscreen');
+  });
+
+  it('should display the correct fullscreen button when YASQE fullscreen mode is toggled using keyboard shortcuts', () => {
+    // WHEN: I open a page with YASQE
+    // AND: I press the fullscreen keyboard shortcut
+    YasqeSteps.getYasqe().type('{ctrl}{alt}f');
+    // THEN: I should see the exit fullscreen button in the editor
+    YasqeSteps.getFullscreenButton().should('have.class', 'ri-fullscreen-exit-line');
+    // AND: YASQE should be in fullscreen mode
+    YasqeSteps.getYasqe().should('have.class', 'yasqe-fullscreen');
+
+    // WHEN: I press the Escape key
+    YasqeSteps.getYasqe().type('{esc}');
+    // THEN: I should see the fullscreen button in the editor
+    YasqeSteps.getFullscreenButton().should('have.class', 'ri-fullscreen-line');
+    // AND: YASQE should not be in fullscreen mode
+    YasqeSteps.getYasqe().should('not.have.class', 'yasqe-fullscreen');
+  });
+});

--- a/cypress/e2e/editor-actions/include-inferred-statements.spec.cy.ts
+++ b/cypress/e2e/editor-actions/include-inferred-statements.spec.cy.ts
@@ -18,26 +18,26 @@ describe('Include inferred action', () => {
 
     // Then I expect inferred button to be on.
     YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-    YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+    YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
     // When I click on inferred button
-    YasqeSteps.getActionButton(3).click({force: true});
+    YasqeSteps.getActionButton(4).click({force: true});
 
     // Then I expect inferred button to not be toggled.
     YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-    YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+    YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
   });
 
   it('Should be able to toggle the include inferred button state', () => {
     // When I open the editor
     // Then I expect that include inferred statements should be enabled by default
     YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-    YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+    YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     // When I click in the include inferred action
     YasqeSteps.includeInferredStatements();
     // Then I expect it to be disabled
     YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: OFF');
-    YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-off');
+    YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-off');
   });
 
   it('Should toggle infer request parameter in requests', () => {
@@ -59,14 +59,14 @@ describe('Include inferred action', () => {
       // and "infer" configuration is not setup.
       // Then I expect that inferred element to be enabled by default
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
       // When I open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I expect that inferred element to be enabled in the new tab.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     });
 
     it('should be enabled if "infer" configuration is set to true.', () => {
@@ -76,14 +76,14 @@ describe('Include inferred action', () => {
 
       // Then I expect that inferred element to be enabled.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
       // When I open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I expect that inferred element to be enabled in the new tab.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     });
 
     it('should not be enabled if "infer" configuration is set to false.', () => {
@@ -91,7 +91,7 @@ describe('Include inferred action', () => {
       // and "infer" configuration is not setup.
       // Then I expect that inferred element to be enabled by default
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
       // When I change configure infer to false,
       ActionsPageSteps.configureInferDisabled();
@@ -100,14 +100,14 @@ describe('Include inferred action', () => {
 
       // Then I expect that infer element to be disabled.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: OFF');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-off');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-off');
 
       // When I come back to the first tab
       YasguiSteps.openTab(0);
 
       // Then I expect "infer" to be enabled.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     });
 
     it('should reset "infer" state when resetting results.', () => {
@@ -115,13 +115,13 @@ describe('Include inferred action', () => {
       // and "infer" configuration is not setup.
       // Then I expect that inferred element to be enabled by default
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
 
       // When I change configure "infer" to false
       YasqeSteps.includeInferredStatements();
       // Then I expect that the infer element to be disabled.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: OFF');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-off');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-off');
 
       // And I execute the query
       YasqeSteps.executeQuery(0);
@@ -134,7 +134,7 @@ describe('Include inferred action', () => {
 
       // And I expect "infer" to be enabled.
       YasqeSteps.getActionButtonTooltip(3).should('have.attr', 'yasgui-data-tooltip', 'Include inferred data in results: ON');
-      YasqeSteps.getActionButton(3).should('have.class', 'icon-inferred-on');
+      YasqeSteps.getActionButton(4).should('have.class', 'icon-inferred-on');
     });
   });
 
@@ -144,14 +144,14 @@ describe('Include inferred action', () => {
       // and "sameAs" configuration is not setup.
       // Then I expect that sameAs element to be enabled
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
 
       // When I open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I expect that include inferred statements should be enabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
     });
 
     it('should be enabled if "sameAs" configuration is set to true.', () => {
@@ -161,14 +161,14 @@ describe('Include inferred action', () => {
 
       // Then I expect that sameAs element to be enabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
 
       // When I open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I expect that sameAs element to be enabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
     });
 
     it('should not be enabled if "sameAs" configuration is set to false.', () => {
@@ -176,28 +176,28 @@ describe('Include inferred action', () => {
       // and "sameAs" element is enabled by default.
       // Then I expect that sameAs element to be enabled by default
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
 
       // When I change configure infer to false,
       ActionsPageSteps.configureSameAsDisabled();
 
       // Then I expect sameAs to not be changed in the first tab.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
 
       // and open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I expect that sameAs element to not be enabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: OFF');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I come back to the first tab
       YasguiSteps.openTab(0);
 
       // Then I expect sameAs to be enabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', 'Expand results over owl:sameAs: ON');
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-on');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-on');
     });
 
     it('should be disabled if "infer" is set to false and "sameAs" configuration not defined.', () => {
@@ -207,21 +207,21 @@ describe('Include inferred action', () => {
       // and "sameAs" configuration is not defined.
       // Then I expect that sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I open a new Tab.
       YasguiSteps.openANewTab();
 
       // Then I same as element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I expect come back to the first tab
       YasguiSteps.openTab(0);
 
       // Then I expect sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
     });
 
     it('should be disabled if "infer" is set to false and "sameAs" configuration is set to true.', () => {
@@ -231,7 +231,7 @@ describe('Include inferred action', () => {
       // and "sameAs" configuration is not defined.
       // Then I expect that sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I configure sameAs to be true,
       ActionsPageSteps.configureSameAsEnabled();
@@ -240,14 +240,14 @@ describe('Include inferred action', () => {
 
       // Then I expect same as element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I come back to the first tab
       YasguiSteps.openTab(0);
 
       // Then I expect sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
     });
 
     it('should be disabled if "infer" is set to false and "sameAs" configuration is set to false.', () => {
@@ -257,7 +257,7 @@ describe('Include inferred action', () => {
       // and "sameAs" configuration is not defined.
       // Then I expect that sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I configure sameAs to be true,
       ActionsPageSteps.configureSameAsEnabled();
@@ -266,14 +266,14 @@ describe('Include inferred action', () => {
 
       // Then I expect same as element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
 
       // When I come back to the first tab
       YasguiSteps.openTab(0);
 
       // Then I expect sameAs element to be disabled.
       YasqeSteps.getActionButtonTooltip(4).should('have.attr', 'yasgui-data-tooltip', "Requires 'Include Inferred'!");
-      YasqeSteps.getActionButton(4).should('have.class', 'icon-same-as-off');
+      YasqeSteps.getActionButton(5).should('have.class', 'icon-same-as-off');
     });
   });
 });

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -192,6 +192,14 @@ export class YasqeSteps {
     this.getShowSavedQueriesButton().eq(index).click();
   }
 
+  static getFullscreenButton() {
+    return cy.get('.yasqe_fullscreenButton')
+  }
+
+  static toggleFullscreen() {
+    YasqeSteps.getFullscreenButton().click();
+  }
+
   static getSavedQueriesPopup() {
     return cy.get('.saved-queries-popup');
   }

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -57,6 +57,7 @@
 
     .CodeMirror {
       border-color: $color-onto-border;
+      min-height: 330px;
     }
 
     /* prevent overlapping of the query text with the yasqe action buttons on the right side of the editor */
@@ -138,7 +139,8 @@
           background-color: $color-onto-white;
           color: $color-ontotext-orange;
           outline: none;
-          font-size: 2.5em;
+          font-size: 1.5em;
+          height: 1.5em;
           cursor: pointer;
           transition: all .15s ease-out;
 

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -383,6 +383,7 @@ export const defaultYasqeConfig: Partial<YasqeDefaultConfiguration> = {
   initialQuery: '',
   createShareableLink: null,
   yasqeActionButtons: [
+    {name: 'fullscreen', visible: true},
     {name: 'createSavedQuery', visible: true},
     {name: 'showSavedQueries', visible: true},
     {name: 'shareQuery', visible: true},

--- a/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui/yasqe.ts
@@ -11,9 +11,11 @@ import {IndentSelection} from './indent-selection';
 export interface Yasqe {
   queryValid: boolean;
   tabId: string;
+  rootEl: HTMLDivElement;
   getInfer: () => boolean;
   getSameAs: () => boolean;
 
+  enterFullScreen: () => void;
   leaveFullScreen: () => void;
 
   isExplainPlanQuery: () => boolean;
@@ -62,8 +64,12 @@ export interface Yasqe {
   getCursor: () => Cursor;
 
   setCursor: (cursor: Cursor) => void;
-  
+
   setOption: (optionName: string, optionValue: unknown) => void;
+  addDestroyCallback: (callback: () => void) => void;
+  setInfer: (infer: boolean) => void;
+  setSameAs: (sameAs: boolean) => void;
+  focus: () => void;
 }
 
 export class Doc {

--- a/ontotext-yasgui-web-component/src/models/yasqe-button-name.ts
+++ b/ontotext-yasgui-web-component/src/models/yasqe-button-name.ts
@@ -1,6 +1,7 @@
 import {MessageCode} from './internal-events/internal-notification-message-event';
 
 export const YasqeButtonName = {
+  FULLSCREEN: 'fullscreen',
   CREATE_SAVED_QUERY: 'createSavedQuery',
   SHOW_SAVED_QUERIES: 'showSavedQueries',
   SHARE_QUERY: 'shareQuery',

--- a/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasqe/yasqe-service.ts
@@ -1,13 +1,14 @@
-import {EventService} from "../event-service";
-import {TranslationService} from "../translation.service";
+import {EventService} from '../event-service';
+import {TranslationService} from '../translation.service';
 import {ServiceFactory} from '../service-factory';
-import {YasguiConfiguration} from "../../models/yasgui-configuration";
+import {YasguiConfiguration} from '../../models/yasgui-configuration';
 import {TooltipService} from '../tooltip-service';
 import {InternalShareQueryEvent} from '../../models/internal-events/internal-share-query-event';
 import {InternalShowSavedQueriesEvent} from '../../models/internal-events/internal-show-saved-queries-event';
 import {YasqeButtonName, YasqeButtonType} from '../../models/yasqe-button-name';
 import {InternalCreateSavedQueryEvent} from '../../models/internal-events/internal-create-saved-query-event';
-import {YasguiBuilder} from "../yasgui/yasgui-builder";
+import {YasguiBuilder} from '../yasgui/yasgui-builder';
+import {Yasqe} from '../../models/yasgui/yasqe';
 
 export class YasqeService {
 
@@ -15,7 +16,6 @@ export class YasqeService {
   private readonly yasguiBuilder: YasguiBuilder;
   private translationService: TranslationService;
 
-  //@ts-ignore
   buttonBuilders: Map<string, ((yasguiConfiguration: YasguiConfiguration, yasqe: Yasqe) => HTMLElement | HTMLElement[])> = new Map<string, (() => HTMLElement | HTMLElement[])>();
 
   private static pluginButtonNameToClassNameMapping: Map<YasqeButtonType, string>;
@@ -29,9 +29,10 @@ export class YasqeService {
       name: 'YasqeServiceLanguageChangeObserver',
       notify: (currentLang) => this.onLanguageChange(currentLang)
     });
-    this.buttonBuilders.set(YasqeButtonName.CREATE_SAVED_QUERY, () => this.buildCreateSaveQueryButton());
-    this.buttonBuilders.set(YasqeButtonName.SHOW_SAVED_QUERIES, () => this.buildShowSavedQueriesButton());
-    this.buttonBuilders.set(YasqeButtonName.SHARE_QUERY, () => this.buildShareQueryButton());
+    this.buttonBuilders.set(YasqeButtonName.FULLSCREEN, (_externalConfiguration, yasqe) => this.buildFullscreenButton(yasqe));
+    this.buttonBuilders.set(YasqeButtonName.CREATE_SAVED_QUERY, (_externalConfiguration, yasqe) => this.buildCreateSaveQueryButton(yasqe));
+    this.buttonBuilders.set(YasqeButtonName.SHOW_SAVED_QUERIES, (_externalConfiguration, yasqe) => this.buildShowSavedQueriesButton(yasqe));
+    this.buttonBuilders.set(YasqeButtonName.SHARE_QUERY, (_externalConfiguration, yasqe) => this.buildShareQueryButton(yasqe));
     this.buttonBuilders.set('includeInferredStatements', (externalConfiguration, yasqe) => this.buildInferAndSameAsButtons(externalConfiguration, yasqe));
   }
 
@@ -66,6 +67,7 @@ export class YasqeService {
 
   private static initPluginButtonNameToClassNameMapping() {
     YasqeService.pluginButtonNameToClassNameMapping = new Map();
+    YasqeService.pluginButtonNameToClassNameMapping.set(YasqeButtonName.FULLSCREEN, `yasqe_${YasqeButtonName.FULLSCREEN}Button`);
     YasqeService.pluginButtonNameToClassNameMapping.set(YasqeButtonName.CREATE_SAVED_QUERY, `yasqe_${YasqeButtonName.CREATE_SAVED_QUERY}Button`);
     YasqeService.pluginButtonNameToClassNameMapping.set(YasqeButtonName.SHOW_SAVED_QUERIES, `yasqe_${YasqeButtonName.SHOW_SAVED_QUERIES}Button`);
     YasqeService.pluginButtonNameToClassNameMapping.set(YasqeButtonName.SHARE_QUERY, `yasqe_${YasqeButtonName.SHARE_QUERY}Button`);
@@ -106,7 +108,6 @@ export class YasqeService {
     actionsButtonNames.forEach((actionsButtonName) => YasqeService.showActionButton(actionsButtonName));
   }
 
-  //@ts-ignore
   getButtonInstance(buttonDefinition: { name }, yasguiConfiguration: YasguiConfiguration, yasqe: Yasqe): HTMLElement | HTMLElement[] {
     if (!this.buttonBuilders.has(buttonDefinition.name)) {
       throw Error(`No yasqe button builder was found for ${buttonDefinition.name}`);
@@ -114,38 +115,71 @@ export class YasqeService {
     return this.buttonBuilders.get(buttonDefinition.name)(yasguiConfiguration, yasqe);
   }
 
-  private buildShowSavedQueriesButton(): HTMLElement {
-    const buttonElement = document.createElement("button");
+  private buildFullscreenButton(yasqe: Yasqe): HTMLElement {
+    const buttonElement = document.createElement('button');
+    buttonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.FULLSCREEN)} custom-button`;
+
+    const updateIcon = () => {
+      const isFullscreen = yasqe.rootEl.classList.contains('yasqe-fullscreen');
+      buttonElement.classList.toggle('ri-fullscreen-line', !isFullscreen);
+      buttonElement.classList.toggle('ri-fullscreen-exit-line', isFullscreen);
+    };
+
+    const handleFullscreen = () => {
+      yasqe.toggleFullScreen();
+      yasqe.focus();
+    }
+    buttonElement.addEventListener('click', handleFullscreen);
+
+    const observer = new MutationObserver(updateIcon);
+    observer.observe(yasqe.rootEl, {
+      attributes: true,
+      attributeFilter: ['class']
+    });
+    yasqe.addDestroyCallback(() => {
+      buttonElement.removeEventListener('click', handleFullscreen);
+      observer.disconnect();
+    });
+    updateIcon();
+    return buttonElement;
+  }
+
+  private buildShowSavedQueriesButton(yasqe: Yasqe): HTMLElement {
+    const buttonElement = document.createElement('button');
     buttonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.SHOW_SAVED_QUERIES)} custom-button ri-folder-3-line`;
-    buttonElement.addEventListener("click",
-      () => {
-        this.eventService.emit(new InternalShowSavedQueriesEvent(buttonElement))
-      });
+
+    const handleShowSavedQuery = () => this.eventService.emit(new InternalShowSavedQueriesEvent(buttonElement));
+    buttonElement.addEventListener('click', handleShowSavedQuery);
+    yasqe.addDestroyCallback(() => buttonElement.removeEventListener('click', handleShowSavedQuery));
 
     const tooltip = this.translationService.translate('yasqe.actions.show_saved_queries.button.tooltip');
     return TooltipService.addTooltip(buttonElement, tooltip);
   }
 
-  private buildCreateSaveQueryButton(): HTMLElement {
-    const buttonElement = document.createElement("button");
+  private buildCreateSaveQueryButton(yasqe: Yasqe): HTMLElement {
+    const buttonElement = document.createElement('button');
     buttonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.CREATE_SAVED_QUERY)} custom-button ri-save-line`;
-    buttonElement.addEventListener("click",
-      () => this.eventService.emit(new InternalCreateSavedQueryEvent()));
+
+    const handleCreateSaveQuery = () => this.eventService.emit(new InternalCreateSavedQueryEvent());
+    buttonElement.addEventListener('click', handleCreateSaveQuery);
+    yasqe.addDestroyCallback(() => buttonElement.removeEventListener('click', handleCreateSaveQuery));
+
     const tooltip = this.translationService.translate('yasqe.actions.save_query.button.tooltip');
     return TooltipService.addTooltip(buttonElement, tooltip);
   }
 
-  private buildShareQueryButton(): HTMLElement {
-    const buttonElement = document.createElement("button");
+  private buildShareQueryButton(yasqe: Yasqe): HTMLElement {
+    const buttonElement = document.createElement('button');
     buttonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.SHARE_QUERY)} custom-button ri-links-line`;
-    buttonElement.addEventListener("click",
-      () => this.eventService.emit(new InternalShareQueryEvent()));
+
+    const handleShareQuery = () => this.eventService.emit(new InternalShareQueryEvent());
+    buttonElement.addEventListener('click', handleShareQuery);
+    yasqe.addDestroyCallback(() => buttonElement.removeEventListener('click', handleShareQuery));
 
     const tooltip = this.translationService.translate('yasqe.actions.share_query.button.tooltip');
     return TooltipService.addTooltip(buttonElement, tooltip);
   }
 
-  //@ts-ignore
   private buildInferAndSameAsButtons(yasguiConfiguration: YasguiConfiguration, yasqe: Yasqe): HTMLElement[] {
     // When a new tab is open and infer action is configured to be visible infer and sameAs are undefined, so we have to initialized them.
     this.initInferAndSameAsState(yasqe, yasguiConfiguration.yasguiConfig);
@@ -158,49 +192,49 @@ export class YasqeService {
     return [inferredElement, sameAsElement];
   }
 
-  //@ts-ignore
   private createInferredElement(yasqe: Yasqe, sameAsElement: HTMLElement, immutable): HTMLElement {
-    const inferredButtonElement = document.createElement("button");
+    const inferredButtonElement = document.createElement('button');
     const inferredTooltipElement = TooltipService.addTooltip(inferredButtonElement, undefined, 'top');
     inferredButtonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.INFER_STATEMENTS)} custom-button`;
     if (immutable) {
       inferredButtonElement.setAttribute('disabled', '');
     } else {
-      inferredButtonElement.addEventListener("click",
-        () => {
-          const newInferredValue = !yasqe.getInfer();
-          yasqe.setInfer(newInferredValue);
-          // Same as value depends on infer value. When a user switch of the infer then same as have to be switched off too
-          // and when it is switched on then same as have to be switched on.
-          const newSameAsValue = newInferredValue;
-          yasqe.setSameAs(newSameAsValue);
-          this.updateInferredElement(inferredTooltipElement, sameAsElement, newInferredValue, newSameAsValue);
-        });
+      const handleInferred = () => {
+        const newInferredValue = !yasqe.getInfer();
+        yasqe.setInfer(newInferredValue);
+        // Same as value depends on infer value. When a user switch of the infer then same as have to be switched off too
+        // and when it is switched on then same as have to be switched on.
+        const newSameAsValue = newInferredValue;
+        yasqe.setSameAs(newSameAsValue);
+        this.updateInferredElement(inferredTooltipElement, sameAsElement, newInferredValue, newSameAsValue);
+      };
+      inferredButtonElement.addEventListener('click', handleInferred);
+      yasqe.addDestroyCallback(() => inferredButtonElement.removeEventListener('click', handleInferred));
     }
     return inferredTooltipElement;
   }
 
-  //@ts-ignore
   private createSameAsElement(yasqe: Yasqe, immutable): HTMLElement {
-    const sameAsButtonElement = document.createElement("button");
+    const sameAsButtonElement = document.createElement('button');
     const sameAsTooltipElement = TooltipService.addTooltip(sameAsButtonElement, undefined, 'top');
     sameAsButtonElement.className = `${YasqeService.getActionButtonClassName(YasqeButtonName.EXPANDS_RESULTS)} custom-button`;
 
     if (immutable) {
       sameAsButtonElement.setAttribute('disabled', '');
     } else {
-      sameAsButtonElement.addEventListener("click",
-        (event) => {
-          if (sameAsButtonElement.classList.contains('disabled')) {
-            // Stops event propagation if the button is disabled. The Disabled attribute is not used because it stops firing events and breaks the button tooltip.
-            event.preventDefault();
-            return;
-          }
-          const newSameAsValue = !yasqe.getSameAs();
-          const inferValue = yasqe.getInfer();
-          yasqe.setSameAs(newSameAsValue);
-          this.updateSameAsElement(sameAsTooltipElement, newSameAsValue, inferValue);
-        });
+      const handleSameAs = (event) => {
+        if (sameAsButtonElement.classList.contains('disabled')) {
+          // Stops event propagation if the button is disabled. The Disabled attribute is not used because it stops firing events and breaks the button tooltip.
+          event.preventDefault();
+          return;
+        }
+        const newSameAsValue = !yasqe.getSameAs();
+        const inferValue = yasqe.getInfer();
+        yasqe.setSameAs(newSameAsValue);
+        this.updateSameAsElement(sameAsTooltipElement, newSameAsValue, inferValue);
+      };
+      sameAsButtonElement.addEventListener('click', handleSameAs);
+      yasqe.addDestroyCallback(() => sameAsButtonElement.removeEventListener('click', handleSameAs));
     }
 
     return sameAsTooltipElement;
@@ -243,7 +277,6 @@ export class YasqeService {
    * @param yasguiConfig - the yasgui configuration
    * @private
    */
-  //@ts-ignore
   private initInferAndSameAsState(yasqe: Yasqe, yasguiConfig) {
     let infer: boolean;
     let sameAs: boolean;

--- a/yasgui-patches/2026-05-27_GDB-13833_Support_fullscreen_mode_for_the_yasgui_sparql_editor.patch
+++ b/yasgui-patches/2026-05-27_GDB-13833_Support_fullscreen_mode_for_the_yasgui_sparql_editor.patch
@@ -1,0 +1,39 @@
+Subject: [PATCH] GDB-13833: Support fullscreen mode for the yasgui sparql editor
+---
+Index: Yasgui/packages/yasqe/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasqe/src/index.ts b/Yasgui/packages/yasqe/src/index.ts
+--- a/Yasgui/packages/yasqe/src/index.ts	(revision 69fb9acefdc01ac4feeb94c5586ec5126194117b)
++++ b/Yasgui/packages/yasqe/src/index.ts	(revision 541cace35347f6ccb9deeb88b84c72ac841b8c2c)
+@@ -516,8 +516,8 @@
+ 
+       this.queryBtn.onclick = () => {
+         if (this.config.queryingDisabled) return; // Don't do anything
+-          this.pageNumber = 1;
+-          this.query().catch(() => {}); //catch this to avoid unhandled rejection
++        this.pageNumber = 1;
++        this.query().catch(() => {}); //catch this to avoid unhandled rejection
+       };
+ 
+       const querySplitButtonEl = document.createElement("query-split-button");
+@@ -1287,6 +1287,17 @@
+     this.setSize(null, "100%");
+   }
+ 
++  /**
++   * Registers a callback to be executed on destroy.
++   *
++   * @param destroyCallback Callback invoked when the instance is destroyed.
++   */
++  public addDestroyCallback(destroyCallback: () => void) {
++    if (typeof destroyCallback === "function") {
++      this.subscriptions.push(destroyCallback);
++    }
++  }
++
+   public destroy() {
+     this.subscriptions.forEach((subscription) => subscription());
+     //  Abort running query;


### PR DESCRIPTION
## What
Add a configurable fullscreen action to YASQE.

## Why
Improve the user experience by allowing users to work with the editor in fullscreen mode.

## How
Add a fullscreen action button to the default YASQE action set, wire it to toggle the editor fullscreen mode, and keep its icon in sync when fullscreen mode is changed either by button click or keyboard shortcut.

### Additional work
Add cleanup for event listeners registered by YASQE action buttons.

<img width="967" height="611" alt="image" src="https://github.com/user-attachments/assets/ab653a35-83b1-478c-824a-8c1a8509e715" />
