### PR TITLE
GDB-14728: Fix YASR pluginOrder configuration

### DIFF
--- a/cypress/e2e/view-configurations.spec.cy.ts
+++ b/cypress/e2e/view-configurations.spec.cy.ts
@@ -167,4 +167,35 @@ describe('View configurations', () => {
     YasrSteps.getExtendedTableTab().should('not.have.class', 'selected');
     YasrSteps.getResponseTableTab().should('have.class', 'selected');
   });
+
+  it('should configure the YASR plugin order', () => {
+    // GIVEN: I open a page that contains the "ontotext-yasgui-web-component" with the default pluginOrder configuration.
+
+    // WHEN: I execute a query.
+    YasqeSteps.executeQuery();
+    // THEN: I expect the default plugin order to be used because no custom plugin order is configured.
+    verifyDefaultPluginOrder();
+
+    // WHEN: I change the plugin order configuration.
+    ViewConfigurationsPageSteps.configurePluginOrder();
+    // THEN: I expect the order of plugins in changed according configuration.
+    YasrSteps.getPluginSelectorButton(0).should('have.text', 'Raw response');
+    YasrSteps.getPluginSelectorButton(1).should('have.text', 'Table');
+    YasrSteps.getPluginSelectorButton(2).should('have.text', 'Geo');
+    YasrSteps.getPluginSelectorButton(3).should('have.text', '\n        \n      Pivot Table');
+    YasrSteps.getPluginSelectorButton(4).should('have.text', '\n        \n      Google Chart');
+
+    // WHEN: I set the plugin order configuration to an empty array.
+    ViewConfigurationsPageSteps.configurePluginOrderEmptyArray();
+    // THEN: I expect the default plugin order to be used because an empty plugin order configuration is treated as missing.
+    verifyDefaultPluginOrder();
+  });
 });
+
+const verifyDefaultPluginOrder = () => {
+  YasrSteps.getPluginSelectorButton(0).should('have.text', 'Table');
+  YasrSteps.getPluginSelectorButton(1).should('have.text', 'Raw response');
+  YasrSteps.getPluginSelectorButton(2).should('have.text', '\n        \n      Pivot Table');
+  YasrSteps.getPluginSelectorButton(3).should('have.text', '\n        \n      Google Chart');
+  YasrSteps.getPluginSelectorButton(4).should('have.text', 'Geo');
+}

--- a/cypress/steps/view-configurations-page-steps.ts
+++ b/cypress/steps/view-configurations-page-steps.ts
@@ -53,6 +53,14 @@ export default class ViewConfigurationsPageSteps {
       cy.get('#configureSelectedPluginToResponsePlugin').click();
     }
 
+    static configurePluginOrder() {
+      cy.get('#configurePluginOrder').click();
+    }
+
+    static configurePluginOrderEmptyArray() {
+      cy.get('#configurePluginOrderEmptyArray').click();
+    }
+
     static getOutputMessage() {
       return cy.get('#output-message');
     }

--- a/cypress/steps/yasr-steps.ts
+++ b/cypress/steps/yasr-steps.ts
@@ -23,6 +23,10 @@ export class YasrSteps {
     return YasrSteps.getPluginsButtons().find('.plugin_selector');
   }
 
+  static getPluginSelectorButton(index = 0) {
+    return YasrSteps.getPluginSelectors().eq(index).find('.yasr_btn');
+  }
+
   static getResultsTable(yasrIndex = 0) {
     return YasrSteps.getYasr(yasrIndex).find('.yasr_results tbody');
   }

