### PR TITLE
Cherry-pick GDB-14713: Show full title of SPARQL saved queries on hover

### DIFF
--- a/cypress/e2e/saved-query/tooltip-saved-query.spec.cy.ts
+++ b/cypress/e2e/saved-query/tooltip-saved-query.spec.cy.ts
@@ -1,0 +1,22 @@
+import ActionsPageSteps from '../../steps/pages/actions-page-steps';
+import {YasqeSteps} from '../../steps/yasqe-steps';
+import {YasguiFloatingTooltipSteps} from '../../steps/yasgui-floating-tooltip-steps';
+
+describe('Saved query tooltip', () => {
+  it('should show tooltip with saved query name', () => {
+    // GIVEN: I have opened a page containing the YASGUI component.
+    ActionsPageSteps.visit();
+
+    // WHEN: I hover over a saved query.
+    YasqeSteps.showSavedQueries();
+    YasqeSteps.hoverSavedQuery();
+    // THEN: I see a tooltip displaying the query name.
+    YasguiFloatingTooltipSteps.getTooltipElement().should('be.visible');
+    YasguiFloatingTooltipSteps.getTooltipElement().should('have.text', 'Add statements');
+
+    // WHEN: I hover over another saved query.
+    YasqeSteps.hoverSavedQuery(1);
+    // THEN: I see a tooltip displaying the second query name.
+    YasguiFloatingTooltipSteps.getTooltipElement().should('have.text', 'Clear graph');
+  });
+});

--- a/cypress/steps/yasgui-floating-tooltip-steps.ts
+++ b/cypress/steps/yasgui-floating-tooltip-steps.ts
@@ -1,0 +1,5 @@
+export class YasguiFloatingTooltipSteps {
+  static getTooltipElement() {
+    return cy.get('.yasgui-floating-tooltip');
+  }
+}

--- a/cypress/steps/yasqe-steps.ts
+++ b/cypress/steps/yasqe-steps.ts
@@ -214,8 +214,16 @@ export class YasqeSteps {
     })
   }
 
