### PR TITLE
Change build display name to release version

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -98,6 +98,12 @@ pipeline {
     }
 
     post {
+        always {
+                script {
+                  currentBuild.displayName = "${params.RELEASE_VERSION ?: currentBuild.displayName}"
+                }
+            }
+
         success {
             script {
                 performCleanup()


### PR DESCRIPTION
## What
Update the JenkinsfileRelease to set the build display name to the release version.

## Why
This change allows for better identification of builds in the Jenkins interface by displaying the release version, improving clarity for users and developers.

## How
- Added a script block in the post section of the JenkinsfileRelease.
- Set `currentBuild.displayName` to the value of `params.RELEASE_VERSION` if available, otherwise retains the existing display name.