--- a/ontotext-yasgui-web-component/docs/developers-guide.md
+++ b/ontotext-yasgui-web-component/docs/developers-guide.md
@@ -341,7 +341,7 @@ Follow the steps below:
   ```
 - **defaultPlugin**: then name of active plugin when yasr is created. Default value is "extended_table".
 - **selectedPlugin**: the plugin name to be selected for the active YASR instance. If not set, the persisted selection or the default plugin will be used.
-- **pluginOrder**: describes the order of how plugins will be displayed. Default is ["extended_table", "response"].
+- **pluginOrder**: describes the order of how plugins will be displayed. Default is ['extended_table', 'extended_response', 'pivot-table-plugin', 'charts', 'geo'].
 - **externalPluginsConfigurations**: An object containing the configuration for each plugin, where the keys are the plugin name and the values is the corresponding plugin configuration.
 
 ## Plugins

--- a/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/external-yasgui-configuration.ts
@@ -265,7 +265,7 @@ export interface ExternalYasguiConfiguration {
 
   /**
    * Describes the order of how YASR plugins will be displayed.
-   * For example: ["extended_table", "response"]
+   * For example: ["extended_table", "response", ...]
    */
   pluginOrder: string[]
 

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -398,7 +398,7 @@ export const defaultYasqeConfig: Partial<YasqeDefaultConfiguration> = {
 
 export const defaultYasrConfig: Partial<YasrConfiguration> = {
   defaultPlugin: 'extended_table',
-  pluginOrder: ['extended_table', 'extended_response', 'pivot-table-plugin', 'charts'],
+  pluginOrder: ['extended_table', 'extended_response', 'pivot-table-plugin', 'charts', 'geo'],
   showQueryLoader: true,
   fullscreen: false,
   defaultGeoPluginConfiguration: {

--- a/ontotext-yasgui-web-component/src/pages/view-configurations/index.html
+++ b/ontotext-yasgui-web-component/src/pages/view-configurations/index.html
@@ -30,6 +30,9 @@
 
   <button id="configureSelectedPluginToResponsePlugin" onclick="configureSelectedPluginToResponsePlugin()">Configure selectedPlugin To Response Plugin</button>
 
+  <button id="configurePluginOrder" onclick="configurePluginOrder()">Configure Plugin Order</button>
+  <button id="configurePluginOrderEmptyArray" onclick="configurePluginOrderEmptyArray()">Configure Plugin Order Empty Array</button>
+
   <ontotext-yasgui data-cy="ontotext-yasgui-tag"></ontotext-yasgui>
   </body>
 </html>

--- a/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
+++ b/ontotext-yasgui-web-component/src/pages/view-configurations/main.js
@@ -46,6 +46,14 @@ function configureSelectedPluginToResponsePlugin() {
   ontoElement.config = {...ontoElement.config, selectedPlugin: 'extended_response'}
 }
 
+const configurePluginOrder = () => {
+  ontoElement.config = {...ontoElement.config, pluginOrder: ['extended_response', 'extended_table', 'geo', 'pivot-table-plugin', 'charts']}
+}
+
+const configurePluginOrderEmptyArray = () => {
+  ontoElement.config = {...ontoElement.config, pluginOrder: []}
+}
+
 function attachMessageHandler() {
   ontoElement.addEventListener('output', (event) => {
     if ('notificationMessage' === event.detail.TYPE) {

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -115,7 +115,7 @@ export class YasguiConfigurationBuilder {
     if(externalConfiguration.selectedPlugin != null) {
       config.yasguiConfig.yasr.selectedPlugin = externalConfiguration.selectedPlugin;
     }
-    config.yasguiConfig.yasr.pluginOrder = externalConfiguration.pluginOrder || defaultYasrConfig.pluginOrder;
+    config.yasguiConfig.yasr.pluginOrder = externalConfiguration.pluginOrder?.length ? externalConfiguration.pluginOrder : defaultYasrConfig.pluginOrder;
     if (externalConfiguration.maxPersistentResponseSize !== undefined) {
       config.yasguiConfig.yasr.maxPersistentResponseSize = externalConfiguration.maxPersistentResponseSize;
     }


### PR DESCRIPTION
## What
YASR has a default pluginOrder configuration that should be used when no custom plugin order is provided. However, when an empty array is configured, the default plugin order is not applied.

## Why
The existing check only handled null and undefined values and did not consider an empty array as a missing configuration.

## How
Updated the configuration check to treat an empty plugin order array as missing and fall back to the default plugin order.