+  static getSavedQuery(index = 0) {
+    return this.getSavedQueries().eq(index);
+  }
+
   static selectSavedQuery(index: number) {
-    this.getSavedQueries().eq(index).find('a').click();
+    YasqeSteps.getSavedQuery(index).find('a').click();
+  }
+
+  static hoverSavedQuery(index = 0) {
+    YasqeSteps.getSavedQuery(index).trigger('mouseenter');
   }
 
   static getTabQuery(tabIndex: number) {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.scss
@@ -875,3 +875,26 @@ svg > g > g.google-visualization-tooltip { pointer-events: none }
 .modal-dialog.google-visualization-charteditor-dialog {
   z-index: 1016;
 }
+.yasgui-floating-tooltip {
+  position: fixed;
+  width: max-content;
+  top: 0;
+  left: 0;
+  background-color: $color-onto-blue;
+  color: $color-onto-white;
+  padding: 5px 9px;
+  font-size: 0.9em;
+  max-width: 520px;
+  white-space: normal;
+  overflow-wrap: break-word;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.yasgui-floating-tooltip-arrow {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background-color: $color-onto-blue;
+  transform: rotate(45deg);
+}

--- a/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
+++ b/ontotext-yasgui-web-component/src/components/saved-queries-popup/saved-queries-popup.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../models/saved-query-configuration";
 import {TranslationService} from "../../services/translation.service";
 import {ServiceFactory} from "../../services/service-factory";
+import {YasguiFloatingTooltipService} from '../../services/yasgui-floating-tooltip-service';
 
 @Component({
   tag: 'saved-queries-popup',
@@ -15,6 +16,7 @@ import {ServiceFactory} from "../../services/service-factory";
 })
 export class SavedQueriesPopup {
   private translationService: TranslationService;
+  private ontotextYasguiTooltipService: YasguiFloatingTooltipService;
 
   @Element() hostElement: HTMLElement;
 
@@ -71,14 +73,39 @@ export class SavedQueriesPopup {
     this.internalSaveQuerySelectedEvent.emit(selectedQuery);
   }
 
+  /**
+   * Displays a tooltip for the element that triggered the event.
+   *
+   * @param event The mouse event originating from the tooltip target element.
+   * @param text The text content to display in the tooltip.
+   */
+  private showTooltip(event: UIEvent, text: string): void {
+    this.ontotextYasguiTooltipService.show(event.currentTarget as HTMLElement, text, 'top');
+  }
+
+  /**
+   * Hides the currently displayed tooltip.
+   */
+  private hideTooltip(): void {
+    this.ontotextYasguiTooltipService.hide();
+  }
+
   componentWillLoad(): void {
     // TranslationService is injected here because the service factory is not available
     // in the constructor.
     this.translationService = this.serviceFactory.get(TranslationService);
+    this.ontotextYasguiTooltipService = this.serviceFactory.get(YasguiFloatingTooltipService);
   }
 
   componentDidRender(): void {
     this.setPopupPosition();
+  }
+
+  /**
+   * Cleans up component resources when the component is removed from the DOM.
+   */
+  disconnectedCallback(): void {
+    this.ontotextYasguiTooltipService.hide();
   }
 
   onEdit(evt: MouseEvent, selectedQuery: SaveQueryData): void {
@@ -100,16 +127,19 @@ export class SavedQueriesPopup {
     const panelRect = this.hostElement.getBoundingClientRect();
     const buttonRect = this.config.popupTarget.getBoundingClientRect();
 
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+
     const isFullScreen = this.hostElement.closest('ontotext-yasgui').querySelector('.yasqe').classList.contains('yasqe-fullscreen');
 
     const arrowEl: HTMLElement = this.hostElement.querySelector('.arrow');
     if (isFullScreen) {
-      this.hostElement.style.top = '13px';
-      this.hostElement.style.left = (buttonRect.left - panelRect.width - 10) + 'px';
+      this.hostElement.style.top = `${scrollTop + 13}px`;
+      this.hostElement.style.left = `${scrollLeft + buttonRect.left - panelRect.width - 10}px`;
       arrowEl.style.top = '40px';
     } else {
-      this.hostElement.style.top = ((buttonRect.top + buttonRect.height / 2) - panelRect.height / 2) + 'px';
-      this.hostElement.style.left = (buttonRect.left - panelRect.width - 10) + 'px';
+      this.hostElement.style.top = `${scrollTop + buttonRect.top + buttonRect.height / 2 - panelRect.height / 2}px`;
+      this.hostElement.style.left = `${scrollLeft + buttonRect.left - panelRect.width - 10}px`;
       arrowEl.style.top = panelRect.height / 2 - 16 + 'px';
     }
   }
@@ -122,7 +152,12 @@ export class SavedQueriesPopup {
           <ul>
             {this.config.savedQueriesList.map((savedQuery) => (
               <li class="saved-query">
-                <a class="saved-query-link" onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
+                <a class="saved-query-link"
+                   onMouseEnter={(event) => this.showTooltip(event, savedQuery.queryName)}
+                   onMouseLeave={() => this.hideTooltip()}
+                   onFocus={(event) => this.showTooltip(event, savedQuery.queryName)}
+                   onBlur={() => this.ontotextYasguiTooltipService.hide()}
+                   onClick={(evt) => this.onSelect(evt, savedQuery)}>{savedQuery.queryName}</a>
                 <span class="saved-query-actions">
                   {!savedQuery.readonly ?
                     <button class="saved-query-action edit-saved-query ri-edit-line"

--- a/ontotext-yasgui-web-component/src/services/yasgui-floating-tooltip-service.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui-floating-tooltip-service.ts
@@ -1,0 +1,110 @@
+import { arrow, autoUpdate, computePosition, flip, offset, shift, Placement } from '@floating-ui/dom';
+
+/**
+* Provides functionality for displaying and positioning tooltips using Floating UI.
+*
+* The tooltip is rendered in the document body and automatically updates its
+* position when the reference element moves, resizes, or the viewport changes.
+*/
+export class YasguiFloatingTooltipService {
+  private cleanupAutoUpdate?: () => void;
+  private tooltipElement?: HTMLDivElement;
+  private arrowElement?: HTMLDivElement;
+
+  /**
+   * Displays a tooltip attached to the specified target element.
+   *
+   * Any previously displayed tooltip is removed before the new one is shown.
+   *
+   * @param target The element to which the tooltip should be attached.
+   * @param text The text content of the tooltip.
+   * @param placement The preferred placement of the tooltip relative to the target element.
+   */
+  show(target: HTMLElement, text: string, placement: Placement): void {
+    this.hide();
+
+    this.tooltipElement = this.createTooltipElement(text);
+    this.arrowElement = this.createArrowElement();
+    this.tooltipElement.appendChild(this.arrowElement);
+    document.body.appendChild(this.tooltipElement);
+
+    this.cleanupAutoUpdate = autoUpdate(target, this.tooltipElement, async () => {
+      if (!this.tooltipElement || !this.arrowElement) {
+        return;
+      }
+
+      const { x, y, placement: finalPlacement, middlewareData } = await computePosition(target, this.tooltipElement, {
+        placement,
+        strategy: 'fixed',
+        middleware: [
+          offset(8),
+          flip(),
+          shift({ padding: 8 }),
+          arrow({ element: this.arrowElement }),
+        ],
+      });
+
+      if (!this.tooltipElement || !this.arrowElement) {
+        return;
+      }
+
+      Object.assign(this.tooltipElement.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+      });
+
+      const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
+      const staticSide = {
+        top: 'bottom',
+        right: 'left',
+        bottom: 'top',
+        left: 'right',
+      }[finalPlacement.split('-')[0]];
+
+      Object.assign(this.arrowElement.style, {
+        left: arrowX != null ? `${arrowX}px` : '',
+        top: arrowY != null ? `${arrowY}px` : '',
+        right: '',
+        bottom: '',
+        [staticSide]: '-4px',
+      });
+    });
+  }
+
+  /**
+   * Hides the currently displayed tooltip and removes all associated listeners.
+   */
+  hide(): void {
+    this.cleanupAutoUpdate?.();
+    this.cleanupAutoUpdate = undefined;
+
+    this.tooltipElement?.remove();
+    this.tooltipElement = undefined;
+    this.arrowElement = undefined;
+  }
+
+  /**
+   * Creates a tooltip element with the provided text content.
+   *
+   * @param text The text content of the tooltip.
+   * @returns The created tooltip element.
+   */
+  private createTooltipElement(text: string): HTMLDivElement {
+    const tooltipElement = document.createElement('div');
+    tooltipElement.className = 'yasgui-floating-tooltip';
+    tooltipElement.setAttribute('role', 'tooltip');
+    tooltipElement.textContent = text;
+    return tooltipElement;
+  }
+
+  /**
+   * Creates an arrow element used to visually connect the tooltip to its target.
+   *
+   * @returns The created tooltip arrow element.
+   */
+  private createArrowElement(): HTMLDivElement {
+    const arrowElement = document.createElement('div');
+    arrowElement.className = 'yasgui-floating-tooltip-arrow';
+    return arrowElement;
+  }
+}


### PR DESCRIPTION
## What
- Added a tooltip for saved queries.
- Fixed incorrect positioning of the saved queries popup when the page is scrolled.

## Why
- Long saved query names are truncated, preventing users from seeing the full query name.
- The popup position was calculated using viewport coordinates returned by `getBoundingClientRect()`, while the popup itself is positioned using `position: absolute`. As a result, the popup was rendered at an incorrect location after the page was scrolled.

## How
- Implemented a tooltip using the Floating UI library.
- Included the current page scroll offsets when calculating the popup position to correctly translate viewport coordinates to document coordinates.

(cherry picked from commit 289fc5018b5bb7fa6d9682c075a8769b84ba7f1d)