### PR TITLE
GDB-14890: Add theme support to YASR plugins and improve theme application logic

### DIFF
--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -265,11 +265,12 @@ export class Yasr extends EventEmitter {
     this.updatePluginSelectorNames();
     const compatiblePlugins = this.getCompatiblePlugins();
     let pluginToDraw: string | undefined;
-    if (this.getSelectedPlugin() && this.getSelectedPlugin()?.canHandleResults()) {
+    const selectedPlugin = this.getSelectedPlugin();
+    if (selectedPlugin && selectedPlugin?.canHandleResults()) {
       pluginToDraw = this.getSelectedPluginName();
       // When present remove fallback box
       this.emptyFallbackElement();
-    } else if (compatiblePlugins[0]) {
+    } else if (compatiblePlugins.length) {
       if (this.drawnPlugin) {
         this.plugins[this.drawnPlugin].destroy?.();
       }
@@ -277,14 +278,14 @@ export class Yasr extends EventEmitter {
       // If the selected plugin cannot handle the results, we should prompt the user to switch to another compatible
       // plugin (via the fallback dialog).
 
-      // However, if the first compatible plugin is hidden from selection (hideFromSelection = true)
-      // and therefore cannot be chosen manually, we must render it directly instead of showing the dialog.
+      // However, if the first compatible plugin is hidden from selection, or the last selected plugin is hidden from selection
+      // we must render the compatible plugin directly instead of showing the dialog.
       // Otherwise, the user would be prompted to switch plugins without having access to the valid options.
       //
       // This can occur when the selected plugin supports only a subset of results, and a new query falls outside of its
       // capabilities. In such cases, hidden compatible plugins must be applied automatically to ensure the results remain visible.
-      if (compatiblePlugin && compatiblePlugin.hideFromSelection) {
-        pluginToDraw = compatiblePlugins[0]
+      if (compatiblePlugin.hideFromSelection ||  selectedPlugin?.hideFromSelection) {
+        pluginToDraw = compatiblePlugins[0];
       } else {
         this.fillFallbackBox();
       }
@@ -301,6 +302,7 @@ export class Yasr extends EventEmitter {
     }
 
     if (pluginToDraw) {
+      this.selectPlugin(pluginToDraw)
       this.updatePluginControlVisibility(true);
       this.drawnPlugin = pluginToDraw;
 

--- a/Yasgui/packages/yasr/src/plugins/index.ts
+++ b/Yasgui/packages/yasr/src/plugins/index.ts
@@ -12,6 +12,9 @@ export interface Plugin<Opts extends any> {
   getIcon(): Element | undefined;
   download?(filename?: string): DownloadInfo | undefined;
   helpReference?: string;
+
+  // Called when the theme changes
+  applyTheme?(persistentConfig: any): void;
 }
 export interface DownloadInfo {
   contentType: string;

--- a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+++ b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
@@ -41,6 +41,10 @@ export default class ExtendedResponse extends Response {
     }
   }
 
+  applyTheme() {
+    this.cm?.setOption("theme", this.yasr.config.themeName);
+  }
+
   // Function is overriden and download button is removed from the view because we already has one.
   showLess(setValue = true) {
     if (!this.cm) return;

--- a/ontotext-yasgui-web-component/src/i18n/locale-en.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-en.json
@@ -141,6 +141,8 @@
   "yasr.plugin_control.plugin.name.extended_table": "Table",
   "yasr.plugin_control.plugin.name.response": "Raw response",
   "yasr.plugin_control.plugin.name.table": "Table",
+  "yasr.plugin_control.plugin.name.boolean": "Boolean",
+  "yasr.plugin_control.plugin.name.extended_boolean": "Boolean",
   "yasr.plugin_control.plugin.name.explain-plan": "Explain plan",
   "yasr.plugin_control.plugin.name.explain-plan.title": "Query explain plan",
   "yasr.plugin_control.plugin.name.pivot-table-plugin": "Pivot Table",

--- a/ontotext-yasgui-web-component/src/i18n/locale-fr.json
+++ b/ontotext-yasgui-web-component/src/i18n/locale-fr.json
@@ -141,6 +141,8 @@
   "yasr.plugin_control.plugin.name.extended_table": "Tableau",
   "yasr.plugin_control.plugin.name.response": "Réponse brute",
   "yasr.plugin_control.plugin.name.table": "Tableau",
+  "yasr.plugin_control.plugin.name.boolean": "Booléen",
+  "yasr.plugin_control.plugin.name.extended_boolean": "Booléen",
   "yasr.plugin_control.plugin.name.explain-plan": "Plan d’exécution",
   "yasr.plugin_control.plugin.name.explain-plan.title": "Plan d’explication de la requête",
   "yasr.plugin_control.plugin.name.pivot-table-plugin": "Table de pivotement",

--- a/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
+++ b/ontotext-yasgui-web-component/src/models/ontotext-yasgui.ts
@@ -72,12 +72,16 @@ export class OntotextYasgui {
     }
 
     const yasqe = tab.getYasqe();
+    const yasr = tab.getYasr();
     if (yasqe) {
       yasqe.setOption('theme', this.config.yasguiConfig.yasqe.themeName);
     }
-    if (tab.getYasr()) {
-      tab.getYasr().config.themeName = this.config.yasguiConfig.yasr.themeName;
-      tab.getYasr().refresh();
+    if (yasr) {
+      const selectedPlugin = yasr.getSelectedPlugin();
+      yasr.config.themeName = this.config.yasguiConfig.yasr.themeName;
+      if (selectedPlugin.applyTheme) {
+        selectedPlugin.applyTheme(selectedPlugin.config);
+      }
     }
   }
 

--- a/ontotext-yasgui-web-component/src/models/yasr-plugin.ts
+++ b/ontotext-yasgui-web-component/src/models/yasr-plugin.ts
@@ -1,3 +1,5 @@
+import {PersistentConfig} from '../../../Yasgui/packages/yasqe/src';
+
 /**
  * This interface must be implemented by all Yasr plugins, and it is initialized with a YASR instance as a constructor argument.
  */
@@ -40,6 +42,12 @@ export interface YasrPlugin {
   draw(persistentConfig: any, runtimeConfig?: any): Promise<void> | void;
 
   getIcon(): Element | undefined;
+
+  /**
+   * Called when the theme changes
+   * @param config
+   */
+  applyTheme?(config: PersistentConfig): void;
 }
 
 export interface DownloadInfo {

--- a/ontotext-yasgui-web-component/src/plugins/yasr/explain-plan/explain-plan-plugin.ts
+++ b/ontotext-yasgui-web-component/src/plugins/yasr/explain-plan/explain-plan-plugin.ts
@@ -7,6 +7,7 @@ import 'codemirror/addon/runmode/runmode';
 import 'codemirror/mode/sparql/sparql';
 import 'codemirror/lib/codemirror.css';
 import { ExplainPlanUtil } from '../../../services/utils/explain-plan-util';
+import {PersistentConfig} from '../../../../../Yasgui/packages/yasqe/src';
 
 export class ExplainPlanPlugin implements YasrPlugin {
   // @ts-ignore
@@ -120,6 +121,10 @@ export class ExplainPlanPlugin implements YasrPlugin {
         }
       }, 0);
     }
+  }
+
+  applyTheme(_persistentConfig: PersistentConfig) {
+    this.draw(_persistentConfig)
   }
 
   private removeHeaderReplacement(): void {

--- a/yasgui-patches/2026-07-27_GDB-14890-Implement-theme-change-for-plugins.patch
+++ b/yasgui-patches/2026-07-27_GDB-14890-Implement-theme-change-for-plugins.patch
@@ -1,0 +1,87 @@
+Index: Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts
+--- a/Yasgui/packages/yasr/src/plugins/response/extended-response.ts	(revision 3c3b1488ab9bea826cf4e5f81be83a1ef7c9db23)
++++ b/Yasgui/packages/yasr/src/plugins/response/extended-response.ts	(revision 8c02f6aff18ec914bd9e822e40a53c91743a6dde)
+@@ -41,6 +41,10 @@
+     }
+   }
+ 
++  applyTheme() {
++    this.cm?.setOption("theme", this.yasr.config.themeName);
++  }
++
+   // Function is overriden and download button is removed from the view because we already has one.
+   showLess(setValue = true) {
+     if (!this.cm) return;
+Index: Yasgui/packages/yasr/src/plugins/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/plugins/index.ts b/Yasgui/packages/yasr/src/plugins/index.ts
+--- a/Yasgui/packages/yasr/src/plugins/index.ts	(revision 3c3b1488ab9bea826cf4e5f81be83a1ef7c9db23)
++++ b/Yasgui/packages/yasr/src/plugins/index.ts	(revision 8c02f6aff18ec914bd9e822e40a53c91743a6dde)
+@@ -12,6 +12,9 @@
+   getIcon(): Element | undefined;
+   download?(filename?: string): DownloadInfo | undefined;
+   helpReference?: string;
++
++  // Called when the theme changes
++  applyTheme?(persistentConfig: any): void;
+ }
+ export interface DownloadInfo {
+   contentType: string;
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision 3c3b1488ab9bea826cf4e5f81be83a1ef7c9db23)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 8c02f6aff18ec914bd9e822e40a53c91743a6dde)
+@@ -265,11 +265,12 @@
+     this.updatePluginSelectorNames();
+     const compatiblePlugins = this.getCompatiblePlugins();
+     let pluginToDraw: string | undefined;
+-    if (this.getSelectedPlugin() && this.getSelectedPlugin()?.canHandleResults()) {
++    const selectedPlugin = this.getSelectedPlugin();
++    if (selectedPlugin && selectedPlugin?.canHandleResults()) {
+       pluginToDraw = this.getSelectedPluginName();
+       // When present remove fallback box
+       this.emptyFallbackElement();
+-    } else if (compatiblePlugins[0]) {
++    } else if (compatiblePlugins.length) {
+       if (this.drawnPlugin) {
+         this.plugins[this.drawnPlugin].destroy?.();
+       }
+@@ -277,14 +278,14 @@
+       // If the selected plugin cannot handle the results, we should prompt the user to switch to another compatible
+       // plugin (via the fallback dialog).
+ 
+-      // However, if the first compatible plugin is hidden from selection (hideFromSelection = true)
+-      // and therefore cannot be chosen manually, we must render it directly instead of showing the dialog.
++      // However, if the first compatible plugin is hidden from selection, or the last selected plugin is hidden from selection
++      // we must render the compatible plugin directly instead of showing the dialog.
+       // Otherwise, the user would be prompted to switch plugins without having access to the valid options.
+       //
+       // This can occur when the selected plugin supports only a subset of results, and a new query falls outside of its
+       // capabilities. In such cases, hidden compatible plugins must be applied automatically to ensure the results remain visible.
+-      if (compatiblePlugin && compatiblePlugin.hideFromSelection) {
+-        pluginToDraw = compatiblePlugins[0]
++      if (compatiblePlugin.hideFromSelection ||  selectedPlugin?.hideFromSelection) {
++        pluginToDraw = compatiblePlugins[0];
+       } else {
+         this.fillFallbackBox();
+       }
+@@ -301,6 +302,7 @@
+     }
+ 
+     if (pluginToDraw) {
++      this.selectPlugin(pluginToDraw)
+       this.updatePluginControlVisibility(true);
+       this.drawnPlugin = pluginToDraw;
+ 


### PR DESCRIPTION
## What
Added a method to handle theme changes across YASR plugins and ensured proper application of themes to selected plugins.

## Why
This enhancement ensures that YASR plugins can dynamically adapt to theme changes, improving user experience and maintaining interface consistency when themes are updated.

## How
- Introduced a new `applyTheme` method to YASR plugins.
- Updated `extended-response.ts` and other plugin implementations to utilize the new method.
- Extended `yasr-plugin.ts` interface to include the optional `applyTheme` method.
- Adjusted the logic in `ontotext-yasgui.ts` to call the `applyTheme` method when themes are updated.
- Modified language files to add missing plugin translations for theme-related elements.
- Refined the plugin selection logic to account for theme changes and hidden plugins.