### PR TITLE
GDB-14890: Add `themeName` configuration to support CodeMirror theming in YASR and explain plan components

### DIFF
--- a/Yasgui/packages/yasgui/src/Tab.ts
+++ b/Yasgui/packages/yasgui/src/Tab.ts
@@ -689,6 +689,7 @@ export class Tab extends EventEmitter {
     yasrConf.tabId = this.getId();
     yasrConf.fullscreen = this.yasgui.config.yasr.fullscreen;
     yasrConf.showFullscreenButton = this.yasgui.config.yasr.showFullscreenButton;
+    yasrConf.themeName = this.yasgui.config.yasr.themeName;
     if (this.yasgui.config.yasr.selectedPlugin != null) {
         yasrConf.selectedPlugin = this.yasgui.config.yasr.selectedPlugin;
     }

--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -834,6 +834,7 @@ export interface Config {
   sparqlResponse?: string;
   fullscreen?: boolean;
   showFullscreenButton?: boolean;
+  themeName?: string;
   selectedPlugin?: string;
   /**
    * Custom renderers for errors.

--- a/Yasgui/packages/yasr/src/plugins/response/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/response/index.ts
@@ -96,6 +96,9 @@ export default class Response implements Plugin<PluginConfig> {
     }
 
     this.cm = CodeMirror(this.yasr.resultsEl, codemirrorOpts);
+    if (this.cm) {
+      this.cm.setOption("theme", this.yasr.config.themeName);
+    }
     // Don't show less originally we've already set the value in the codemirrorOpts
     if (lines.length > config.maxLines) this.showLess(false);
   }

--- a/ontotext-yasgui-web-component/src/components.d.ts
+++ b/ontotext-yasgui-web-component/src/components.d.ts
@@ -121,6 +121,11 @@ export namespace Components {
          */
         "forHtml": boolean;
         /**
+          * Optional theme name used to apply CodeMirror theme styling to the explain-plan query.
+          * @public
+         */
+        "themeName"?: string;
+        /**
           * Optional translation service used to get localized labels/messages
           * @public
          */
@@ -559,6 +564,11 @@ declare namespace LocalJSX {
           * @public
          */
         "forHtml"?: boolean;
+        /**
+          * Optional theme name used to apply CodeMirror theme styling to the explain-plan query.
+          * @public
+         */
+        "themeName"?: string;
         /**
           * Optional translation service used to get localized labels/messages
           * @public

--- a/ontotext-yasgui-web-component/src/components/explain-plan/explain-plan.tsx
+++ b/ontotext-yasgui-web-component/src/components/explain-plan/explain-plan.tsx
@@ -43,6 +43,12 @@ export class ExplainPlan {
    */
   @Prop() translationService?: TranslationService;
 
+  /**
+   * Optional theme name used to apply CodeMirror theme styling to the explain-plan query.
+   * @public
+   */
+  @Prop() themeName?: string;
+
   private getStringRepresentation(): string {
     const value = this.binding?.value ?? '';
     return HtmlUtil.escapeHTMLEntities(value);
@@ -112,14 +118,15 @@ export class ExplainPlan {
     }
 
     const copyLabel = this.translationService.translate('yasr.explain_plan.copy_button.label');
-
+    const themeClass = this.themeName ? `cm-s-${this.themeName}` : 'cm-s-default';
+    const classList = `explainPlanQuery ${themeClass}`;
     return (
       <div class="yasr-explain-plan-component">
         <button class="explain-plan-copy-btn" type="button" onClick={() => this.onCopy()}>
           {copyLabel}
         </button>
         <div class="explain-plan-container">
-          <div class="cm-s-default explainPlanQuery" innerHTML={stringRepresentation}></div>
+          <div class={classList} innerHTML={stringRepresentation}></div>
         </div>
       </div>
     );

--- a/ontotext-yasgui-web-component/src/components/explain-plan/readme.md
+++ b/ontotext-yasgui-web-component/src/components/explain-plan/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property             | Attribute  | Description                                                                                                                                                                                                            | Type                                  | Default     |
-| -------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
-| `binding`            | --         | The SPARQL results binding cell that contains the explain-plan literal. Expected shape: `{ type: 'literal', value: string }`. If undefined or not containing the explain marker, component will render an empty query. | `{ type: "literal"; value: string; }` | `undefined` |
-| `forHtml`            | `for-html` | When `true` the explain-plan is rendered as HTML (with CodeMirror styling applied). When `false` the component renders a plain string representation. Default: `true`                                                  | `boolean`                             | `true`      |
-| `translationService` | --         | Optional translation service used to get localized labels/messages                                                                                                                                                     | `TranslationService`                  | `undefined` |
+| Property             | Attribute    | Description                                                                                                                                                                                                            | Type                                  | Default     |
+| -------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
+| `binding`            | --           | The SPARQL results binding cell that contains the explain-plan literal. Expected shape: `{ type: 'literal', value: string }`. If undefined or not containing the explain marker, component will render an empty query. | `{ type: "literal"; value: string; }` | `undefined` |
+| `forHtml`            | `for-html`   | When `true` the explain-plan is rendered as HTML (with CodeMirror styling applied). When `false` the component renders a plain string representation. Default: `true`                                                  | `boolean`                             | `true`      |
+| `themeName`          | `theme-name` | Optional theme name used to apply CodeMirror theme styling to the explain-plan query.                                                                                                                                  | `string`                              | `undefined` |
+| `translationService` | --           | Optional translation service used to get localized labels/messages                                                                                                                                                     | `TranslationService`                  | `undefined` |
 
 
 ----------------------------------------------

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -310,6 +310,7 @@ export class OntotextYasguiWebComponent {
   setTheme(themeName = DEFAULT_THEME): Promise<void> {
     return this.getOntotextYasgui().then((ontotextYasgui) => {
       ontotextYasgui.getYasguiConfiguration().yasguiConfig.yasqe.themeName = themeName;
+      ontotextYasgui.getYasguiConfiguration().yasguiConfig.yasr.themeName = themeName;
       ontotextYasgui.applyTheme();
     });
   }

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -75,6 +75,10 @@ export class OntotextYasgui {
     if (yasqe) {
       yasqe.setOption('theme', this.config.yasguiConfig.yasqe.themeName);
     }
+    if (tab.getYasr()) {
+      tab.getYasr().config.themeName = this.config.yasguiConfig.yasr.themeName;
+      tab.getYasr().refresh();
+    }
   }
 
   /**

--- a/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
+++ b/ontotext-yasgui-web-component/src/models/yasgui-configuration.ts
@@ -319,6 +319,32 @@ export interface YasrConfiguration {
    * Default configuration for Geo Plugin
    */
   defaultGeoPluginConfiguration?: GeoPluginConfiguration;
+
+  /**
+   * Name of the CodeMirror 5 theme to apply in YASR plugins.
+   *
+   * Usage:
+   * - This must match a theme name recognized by CodeMirror (e.g. "dracula", "monokai").
+   *
+   * Theme CSS requirement:
+   * - CodeMirror themes are entirely CSS-based. The corresponding theme CSS must be
+   *   loaded (via <link>, import, or injected <style>) before the theme can take effect.
+   *
+   * Custom themes:
+   * - You may define your own theme without a separate CSS file by adding styles for:
+   *       .cm-s-{themeName}.CodeMirror { ... }
+   *       .cm-s-{themeName} .cm-keyword { ... }
+   *       etc.
+   *   Example:
+   *       <style>
+   *         .cm-s-mytheme.CodeMirror { background: #222; color: #eee; }
+   *       </style>
+   *   Then set: themeName = "mytheme".
+   *
+   * If the <code>themeName</code> is not passed or the required CSS rules are not present,
+   * the editor will fall back to the default theme.
+   */
+  themeName?: string;
 }
 
 // namespaces mapped to their prefixes as keys

--- a/ontotext-yasgui-web-component/src/plugins/yasr/explain-plan/explain-plan-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/explain-plan/explain-plan-plugin.ts
@@ -84,6 +84,7 @@ export class ExplainPlanPlugin implements YasrPlugin {
     explainComponent.binding = explainBinding;
     explainComponent.forHtml = true;
     explainComponent.translationService = this.translationService;
+    explainComponent.themeName = this.yasr.config.themeName;
     const wrapper = document.createElement('div');
     wrapper.classList.add('yasr-explain-plan-plugin');
     wrapper.appendChild(explainComponent);

--- a/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
+++ b/ontotext-yasgui-web-component/src/services/yasgui/configuration/yasgui-configuration-builder.ts
@@ -86,7 +86,7 @@ export class YasguiConfigurationBuilder {
         isVirtualRepository: externalConfiguration.isVirtualRepository !== undefined ? externalConfiguration.isVirtualRepository : defaultYasqeConfig.isVirtualRepository,
         beforeUpdateQuery: externalConfiguration.beforeUpdateQuery !== undefined ? externalConfiguration.beforeUpdateQuery : defaultYasqeConfig.beforeUpdateQuery,
         getRepositoryStatementsCount: externalConfiguration.getRepositoryStatementsCount !== undefined ? externalConfiguration.getRepositoryStatementsCount : defaultYasqeConfig.getRepositoryStatementsCount,
-        themeName: externalConfiguration.themeName || DEFAULT_THEME
+        themeName: externalConfiguration.themeName ?? DEFAULT_THEME
       },
       yasr: {
         showQueryLoader: externalConfiguration.showQueryLoader !== undefined ? externalConfiguration.showQueryLoader : defaultYasrConfig.showQueryLoader,
@@ -97,7 +97,8 @@ export class YasguiConfigurationBuilder {
         externalPluginsConfigurations: YasrService.getPluginsConfigurations(externalConfiguration),
         isExplainPlan: ExplainPlanUtil.isExplainResults,
         fullscreen: externalConfiguration.yasrFullscreen ?? defaultYasrConfig.fullscreen,
-        showFullscreenButton: externalConfiguration.showFullscreenButton ?? defaultYasrConfig.showFullscreenButton
+        showFullscreenButton: externalConfiguration.showFullscreenButton ?? defaultYasrConfig.showFullscreenButton,
+        themeName: externalConfiguration.themeName ?? DEFAULT_THEME
       },
       yasrFullscreen: externalConfiguration.yasrFullscreen ?? defaultYasguiConfig.yasrFullscreen
     };


### PR DESCRIPTION
## What
Introduced a `themeName` configuration to apply CodeMirror themes in YASR and explain plan components. Updated UI and documentation to reflect this feature.

## Why
Enhances customization by enabling users to specify a CodeMirror theme for a consistent visual style across the application.

## How
- Added `themeName` property to relevant configurations (`YasguiConfiguration`, `YasrConfiguration`, and explain plan components).
- Updated components to use the theme name and dynamically apply corresponding CSS classes.
- Adjusted the `YASR` plugin logic to pass `themeName` to explain plan components.
- Updated `response` plugin to pass `themeName` to CodeMirror options in YASR.
- Extended `setTheme` method to include `yasr` theme configuration.
- Adjusted logic to refresh YASR components when theme changes dynamically.