### PR TITLE
GDB-14655: Fix uncaught exception in extended table rendering (#386)

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -33,90 +33,103 @@ export class ExtendedTable extends Table {
     return super.getCellContent(binding, prefixes);
   }
 
-  public draw(persistentConfig: PersistentConfig) {
-    const previousFilter = this.getCurrentFilterValue();
-    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
-    this.tableEl = document.createElement("table");
-    const rows = this.getRows();
-    const columns = this.getColumns();
-    const types = this.resolveTypes();
-    const columnDefinitions = this.getColumnDefinitions(types);
-    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
-      this.yasr.pluginControls;
-      addClass(this.yasr.rootEl, "isSinglePage");
-    } else {
-      removeClass(this.yasr.rootEl, "isSinglePage");
-    }
+  public draw(persistentConfig: PersistentConfig): Promise<void> {
+    let waitForResolve = false;
+    return new Promise<void>((resolve) => {
+      const previousFilter = this.getCurrentFilterValue();
+      this.persistentConfig = {...this.persistentConfig, ...persistentConfig};
+      this.tableEl = document.createElement('table');
+      const rows = this.getRows();
+      const columns = this.getColumns();
+      const types = this.resolveTypes();
+      const columnDefinitions = this.getColumnDefinitions(types);
+      if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+        this.yasr.pluginControls;
+        addClass(this.yasr.rootEl, 'isSinglePage');
+      } else {
+        removeClass(this.yasr.rootEl, 'isSinglePage');
+      }
 
-    if (this.dataTable) {
-      this.destroyResizer();
-      this.removeDataTableEventHandlers(this.dataTable);
-      this.dataTable.destroy(true);
-      this.dataTable = undefined;
-    }
-    this.yasr.resultsEl.appendChild(this.tableEl);
-    // reset some default config properties as they couldn't be initialized beforehand
-    const dtConfig: DataTables.Settings = {
-      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
-      pageLength: -1,
-      data: rows,
-      columns: columns,
-      columnDefs: columnDefinitions,
-      // DataTables will only render the rows that are initially visible on the page.
-      deferRender: true,
-      // // Switch off the pagination.
-      paging: false,
-      // Switched off for optimization purposes.
-      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
-      autoWidth: false,
-      language: {
-        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
-        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
-        paginate: {
-          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
-          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
-          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
-          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
-        },
-      },
-    };
+      if (this.dataTable) {
+        this.destroyResizer();
+        this.removeDataTableEventHandlers(this.dataTable);
+        this.dataTable.destroy(true);
+        this.dataTable = undefined;
+      }
+      this.yasr.resultsEl.appendChild(this.tableEl);
+      // reset some default config properties as they couldn't be initialized beforehand
+      const dtConfig: DataTables.Settings = {
+        ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
+        pageLength: -1,
+        data: rows,
+        columns: columns,
+        columnDefs: columnDefinitions,
+        // DataTables will only render the rows that are initially visible on the page.
+        deferRender: true,
+        // // Switch off the pagination.
+        paging: false,
+        // Switched off for optimization purposes.
+        // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+        autoWidth: false,
+        language: {
+          zeroRecords: this.translationService.translate('yasr.plugin_control.table.empty_result.label'),
+          info: this.translationService.translate('yasr.plugin.table.data_tables.info.result_info'),
+          paginate: {
+            first: this.translationService.translate('yasr.plugin.table.data_tables.paginate.first'),
+            last: this.translationService.translate('yasr.plugin.table.data_tables.paginate.last'),
+            next: this.translationService.translate('yasr.plugin.table.data_tables.paginate.next'),
+            previous: this.translationService.translate('yasr.plugin.table.data_tables.paginate.previous')
+          }
+        }
+      };
 
-    this.dataTable = $(this.tableEl).DataTable(dtConfig);
-    this.tableEl.style.removeProperty("width");
-    this.tableEl.style.width = this.tableEl.clientWidth + "px";
+      this.dataTable = $(this.tableEl).DataTable(dtConfig);
+      this.tableEl.style.removeProperty('width');
+      this.tableEl.style.width = this.tableEl.clientWidth + 'px';
 
-    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
-    const maxResizableResultsColumns = this.persistentConfig.compact
-      ? this.config.maxResizableResultsColumns - 1
-      : this.config.maxResizableResultsColumns;
+      // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+      const maxResizableResultsColumns = this.persistentConfig.compact
+        ? this.config.maxResizableResultsColumns - 1
+        : this.config.maxResizableResultsColumns;
 
-    if (columns.length <= maxResizableResultsColumns) {
-      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
-      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
-      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
-      setTimeout(() => {
-        this.tableResizer = new ColumnResizer.default(this.tableEl, {
-          partialRefresh: true,
-          headerOnly: false,
-          disabledColumns: this.persistentConfig.compact ? [] : [0],
+      if (columns.length <= maxResizableResultsColumns) {
+        waitForResolve = true;
+        // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+        // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+        // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+        setTimeout(() => {
+          try {
+            this.tableResizer = new ColumnResizer.default(this.tableEl, {
+              partialRefresh: true,
+              headerOnly: false,
+              disabledColumns: this.persistentConfig.compact ? [] : [0]
+            });
+          } catch (error) {
+            // Just log the error and continue without the column resizer, the table will still be functional.
+            console.error('Failed to initialize column resizer', error);
+          }
+          resolve();
         });
-      }, 0);
-    } else {
-      addClass(this.tableEl, "fixedColumns");
-    }
+      } else {
+        addClass(this.tableEl, 'fixedColumns');
+      }
 
-    this.registerDataTableEventHandlers(this.dataTable);
+      this.registerDataTableEventHandlers(this.dataTable);
 
-    this.drawControls();
-    this.updateTableEllipseClasses();
-    this.afterDraw();
-    if (previousFilter) {
-      this.applyFilterValue(previousFilter);
-    }
+      this.drawControls();
+      this.updateTableEllipseClasses();
+      this.afterDraw();
+      if (previousFilter) {
+        this.applyFilterValue(previousFilter);
+      }
 
-    if (!rows || rows.length < 1) {
-      this.updateEmptyTable(this.persistentConfig);
-    }
+      if (!rows || rows.length < 1) {
+        this.updateEmptyTable(this.persistentConfig);
+      }
+      if (!waitForResolve) {
+        resolve();
+      }
+    });
   }
 
   /**

--- a/Yasgui/packages/yasr/src/plugins/table/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/index.ts
@@ -204,125 +204,138 @@ export default class Table implements Plugin<PluginConfig> {
     return this.tableEl;
   }
 
-  public draw(persistentConfig: PersistentConfig) {
-    const previousFilter = this.getCurrentFilterValue();
-    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
-    this.tableEl = document.createElement("table");
-    const rows = this.getRows();
-    const columns = this.getColumns();
+  public draw(persistentConfig: PersistentConfig): Promise<void> {
+    let waitForResolve = false;
+    return new Promise<void>((resolve) => {
+      const previousFilter = this.getCurrentFilterValue();
+      this.persistentConfig = {...this.persistentConfig, ...persistentConfig};
+      this.tableEl = document.createElement('table');
+      const rows = this.getRows();
+      const columns = this.getColumns();
 
-    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
-      this.yasr.pluginControls;
-      addClass(this.yasr.rootEl, "isSinglePage");
-    } else {
-      removeClass(this.yasr.rootEl, "isSinglePage");
-    }
+      if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+        this.yasr.pluginControls;
+        addClass(this.yasr.rootEl, 'isSinglePage');
+      } else {
+        removeClass(this.yasr.rootEl, 'isSinglePage');
+      }
 
-    if (this.dataTable) {
-      this.destroyResizer();
+      if (this.dataTable) {
+        this.destroyResizer();
 
-      this.dataTable.destroy(true);
-      this.dataTable = undefined;
-    }
-    this.yasr.resultsEl.appendChild(this.tableEl);
-    // reset some default config properties as they couldn't be initialized beforehand
-    const dtConfig: DataTables.Settings = {
-      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
-      pageLength: -1,
-      data: rows,
-      columns: columns,
-      // DataTables will only render the rows that are initially visible on the page.
-      deferRender: true,
-      // // Switch off the pagination.
-      paging: false,
-      // Switched off for optimization purposes.
-      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
-      autoWidth: false,
-      language: {
-        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
-        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
-        paginate: {
-          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
-          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
-          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
-          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
-        },
-      },
-    };
-    this.dataTable = $(this.tableEl).DataTable(dtConfig);
-    this.tableEl.style.removeProperty("width");
-    this.tableEl.style.width = this.tableEl.clientWidth + "px";
+        this.dataTable.destroy(true);
+        this.dataTable = undefined;
+      }
+      this.yasr.resultsEl.appendChild(this.tableEl);
+      // reset some default config properties as they couldn't be initialized beforehand
+      const dtConfig: DataTables.Settings = {
+        ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
+        pageLength: -1,
+        data: rows,
+        columns: columns,
+        // DataTables will only render the rows that are initially visible on the page.
+        deferRender: true,
+        // // Switch off the pagination.
+        paging: false,
+        // Switched off for optimization purposes.
+        // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+        autoWidth: false,
+        language: {
+          zeroRecords: this.translationService.translate('yasr.plugin_control.table.empty_result.label'),
+          info: this.translationService.translate('yasr.plugin.table.data_tables.info.result_info'),
+          paginate: {
+            first: this.translationService.translate('yasr.plugin.table.data_tables.paginate.first'),
+            last: this.translationService.translate('yasr.plugin.table.data_tables.paginate.last'),
+            next: this.translationService.translate('yasr.plugin.table.data_tables.paginate.next'),
+            previous: this.translationService.translate('yasr.plugin.table.data_tables.paginate.previous')
+          }
+        }
+      };
+      this.dataTable = $(this.tableEl).DataTable(dtConfig);
+      this.tableEl.style.removeProperty('width');
+      this.tableEl.style.width = this.tableEl.clientWidth + 'px';
 
-    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
-    const maxResizableResultsColumns = this.persistentConfig.compact
-      ? this.config.maxResizableResultsColumns - 1
-      : this.config.maxResizableResultsColumns;
+      // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+      const maxResizableResultsColumns = this.persistentConfig.compact
+        ? this.config.maxResizableResultsColumns - 1
+        : this.config.maxResizableResultsColumns;
 
-    if (columns.length <= maxResizableResultsColumns) {
-      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
-      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
-      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
-      setTimeout(() => {
-        this.tableResizer = new ColumnResizer.default(this.tableEl, {
-          partialRefresh: true,
-          onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
-          headerOnly: false,
-          disabledColumns: this.persistentConfig.compact ? [] : [0],
+      if (columns.length <= maxResizableResultsColumns) {
+        waitForResolve = true;
+        // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+        // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+        // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+        setTimeout(() => {
+          try {
+            this.tableResizer = new ColumnResizer.default(this.tableEl, {
+              partialRefresh: true,
+              onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+              headerOnly: false,
+              disabledColumns: this.persistentConfig.compact ? [] : [0]
+            });
+          } catch (error) {
+            // Just log the error and continue without the column resizer, the table will still be functional.
+            console.error('Failed to initialize column resizer', error);
+          }
+          resolve();
+        }, 200);
+      } else {
+        addClass(this.tableEl, 'fixedColumns');
+      }
+      // DataTables uses the rendered style to decide the widths of columns.
+      // Before a draw remove the ellipseTable styling
+      if (this.persistentConfig.isEllipsed !== false) {
+        this.dataTable?.on('preDraw', () => {
+          this.tableResizer?.reset({disable: true});
+          removeClass(this.tableEl, 'ellipseTable');
+          this.tableEl?.style.removeProperty('width');
+          this.tableEl?.style.setProperty('width', this.tableEl.clientWidth + 'px');
+          return true; // Indicate it should re-render
         });
-      }, 0);
-    } else {
-      addClass(this.tableEl, "fixedColumns");
-    }
-    // DataTables uses the rendered style to decide the widths of columns.
-    // Before a draw remove the ellipseTable styling
-    if (this.persistentConfig.isEllipsed !== false) {
-      this.dataTable?.on("preDraw", () => {
-        this.tableResizer?.reset({ disable: true });
-        removeClass(this.tableEl, "ellipseTable");
-        this.tableEl?.style.removeProperty("width");
-        this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
-        return true; // Indicate it should re-render
-      });
-      // After a draw
-      this.dataTable?.on("draw", () => {
-        if (!this.tableEl) return;
-        // Width of table after render, removing width will make it fall back to 100%
-        let targetSize = this.tableEl.clientWidth;
-        this.tableEl.style.removeProperty("width");
-        // Let's make sure the new size is not bigger
-        if (targetSize > this.tableEl.clientWidth) targetSize = this.tableEl.clientWidth;
-        this.tableEl?.style.setProperty("width", `${targetSize}px`);
-        // Enable the re-sizer
-        this.tableResizer?.reset({
-          disable: false,
-          partialRefresh: true,
-          onResize: this.setEllipsisHandlers,
-          headerOnly: false,
-          disabledColumns: this.persistentConfig.compact ? [] : [0],
+        // After a draw
+        this.dataTable?.on('draw', () => {
+          if (!this.tableEl) return;
+          // Width of table after render, removing width will make it fall back to 100%
+          let targetSize = this.tableEl.clientWidth;
+          this.tableEl.style.removeProperty('width');
+          // Let's make sure the new size is not bigger
+          if (targetSize > this.tableEl.clientWidth) targetSize = this.tableEl.clientWidth;
+          this.tableEl?.style.setProperty('width', `${targetSize}px`);
+          // Enable the re-sizer
+          this.tableResizer?.reset({
+            disable: false,
+            partialRefresh: true,
+            onResize: this.setEllipsisHandlers,
+            headerOnly: false,
+            disabledColumns: this.persistentConfig.compact ? [] : [0]
+          });
+          // Re-add the ellipsis
+          addClass(this.tableEl, 'ellipseTable');
+          // Check if cells need the ellipsisHandlers
+          this.setEllipsisHandlers();
         });
-        // Re-add the ellipsis
-        addClass(this.tableEl, "ellipseTable");
-        // Check if cells need the ellipsisHandlers
+      }
+
+      this.drawControls();
+      if (previousFilter) {
+        this.applyFilterValue(previousFilter);
+      }
+
+      // Draw again but with the events
+      if (this.persistentConfig.isEllipsed !== false) {
+        addClass(this.tableEl, 'ellipseTable');
         this.setEllipsisHandlers();
-      });
-    }
+      }
 
-    this.drawControls();
-    if (previousFilter) {
-      this.applyFilterValue(previousFilter);
-    }
+      if (!rows || rows.length < 1) {
+        this.updateEmptyTable(this.persistentConfig);
+      }
 
-    // Draw again but with the events
-    if (this.persistentConfig.isEllipsed !== false) {
-      addClass(this.tableEl, "ellipseTable");
-      this.setEllipsisHandlers();
-    }
-
-    if (!rows || rows.length < 1) {
-      this.updateEmptyTable(this.persistentConfig);
-    }
-
-    // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
+      // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
+      if (!waitForResolve) {
+        resolve();
+      }
+    });
   }
 
   protected updateEmptyTable(persistentConfig: PersistentConfig): void {

--- a/yasgui-patches/2026-05-26-gdb-14655-fix-uncaught-exception-from-extended-table.patch
+++ b/yasgui-patches/2026-05-26-gdb-14655-fix-uncaught-exception-from-extended-table.patch
@@ -1,0 +1,445 @@
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 54b1ad5eb92d87463f5e43e708318d81912c2235)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision 2ec7827fe929ead556dd283a0cab0e05114e1a16)
+@@ -33,90 +33,103 @@
+     return super.getCellContent(binding, prefixes);
+   }
+ 
+-  public draw(persistentConfig: PersistentConfig) {
+-    const previousFilter = this.getCurrentFilterValue();
+-    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
+-    this.tableEl = document.createElement("table");
+-    const rows = this.getRows();
+-    const columns = this.getColumns();
+-    const types = this.resolveTypes();
+-    const columnDefinitions = this.getColumnDefinitions(types);
+-    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+-      this.yasr.pluginControls;
+-      addClass(this.yasr.rootEl, "isSinglePage");
+-    } else {
+-      removeClass(this.yasr.rootEl, "isSinglePage");
+-    }
++  public draw(persistentConfig: PersistentConfig): Promise<void> {
++    let waitForResolve = false;
++    return new Promise<void>((resolve) => {
++      const previousFilter = this.getCurrentFilterValue();
++      this.persistentConfig = {...this.persistentConfig, ...persistentConfig};
++      this.tableEl = document.createElement('table');
++      const rows = this.getRows();
++      const columns = this.getColumns();
++      const types = this.resolveTypes();
++      const columnDefinitions = this.getColumnDefinitions(types);
++      if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
++        this.yasr.pluginControls;
++        addClass(this.yasr.rootEl, 'isSinglePage');
++      } else {
++        removeClass(this.yasr.rootEl, 'isSinglePage');
++      }
+ 
+-    if (this.dataTable) {
+-      this.destroyResizer();
+-      this.removeDataTableEventHandlers(this.dataTable);
+-      this.dataTable.destroy(true);
+-      this.dataTable = undefined;
+-    }
+-    this.yasr.resultsEl.appendChild(this.tableEl);
+-    // reset some default config properties as they couldn't be initialized beforehand
+-    const dtConfig: DataTables.Settings = {
+-      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
+-      pageLength: -1,
+-      data: rows,
+-      columns: columns,
+-      columnDefs: columnDefinitions,
+-      // DataTables will only render the rows that are initially visible on the page.
+-      deferRender: true,
+-      // // Switch off the pagination.
+-      paging: false,
+-      // Switched off for optimization purposes.
+-      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+-      autoWidth: false,
+-      language: {
+-        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
+-        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
+-        paginate: {
+-          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
+-          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
+-          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
+-          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
+-        },
+-      },
+-    };
++      if (this.dataTable) {
++        this.destroyResizer();
++        this.removeDataTableEventHandlers(this.dataTable);
++        this.dataTable.destroy(true);
++        this.dataTable = undefined;
++      }
++      this.yasr.resultsEl.appendChild(this.tableEl);
++      // reset some default config properties as they couldn't be initialized beforehand
++      const dtConfig: DataTables.Settings = {
++        ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
++        pageLength: -1,
++        data: rows,
++        columns: columns,
++        columnDefs: columnDefinitions,
++        // DataTables will only render the rows that are initially visible on the page.
++        deferRender: true,
++        // // Switch off the pagination.
++        paging: false,
++        // Switched off for optimization purposes.
++        // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
++        autoWidth: false,
++        language: {
++          zeroRecords: this.translationService.translate('yasr.plugin_control.table.empty_result.label'),
++          info: this.translationService.translate('yasr.plugin.table.data_tables.info.result_info'),
++          paginate: {
++            first: this.translationService.translate('yasr.plugin.table.data_tables.paginate.first'),
++            last: this.translationService.translate('yasr.plugin.table.data_tables.paginate.last'),
++            next: this.translationService.translate('yasr.plugin.table.data_tables.paginate.next'),
++            previous: this.translationService.translate('yasr.plugin.table.data_tables.paginate.previous')
++          }
++        }
++      };
+ 
+-    this.dataTable = $(this.tableEl).DataTable(dtConfig);
+-    this.tableEl.style.removeProperty("width");
+-    this.tableEl.style.width = this.tableEl.clientWidth + "px";
++      this.dataTable = $(this.tableEl).DataTable(dtConfig);
++      this.tableEl.style.removeProperty('width');
++      this.tableEl.style.width = this.tableEl.clientWidth + 'px';
+ 
+-    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+-    const maxResizableResultsColumns = this.persistentConfig.compact
+-      ? this.config.maxResizableResultsColumns - 1
+-      : this.config.maxResizableResultsColumns;
++      // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
++      const maxResizableResultsColumns = this.persistentConfig.compact
++        ? this.config.maxResizableResultsColumns - 1
++        : this.config.maxResizableResultsColumns;
+ 
+-    if (columns.length <= maxResizableResultsColumns) {
+-      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+-      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+-      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+-      setTimeout(() => {
+-        this.tableResizer = new ColumnResizer.default(this.tableEl, {
+-          partialRefresh: true,
+-          headerOnly: false,
+-          disabledColumns: this.persistentConfig.compact ? [] : [0],
++      if (columns.length <= maxResizableResultsColumns) {
++        waitForResolve = true;
++        // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
++        // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
++        // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
++        setTimeout(() => {
++          try {
++            this.tableResizer = new ColumnResizer.default(this.tableEl, {
++              partialRefresh: true,
++              headerOnly: false,
++              disabledColumns: this.persistentConfig.compact ? [] : [0]
++            });
++          } catch (error) {
++            // Just log the error and continue without the column resizer, the table will still be functional.
++            console.error('Failed to initialize column resizer', error);
++          }
++          resolve();
+         });
+-      }, 0);
+-    } else {
+-      addClass(this.tableEl, "fixedColumns");
+-    }
++      } else {
++        addClass(this.tableEl, 'fixedColumns');
++      }
+ 
+-    this.registerDataTableEventHandlers(this.dataTable);
++      this.registerDataTableEventHandlers(this.dataTable);
+ 
+-    this.drawControls();
+-    this.updateTableEllipseClasses();
+-    this.afterDraw();
+-    if (previousFilter) {
+-      this.applyFilterValue(previousFilter);
+-    }
++      this.drawControls();
++      this.updateTableEllipseClasses();
++      this.afterDraw();
++      if (previousFilter) {
++        this.applyFilterValue(previousFilter);
++      }
+ 
+-    if (!rows || rows.length < 1) {
+-      this.updateEmptyTable(this.persistentConfig);
+-    }
++      if (!rows || rows.length < 1) {
++        this.updateEmptyTable(this.persistentConfig);
++      }
++      if (!waitForResolve) {
++        resolve();
++      }
++    });
+   }
+ 
+   /**
+Index: Yasgui/packages/yasr/src/plugins/table/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/index.ts b/Yasgui/packages/yasr/src/plugins/table/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 54b1ad5eb92d87463f5e43e708318d81912c2235)
++++ b/Yasgui/packages/yasr/src/plugins/table/index.ts	(revision 2ec7827fe929ead556dd283a0cab0e05114e1a16)
+@@ -204,125 +204,138 @@
+     return this.tableEl;
+   }
+ 
+-  public draw(persistentConfig: PersistentConfig) {
+-    const previousFilter = this.getCurrentFilterValue();
+-    this.persistentConfig = { ...this.persistentConfig, ...persistentConfig };
+-    this.tableEl = document.createElement("table");
+-    const rows = this.getRows();
+-    const columns = this.getColumns();
++  public draw(persistentConfig: PersistentConfig): Promise<void> {
++    let waitForResolve = false;
++    return new Promise<void>((resolve) => {
++      const previousFilter = this.getCurrentFilterValue();
++      this.persistentConfig = {...this.persistentConfig, ...persistentConfig};
++      this.tableEl = document.createElement('table');
++      const rows = this.getRows();
++      const columns = this.getColumns();
+ 
+-    if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
+-      this.yasr.pluginControls;
+-      addClass(this.yasr.rootEl, "isSinglePage");
+-    } else {
+-      removeClass(this.yasr.rootEl, "isSinglePage");
+-    }
++      if (rows.length <= (persistentConfig?.pageSize || DEFAULT_PAGE_SIZE)) {
++        this.yasr.pluginControls;
++        addClass(this.yasr.rootEl, 'isSinglePage');
++      } else {
++        removeClass(this.yasr.rootEl, 'isSinglePage');
++      }
+ 
+-    if (this.dataTable) {
+-      this.destroyResizer();
++      if (this.dataTable) {
++        this.destroyResizer();
+ 
+-      this.dataTable.destroy(true);
+-      this.dataTable = undefined;
+-    }
+-    this.yasr.resultsEl.appendChild(this.tableEl);
+-    // reset some default config properties as they couldn't be initialized beforehand
+-    const dtConfig: DataTables.Settings = {
+-      ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
+-      pageLength: -1,
+-      data: rows,
+-      columns: columns,
+-      // DataTables will only render the rows that are initially visible on the page.
+-      deferRender: true,
+-      // // Switch off the pagination.
+-      paging: false,
+-      // Switched off for optimization purposes.
+-      // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
+-      autoWidth: false,
+-      language: {
+-        zeroRecords: this.translationService.translate("yasr.plugin_control.table.empty_result.label"),
+-        info: this.translationService.translate("yasr.plugin.table.data_tables.info.result_info"),
+-        paginate: {
+-          first: this.translationService.translate("yasr.plugin.table.data_tables.paginate.first"),
+-          last: this.translationService.translate("yasr.plugin.table.data_tables.paginate.last"),
+-          next: this.translationService.translate("yasr.plugin.table.data_tables.paginate.next"),
+-          previous: this.translationService.translate("yasr.plugin.table.data_tables.paginate.previous"),
+-        },
+-      },
+-    };
+-    this.dataTable = $(this.tableEl).DataTable(dtConfig);
+-    this.tableEl.style.removeProperty("width");
+-    this.tableEl.style.width = this.tableEl.clientWidth + "px";
++        this.dataTable.destroy(true);
++        this.dataTable = undefined;
++      }
++      this.yasr.resultsEl.appendChild(this.tableEl);
++      // reset some default config properties as they couldn't be initialized beforehand
++      const dtConfig: DataTables.Settings = {
++        ...((cloneDeep(this.config.tableConfig) as unknown) as DataTables.Settings),
++        pageLength: -1,
++        data: rows,
++        columns: columns,
++        // DataTables will only render the rows that are initially visible on the page.
++        deferRender: true,
++        // // Switch off the pagination.
++        paging: false,
++        // Switched off for optimization purposes.
++        // Our cells are calculated dynamically, and with this configuration on, rendering the datatable results becomes very slow.
++        autoWidth: false,
++        language: {
++          zeroRecords: this.translationService.translate('yasr.plugin_control.table.empty_result.label'),
++          info: this.translationService.translate('yasr.plugin.table.data_tables.info.result_info'),
++          paginate: {
++            first: this.translationService.translate('yasr.plugin.table.data_tables.paginate.first'),
++            last: this.translationService.translate('yasr.plugin.table.data_tables.paginate.last'),
++            next: this.translationService.translate('yasr.plugin.table.data_tables.paginate.next'),
++            previous: this.translationService.translate('yasr.plugin.table.data_tables.paginate.previous')
++          }
++        }
++      };
++      this.dataTable = $(this.tableEl).DataTable(dtConfig);
++      this.tableEl.style.removeProperty('width');
++      this.tableEl.style.width = this.tableEl.clientWidth + 'px';
+ 
+-    // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
+-    const maxResizableResultsColumns = this.persistentConfig.compact
+-      ? this.config.maxResizableResultsColumns - 1
+-      : this.config.maxResizableResultsColumns;
++      // If it is a compact view, the first column (row number column) is not visible, we decrease the maximum resizable columns.
++      const maxResizableResultsColumns = this.persistentConfig.compact
++        ? this.config.maxResizableResultsColumns - 1
++        : this.config.maxResizableResultsColumns;
+ 
+-    if (columns.length <= maxResizableResultsColumns) {
+-      // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+-      // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+-      // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+-      setTimeout(() => {
+-        this.tableResizer = new ColumnResizer.default(this.tableEl, {
+-          partialRefresh: true,
+-          onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
+-          headerOnly: false,
+-          disabledColumns: this.persistentConfig.compact ? [] : [0],
+-        });
+-      }, 0);
+-    } else {
+-      addClass(this.tableEl, "fixedColumns");
+-    }
+-    // DataTables uses the rendered style to decide the widths of columns.
+-    // Before a draw remove the ellipseTable styling
+-    if (this.persistentConfig.isEllipsed !== false) {
+-      this.dataTable?.on("preDraw", () => {
+-        this.tableResizer?.reset({ disable: true });
+-        removeClass(this.tableEl, "ellipseTable");
+-        this.tableEl?.style.removeProperty("width");
+-        this.tableEl?.style.setProperty("width", this.tableEl.clientWidth + "px");
+-        return true; // Indicate it should re-render
+-      });
+-      // After a draw
+-      this.dataTable?.on("draw", () => {
+-        if (!this.tableEl) return;
+-        // Width of table after render, removing width will make it fall back to 100%
+-        let targetSize = this.tableEl.clientWidth;
+-        this.tableEl.style.removeProperty("width");
+-        // Let's make sure the new size is not bigger
+-        if (targetSize > this.tableEl.clientWidth) targetSize = this.tableEl.clientWidth;
+-        this.tableEl?.style.setProperty("width", `${targetSize}px`);
+-        // Enable the re-sizer
+-        this.tableResizer?.reset({
+-          disable: false,
+-          partialRefresh: true,
+-          onResize: this.setEllipsisHandlers,
+-          headerOnly: false,
+-          disabledColumns: this.persistentConfig.compact ? [] : [0],
+-        });
+-        // Re-add the ellipsis
+-        addClass(this.tableEl, "ellipseTable");
+-        // Check if cells need the ellipsisHandlers
+-        this.setEllipsisHandlers();
+-      });
+-    }
++      if (columns.length <= maxResizableResultsColumns) {
++        waitForResolve = true;
++        // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
++        // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
++        // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
++        setTimeout(() => {
++          try {
++            this.tableResizer = new ColumnResizer.default(this.tableEl, {
++              partialRefresh: true,
++              onResize: this.persistentConfig.isEllipsed !== false && this.setEllipsisHandlers,
++              headerOnly: false,
++              disabledColumns: this.persistentConfig.compact ? [] : [0]
++            });
++          } catch (error) {
++            // Just log the error and continue without the column resizer, the table will still be functional.
++            console.error('Failed to initialize column resizer', error);
++          }
++          resolve();
++        }, 200);
++      } else {
++        addClass(this.tableEl, 'fixedColumns');
++      }
++      // DataTables uses the rendered style to decide the widths of columns.
++      // Before a draw remove the ellipseTable styling
++      if (this.persistentConfig.isEllipsed !== false) {
++        this.dataTable?.on('preDraw', () => {
++          this.tableResizer?.reset({disable: true});
++          removeClass(this.tableEl, 'ellipseTable');
++          this.tableEl?.style.removeProperty('width');
++          this.tableEl?.style.setProperty('width', this.tableEl.clientWidth + 'px');
++          return true; // Indicate it should re-render
++        });
++        // After a draw
++        this.dataTable?.on('draw', () => {
++          if (!this.tableEl) return;
++          // Width of table after render, removing width will make it fall back to 100%
++          let targetSize = this.tableEl.clientWidth;
++          this.tableEl.style.removeProperty('width');
++          // Let's make sure the new size is not bigger
++          if (targetSize > this.tableEl.clientWidth) targetSize = this.tableEl.clientWidth;
++          this.tableEl?.style.setProperty('width', `${targetSize}px`);
++          // Enable the re-sizer
++          this.tableResizer?.reset({
++            disable: false,
++            partialRefresh: true,
++            onResize: this.setEllipsisHandlers,
++            headerOnly: false,
++            disabledColumns: this.persistentConfig.compact ? [] : [0]
++          });
++          // Re-add the ellipsis
++          addClass(this.tableEl, 'ellipseTable');
++          // Check if cells need the ellipsisHandlers
++          this.setEllipsisHandlers();
++        });
++      }
+ 
+-    this.drawControls();
+-    if (previousFilter) {
+-      this.applyFilterValue(previousFilter);
+-    }
++      this.drawControls();
++      if (previousFilter) {
++        this.applyFilterValue(previousFilter);
++      }
+ 
+-    // Draw again but with the events
+-    if (this.persistentConfig.isEllipsed !== false) {
+-      addClass(this.tableEl, "ellipseTable");
+-      this.setEllipsisHandlers();
+-    }
++      // Draw again but with the events
++      if (this.persistentConfig.isEllipsed !== false) {
++        addClass(this.tableEl, 'ellipseTable');
++        this.setEllipsisHandlers();
++      }
+ 
+-    if (!rows || rows.length < 1) {
+-      this.updateEmptyTable(this.persistentConfig);
+-    }
++      if (!rows || rows.length < 1) {
++        this.updateEmptyTable(this.persistentConfig);
++      }
+ 
+-    // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
++      // if (this.tableEl.clientWidth > width) this.tableEl.parentElement?.style.setProperty("overflow", "hidden");
++      if (!waitForResolve) {
++        resolve();
++      }
++    });
+   }
+ 
+   protected updateEmptyTable(persistentConfig: PersistentConfig): void {


### PR DESCRIPTION
* GDB-14655: Fix uncaught exception in extended table rendering

## What
Refactored the `draw` method in the extended table to handle asynchronous rendering and prevent uncaught exceptions.

## Why
This change ensures that the table rendering process is robust and can handle cases where the data may not be fully ready, improving the user experience by preventing crashes.

## How
- Introduced a promise to manage the asynchronous rendering of the table.
- Added a `waitForResolve` flag to control the resolution of the promise based on the rendering state.
- Ensured that the table resizer initialization occurs after the table is fully rendered.
- Updated the logic to handle empty rows gracefully.

* added patch "2026-05-26-gdb-14655-fix-uncaught-exception-from-extended-table.patch"

---------


(cherry picked from commit 69fb9acefdc01ac4feeb94c5586ec5126194117b)