### PR TITLE
GDB-14655: Fix uncaught exception in extended table rendering

### DIFF
--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
@@ -12,6 +12,7 @@ export class ExtendedTable extends Table {
   public label = "Extended_Table";
   public priority = 11;
   private tableRenderingHandlerId: number | undefined;
+  private tableResizerTimeout: number | undefined;
 
   private readonly getCellContentCustom?: (
     binding: Parser.BindingValue,
@@ -97,17 +98,12 @@ export class ExtendedTable extends Table {
         // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
         // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
         // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
-        setTimeout(() => {
-          try {
-            this.tableResizer = new ColumnResizer.default(this.tableEl, {
-              partialRefresh: true,
-              headerOnly: false,
-              disabledColumns: this.persistentConfig.compact ? [] : [0]
-            });
-          } catch (error) {
-            // Just log the error and continue without the column resizer, the table will still be functional.
-            console.error('Failed to initialize column resizer', error);
-          }
+        this.tableResizerTimeout = setTimeout(() => {
+          this.tableResizer = new ColumnResizer.default(this.tableEl, {
+            partialRefresh: true,
+            headerOnly: false,
+            disabledColumns: this.persistentConfig.compact ? [] : [0],
+          });
           resolve();
         });
       } else {
@@ -475,7 +471,7 @@ export class ExtendedTable extends Table {
         const message = this.translationService.translate("loader.message.query.editor.render.results");
         this.yasr.showLoader(message, false, false);
       } else {
-        requestAnimationFrame(() => {
+        this.tableRenderingHandlerId = requestAnimationFrame(() => {
           this.tableRenderingHandlerId = undefined;
           this.yasr.hideLoader();
         });
@@ -515,6 +511,7 @@ export class ExtendedTable extends Table {
   }
 
   destroy() {
+    clearTimeout(this.tableResizerTimeout);
     if (this.tableEl) {
       this.tableEl.removeEventListener('click', this.dataTableClickHandler.bind(this));
       this.tableEl.removeEventListener('mouseover', this.tableMouseoverHandler.bind(this));

--- a/yasgui-patches/2026-05-28_GDB-14655__Fix_uncaught_exception_in_extended_table_rendering.patch
+++ b/yasgui-patches/2026-05-28_GDB-14655__Fix_uncaught_exception_in_extended_table_rendering.patch
@@ -1,0 +1,59 @@
+Subject: [PATCH] GDB-14655: Fix uncaught exception in extended table rendering
+---
+Index: Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts
+--- a/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision be826e74078fc556d28fdd0b1743bb80d5aa6b45)
++++ b/Yasgui/packages/yasr/src/plugins/table/extended-table.ts	(revision a263ab91fc6812b6db8abb84eaeb8300b4e11eec)
+@@ -12,6 +12,7 @@
+   public label = "Extended_Table";
+   public priority = 11;
+   private tableRenderingHandlerId: number | undefined;
++  private tableResizerTimeout: number | undefined;
+ 
+   private readonly getCellContentCustom?: (
+     binding: Parser.BindingValue,
+@@ -97,17 +98,12 @@
+         // There is an issue with columns resizing. When the table is rendered the columns resizing doesn't working until a column header is clicked.
+         // A possible reason could be that the table columns have not been fully rendered before the table resizer initialized.
+         // The timeout will ensure that the rendering of the table resizer occurs after the table is rendered.
+-        setTimeout(() => {
+-          try {
+-            this.tableResizer = new ColumnResizer.default(this.tableEl, {
+-              partialRefresh: true,
+-              headerOnly: false,
+-              disabledColumns: this.persistentConfig.compact ? [] : [0]
+-            });
+-          } catch (error) {
+-            // Just log the error and continue without the column resizer, the table will still be functional.
+-            console.error('Failed to initialize column resizer', error);
+-          }
++        this.tableResizerTimeout = setTimeout(() => {
++          this.tableResizer = new ColumnResizer.default(this.tableEl, {
++            partialRefresh: true,
++            headerOnly: false,
++            disabledColumns: this.persistentConfig.compact ? [] : [0],
++          });
+           resolve();
+         });
+       } else {
+@@ -475,7 +471,7 @@
+         const message = this.translationService.translate("loader.message.query.editor.render.results");
+         this.yasr.showLoader(message, false, false);
+       } else {
+-        requestAnimationFrame(() => {
++        this.tableRenderingHandlerId = requestAnimationFrame(() => {
+           this.tableRenderingHandlerId = undefined;
+           this.yasr.hideLoader();
+         });
+@@ -515,6 +511,7 @@
+   }
+ 
+   destroy() {
++    clearTimeout(this.tableResizerTimeout);
+     if (this.tableEl) {
+       this.tableEl.removeEventListener('click', this.dataTableClickHandler.bind(this));
+       this.tableEl.removeEventListener('mouseover', this.tableMouseoverHandler.bind(this));


### PR DESCRIPTION
## What
An exception occurs when the extended table plugin is created and then quickly destroyed.

## Why
A column resizer is initialized inside a `setTimeout` to ensure that the table is fully rendered and ready before the resizer is attached. The issue occurred when YASR was destroyed before the `setTimeout` callback executed, causing the column resizer to be initialized on a detached table element.

## How
Added cancellation of the scheduled timeout during destroy, preventing the callback from executing if YASR is destroyed before it runs.

## Additional work
There was an issue where the browser could freeze when the compact view was clicked and the table contained many results. To address this problem, a loader is shown instead of the results table to indicate to the user that processing is in progress until table rendering is completed.

The loader hiding logic is scheduled using `requestAnimationFrame`, which executes before the browser renders the next frame. A cancellation mechanism was introduced to prevent the scheduled callback from executing if YASR is destroyed or if the user quickly switches the compact view option multiple times.

The cancellation logic relies on the animation frame ID returned by `requestAnimationFrame`, but this ID was never assigned, meaning the cancellation never actually worked. This is now fixed by storing the animation frame ID when the handler is registered.

(cherry picked from commit 67320decc198303dfe4dcc5ce6307269c32f56ae)