### PR TITLE
GDB-14890: Fix double-draw of plugins on selection (#402)

### DIFF
--- a/Yasgui/packages/yasr/src/index.ts
+++ b/Yasgui/packages/yasr/src/index.ts
@@ -302,7 +302,7 @@ export class Yasr extends EventEmitter {
     }
 
     if (pluginToDraw) {
-      this.selectPlugin(pluginToDraw)
+      this.selectPlugin(pluginToDraw, true)
       this.updatePluginControlVisibility(true);
       this.drawnPlugin = pluginToDraw;
 
@@ -364,7 +364,7 @@ export class Yasr extends EventEmitter {
     }
     return {};
   }
-  public selectPlugin(plugin: string) {
+  public selectPlugin(plugin: string, skipDraw = false) {
     this.hideWarning();
     if (this.selectedPlugin === plugin) {
       // Don't re-render when selecting the same plugin. Also see #1893
@@ -377,9 +377,11 @@ export class Yasr extends EventEmitter {
       this.selectedPlugin = this.config.defaultPlugin;
     }
     this.storeConfig();
-    this.emit("change", this);
     this.updatePluginSelectors();
-    this.draw();
+    if (!skipDraw) {
+      this.emit("change", this);
+      this.draw();
+    }
   }
   private pluginSelectorsEl!: HTMLUListElement;
   getPluginSelectorsEl(): HTMLUListElement {

--- a/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
+++ b/ontotext-yasgui-web-component/src/components/ontotext-yasgui-web-component/ontotext-yasgui-web-component.tsx
@@ -129,6 +129,9 @@ export class OntotextYasguiWebComponent {
 
   @Watch('language')
   languageChanged(newLang: string) {
+    if (newLang === this.language) {
+      return;
+    }
     this.translationService.setLanguage(newLang);
     this.getOntotextYasgui()
       .then((ontotextYasgui) => {

--- a/yasgui-patches/2026-07-28-GDB-14890-fix-double-draw-of-plugins-on-selection.patch
+++ b/yasgui-patches/2026-07-28-GDB-14890-fix-double-draw-of-plugins-on-selection.patch
@@ -1,0 +1,40 @@
+Index: Yasgui/packages/yasr/src/index.ts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Yasgui/packages/yasr/src/index.ts b/Yasgui/packages/yasr/src/index.ts
+--- a/Yasgui/packages/yasr/src/index.ts	(revision fd376bc22933d39bc9b26d46f2adff1033a5d163)
++++ b/Yasgui/packages/yasr/src/index.ts	(revision 0d915726f25d8b937eb2d38c8914d77c5e9a0b3d)
+@@ -302,7 +302,7 @@
+     }
+ 
+     if (pluginToDraw) {
+-      this.selectPlugin(pluginToDraw)
++      this.selectPlugin(pluginToDraw, true)
+       this.updatePluginControlVisibility(true);
+       this.drawnPlugin = pluginToDraw;
+ 
+@@ -364,7 +364,7 @@
+     }
+     return {};
+   }
+-  public selectPlugin(plugin: string) {
++  public selectPlugin(plugin: string, skipDraw = false) {
+     this.hideWarning();
+     if (this.selectedPlugin === plugin) {
+       // Don't re-render when selecting the same plugin. Also see #1893
+@@ -377,9 +377,11 @@
+       this.selectedPlugin = this.config.defaultPlugin;
+     }
+     this.storeConfig();
+-    this.emit("change", this);
+     this.updatePluginSelectors();
+-    this.draw();
++    if (!skipDraw) {
++      this.emit("change", this);
++      this.draw();
++    }
+   }
+   private pluginSelectorsEl!: HTMLUListElement;
+   getPluginSelectorsEl(): HTMLUListElement {


### PR DESCRIPTION
* GDB-14890 Fix double draw of plugins on selection

## What
Resolved an issue where plugins were being drawn twice during selection, causing redundant operations.

## Why
Unnecessary rendering was taking place when re-selecting the same plugin, leading to performance inefficiencies.

## How
- Added a `skipDraw` parameter to the `selectPlugin` method.
- Updated the plugin selection logic to conditionally skip redundant calls to `emit` and `draw`.
- Prevented redundant calls to `languageChanged` when the new language matches the current one.

* Add patch "2026-07-28-GDB-14890-fix-double-draw-of-plugins-on-selection.patch"

---------


(cherry picked from commit 040f76455e983aed7bdc293b3a89738e1a0aa853)